### PR TITLE
Add prediction accuracy loop scaffolding

### DIFF
--- a/accuracy_program/__init__.py
+++ b/accuracy_program/__init__.py
@@ -1,0 +1,18 @@
+"""Leakage-safe prediction accuracy helpers.
+
+These modules are intentionally additive: they measure, snapshot, and evaluate
+predictions without changing model scoring or ranking behavior.
+"""
+
+from .bet_readiness import apply_bet_readiness_gates
+from .evaluation import score_predictions, validate_feature_columns
+from .odds_coverage import analyze_odds_coverage
+from .snapshots import build_prediction_snapshot
+
+__all__ = [
+    "analyze_odds_coverage",
+    "apply_bet_readiness_gates",
+    "build_prediction_snapshot",
+    "score_predictions",
+    "validate_feature_columns",
+]

--- a/accuracy_program/bet_readiness.py
+++ b/accuracy_program/bet_readiness.py
@@ -1,0 +1,286 @@
+"""Prediction quality gates that separate prediction from betting advice."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Mapping
+
+
+ABSTAIN_FLAGS = {
+    "stale_form_guide",
+    "jumped_pending_results",
+    "missing_live_odds",
+    "stale_live_odds",
+    "thin_history",
+    "probabilities_too_uniform",
+    "single_model_only",
+    "market_model_disagreement",
+    "low_calibration_confidence",
+}
+
+
+def _predictions(prediction_result: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = prediction_result.get("predictions")
+    if not isinstance(rows, list):
+        rows = prediction_result.get("enhanced_predictions")
+    return [row for row in rows or [] if isinstance(row, dict)]
+
+
+def _append_flag(target: dict[str, Any], flag: str) -> None:
+    flags = target.get("quality_flags")
+    if not isinstance(flags, list):
+        flags = []
+    if flag not in flags:
+        flags.append(flag)
+    target["quality_flags"] = flags
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    for candidate in (raw, raw.replace("Z", "+00:00")):
+        try:
+            return datetime.fromisoformat(candidate)
+        except ValueError:
+            continue
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return datetime.strptime(raw[:19], fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _odds_timestamp(row: Mapping[str, Any]) -> datetime | None:
+    odds_snapshot = row.get("odds_snapshot")
+    candidates = []
+    if isinstance(odds_snapshot, Mapping):
+        candidates.extend(
+            odds_snapshot.get(key)
+            for key in (
+                "odds_timestamp",
+                "market_odds_timestamp",
+                "live_odds_timestamp",
+                "odds_updated_at",
+                "odds_last_updated",
+            )
+        )
+    candidates.extend(
+        row.get(key)
+        for key in (
+            "odds_timestamp",
+            "market_odds_timestamp",
+            "live_odds_timestamp",
+            "odds_updated_at",
+            "odds_last_updated",
+        )
+    )
+    for candidate in candidates:
+        parsed = _parse_timestamp(candidate)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _history_count(row: Mapping[str, Any]) -> int | None:
+    for key in (
+        "csv_historical_races",
+        "csv_prefixed_history_rows",
+        "historical_races",
+        "history_races",
+        "starts",
+    ):
+        value = row.get(key)
+        if value is None:
+            continue
+        try:
+            return int(float(value))
+        except Exception:
+            continue
+    return None
+
+
+def _probability_uniform_flag(rows: list[Mapping[str, Any]], threshold: float) -> bool:
+    probs = [
+        _safe_float(row.get("win_prob_norm", row.get("win_probability")))
+        for row in rows
+    ]
+    probs = [p for p in probs if p is not None]
+    if len(probs) < 2:
+        return False
+    return max(probs) - min(probs) <= threshold
+
+
+def _model_count(prediction_result: Mapping[str, Any]) -> int | None:
+    for key in ("ensemble_models_used", "ensemble_models", "model_count"):
+        value = prediction_result.get(key)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except Exception:
+            continue
+    model_ids = prediction_result.get("model_ids_used")
+    if isinstance(model_ids, list):
+        return len(model_ids)
+    return None
+
+
+def apply_bet_readiness_gates(
+    prediction_result: dict[str, Any],
+    *,
+    lifecycle: Mapping[str, Any] | None = None,
+    min_history_races: int = 3,
+    uniform_threshold: float = 0.015,
+    stale_odds_after_minutes: float = 30.0,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Add abstain gates without changing rank, probability, or EV values."""
+
+    rows = _predictions(prediction_result)
+    lifecycle = lifecycle or prediction_result.get("lifecycle") or {}
+    lifecycle_status = (
+        lifecycle.get("status")
+        or lifecycle.get("lifecycle_status")
+        or prediction_result.get("lifecycle_status")
+    )
+    flags: list[str] = []
+    reasons: dict[str, Any] = {}
+
+    def add(flag: str, reason: Any = True) -> None:
+        if flag not in flags:
+            flags.append(flag)
+        reasons[flag] = reason
+
+    if lifecycle_status == "stale_form_guide":
+        add("stale_form_guide", "race is a stale form guide, not a live pre-jump target")
+    if lifecycle_status == "jumped_pending_results":
+        add("jumped_pending_results", "race has jumped and official labels are still pending")
+    if lifecycle_status == "resulted":
+        add("jumped_pending_results", "race has result evidence and is not bet-eligible")
+
+    missing_odds = []
+    stale_odds = []
+    now_dt = now or datetime.now()
+    for row in rows:
+        odds = _safe_float(row.get("market_odds_win", row.get("odds_win", row.get("live_odds"))))
+        ev = _safe_float(row.get("ev_win"))
+        if odds is None or odds <= 1:
+            _append_flag(row, "missing_live_odds")
+            missing_odds.append(row.get("dog_clean_name") or row.get("dog_name"))
+        elif ev is None:
+            _append_flag(row, "missing_live_odds")
+            missing_odds.append(row.get("dog_clean_name") or row.get("dog_name"))
+        odds_ts = _odds_timestamp(row)
+        if odds_ts is not None:
+            compare_now = now_dt
+            if odds_ts.tzinfo is not None and compare_now.tzinfo is None:
+                compare_now = compare_now.replace(tzinfo=odds_ts.tzinfo)
+            elif odds_ts.tzinfo is None and compare_now.tzinfo is not None:
+                compare_now = compare_now.replace(tzinfo=None)
+            age_minutes = (compare_now - odds_ts).total_seconds() / 60.0
+            if age_minutes > stale_odds_after_minutes:
+                _append_flag(row, "stale_live_odds")
+                stale_odds.append(row.get("dog_clean_name") or row.get("dog_name"))
+    if rows and missing_odds:
+        add("missing_live_odds", {"runner_count": len(missing_odds)})
+    if rows and stale_odds:
+        add(
+            "stale_live_odds",
+            {
+                "runner_count": len(stale_odds),
+                "stale_after_minutes": stale_odds_after_minutes,
+            },
+        )
+
+    thin = []
+    for row in rows:
+        count = _history_count(row)
+        if count is not None and count < min_history_races:
+            _append_flag(row, "thin_history")
+            thin.append(row.get("dog_clean_name") or row.get("dog_name"))
+    if thin:
+        add("thin_history", {"runner_count": len(thin), "min_history_races": min_history_races})
+
+    if _probability_uniform_flag(rows, uniform_threshold):
+        add("probabilities_too_uniform", {"threshold": uniform_threshold})
+        for row in rows:
+            _append_flag(row, "probabilities_too_uniform")
+
+    count = _model_count(prediction_result)
+    if count is None:
+        if any("single_model_no_ensemble_agreement" in (row.get("quality_flags") or []) for row in rows):
+            add("single_model_only", "single model quality flag already present")
+    elif count <= 1:
+        add("single_model_only", {"model_count": count})
+        for row in rows:
+            _append_flag(row, "single_model_only")
+
+    market_context = prediction_result.get("market_context") or {}
+    disagreement_count = int(market_context.get("large_disagreement_count") or 0)
+    if disagreement_count > 0 or any(
+        "large_model_market_disagreement" in (row.get("quality_flags") or [])
+        for row in rows
+    ):
+        add("market_model_disagreement", {"large_disagreement_count": disagreement_count})
+        for row in rows:
+            if "large_model_market_disagreement" in (row.get("quality_flags") or []):
+                _append_flag(row, "market_model_disagreement")
+
+    model_version = str(prediction_result.get("model_version") or "").strip().lower()
+    metrics = prediction_result.get("metrics")
+    if (
+        not model_version
+        or model_version == "unknown"
+        or prediction_result.get("degraded")
+        or prediction_result.get("synthetic")
+        or metrics in (None, {})
+    ):
+        add("low_calibration_confidence", "no current temporal calibration metrics attached")
+
+    flag_map = {flag: flag in flags for flag in sorted(ABSTAIN_FLAGS)}
+    probs = [
+        _safe_float(row.get("win_prob_norm", row.get("win_probability")))
+        for row in rows
+    ]
+    probs = [p for p in probs if p is not None]
+    history_counts = [_history_count(row) for row in rows]
+    history_counts = [count for count in history_counts if count is not None]
+    market_context = prediction_result.get("market_context") or {}
+    status = "bet_qualified" if not flags else "prediction_available_not_bet_qualified"
+    result = {
+        "schema_version": "bet_readiness_v1",
+        "status": status,
+        "ready": not flags,
+        "abstain": bool(flags),
+        "abstain_reasons": flags,
+        "bet_qualified": not flags,
+        "abstain_flags": flags,
+        "flags": flag_map,
+        "reasons": reasons,
+        "inputs": {
+            "lifecycle_status": lifecycle_status,
+            "market_odds_count": market_context.get("market_odds_count"),
+            "stale_odds_count": len(stale_odds),
+            "stale_odds_after_minutes": stale_odds_after_minutes,
+            "min_history_races": min(history_counts) if history_counts else None,
+            "probability_spread": (
+                max(probs) - min(probs) if len(probs) >= 2 else None
+            ),
+            "calibration_metrics_present": metrics not in (None, {}),
+        },
+    }
+    prediction_result["bet_readiness"] = result
+    return result

--- a/accuracy_program/evaluation.py
+++ b/accuracy_program/evaluation.py
@@ -1,0 +1,329 @@
+"""Leakage-safe prediction evaluation primitives."""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Iterable, Mapping, Sequence
+
+import numpy as np
+
+
+FORBIDDEN_FEATURE_COLUMNS = {
+    "actual_results",
+    "actual_winner",
+    "beaten_margin",
+    "finish_position",
+    "margin",
+    "placing",
+    "result",
+    "result_status",
+    "results_status",
+    "scraped_finish_position",
+    "scraped_raw_result",
+    "target_finish_position",
+    "winner_margin",
+    "winner_name",
+    "winner_odds",
+    "winning_time",
+}
+
+
+@dataclass(frozen=True)
+class TemporalHoldoutCheck:
+    ok: bool
+    train_max_date: str | None
+    test_min_date: str | None
+    race_id_overlap: list[str]
+    violations: list[str]
+
+
+def _norm_column(name: str) -> str:
+    return str(name).strip().lower()
+
+
+def validate_feature_columns(columns: Iterable[str]) -> list[str]:
+    """Return forbidden post-result/target columns present in feature inputs."""
+
+    present = {_norm_column(col) for col in columns}
+    return sorted(present & FORBIDDEN_FEATURE_COLUMNS)
+
+
+def _parse_date(value: Any) -> date | None:
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw[:10]).date()
+    except ValueError:
+        return None
+
+
+def validate_temporal_holdout(
+    train_rows: Sequence[Mapping[str, Any]],
+    test_rows: Sequence[Mapping[str, Any]],
+    *,
+    race_id_key: str = "race_id",
+    date_key: str = "race_date",
+) -> TemporalHoldoutCheck:
+    """Validate no race overlap and test dates strictly after train dates."""
+
+    train_ids = {str(row.get(race_id_key)) for row in train_rows if row.get(race_id_key)}
+    test_ids = {str(row.get(race_id_key)) for row in test_rows if row.get(race_id_key)}
+    overlap = sorted(train_ids & test_ids)
+    train_dates = [_parse_date(row.get(date_key)) for row in train_rows]
+    test_dates = [_parse_date(row.get(date_key)) for row in test_rows]
+    train_dates = [d for d in train_dates if d is not None]
+    test_dates = [d for d in test_dates if d is not None]
+
+    train_max = max(train_dates) if train_dates else None
+    test_min = min(test_dates) if test_dates else None
+    violations: list[str] = []
+    if overlap:
+        violations.append("race_id_overlap")
+    if train_max is None or test_min is None:
+        violations.append("missing_temporal_dates")
+    elif test_min <= train_max:
+        violations.append("test_not_strictly_after_train")
+
+    return TemporalHoldoutCheck(
+        ok=not violations,
+        train_max_date=train_max.isoformat() if train_max else None,
+        test_min_date=test_min.isoformat() if test_min else None,
+        race_id_overlap=overlap,
+        violations=violations,
+    )
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        parsed = float(value)
+        if math.isnan(parsed) or math.isinf(parsed):
+            return None
+        return parsed
+    except Exception:
+        return None
+
+
+def _race_groups(rows: Iterable[Mapping[str, Any]]) -> dict[str, list[Mapping[str, Any]]]:
+    groups: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in rows:
+        race_id = row.get("race_id")
+        if race_id is None:
+            continue
+        groups[str(race_id)].append(row)
+    return groups
+
+
+def _brier(pairs: list[tuple[float, int]]) -> float | None:
+    if not pairs:
+        return None
+    return float(np.mean([(p - y) ** 2 for p, y in pairs]))
+
+
+def _log_loss_by_race(groups: dict[str, list[Mapping[str, Any]]], probability_key: str, actual_key: str) -> float | None:
+    losses: list[float] = []
+    eps = 1e-12
+    for rows in groups.values():
+        winner_probs = [
+            _safe_float(row.get(probability_key))
+            for row in rows
+            if int(row.get(actual_key) or 0) == 1
+        ]
+        winner_probs = [p for p in winner_probs if p is not None]
+        if not winner_probs:
+            continue
+        losses.append(-math.log(max(eps, min(1.0, winner_probs[0]))))
+    return float(np.mean(losses)) if losses else None
+
+
+def _calibration(pairs: list[tuple[float, int]]) -> dict[str, float | None]:
+    if len(pairs) < 10 or len({y for _, y in pairs}) < 2:
+        return {"slope": None, "intercept": None}
+    probs = np.array([max(1e-6, min(1.0 - 1e-6, p)) for p, _ in pairs], dtype=float)
+    y = np.array([y for _, y in pairs], dtype=int)
+    x = np.log(probs / (1.0 - probs)).reshape(-1, 1)
+    try:
+        from sklearn.linear_model import LogisticRegression
+
+        model = LogisticRegression(solver="lbfgs")
+        model.fit(x, y)
+        return {
+            "slope": float(model.coef_[0][0]),
+            "intercept": float(model.intercept_[0]),
+        }
+    except Exception:
+        return {"slope": None, "intercept": None}
+
+
+def _reliability_bins(
+    pairs: list[tuple[float, int]],
+    *,
+    bins: int = 10,
+) -> list[dict[str, float | int]]:
+    bucketed: list[list[tuple[float, int]]] = [[] for _ in range(bins)]
+    for prob, actual in pairs:
+        idx = max(0, min(bins - 1, int(prob * bins)))
+        bucketed[idx].append((prob, actual))
+    out = []
+    for idx, bucket in enumerate(bucketed):
+        if not bucket:
+            continue
+        out.append(
+            {
+                "bin": idx,
+                "lower": idx / bins,
+                "upper": (idx + 1) / bins,
+                "count": len(bucket),
+                "avg_predicted": float(np.mean([p for p, _ in bucket])),
+                "actual_rate": float(np.mean([y for _, y in bucket])),
+            }
+        )
+    return out
+
+
+def _roi_by_ev_decile(
+    rows: list[Mapping[str, Any]],
+    *,
+    probability_key: str,
+    actual_key: str,
+    odds_key: str,
+) -> list[dict[str, float | int]]:
+    eligible = []
+    for row in rows:
+        p = _safe_float(row.get(probability_key))
+        odds = _safe_float(row.get(odds_key))
+        if p is None or odds is None or odds <= 1:
+            continue
+        ev = p * odds - 1.0
+        actual = int(row.get(actual_key) or 0)
+        roi = odds - 1.0 if actual == 1 else -1.0
+        eligible.append((ev, roi))
+    if not eligible:
+        return []
+    eligible.sort(key=lambda item: item[0])
+    out = []
+    chunks = np.array_split(np.array(eligible, dtype=float), min(10, len(eligible)))
+    for idx, chunk in enumerate(chunks):
+        if len(chunk) == 0:
+            continue
+        out.append(
+            {
+                "decile": idx + 1,
+                "count": int(len(chunk)),
+                "ev_min": float(np.min(chunk[:, 0])),
+                "ev_max": float(np.max(chunk[:, 0])),
+                "avg_ev": float(np.mean(chunk[:, 0])),
+                "realized_roi": float(np.mean(chunk[:, 1])),
+            }
+        )
+    return out
+
+
+def score_predictions(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    probability_key: str = "win_prob_norm",
+    actual_key: str = "actual_win",
+    odds_key: str = "odds_win",
+) -> dict[str, Any]:
+    """Score already frozen dog-level predictions with result labels."""
+
+    groups = _race_groups(rows)
+    top_hits = {1: 0, 2: 0, 3: 0}
+    scored_races = 0
+    prob_sum_errors: list[float] = []
+    pairs: list[tuple[float, int]] = []
+
+    for race_rows in groups.values():
+        ranked = sorted(
+            race_rows,
+            key=lambda row: _safe_float(row.get(probability_key)) or 0.0,
+            reverse=True,
+        )
+        if not ranked:
+            continue
+        winners = {
+            str(row.get("dog_name") or row.get("dog_clean_name") or row.get("box_number"))
+            for row in ranked
+            if int(row.get(actual_key) or 0) == 1
+        }
+        if not winners:
+            continue
+        scored_races += 1
+        for k in (1, 2, 3):
+            top_names = {
+                str(row.get("dog_name") or row.get("dog_clean_name") or row.get("box_number"))
+                for row in ranked[:k]
+            }
+            top_hits[k] += int(bool(winners & top_names))
+        probs = [_safe_float(row.get(probability_key)) for row in ranked]
+        probs = [p for p in probs if p is not None]
+        if probs:
+            prob_sum_errors.append(abs(sum(probs) - 1.0))
+        for row in ranked:
+            p = _safe_float(row.get(probability_key))
+            if p is not None:
+                pairs.append((p, int(row.get(actual_key) or 0)))
+
+    rows_list = list(rows)
+    return {
+        "races_evaluated": scored_races,
+        "dog_predictions_evaluated": len(pairs),
+        "top1": top_hits[1] / scored_races if scored_races else None,
+        "top2": top_hits[2] / scored_races if scored_races else None,
+        "top3": top_hits[3] / scored_races if scored_races else None,
+        "brier": _brier(pairs),
+        "log_loss": _log_loss_by_race(groups, probability_key, actual_key),
+        "calibration": _calibration(pairs),
+        "reliability_bins": _reliability_bins(pairs),
+        "roi_ev_by_decile": _roi_by_ev_decile(
+            rows_list,
+            probability_key=probability_key,
+            actual_key=actual_key,
+            odds_key=odds_key,
+        ),
+        "probability_sum": {
+            "max_abs_error": max(prob_sum_errors) if prob_sum_errors else None,
+            "mean_abs_error": float(np.mean(prob_sum_errors)) if prob_sum_errors else None,
+        },
+    }
+
+
+def market_implied_probabilities(odds_by_runner: Mapping[str, float]) -> dict[str, float]:
+    implied = {
+        runner: 1.0 / float(odds)
+        for runner, odds in odds_by_runner.items()
+        if odds is not None and float(odds) > 1.0
+    }
+    total = sum(implied.values())
+    if total <= 0:
+        return {}
+    return {runner: value / total for runner, value in implied.items()}
+
+
+def blend_probabilities(
+    model_probs: Mapping[str, float],
+    market_probs: Mapping[str, float],
+    *,
+    model_weight: float,
+) -> dict[str, float]:
+    """Return a normalized simple blend for experiment reporting only."""
+
+    weight = max(0.0, min(1.0, float(model_weight)))
+    runners = set(model_probs) | set(market_probs)
+    blended = {
+        runner: weight * float(model_probs.get(runner, 0.0))
+        + (1.0 - weight) * float(market_probs.get(runner, 0.0))
+        for runner in runners
+    }
+    total = sum(max(0.0, value) for value in blended.values())
+    if total <= 0:
+        return {}
+    return {runner: max(0.0, value) / total for runner, value in blended.items()}

--- a/accuracy_program/odds_coverage.py
+++ b/accuracy_program/odds_coverage.py
@@ -1,0 +1,328 @@
+"""Read-only dog-level odds coverage analysis."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def _open_readonly(db_path: str | os.PathLike[str]) -> sqlite3.Connection:
+    uri = f"file:{Path(db_path).resolve()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def _dict_row(row: sqlite3.Row | None) -> dict[str, Any]:
+    return dict(row) if row is not None else {}
+
+
+def _scalar(conn: sqlite3.Connection, sql: str, params: tuple[Any, ...] = ()) -> int:
+    row = conn.execute(sql, params).fetchone()
+    return int(row[0] or 0) if row else 0
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    for candidate in (raw, raw.replace("Z", "+00:00")):
+        try:
+            return datetime.fromisoformat(candidate)
+        except ValueError:
+            continue
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return datetime.strptime(raw[:19], fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _current_win_where(current_only: bool) -> str:
+    current_clause = "AND (is_current = 1 OR is_current IS NULL)" if current_only else ""
+    return f"""
+        lower(coalesce(market_type, 'win')) = 'win'
+        AND odds_decimal IS NOT NULL
+        AND odds_decimal > 1
+        {current_clause}
+    """
+
+
+def analyze_odds_coverage(
+    db_path: str | os.PathLike[str],
+    *,
+    current_only: bool = True,
+    stale_after_hours: float = 6.0,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Return dog-level odds coverage metrics from a SQLite DB.
+
+    The DB is opened in SQLite read-only mode with query_only enabled. The
+    function never scrapes and never writes.
+    """
+
+    with _open_readonly(db_path) as conn:
+        tables = {
+            table: _table_exists(conn, table)
+            for table in ("live_odds", "odds_history", "race_metadata", "dog_race_data")
+        }
+        if not all(tables.values()):
+            return {
+                "db_path": str(db_path),
+                "current_only": current_only,
+                "tables": tables,
+                "error": "required table missing",
+            }
+
+        win_where = _current_win_where(current_only)
+        counts = {
+            "live_odds_rows": _scalar(conn, "SELECT COUNT(*) FROM live_odds"),
+            "odds_history_rows": _scalar(conn, "SELECT COUNT(*) FROM odds_history"),
+            "live_odds_races": _scalar(conn, "SELECT COUNT(DISTINCT race_id) FROM live_odds"),
+            "odds_history_races": _scalar(conn, "SELECT COUNT(DISTINCT race_id) FROM odds_history"),
+            "dog_rows": _scalar(conn, "SELECT COUNT(*) FROM dog_race_data"),
+            "race_rows": _scalar(conn, "SELECT COUNT(*) FROM race_metadata"),
+        }
+
+        win_counts = _dict_row(
+            conn.execute(
+                f"""
+                SELECT
+                    COUNT(*) AS dog_level_win_odds_rows,
+                    COUNT(DISTINCT race_id) AS races_with_dog_level_win_odds
+                FROM live_odds
+                WHERE {win_where}
+                """
+            ).fetchone()
+        )
+
+        match_counts = _dict_row(
+            conn.execute(
+                f"""
+                WITH win AS (
+                    SELECT *
+                    FROM live_odds
+                    WHERE {win_where}
+                ),
+                m_rid_name AS (
+                    SELECT win.id
+                    FROM win
+                    JOIN dog_race_data d
+                      ON d.race_id = win.race_id
+                     AND lower(trim(coalesce(d.dog_clean_name, d.dog_name))) =
+                         lower(trim(coalesce(win.dog_clean_name, win.dog_name)))
+                ),
+                m_rid_box AS (
+                    SELECT win.id
+                    FROM win
+                    JOIN dog_race_data d
+                      ON d.race_id = win.race_id
+                     AND d.box_number = win.box_number
+                ),
+                m_vdr_name AS (
+                    SELECT win.id
+                    FROM win
+                    JOIN race_metadata rm
+                      ON lower(trim(rm.venue)) = lower(trim(win.venue))
+                     AND rm.race_date = win.race_date
+                     AND rm.race_number = win.race_number
+                    JOIN dog_race_data d
+                      ON d.race_id = rm.race_id
+                     AND lower(trim(coalesce(d.dog_clean_name, d.dog_name))) =
+                         lower(trim(coalesce(win.dog_clean_name, win.dog_name)))
+                ),
+                m_vdr_box AS (
+                    SELECT win.id
+                    FROM win
+                    JOIN race_metadata rm
+                      ON lower(trim(rm.venue)) = lower(trim(win.venue))
+                     AND rm.race_date = win.race_date
+                     AND rm.race_number = win.race_number
+                    JOIN dog_race_data d
+                      ON d.race_id = rm.race_id
+                     AND d.box_number = win.box_number
+                )
+                SELECT
+                    (SELECT COUNT(DISTINCT id) FROM m_rid_name) AS race_id_name_matches,
+                    (SELECT COUNT(DISTINCT id) FROM m_rid_box) AS race_id_box_matches,
+                    (SELECT COUNT(DISTINCT id) FROM m_vdr_name) AS venue_date_race_name_matches,
+                    (SELECT COUNT(DISTINCT id) FROM m_vdr_box) AS venue_date_race_box_matches
+                """
+            ).fetchone()
+        )
+
+        missing_reasons = [
+            dict(row)
+            for row in conn.execute(
+                f"""
+                WITH win AS (
+                    SELECT *
+                    FROM live_odds
+                    WHERE {win_where}
+                ),
+                matched AS (
+                    SELECT DISTINCT win.id
+                    FROM win
+                    JOIN dog_race_data d
+                      ON d.race_id = win.race_id
+                     AND (
+                            lower(trim(coalesce(d.dog_clean_name, d.dog_name))) =
+                            lower(trim(coalesce(win.dog_clean_name, win.dog_name)))
+                         OR d.box_number = win.box_number
+                     )
+                ),
+                rm AS (SELECT race_id FROM race_metadata),
+                dr AS (SELECT DISTINCT race_id FROM dog_race_data)
+                SELECT
+                    CASE
+                        WHEN win.race_id NOT IN (SELECT race_id FROM rm)
+                            THEN 'no_race_metadata_race_id'
+                        WHEN win.race_id NOT IN (SELECT race_id FROM dr)
+                            THEN 'no_dog_rows_race_id'
+                        WHEN win.box_number IS NULL
+                         AND trim(coalesce(win.dog_clean_name, win.dog_name, '')) = ''
+                            THEN 'no_box_or_dog_name'
+                        ELSE 'dog_match_failed'
+                    END AS missing_reason,
+                    COUNT(*) AS rows,
+                    COUNT(DISTINCT win.race_id) AS races
+                FROM win
+                WHERE win.id NOT IN (SELECT id FROM matched)
+                GROUP BY missing_reason
+                ORDER BY rows DESC, missing_reason ASC
+                """
+            ).fetchall()
+        ]
+
+        race_coverage = _dict_row(
+            conn.execute(
+                f"""
+                WITH win AS (
+                    SELECT *
+                    FROM live_odds
+                    WHERE {win_where}
+                ),
+                race_field AS (
+                    SELECT race_id, COUNT(*) AS dog_rows
+                    FROM dog_race_data
+                    GROUP BY race_id
+                ),
+                race_odds AS (
+                    SELECT race_id, COUNT(*) AS odds_rows
+                    FROM win
+                    GROUP BY race_id
+                )
+                SELECT
+                    COUNT(*) AS odds_races,
+                    SUM(CASE WHEN rf.dog_rows IS NOT NULL THEN 1 ELSE 0 END)
+                        AS races_with_field_by_race_id,
+                    ROUND(AVG(CASE WHEN rf.dog_rows IS NOT NULL
+                        THEN 1.0 * ro.odds_rows / rf.dog_rows END), 6)
+                        AS avg_row_coverage_by_race_id,
+                    SUM(CASE WHEN ro.odds_rows >= COALESCE(rf.dog_rows, 9999)
+                        THEN 1 ELSE 0 END) AS races_full_or_more_by_race_id
+                FROM race_odds ro
+                LEFT JOIN race_field rf ON rf.race_id = ro.race_id
+                """
+            ).fetchone()
+        )
+
+        timestamp_bounds = _dict_row(
+            conn.execute(
+                f"""
+                SELECT MIN(timestamp) AS min_timestamp, MAX(timestamp) AS max_timestamp
+                FROM live_odds
+                WHERE {win_where}
+                """
+            ).fetchone()
+        )
+        current_rows = conn.execute(
+            f"""
+            SELECT timestamp
+            FROM live_odds
+            WHERE {win_where}
+            """
+        ).fetchall()
+
+        now_dt = now or datetime.now()
+        stale_rows = 0
+        for row in current_rows:
+            parsed = _parse_timestamp(row["timestamp"])
+            if parsed is None:
+                continue
+            compare_now = now_dt
+            if parsed.tzinfo is not None and compare_now.tzinfo is None:
+                compare_now = compare_now.replace(tzinfo=parsed.tzinfo)
+            age_hours = (compare_now - parsed).total_seconds() / 3600.0
+            if age_hours > stale_after_hours:
+                stale_rows += 1
+
+        late_risk = _dict_row(
+            conn.execute(
+                f"""
+                WITH win AS (
+                    SELECT *
+                    FROM live_odds
+                    WHERE {win_where}
+                )
+                SELECT
+                    SUM(CASE
+                        WHEN rm.start_datetime IS NOT NULL
+                         AND win.timestamp IS NOT NULL
+                         AND datetime(win.timestamp) > datetime(rm.start_datetime)
+                        THEN 1 ELSE 0 END) AS rows_after_start_datetime,
+                    SUM(CASE
+                        WHEN rm.start_datetime IS NOT NULL
+                        THEN 1 ELSE 0 END) AS rows_with_start_datetime
+                FROM win
+                LEFT JOIN race_metadata rm ON rm.race_id = win.race_id
+                """
+            ).fetchone()
+        )
+
+    dog_level_win_rows = int(win_counts.get("dog_level_win_odds_rows") or 0)
+    matched_by_name = int(match_counts.get("race_id_name_matches") or 0)
+    matched_by_box = int(match_counts.get("race_id_box_matches") or 0)
+    best_direct_match = max(matched_by_name, matched_by_box)
+    return {
+        "db_path": str(db_path),
+        "current_only": current_only,
+        "tables": tables,
+        "counts": {**counts, **win_counts},
+        "match_counts": match_counts,
+        "missing_reasons": missing_reasons,
+        "race_coverage": race_coverage,
+        "stale_late_risks": {
+            **timestamp_bounds,
+            "stale_after_hours": stale_after_hours,
+            "stale_current_win_rows": stale_rows,
+            **late_risk,
+        },
+        "coverage_rates": {
+            "race_id_name_match_rate": (
+                matched_by_name / dog_level_win_rows if dog_level_win_rows else None
+            ),
+            "race_id_box_match_rate": (
+                matched_by_box / dog_level_win_rows if dog_level_win_rows else None
+            ),
+            "best_direct_match_rate": (
+                best_direct_match / dog_level_win_rows if dog_level_win_rows else None
+            ),
+        },
+    }

--- a/accuracy_program/snapshots.py
+++ b/accuracy_program/snapshots.py
@@ -1,0 +1,187 @@
+"""Prediction-before-result snapshot construction."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+
+RESULT_FIELD_NAMES = {
+    "actual_results",
+    "actual_winner",
+    "beaten_margin",
+    "finish_position",
+    "placing",
+    "result",
+    "result_status",
+    "results_status",
+    "scraped_finish_position",
+    "scraped_raw_result",
+    "winner_margin",
+    "winner_name",
+    "winner_odds",
+}
+
+
+def _iso_now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if hasattr(value, "to_dict"):
+        try:
+            return dict(value.to_dict())
+        except Exception:
+            return {}
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _safe_int(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except Exception:
+        return None
+
+
+def _prediction_rows(prediction_result: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = prediction_result.get("predictions")
+    if not isinstance(rows, list):
+        rows = prediction_result.get("enhanced_predictions")
+    if not isinstance(rows, list):
+        return []
+
+    snapshot_rows: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        leaked = sorted(str(key) for key in row.keys() if str(key) in RESULT_FIELD_NAMES)
+        if leaked:
+            raise ValueError(
+                "result field leaked into runner prediction: " + ", ".join(leaked)
+            )
+        odds_snapshot = {
+            "market_odds_win": _safe_float(
+                row.get("market_odds_win", row.get("odds_win", row.get("live_odds")))
+            ),
+            "odds_implied_prob": _safe_float(row.get("odds_implied_prob")),
+            "odds_implied_prob_norm": _safe_float(row.get("odds_implied_prob_norm")),
+        }
+        odds_snapshot = {k: v for k, v in odds_snapshot.items() if v is not None}
+        odds_timestamp = (
+            row.get("odds_timestamp")
+            or row.get("market_odds_timestamp")
+            or row.get("live_odds_timestamp")
+            or row.get("odds_updated_at")
+            or row.get("odds_last_updated")
+        )
+        if odds_timestamp:
+            odds_snapshot["odds_timestamp"] = str(odds_timestamp)
+        snapshot_rows.append(
+            {
+                "dog_name": row.get("dog_clean_name") or row.get("dog_name") or row.get("name"),
+                "box_number": _safe_int(row.get("box_number")),
+                "win_prob_raw": _safe_float(
+                    row.get("win_prob_raw", row.get("win_probability_raw"))
+                ),
+                "win_prob_norm": _safe_float(
+                    row.get("win_prob_norm", row.get("win_probability"))
+                ),
+                "rank": _safe_int(row.get("predicted_rank", row.get("rank"))),
+                "confidence": _safe_float(
+                    row.get("confidence_score", row.get("confidence"))
+                ),
+                "odds_snapshot": odds_snapshot,
+                "ev_win": _safe_float(row.get("ev_win")),
+                "data_quality_flags": list(row.get("quality_flags") or []),
+            }
+        )
+    return snapshot_rows
+
+
+def build_prediction_snapshot(
+    prediction_result: Mapping[str, Any],
+    *,
+    source_file_path: str | None = None,
+    lifecycle: Any = None,
+    prediction_timestamp: str | None = None,
+    feature_freeze_timestamp: str | None = None,
+) -> dict[str, Any]:
+    """Build a result-free snapshot record from an already computed prediction.
+
+    The snapshot intentionally contains no target-result labels. It can be
+    written by callers only after they choose a safe storage target.
+    """
+
+    lifecycle_data = _as_dict(lifecycle)
+    lifecycle_status = (
+        lifecycle_data.get("status")
+        or lifecycle_data.get("lifecycle_status")
+        or prediction_result.get("lifecycle_status")
+    )
+    timestamp = prediction_timestamp or _iso_now()
+    feature_freeze = feature_freeze_timestamp or timestamp
+    race_id = (
+        prediction_result.get("race_id")
+        or prediction_result.get("raceId")
+        or (Path(source_file_path).stem if source_file_path else None)
+    )
+    model_version = (
+        prediction_result.get("model_version")
+        or prediction_result.get("primary_model_id")
+        or prediction_result.get("model_info")
+        or "unknown"
+    )
+
+    snapshot = {
+        "race_id": race_id,
+        "source_file_path": source_file_path,
+        "lifecycle_status": lifecycle_status,
+        "lifecycle_status_reason": lifecycle_data.get("status_reason")
+        or lifecycle_data.get("lifecycle_status_reason"),
+        "model_version": model_version,
+        "prediction_timestamp": timestamp,
+        "feature_freeze_timestamp": feature_freeze,
+        "is_pre_jump_snapshot": lifecycle_status == "upcoming_not_jumped",
+        "snapshot_state": (
+            "pre_jump_feature_freeze"
+            if lifecycle_status == "upcoming_not_jumped"
+            else "not_bet_qualified_lifecycle"
+        ),
+        "predictions": _prediction_rows(prediction_result),
+        "data_quality_flags": list(prediction_result.get("quality_flags") or []),
+    }
+    assert_no_result_fields(snapshot)
+    return snapshot
+
+
+def assert_no_result_fields(value: Any) -> None:
+    """Raise ValueError if a snapshot contains result/label fields."""
+
+    def visit(node: Any, path: str) -> None:
+        if isinstance(node, Mapping):
+            for key, child in node.items():
+                key_text = str(key)
+                if key_text in RESULT_FIELD_NAMES:
+                    raise ValueError(f"result field leaked into snapshot: {path}.{key_text}")
+                visit(child, f"{path}.{key_text}")
+        elif isinstance(node, list):
+            for idx, child in enumerate(node):
+                visit(child, f"{path}[{idx}]")
+
+    visit(value, "snapshot")

--- a/app.py
+++ b/app.py
@@ -300,6 +300,8 @@ from features import (
     V3WeatherTrackFeatures,
 )
 from sportsbet_odds_integrator import SportsbetOddsIntegrator
+from accuracy_program.bet_readiness import apply_bet_readiness_gates
+from accuracy_program.snapshots import build_prediction_snapshot
 from utils.csv_metadata import parse_race_csv_meta
 from utils.race_lifecycle import (
     RaceLifecycle,
@@ -4385,6 +4387,66 @@ def api_predict_file():
         resp.update(lifecycle_fields)
         if isinstance(prediction_result, dict):
             prediction_result["lifecycle"] = lifecycle.to_dict()
+            try:
+                readiness = apply_bet_readiness_gates(
+                    prediction_result,
+                    lifecycle=lifecycle.to_dict(),
+                )
+                resp["bet_readiness"] = readiness
+                resp["abstain"] = readiness.get("abstain")
+                resp["abstain_reasons"] = readiness.get("abstain_reasons", [])
+            except Exception as readiness_error:
+                logger.warning(
+                    f"Prediction readiness enrichment failed: {readiness_error}"
+                )
+                readiness = {
+                    "schema_version": "bet_readiness_v1",
+                    "status": "prediction_available_not_bet_qualified",
+                    "ready": False,
+                    "abstain": True,
+                    "abstain_reasons": ["readiness_unavailable"],
+                    "bet_qualified": False,
+                    "abstain_flags": ["readiness_unavailable"],
+                    "reasons": {
+                        "readiness_unavailable": "readiness enrichment failed"
+                    },
+                }
+                prediction_result["bet_readiness"] = readiness
+                resp["bet_readiness"] = readiness
+                resp["abstain"] = True
+                resp["abstain_reasons"] = ["readiness_unavailable"]
+            try:
+                prediction_result["prediction_snapshot"] = build_prediction_snapshot(
+                    prediction_result,
+                    source_file_path=race_file_path,
+                    lifecycle=lifecycle,
+                )
+                resp["prediction_snapshot_status"] = "created"
+            except ValueError as snapshot_error:
+                logger.warning(
+                    f"Prediction snapshot rejected for {race_file_path}: {snapshot_error}"
+                )
+                return (
+                    jsonify(
+                        {
+                            "success": False,
+                            "error": "prediction snapshot rejected",
+                            "reason": str(snapshot_error),
+                            "resolved_path": race_file_path,
+                            **lifecycle_fields,
+                        }
+                    ),
+                    500,
+                )
+            except Exception as snapshot_error:
+                logger.warning(
+                    f"Prediction snapshot enrichment failed: {snapshot_error}"
+                )
+                prediction_result["prediction_snapshot_status"] = {
+                    "status": "unavailable",
+                    "reason": str(snapshot_error),
+                }
+                resp["prediction_snapshot_status"] = "unavailable"
         # Surface model metadata and metrics at top-level for convenience
         try:
             if isinstance(prediction_result, dict):

--- a/scripts/evaluate_prediction_snapshots.py
+++ b/scripts/evaluate_prediction_snapshots.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Evaluate frozen prediction snapshots against post-race labels.
+
+This script is intentionally read-only for SQLite. It does not train, scrape,
+or change model/ranking behavior. It scores only predictions that were already
+frozen in snapshot JSON files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from accuracy_program.evaluation import (
+    blend_probabilities,
+    market_implied_probabilities,
+    score_predictions,
+)
+from accuracy_program.snapshots import assert_no_result_fields
+
+
+def _open_readonly(db_path: str | Path) -> sqlite3.Connection:
+    uri = f"file:{Path(db_path).resolve()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    return conn
+
+
+def _snapshot_files(paths: Iterable[str]) -> list[Path]:
+    files: list[Path] = []
+    for raw in paths:
+        path = Path(raw)
+        if path.is_dir():
+            files.extend(sorted(path.glob("**/*.json")))
+        elif path.is_file():
+            files.append(path)
+    return files
+
+
+def _norm_name(value: Any) -> str:
+    import re
+
+    return re.sub(r"[^A-Z0-9]", "", str(value or "").upper())
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _race_metadata(conn: sqlite3.Connection, race_id: str) -> dict[str, Any]:
+    row = conn.execute(
+        """
+        SELECT race_id, venue, race_date, distance, results_status, winner_source,
+               data_quality_note, winner_name
+        FROM race_metadata
+        WHERE race_id = ?
+        LIMIT 1
+        """,
+        (race_id,),
+    ).fetchone()
+    return dict(row) if row else {}
+
+
+def _labels_by_runner(conn: sqlite3.Connection, race_id: str) -> dict[str, dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT dog_clean_name, dog_name, box_number, finish_position,
+               placing, scraped_finish_position, data_source
+        FROM dog_race_data
+        WHERE race_id = ?
+        """,
+        (race_id,),
+    ).fetchall()
+    labels: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        data = dict(row)
+        pos = data.get("finish_position") or data.get("placing") or data.get("scraped_finish_position")
+        try:
+            actual_win = int(str(pos).strip()) == 1
+        except Exception:
+            actual_win = False
+        label = {
+            "actual_win": int(actual_win),
+            "finish_position": pos,
+            "label_source": data.get("data_source"),
+        }
+        for key in (
+            _norm_name(data.get("dog_clean_name") or data.get("dog_name")),
+            f"box:{data.get('box_number')}",
+        ):
+            if key and key != "box:None":
+                labels[key] = label
+    return labels
+
+
+def _runner_rows(snapshot: Mapping[str, Any], conn: sqlite3.Connection) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    race_id = str(snapshot.get("race_id") or "")
+    metadata = _race_metadata(conn, race_id)
+    labels = _labels_by_runner(conn, race_id)
+    rows: list[dict[str, Any]] = []
+    label_status = str(metadata.get("results_status") or "").strip().lower()
+    source_note = str(metadata.get("winner_source") or metadata.get("data_quality_note") or "")
+    if label_status == "partial_sportsbet_results" or "partial_sportsbet_results" in source_note:
+        label_quality = "partial_sportsbet_results"
+    elif metadata.get("winner_name") or label_status in {"complete", "completed", "resulted"}:
+        label_quality = "official_or_complete_result"
+    else:
+        label_quality = "missing_result_label"
+
+    for runner in snapshot.get("predictions") or []:
+        if not isinstance(runner, Mapping):
+            continue
+        name = runner.get("dog_name") or runner.get("dog_clean_name")
+        box = runner.get("box_number")
+        label = labels.get(_norm_name(name)) or labels.get(f"box:{box}") or {}
+        if "actual_win" not in label:
+            continue
+        odds_snapshot = runner.get("odds_snapshot") if isinstance(runner.get("odds_snapshot"), Mapping) else {}
+        odds_win = _safe_float(
+            odds_snapshot.get("market_odds_win")
+            or runner.get("odds_win")
+            or runner.get("market_odds_win")
+        )
+        rows.append(
+            {
+                "race_id": race_id,
+                "dog_name": str(name or ""),
+                "box_number": box,
+                "race_date": metadata.get("race_date") or snapshot.get("race_date"),
+                "venue": metadata.get("venue"),
+                "distance": metadata.get("distance"),
+                "win_prob_norm": _safe_float(runner.get("win_prob_norm")),
+                "actual_win": int(label["actual_win"]),
+                "odds_win": odds_win,
+                "label_quality": label_quality,
+            }
+        )
+    return rows, {"race_id": race_id, "label_quality": label_quality}
+
+
+def _arm_rows_from_market(rows: list[Mapping[str, Any]], arm: str) -> list[dict[str, Any]]:
+    by_race: dict[str, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        by_race.setdefault(str(row.get("race_id")), []).append(row)
+
+    out: list[dict[str, Any]] = []
+    for race_rows in by_race.values():
+        odds = {
+            str(row.get("dog_name")): float(row.get("odds_win"))
+            for row in race_rows
+            if row.get("odds_win") is not None
+        }
+        market = market_implied_probabilities(odds)
+        if not market:
+            continue
+        if arm == "market_implied":
+            probs = market
+        else:
+            model = {
+                str(row.get("dog_name")): float(row.get("win_prob_norm"))
+                for row in race_rows
+                if row.get("win_prob_norm") is not None
+            }
+            probs = blend_probabilities(model, market, model_weight=0.5)
+        for row in race_rows:
+            name = str(row.get("dog_name"))
+            if name not in probs:
+                continue
+            cloned = dict(row)
+            cloned["win_prob_norm"] = probs[name]
+            out.append(cloned)
+    return out
+
+
+def evaluate_snapshots(db_path: str, snapshot_paths: list[str]) -> dict[str, Any]:
+    files = _snapshot_files(snapshot_paths)
+    if not files:
+        return {
+            "status": "DATA_MISSING",
+            "reason": "no_snapshot_files_found",
+            "metrics_by_arm": {},
+        }
+
+    rows: list[dict[str, Any]] = []
+    lifecycle_counts: Counter[str] = Counter()
+    label_quality_counts: Counter[str] = Counter()
+    rejected_snapshots: list[dict[str, str]] = []
+
+    with _open_readonly(db_path) as conn:
+        for path in files:
+            try:
+                snapshot = json.loads(path.read_text(encoding="utf-8"))
+                assert_no_result_fields(snapshot)
+            except Exception as exc:
+                rejected_snapshots.append({"path": str(path), "reason": str(exc)})
+                continue
+            lifecycle_counts[str(snapshot.get("lifecycle_status") or "unknown")] += 1
+            race_rows, summary = _runner_rows(snapshot, conn)
+            rows.extend(race_rows)
+            label_quality_counts[str(summary.get("label_quality") or "unknown")] += 1
+
+    scorable_rows = [row for row in rows if row.get("win_prob_norm") is not None]
+    if not scorable_rows:
+        return {
+            "status": "DATA_MISSING",
+            "reason": "no_scorable_snapshot_rows_with_labels",
+            "snapshot_files": len(files),
+            "rejected_snapshots": rejected_snapshots,
+            "lifecycle_counts": dict(lifecycle_counts),
+            "label_quality_counts": dict(label_quality_counts),
+            "metrics_by_arm": {},
+        }
+
+    metrics_by_arm = {"model_only": score_predictions(scorable_rows)}
+    market_rows = _arm_rows_from_market(scorable_rows, "market_implied")
+    if market_rows:
+        metrics_by_arm["market_implied"] = score_predictions(market_rows)
+    blend_rows = _arm_rows_from_market(scorable_rows, "simple_blend_50")
+    if blend_rows:
+        metrics_by_arm["simple_blend_50"] = score_predictions(blend_rows)
+
+    return {
+        "status": "SUCCESS",
+        "snapshot_files": len(files),
+        "snapshots_rejected": len(rejected_snapshots),
+        "rejected_snapshots": rejected_snapshots,
+        "runner_rows_scored": len(scorable_rows),
+        "lifecycle_counts": dict(lifecycle_counts),
+        "label_quality_counts": dict(label_quality_counts),
+        "metrics_by_arm": metrics_by_arm,
+        "calibration_blending_decision": (
+            "report_only: no calibration/blending deployment is made by this script"
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", default="greyhound_racing_data.db")
+    parser.add_argument(
+        "--snapshots",
+        nargs="+",
+        required=True,
+        help="Snapshot JSON files or directories",
+    )
+    parser.add_argument("--output", help="Optional JSON output path")
+    args = parser.parse_args()
+
+    report = evaluate_snapshots(args.db, args.snapshots)
+    text = json.dumps(report, indent=2, sort_keys=True)
+    print(text)
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text + "\n", encoding="utf-8")
+    return 0 if report.get("status") == "SUCCESS" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/report_odds_coverage.py
+++ b/scripts/report_odds_coverage.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Report dog-level odds coverage without scraping or writing to the DB."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from accuracy_program.odds_coverage import analyze_odds_coverage
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db",
+        default="greyhound_racing_data.db",
+        help="SQLite DB path to inspect read-only",
+    )
+    parser.add_argument(
+        "--all-odds",
+        action="store_true",
+        help="Include non-current live_odds rows in dog-level win coverage",
+    )
+    parser.add_argument("--output", help="Optional JSON output path")
+    args = parser.parse_args()
+
+    metrics = analyze_odds_coverage(args.db, current_only=not args.all_odds)
+    text = json.dumps(metrics, indent=2, sort_keys=True)
+    print(text)
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_accuracy_program.py
+++ b/tests/test_accuracy_program.py
@@ -1,0 +1,158 @@
+from datetime import datetime
+
+import pytest
+
+from accuracy_program.bet_readiness import apply_bet_readiness_gates
+from accuracy_program.evaluation import (
+    blend_probabilities,
+    market_implied_probabilities,
+    score_predictions,
+    validate_feature_columns,
+    validate_temporal_holdout,
+)
+from accuracy_program.snapshots import build_prediction_snapshot
+
+
+def test_snapshot_excludes_result_labels_and_preserves_ev_contract():
+    prediction_result = {
+        "race_id": "Race 4 - WRGL - 2026-05-21",
+        "model_version": "model-v1",
+        "predictions": [
+            {
+                "dog_clean_name": "Alpha Runner",
+                "box_number": 1,
+                "win_prob_raw": 0.44,
+                "win_prob_norm": 0.4,
+                "predicted_rank": 1,
+                "confidence_score": 0.62,
+                "odds_win": 3.0,
+                "odds_timestamp": "2026-05-21T15:44:00",
+                "ev_win": 0.2,
+            }
+        ],
+        "actual_results": {"winner": "Beta Runner"},
+    }
+
+    snapshot = build_prediction_snapshot(
+        prediction_result,
+        source_file_path="Race 4 - WRGL - 2026-05-21.csv",
+        lifecycle={
+            "status": "upcoming_not_jumped",
+            "status_reason": "jump_time_after_now_no_result",
+        },
+        prediction_timestamp="2026-05-21T15:45:00",
+    )
+
+    assert snapshot["is_pre_jump_snapshot"] is True
+    assert snapshot["predictions"][0]["ev_win"] == pytest.approx(0.2)
+    assert (
+        snapshot["predictions"][0]["odds_snapshot"]["odds_timestamp"]
+        == "2026-05-21T15:44:00"
+    )
+    assert "actual_results" not in snapshot
+    assert "actual_results" not in snapshot["predictions"][0]
+
+
+def test_snapshot_rejects_result_fields_inside_runner_rows():
+    with pytest.raises(ValueError):
+        build_prediction_snapshot(
+            {
+                "race_id": "Race 4 - WRGL - 2026-05-21",
+                "predictions": [{"dog_clean_name": "Alpha", "finish_position": 1}],
+            },
+            lifecycle={"status": "upcoming_not_jumped"},
+        )
+
+
+def test_bet_readiness_marks_abstain_without_reranking_or_ev_changes():
+    prediction_result = {
+        "race_id": "Race 4 - WRGL - 2026-05-21",
+        "model_version": "unknown",
+        "ensemble_models_used": 1,
+        "market_context": {"large_disagreement_count": 1},
+        "predictions": [
+            {
+                "dog_clean_name": "Alpha",
+                "win_prob_norm": 0.251,
+                "predicted_rank": 1,
+                "ev_win": None,
+                "quality_flags": ["large_model_market_disagreement"],
+            },
+            {
+                "dog_clean_name": "Beta",
+                "win_prob_norm": 0.249,
+                "predicted_rank": 2,
+                "odds_win": 4.0,
+                "odds_timestamp": "2026-05-21T14:30:00",
+                "ev_win": -0.004,
+            },
+            {"dog_clean_name": "Gamma", "win_prob_norm": 0.25, "predicted_rank": 3},
+            {"dog_clean_name": "Delta", "win_prob_norm": 0.25, "predicted_rank": 4},
+        ],
+    }
+
+    readiness = apply_bet_readiness_gates(
+        prediction_result,
+        lifecycle={"status": "jumped_pending_results"},
+        uniform_threshold=0.005,
+        now=datetime.fromisoformat("2026-05-21T15:45:00"),
+    )
+
+    assert readiness["status"] == "prediction_available_not_bet_qualified"
+    assert "jumped_pending_results" in readiness["abstain_flags"]
+    assert "missing_live_odds" in readiness["abstain_flags"]
+    assert "probabilities_too_uniform" in readiness["abstain_flags"]
+    assert "single_model_only" in readiness["abstain_flags"]
+    assert "market_model_disagreement" in readiness["abstain_flags"]
+    assert "low_calibration_confidence" in readiness["abstain_flags"]
+    assert "stale_live_odds" in readiness["abstain_flags"]
+    assert [p["predicted_rank"] for p in prediction_result["predictions"]] == [
+        1,
+        2,
+        3,
+        4,
+    ]
+    assert prediction_result["predictions"][1]["ev_win"] == pytest.approx(-0.004)
+
+
+def test_evaluation_checks_leakage_temporal_holdout_and_scores_market_metrics():
+    assert validate_feature_columns(["dog_name", "winner_name", "finish_position"]) == [
+        "finish_position",
+        "winner_name",
+    ]
+
+    holdout = validate_temporal_holdout(
+        [{"race_id": "R1", "race_date": "2026-05-20"}],
+        [{"race_id": "R2", "race_date": "2026-05-21"}],
+    )
+    assert holdout.ok is True
+
+    bad_holdout = validate_temporal_holdout(
+        [{"race_id": "R1", "race_date": "2026-05-21"}],
+        [{"race_id": "R1", "race_date": "2026-05-21"}],
+    )
+    assert bad_holdout.ok is False
+    assert "race_id_overlap" in bad_holdout.violations
+    assert "test_not_strictly_after_train" in bad_holdout.violations
+
+    metrics = score_predictions(
+        [
+            {"race_id": "R1", "dog_name": "A", "win_prob_norm": 0.6, "actual_win": 1, "odds_win": 2.0},
+            {"race_id": "R1", "dog_name": "B", "win_prob_norm": 0.4, "actual_win": 0, "odds_win": 3.0},
+            {"race_id": "R2", "dog_name": "C", "win_prob_norm": 0.7, "actual_win": 0, "odds_win": 1.5},
+            {"race_id": "R2", "dog_name": "D", "win_prob_norm": 0.3, "actual_win": 1, "odds_win": 5.0},
+        ]
+    )
+    assert metrics["races_evaluated"] == 2
+    assert metrics["top1"] == pytest.approx(0.5)
+    assert metrics["top2"] == pytest.approx(1.0)
+    assert metrics["probability_sum"]["max_abs_error"] == pytest.approx(0.0)
+    assert metrics["roi_ev_by_decile"]
+
+
+def test_market_implied_and_blend_are_normalized_experiment_helpers():
+    market = market_implied_probabilities({"A": 2.0, "B": 4.0})
+    assert sum(market.values()) == pytest.approx(1.0)
+    blend = blend_probabilities({"A": 0.6, "B": 0.4}, market, model_weight=0.5)
+    assert sum(blend.values()) == pytest.approx(1.0)
+    assert blend["A"] > blend["B"]

--- a/tests/test_api_predict_file.py
+++ b/tests/test_api_predict_file.py
@@ -1,4 +1,5 @@
 import app as app_module
+from utils.race_lifecycle import RaceLifecycle
 
 
 def test_predict_file_top_pick_order_by_win_prob(monkeypatch):
@@ -38,6 +39,16 @@ def test_predict_file_top_pick_order_by_win_prob(monkeypatch):
 
     computed = data.get("computed") or {}
     assert computed.get("top_pick", {}).get("name") == "Bravo"
+    readiness = data.get("bet_readiness") or {}
+    assert readiness.get("schema_version") == "bet_readiness_v1"
+    assert data.get("abstain") is True
+    assert "missing_live_odds" in data.get("abstain_reasons", [])
+    assert (
+        data["prediction_result"]["bet_readiness"]["status"]
+        == "prediction_available_not_bet_qualified"
+    )
+    assert "prediction_snapshot" in data["prediction_result"]
+    assert data.get("prediction_snapshot_status") == "created"
 
     top3 = computed.get("top3") or []
     names = [e.get("name") for e in top3]
@@ -45,6 +56,101 @@ def test_predict_file_top_pick_order_by_win_prob(monkeypatch):
 
     probs = [e.get("win_prob") for e in top3]
     assert probs == sorted(probs, reverse=True)
+
+
+def test_predict_file_readiness_snapshot_preserves_prediction_values(monkeypatch):
+    monkeypatch.setattr(
+        app_module, "resolve_race_file_path", lambda fn: "/tmp/dummy.csv", raising=True
+    )
+    monkeypatch.setattr(
+        app_module, "enhance_prediction_with_csv_meta", lambda pr, p: pr, raising=True
+    )
+    monkeypatch.setattr(
+        app_module,
+        "_classify_file_lifecycle",
+        lambda *_args, **_kwargs: RaceLifecycle(
+            status="upcoming_not_jumped",
+            status_reason="jump_time_after_now_no_result",
+        ),
+        raising=True,
+    )
+
+    def fake_run_prediction(path: str):
+        return {
+            "success": True,
+            "race_id": "RACE_1",
+            "model_version": "model-v1",
+            "predictions": [
+                {
+                    "dog_name": "Alpha",
+                    "win_prob_norm": 0.6,
+                    "predicted_rank": 1,
+                    "odds_win": 2.0,
+                    "ev_win": 0.2,
+                },
+                {
+                    "dog_name": "Bravo",
+                    "win_prob_norm": 0.4,
+                    "predicted_rank": 2,
+                    "ev_win": None,
+                },
+            ],
+        }
+
+    monkeypatch.setattr(
+        app_module, "run_prediction_for_race_file", fake_run_prediction, raising=True
+    )
+
+    client = app_module.app.test_client()
+    resp = client.post("/api/predict_file", json={"race_file": "Any.csv"})
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["lifecycle_status"] == "upcoming_not_jumped"
+    result = data["prediction_result"]
+    assert [p["predicted_rank"] for p in result["predictions"]] == [1, 2]
+    assert [p["win_prob_norm"] for p in result["predictions"]] == [0.6, 0.4]
+    assert result["predictions"][0]["ev_win"] == 0.2
+    assert result["predictions"][1]["ev_win"] is None
+    snapshot = result["prediction_snapshot"]
+    assert snapshot["is_pre_jump_snapshot"] is True
+    assert "finish_position" not in str(snapshot)
+
+
+def test_predict_file_rejects_snapshot_result_field_leakage(monkeypatch):
+    monkeypatch.setattr(
+        app_module, "resolve_race_file_path", lambda fn: "/tmp/dummy.csv", raising=True
+    )
+    monkeypatch.setattr(
+        app_module, "enhance_prediction_with_csv_meta", lambda pr, p: pr, raising=True
+    )
+
+    def fake_run_prediction(path: str):
+        return {
+            "success": True,
+            "race_id": "RACE_1",
+            "predictions": [
+                {
+                    "dog_name": "Alpha",
+                    "win_prob_norm": 1.0,
+                    "predicted_rank": 1,
+                    "finish_position": 1,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(
+        app_module, "run_prediction_for_race_file", fake_run_prediction, raising=True
+    )
+
+    client = app_module.app.test_client()
+    resp = client.post("/api/predict_file", json={"race_file": "Any.csv"})
+
+    assert resp.status_code == 500
+    data = resp.get_json()
+    assert data["success"] is False
+    assert data["error"] == "prediction snapshot rejected"
+    assert "finish_position" in data["reason"]
 
 
 def test_predict_file_percentage_conversion(monkeypatch):


### PR DESCRIPTION
Adds prediction accuracy loop scaffolding/readiness only.

- Adds result-free prediction snapshots.
- Adds read-only odds coverage reporting.
- Adds snapshot evaluation helpers.
- Adds report-only market-implied/blend experiment helpers.
- Adds bet-readiness abstain gates.
- /api/predict_file reports bet_readiness, abstain, abstain_reasons, and snapshot status.
- No ranking change.
- No deployed calibration/blending change.
- No EV formula change.
- No scraping default change.
- Current odds coverage is not betting-grade: best direct match rate about 36.7%, all current win odds stale by six-hour threshold.
- Frozen pre-jump snapshot corpus is still DATA_MISSING.