### PR TITLE
[codex] Add snapshot eval calibration readiness

### DIFF
--- a/accuracy_program/__init__.py
+++ b/accuracy_program/__init__.py
@@ -8,6 +8,8 @@ __all__ = [
     "analyze_odds_coverage",
     "apply_bet_readiness_gates",
     "build_prediction_snapshot",
+    "power_normalize_by_race",
+    "power_normalize_prediction_group",
     "score_predictions",
     "validate_feature_columns",
 ]
@@ -33,4 +35,14 @@ def __getattr__(name):
         from .snapshots import build_prediction_snapshot
 
         return build_prediction_snapshot
+    if name in {"power_normalize_by_race", "power_normalize_prediction_group"}:
+        from .calibration import (
+            power_normalize_by_race,
+            power_normalize_prediction_group,
+        )
+
+        return {
+            "power_normalize_by_race": power_normalize_by_race,
+            "power_normalize_prediction_group": power_normalize_prediction_group,
+        }[name]
     raise AttributeError(name)

--- a/accuracy_program/calibration.py
+++ b/accuracy_program/calibration.py
@@ -1,0 +1,117 @@
+"""Probability calibration helpers for report-only and gated runtime paths."""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from typing import Any, Mapping, Sequence
+
+
+def _finite_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(parsed) or math.isinf(parsed):
+        return None
+    return parsed
+
+
+def power_normalize_by_race(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    alpha: float,
+    input_key: str = "win_prob_norm",
+    output_key: str,
+    race_key: str = "race_id",
+    min_probability: float = 1e-12,
+) -> list[dict[str, Any]]:
+    """Apply positive-alpha power normalization independently per race.
+
+    The transform is additive: input rows are copied, and the calibrated
+    probability is written to ``output_key``. It intentionally depends only on
+    model probabilities and race grouping, not labels, odds, or results.
+    """
+
+    parsed_alpha = _finite_float(alpha)
+    if parsed_alpha is None or parsed_alpha <= 0:
+        raise ValueError("alpha_must_be_positive_finite")
+    parsed_floor = _finite_float(min_probability)
+    if parsed_floor is None or parsed_floor <= 0:
+        raise ValueError("min_probability_must_be_positive_finite")
+    if not input_key:
+        raise ValueError("input_key_missing")
+    if not output_key:
+        raise ValueError("output_key_missing")
+    if not race_key:
+        raise ValueError("race_key_missing")
+    if not rows:
+        raise ValueError("rows_missing")
+
+    output: list[dict[str, Any]] = []
+    grouped_indexes: dict[str, list[int]] = defaultdict(list)
+    original_probability_totals: dict[str, float] = defaultdict(float)
+    raw_scores: list[float] = []
+
+    for index, row in enumerate(rows):
+        race_id = row.get(race_key)
+        if race_id in (None, ""):
+            raise ValueError(f"{race_key}_missing")
+        probability = _finite_float(row.get(input_key))
+        if probability is None:
+            raise ValueError(f"{input_key}_invalid")
+        if probability < 0:
+            raise ValueError(f"{input_key}_negative")
+
+        race_id_text = str(race_id)
+        output.append(dict(row))
+        grouped_indexes[race_id_text].append(index)
+        original_probability_totals[race_id_text] += probability
+        raw_scores.append(max(parsed_floor, probability) ** parsed_alpha)
+
+    for race_id, indexes in grouped_indexes.items():
+        if original_probability_totals[race_id] <= 0:
+            raise ValueError(f"{input_key}_race_total_nonpositive")
+        total = sum(raw_scores[index] for index in indexes)
+        if total <= 0:
+            raise ValueError(f"{output_key}_race_total_nonpositive")
+        for index in indexes:
+            output[index][output_key] = raw_scores[index] / total
+
+    return output
+
+
+def power_normalize_prediction_group(
+    predictions: Sequence[Mapping[str, Any]],
+    *,
+    alpha: float,
+    input_key: str = "win_prob_norm",
+    output_key: str = "calibrated_win_prob_report_only",
+    output_rank_key: str = "calibrated_predicted_rank_report_only",
+) -> list[dict[str, Any]]:
+    """Apply report-only power calibration to one race's prediction rows."""
+
+    temporary_race_key = "__calibration_race_id"
+    prepared: list[dict[str, Any]] = []
+    for row in predictions:
+        if temporary_race_key in row:
+            raise ValueError("reserved_calibration_key_present")
+        item = dict(row)
+        item[temporary_race_key] = "__single_prediction_group__"
+        prepared.append(item)
+
+    calibrated = power_normalize_by_race(
+        prepared,
+        alpha=alpha,
+        input_key=input_key,
+        output_key=output_key,
+        race_key=temporary_race_key,
+    )
+    ranked_indexes = sorted(
+        range(len(calibrated)),
+        key=lambda index: (-float(calibrated[index][output_key]), index),
+    )
+    for rank, index in enumerate(ranked_indexes, start=1):
+        calibrated[index].pop(temporary_race_key, None)
+        calibrated[index][output_rank_key] = rank
+    return calibrated

--- a/accuracy_program/evaluation.py
+++ b/accuracy_program/evaluation.py
@@ -116,10 +116,14 @@ def _safe_float(value: Any) -> float | None:
         return None
 
 
-def _race_groups(rows: Iterable[Mapping[str, Any]]) -> dict[str, list[Mapping[str, Any]]]:
+def _race_groups(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    race_id_key: str = "race_id",
+) -> dict[str, list[Mapping[str, Any]]]:
     groups: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
     for row in rows:
-        race_id = row.get("race_id")
+        race_id = row.get(race_id_key)
         if race_id is None:
             continue
         groups[str(race_id)].append(row)
@@ -237,10 +241,11 @@ def score_predictions(
     probability_key: str = "win_prob_norm",
     actual_key: str = "actual_win",
     odds_key: str = "odds_win",
+    race_id_key: str = "race_id",
 ) -> dict[str, Any]:
     """Score already frozen dog-level predictions with result labels."""
 
-    groups = _race_groups(rows)
+    groups = _race_groups(rows, race_id_key=race_id_key)
     top_hits = {1: 0, 2: 0, 3: 0}
     scored_races = 0
     prob_sum_errors: list[float] = []

--- a/accuracy_program/snapshots.py
+++ b/accuracy_program/snapshots.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Mapping
 from urllib.parse import urlparse
+
+from accuracy_program.calibration import power_normalize_prediction_group
 
 try:
     from config.venue_mapping import normalize_venue
@@ -655,6 +658,66 @@ def _metadata_source_detail(row: Mapping[str, Any]) -> Any:
     return detail or None
 
 
+def _ev_readiness(predictions: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize whether captured odds are trustworthy enough to expose EV."""
+
+    priced_count = 0
+    eligible_count = 0
+    ev_present_count = 0
+    ev_leak_count = 0
+    exclusion_counts: Counter[str] = Counter()
+    for row in predictions:
+        odds = row.get("odds")
+        has_odds = odds is not None
+        if has_odds:
+            priced_count += 1
+        match_status = str(row.get("odds_match_status") or "")
+        provenance_status = str(row.get("odds_provenance_status") or "")
+        eligible = (
+            has_odds
+            and match_status == "valid_pre_jump_dog_odds"
+            and provenance_status == "complete"
+        )
+        if eligible:
+            eligible_count += 1
+        ev_present = row.get("ev_win") is not None
+        if ev_present:
+            ev_present_count += 1
+        if ev_present and not eligible:
+            ev_leak_count += 1
+        if has_odds and not eligible:
+            reason = (
+                row.get("odds_exclusion_reason")
+                or row.get("odds_match_status")
+                or "unknown_odds_exclusion"
+            )
+            exclusion_counts[str(reason)] += 1
+        if not has_odds:
+            exclusion_counts["missing_live_odds"] += 1
+
+    runner_count = len(predictions)
+    requirements = {
+        "all_runners_priced": runner_count > 0 and priced_count == runner_count,
+        "all_priced_odds_ev_eligible": priced_count > 0 and eligible_count == priced_count,
+        "ev_present_only_for_eligible_odds": ev_leak_count == 0,
+        "ev_null_for_unpriced_or_ineligible": (
+            ev_present_count == eligible_count
+        ),
+    }
+    return {
+        "schema_version": "ev_readiness_v1",
+        "status": "EV_READY" if all(requirements.values()) else "EV_NOT_READY",
+        "runner_count": runner_count,
+        "priced_runner_count": priced_count,
+        "ev_eligible_runner_count": eligible_count,
+        "ev_present_runner_count": ev_present_count,
+        "ev_null_runner_count": runner_count - ev_present_count,
+        "ev_leak_count": ev_leak_count,
+        "odds_exclusion_counts": dict(sorted(exclusion_counts.items())),
+        "requirements": requirements,
+    }
+
+
 def _snapshot_readiness(
     predictions: list[dict[str, Any]],
     *,
@@ -707,6 +770,7 @@ def _snapshot_readiness(
     source_verified = bool(source_report)
     final_runner_report = dict(final_runner_set_verification or {})
     final_runner_status = str(final_runner_report.get("final_runner_set_status") or "")
+    ev_readiness = _ev_readiness(predictions)
     requirements = {
         "result_free": True,
         "pre_jump_lifecycle": lifecycle_status == "upcoming_not_jumped",
@@ -753,6 +817,7 @@ def _snapshot_readiness(
         "source_runner_completeness": source_report or None,
         "prediction_runner_match": runner_match if source_verified else None,
         "final_runner_set_verification": final_runner_report or None,
+        "ev_readiness": ev_readiness,
     }
 
 
@@ -883,6 +948,54 @@ def _prediction_rows(
     return snapshot_rows
 
 
+def _apply_report_only_calibration(
+    predictions: list[dict[str, Any]],
+    calibration: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    algorithm = str(calibration.get("algorithm") or "")
+    if algorithm != "power_normalize_per_race":
+        raise ValueError("unsupported_report_only_calibration_algorithm")
+    input_key = str(calibration.get("input_probability_key") or "win_prob_norm")
+    output_key = str(
+        calibration.get("output_probability_key")
+        or "calibrated_win_prob_report_only"
+    )
+    output_rank_key = str(
+        calibration.get("output_rank_key")
+        or "calibrated_predicted_rank_report_only"
+    )
+    alpha = calibration.get("alpha")
+    original_probabilities = [row.get(input_key) for row in predictions]
+    original_ranks = [row.get("predicted_rank") for row in predictions]
+    calibrated = power_normalize_prediction_group(
+        predictions,
+        alpha=alpha,
+        input_key=input_key,
+        output_key=output_key,
+        output_rank_key=output_rank_key,
+    )
+    return calibrated, {
+        "algorithm": algorithm,
+        "alpha": float(alpha),
+        "input_probability_key": input_key,
+        "output_probability_key": output_key,
+        "output_rank_key": output_rank_key,
+        "status": "APPLIED_REPORT_ONLY",
+        "canonical_probabilities_unchanged": (
+            [row.get(input_key) for row in calibrated] == original_probabilities
+        ),
+        "canonical_ranks_unchanged": (
+            [row.get("predicted_rank") for row in calibrated] == original_ranks
+        ),
+        "uses_labels_at_runtime": False,
+        "uses_odds_at_runtime": False,
+        "model_artifact_written": False,
+        "registry_mutation_allowed": False,
+        "promotion_allowed": False,
+        "betting_allowed": False,
+    }
+
+
 def _race_identity(prediction_result: Mapping[str, Any], lifecycle_data: Mapping[str, Any]) -> dict[str, Any]:
     race_context = _as_dict(prediction_result.get("race_context"))
     race_date = (
@@ -926,6 +1039,7 @@ def build_prediction_snapshot(
     stale_odds_after_minutes: float = 30.0,
     source_runner_completeness: Mapping[str, Any] | None = None,
     final_runner_set_verification: Mapping[str, Any] | None = None,
+    report_only_calibration: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a result-free snapshot record from an already computed prediction.
 
@@ -974,6 +1088,19 @@ def build_prediction_snapshot(
     source_runner_completeness = dict(source_runner_completeness or {})
     frozen_participants = list(source_runner_completeness.get("participants") or [])
     final_runner_set_verification = dict(final_runner_set_verification or {})
+    prediction_rows = _prediction_rows(
+        prediction_result,
+        prediction_timestamp=timestamp,
+        feature_freeze_timestamp=feature_freeze,
+        jump_datetime=str(jump_datetime) if jump_datetime else None,
+        stale_odds_after_minutes=stale_odds_after_minutes,
+    )
+    report_only_calibration_state: dict[str, Any] | None = None
+    if report_only_calibration is not None:
+        prediction_rows, report_only_calibration_state = _apply_report_only_calibration(
+            prediction_rows,
+            report_only_calibration,
+        )
 
     snapshot = {
         "schema_version": "prediction_snapshot_v1",
@@ -997,13 +1124,7 @@ def build_prediction_snapshot(
             if lifecycle_status == "upcoming_not_jumped"
             else "not_bet_qualified_lifecycle"
         ),
-        "predictions": _prediction_rows(
-            prediction_result,
-            prediction_timestamp=timestamp,
-            feature_freeze_timestamp=feature_freeze,
-            jump_datetime=str(jump_datetime) if jump_datetime else None,
-            stale_odds_after_minutes=stale_odds_after_minutes,
-        ),
+        "predictions": prediction_rows,
         "source_runner_completeness": source_runner_completeness or None,
         "expected_runner_count": source_runner_completeness.get("runner_count"),
         "frozen_participants": frozen_participants,
@@ -1017,6 +1138,8 @@ def build_prediction_snapshot(
             "source_file_path": source_file_path,
         },
     }
+    if report_only_calibration_state is not None:
+        snapshot["report_only_calibration"] = report_only_calibration_state
     if final_runner_set_verification:
         snapshot.update(
             {

--- a/scripts/evaluate_prediction_snapshots.py
+++ b/scripts/evaluate_prediction_snapshots.py
@@ -76,6 +76,31 @@ def _snapshot_files(paths: Iterable[str]) -> list[Path]:
     return files
 
 
+def _snapshot_paths_from_manifests(paths: Iterable[str]) -> list[str]:
+    snapshot_paths: list[str] = []
+    for raw in paths:
+        manifest = Path(raw)
+        with manifest.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                text = line.strip()
+                if not text or text.startswith("#"):
+                    continue
+                snapshot_paths.append(text)
+    return snapshot_paths
+
+
+def _snapshot_instance_id(race_id: Any, path: str | Path) -> str:
+    race_part = str(race_id or "DATA_MISSING")
+    return f"{race_part}|snapshot:{Path(path)}"
+
+
+def _is_prediction_snapshot_artifact(value: Mapping[str, Any]) -> bool:
+    return (
+        value.get("schema_version") == "prediction_snapshot_v1"
+        and isinstance(value.get("predictions"), list)
+    )
+
+
 def _norm_name(value: Any) -> str:
     import re
 
@@ -328,15 +353,21 @@ def _snapshot_provenance_report(snapshots: Iterable[Mapping[str, Any]]) -> dict[
 
 def _corpus_readiness_report(
     *,
-    files_found: int,
+    json_files_scanned: int,
+    prediction_snapshot_files: int,
+    skipped_non_snapshot_artifacts: list[dict[str, str]],
     rejected_snapshots: list[dict[str, str]],
     readiness_status_counts: Counter[str],
     readiness_failures: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    if files_found == 0:
+    if prediction_snapshot_files == 0:
         return {
             "status": "DATA_MISSING",
             "reason": "no_frozen_pre_jump_snapshot_files_found",
+            "json_files_scanned": json_files_scanned,
+            "snapshot_files": prediction_snapshot_files,
+            "non_snapshot_artifacts_skipped": len(skipped_non_snapshot_artifacts),
+            "skipped_non_snapshot_artifacts": skipped_non_snapshot_artifacts[:25],
             "durable_pre_jump_snapshot_requirements": sorted(
                 DURABLE_SNAPSHOT_REQUIREMENTS
             ),
@@ -344,7 +375,10 @@ def _corpus_readiness_report(
     if rejected_snapshots or readiness_status_counts.get("NOT_READY", 0):
         return {
             "status": "NOT_READY",
-            "snapshot_files": files_found,
+            "json_files_scanned": json_files_scanned,
+            "snapshot_files": prediction_snapshot_files,
+            "non_snapshot_artifacts_skipped": len(skipped_non_snapshot_artifacts),
+            "skipped_non_snapshot_artifacts": skipped_non_snapshot_artifacts[:25],
             "readiness_status_counts": dict(readiness_status_counts),
             "rejected_snapshots": rejected_snapshots,
             "readiness_failures": readiness_failures[:25],
@@ -354,7 +388,10 @@ def _corpus_readiness_report(
         }
     return {
         "status": "READY",
-        "snapshot_files": files_found,
+        "json_files_scanned": json_files_scanned,
+        "snapshot_files": prediction_snapshot_files,
+        "non_snapshot_artifacts_skipped": len(skipped_non_snapshot_artifacts),
+        "skipped_non_snapshot_artifacts": skipped_non_snapshot_artifacts[:25],
         "readiness_status_counts": dict(readiness_status_counts),
         "durable_pre_jump_snapshot_requirements": sorted(
             DURABLE_SNAPSHOT_REQUIREMENTS
@@ -613,7 +650,10 @@ def _runner_rows(snapshot: Mapping[str, Any], conn: sqlite3.Connection) -> tuple
                 "box_number": box,
                 "race_date": metadata.get("race_date") or snapshot.get("race_date"),
                 "venue": metadata.get("venue"),
-                "distance": metadata.get("distance"),
+                "distance": metadata.get("distance") or snapshot.get("target_distance"),
+                "target_distance": snapshot.get("target_distance") or metadata.get("distance"),
+                "target_grade": snapshot.get("target_grade"),
+                "model_version": snapshot.get("model_version"),
                 "win_prob_norm": _safe_float(runner.get("win_prob_norm")),
                 "actual_win": int(label["actual_win"]),
                 "finish_position": label.get("finish_position"),
@@ -841,6 +881,7 @@ def _failure_mode_diagnostics(rows: list[Mapping[str, Any]]) -> dict[str, Any]:
                 "result_detail_quality": top_pick.get("result_detail_quality"),
                 "venue": top_pick.get("venue"),
                 "distance": top_pick.get("distance"),
+                "target_grade": top_pick.get("target_grade"),
                 "field_size": len(ranked),
                 "winner_name": winner.get("dog_name"),
                 "winner_box": winner.get("box_number"),
@@ -949,15 +990,33 @@ def _failure_mode_diagnostics(rows: list[Mapping[str, Any]]) -> dict[str, Any]:
         },
         "venue_breakdown": _group_breakdown(race_summaries, "venue"),
         "distance_breakdown": distance_breakdown,
+        "grade_breakdown": _group_breakdown(race_summaries, "target_grade"),
         "label_quality_breakdown": label_breakdown,
         "complete_vs_partial_labels": label_group_breakdown,
     }
 
 
-def _arm_rows_from_market(rows: list[Mapping[str, Any]], arm: str) -> list[dict[str, Any]]:
+def _race_outcome_id(row: Mapping[str, Any]) -> str:
+    return str(row.get("label_race_id") or row.get("race_id") or "DATA_MISSING")
+
+
+def _evaluation_group_id(
+    row: Mapping[str, Any],
+    *,
+    group_key: str = "race_id",
+) -> str:
+    return str(row.get(group_key) or row.get("race_id") or "DATA_MISSING")
+
+
+def _arm_rows_from_market(
+    rows: list[Mapping[str, Any]],
+    arm: str,
+    *,
+    group_key: str = "race_id",
+) -> list[dict[str, Any]]:
     by_race: dict[str, list[Mapping[str, Any]]] = {}
     for row in rows:
-        by_race.setdefault(str(row.get("race_id")), []).append(row)
+        by_race.setdefault(_evaluation_group_id(row, group_key=group_key), []).append(row)
 
     out: list[dict[str, Any]] = []
     for race_rows in by_race.values():
@@ -988,14 +1047,251 @@ def _arm_rows_from_market(rows: list[Mapping[str, Any]], arm: str) -> list[dict[
     return out
 
 
-def evaluate_snapshots(db_path: str, snapshot_paths: list[str]) -> dict[str, Any]:
+def _metrics_by_arm(
+    rows: list[Mapping[str, Any]],
+    *,
+    group_key: str = "race_id",
+) -> dict[str, Any]:
+    if not rows:
+        return {}
+    metrics: dict[str, Any] = {
+        "model_only": score_predictions(rows, race_id_key=group_key)
+    }
+    market_rows = _arm_rows_from_market(rows, "market_implied", group_key=group_key)
+    if market_rows:
+        metrics["market_implied"] = score_predictions(
+            market_rows,
+            race_id_key=group_key,
+        )
+    blend_rows = _arm_rows_from_market(rows, "simple_blend_50", group_key=group_key)
+    if blend_rows:
+        metrics["simple_blend_50"] = score_predictions(
+            blend_rows,
+            race_id_key=group_key,
+        )
+    return metrics
+
+
+def _clean_official_evaluation_rows(
+    rows: list[Mapping[str, Any]],
+) -> tuple[list[Mapping[str, Any]], list[dict[str, Any]]]:
+    by_race: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_race[_evaluation_group_id(row, group_key="snapshot_instance_id")].append(row)
+
+    clean_rows: list[Mapping[str, Any]] = []
+    excluded: list[dict[str, Any]] = []
+    for snapshot_instance_id, race_rows in sorted(by_race.items()):
+        race_ids = sorted({_race_outcome_id(row) for row in race_rows})
+        reasons: list[str] = []
+        if any(row.get("label_quality") != "official_or_complete_result" for row in race_rows):
+            reasons.append("label_quality_not_official_or_complete")
+        if any(row.get("result_detail_quality") != "finish_position" for row in race_rows):
+            reasons.append("result_detail_not_full_finish_position")
+        if any(row.get("finish_position") is None for row in race_rows):
+            reasons.append("finish_position_missing")
+        winner_count = sum(int(row.get("actual_win") or 0) for row in race_rows)
+        if winner_count != 1:
+            reasons.append(f"winner_count_not_one:{winner_count}")
+        if reasons:
+            excluded.append(
+                {
+                    "race_id": race_ids[0] if race_ids else "DATA_MISSING",
+                    "snapshot_instance_id": snapshot_instance_id,
+                    "reasons": reasons,
+                    "label_quality": sorted(
+                        {str(row.get("label_quality") or "DATA_MISSING") for row in race_rows}
+                    ),
+                    "result_detail_quality": sorted(
+                        {
+                            str(row.get("result_detail_quality") or "DATA_MISSING")
+                            for row in race_rows
+                        }
+                    ),
+                }
+            )
+            continue
+        clean_rows.extend(race_rows)
+
+    return clean_rows, excluded
+
+
+def _clean_official_evaluation_report(
+    clean_rows: list[Mapping[str, Any]],
+    excluded: list[Mapping[str, Any]],
+    *,
+    metrics_by_arm: Mapping[str, Any],
+) -> dict[str, Any]:
+    clean_race_ids = sorted({_race_outcome_id(row) for row in clean_rows})
+    clean_snapshot_instance_ids = sorted(
+        {
+            _evaluation_group_id(row, group_key="snapshot_instance_id")
+            for row in clean_rows
+        }
+    )
+    excluded_reason_counts: Counter[str] = Counter()
+    for item in excluded:
+        for reason in item.get("reasons") or []:
+            excluded_reason_counts[str(reason)] += 1
+    return {
+        "status": "SUCCESS" if clean_rows else "DATA_MISSING",
+        "requirements": [
+            "snapshot_result_free",
+            "snapshot_readiness_ready",
+            "label_quality_official_or_complete_result",
+            "finish_position_labels_for_all_runners",
+            "exactly_one_winner_per_snapshot_instance",
+        ],
+        "races_evaluated": len(clean_race_ids),
+        "snapshot_instances_evaluated": len(clean_snapshot_instance_ids),
+        "runner_rows_evaluated": len(clean_rows),
+        "race_ids": clean_race_ids,
+        "snapshot_instance_ids": clean_snapshot_instance_ids,
+        "excluded_races": list(excluded)[:25],
+        "excluded_reason_counts": dict(sorted(excluded_reason_counts.items())),
+        "metrics_by_arm": dict(metrics_by_arm),
+    }
+
+
+def _model_quality_diagnosis(
+    rows: list[Mapping[str, Any]],
+    *,
+    metrics_by_arm: Mapping[str, Any],
+    clean_official_rows: list[Mapping[str, Any]],
+    clean_official_metrics_by_arm: Mapping[str, Any],
+    provenance_report: Mapping[str, Any],
+    min_retrain_races: int = 100,
+) -> dict[str, Any]:
+    by_race: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_race[_evaluation_group_id(row, group_key="snapshot_instance_id")].append(row)
+
+    top_pick_boxes: Counter[str] = Counter()
+    winner_boxes: Counter[str] = Counter()
+    for race_rows in by_race.values():
+        ranked = sorted(
+            race_rows,
+            key=lambda row: _safe_float(row.get("win_prob_norm")) or 0.0,
+            reverse=True,
+        )
+        if ranked:
+            top_pick_boxes[str(ranked[0].get("box_number") or "DATA_MISSING")] += 1
+        for row in ranked:
+            if int(row.get("actual_win") or 0) == 1:
+                winner_boxes[str(row.get("box_number") or "DATA_MISSING")] += 1
+                break
+
+    model_metrics = (
+        metrics_by_arm.get("model_only")
+        if isinstance(metrics_by_arm.get("model_only"), Mapping)
+        else {}
+    )
+    clean_model_metrics = (
+        clean_official_metrics_by_arm.get("model_only")
+        if isinstance(clean_official_metrics_by_arm.get("model_only"), Mapping)
+        else {}
+    )
+    snapshot_instances_evaluated = int(
+        model_metrics.get("races_evaluated") or len(by_race)
+    )
+    clean_official_snapshot_instances_evaluated = int(
+        clean_model_metrics.get("races_evaluated")
+        or len(
+            {
+                _evaluation_group_id(row, group_key="snapshot_instance_id")
+                for row in clean_official_rows
+            }
+        )
+    )
+    races_evaluated = len({_race_outcome_id(row) for row in rows})
+    clean_official_races_evaluated = len(
+        {_race_outcome_id(row) for row in clean_official_rows}
+    )
+    no_history_rows = 0
+    history_counts = provenance_report.get("history_source_distribution")
+    if isinstance(history_counts, Mapping):
+        no_history_rows = sum(
+            int(count or 0)
+            for source, count in history_counts.items()
+            if "no_usable_history" in str(source)
+        )
+
+    retrain_ready = clean_official_races_evaluated >= min_retrain_races
+    return {
+        "status": "SUCCESS" if rows else "DATA_MISSING",
+        "races_evaluated": races_evaluated,
+        "snapshot_instances_evaluated": snapshot_instances_evaluated,
+        "runner_rows_evaluated": len(rows),
+        "clean_official_races_evaluated": clean_official_races_evaluated,
+        "clean_official_snapshot_instances_evaluated": (
+            clean_official_snapshot_instances_evaluated
+        ),
+        "clean_official_runner_rows_evaluated": len(clean_official_rows),
+        "feature_missingness": {
+            "history_source_distribution": provenance_report.get(
+                "history_source_distribution", {}
+            ),
+            "no_usable_history_runner_rows": no_history_rows,
+            "distance_source_distribution": provenance_report.get(
+                "distance_source_distribution", {}
+            ),
+            "grade_source_distribution": provenance_report.get(
+                "grade_source_distribution", {}
+            ),
+            "metadata_is_leakage_safe_distribution": provenance_report.get(
+                "metadata_is_leakage_safe_distribution", {}
+            ),
+        },
+        "box_bias": {
+            "top_pick_box_distribution": dict(sorted(top_pick_boxes.items())),
+            "winner_box_distribution": dict(sorted(winner_boxes.items())),
+        },
+        "calibration": {
+            "brier": model_metrics.get("brier"),
+            "log_loss": model_metrics.get("log_loss"),
+            "calibration": model_metrics.get("calibration"),
+            "reliability_bins": model_metrics.get("reliability_bins"),
+        },
+        "clean_official_calibration": {
+            "brier": clean_model_metrics.get("brier"),
+            "log_loss": clean_model_metrics.get("log_loss"),
+            "calibration": clean_model_metrics.get("calibration"),
+            "reliability_bins": clean_model_metrics.get("reliability_bins"),
+        },
+        "retrain_gate": {
+            "status": "READY_FOR_REVIEW" if retrain_ready else "NOT_READY",
+            "minimum_clean_evaluated_races": min_retrain_races,
+            "clean_official_evaluated_races": clean_official_races_evaluated,
+            "reason": (
+                None
+                if retrain_ready
+                else "insufficient_clean_official_evaluated_corpus_for_leakage_safe_retrain"
+            ),
+            "action_taken": "none",
+        },
+        "promotion_gate": {
+            "status": "REPORT_ONLY",
+            "reason": "promotion requires a separately approved challenger evaluation",
+            "action_taken": "none",
+        },
+    }
+
+
+def evaluate_snapshots(
+    db_path: str,
+    snapshot_paths: list[str],
+    *,
+    include_dataset_rows: bool = False,
+) -> dict[str, Any]:
     files = _snapshot_files(snapshot_paths)
     if not files:
         return {
             "status": "DATA_MISSING",
             "reason": "no_snapshot_files_found",
             "snapshot_corpus_readiness": _corpus_readiness_report(
-                files_found=0,
+                json_files_scanned=0,
+                prediction_snapshot_files=0,
+                skipped_non_snapshot_artifacts=[],
                 rejected_snapshots=[],
                 readiness_status_counts=Counter(),
                 readiness_failures=[],
@@ -1008,13 +1304,26 @@ def evaluate_snapshots(db_path: str, snapshot_paths: list[str]) -> dict[str, Any
     label_quality_counts: Counter[str] = Counter()
     readiness_status_counts: Counter[str] = Counter()
     rejected_snapshots: list[dict[str, str]] = []
+    skipped_non_snapshot_artifacts: list[dict[str, str]] = []
     readiness_failures: list[dict[str, Any]] = []
     loaded_snapshots: list[Mapping[str, Any]] = []
+    prediction_snapshot_files = 0
 
     with _open_readonly(db_path) as conn:
         for path in files:
             try:
                 snapshot = json.loads(path.read_text(encoding="utf-8"))
+                if not isinstance(snapshot, Mapping):
+                    skipped_non_snapshot_artifacts.append(
+                        {"path": str(path), "reason": "json_root_not_object"}
+                    )
+                    continue
+                if not _is_prediction_snapshot_artifact(snapshot):
+                    skipped_non_snapshot_artifacts.append(
+                        {"path": str(path), "reason": "not_prediction_snapshot_v1"}
+                    )
+                    continue
+                prediction_snapshot_files += 1
                 assert_no_result_fields(snapshot)
             except Exception as exc:
                 rejected_snapshots.append({"path": str(path), "reason": str(exc)})
@@ -1034,11 +1343,19 @@ def evaluate_snapshots(db_path: str, snapshot_paths: list[str]) -> dict[str, Any
                 continue
             lifecycle_counts[str(snapshot.get("lifecycle_status") or "unknown")] += 1
             race_rows, summary = _runner_rows(snapshot, conn)
+            for row in race_rows:
+                row["snapshot_path"] = str(path)
+                row["snapshot_instance_id"] = _snapshot_instance_id(
+                    row.get("race_id"),
+                    path,
+                )
             rows.extend(race_rows)
             label_quality_counts[str(summary.get("label_quality") or "unknown")] += 1
 
     corpus_readiness = _corpus_readiness_report(
-        files_found=len(files),
+        json_files_scanned=len(files),
+        prediction_snapshot_files=prediction_snapshot_files,
+        skipped_non_snapshot_artifacts=skipped_non_snapshot_artifacts,
         rejected_snapshots=rejected_snapshots,
         readiness_status_counts=readiness_status_counts,
         readiness_failures=readiness_failures,
@@ -1050,7 +1367,11 @@ def evaluate_snapshots(db_path: str, snapshot_paths: list[str]) -> dict[str, Any
         return {
             "status": "DATA_MISSING",
             "reason": "no_scorable_snapshot_rows_with_labels",
-            "snapshot_files": len(files),
+            "json_files_scanned": len(files),
+            "snapshot_files": prediction_snapshot_files,
+            "non_snapshot_artifacts_skipped": len(skipped_non_snapshot_artifacts),
+            "skipped_non_snapshot_artifacts": skipped_non_snapshot_artifacts,
+            "snapshots_rejected": len(rejected_snapshots),
             "rejected_snapshots": rejected_snapshots,
             "snapshot_corpus_readiness": corpus_readiness,
             "snapshot_provenance_report": provenance_report,
@@ -1059,17 +1380,33 @@ def evaluate_snapshots(db_path: str, snapshot_paths: list[str]) -> dict[str, Any
             "metrics_by_arm": {},
         }
 
-    metrics_by_arm = {"model_only": score_predictions(scorable_rows)}
-    market_rows = _arm_rows_from_market(scorable_rows, "market_implied")
-    if market_rows:
-        metrics_by_arm["market_implied"] = score_predictions(market_rows)
-    blend_rows = _arm_rows_from_market(scorable_rows, "simple_blend_50")
-    if blend_rows:
-        metrics_by_arm["simple_blend_50"] = score_predictions(blend_rows)
+    metrics_by_arm = _metrics_by_arm(scorable_rows, group_key="snapshot_instance_id")
+    clean_official_rows, clean_official_excluded = _clean_official_evaluation_rows(
+        scorable_rows
+    )
+    clean_official_metrics_by_arm = _metrics_by_arm(
+        clean_official_rows,
+        group_key="snapshot_instance_id",
+    )
+    clean_official_evaluation = _clean_official_evaluation_report(
+        clean_official_rows,
+        clean_official_excluded,
+        metrics_by_arm=clean_official_metrics_by_arm,
+    )
+    model_quality_diagnosis = _model_quality_diagnosis(
+        scorable_rows,
+        metrics_by_arm=metrics_by_arm,
+        clean_official_rows=clean_official_rows,
+        clean_official_metrics_by_arm=clean_official_metrics_by_arm,
+        provenance_report=provenance_report,
+    )
 
-    return {
+    report = {
         "status": "SUCCESS",
-        "snapshot_files": len(files),
+        "json_files_scanned": len(files),
+        "snapshot_files": prediction_snapshot_files,
+        "non_snapshot_artifacts_skipped": len(skipped_non_snapshot_artifacts),
+        "skipped_non_snapshot_artifacts": skipped_non_snapshot_artifacts,
         "snapshots_rejected": len(rejected_snapshots),
         "rejected_snapshots": rejected_snapshots,
         "snapshot_corpus_readiness": corpus_readiness,
@@ -1079,11 +1416,23 @@ def evaluate_snapshots(db_path: str, snapshot_paths: list[str]) -> dict[str, Any
         "snapshot_provenance_report": provenance_report,
         "ev_roi_coverage": _ev_roi_coverage(scorable_rows),
         "metrics_by_arm": metrics_by_arm,
+        "clean_official_evaluation": clean_official_evaluation,
         "failure_mode_diagnostics": _failure_mode_diagnostics(scorable_rows),
+        "model_quality_diagnosis": model_quality_diagnosis,
         "calibration_blending_decision": (
             "report_only: no calibration/blending deployment is made by this script"
         ),
     }
+    if include_dataset_rows:
+        report["evaluation_dataset_rows"] = scorable_rows
+    return report
+
+
+def _write_dataset_jsonl(path: Path, rows: list[Mapping[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(dict(row), sort_keys=True) + "\n")
 
 
 def main() -> int:
@@ -1091,14 +1440,49 @@ def main() -> int:
     parser.add_argument("--db", default="greyhound_racing_data.db")
     parser.add_argument(
         "--snapshots",
-        nargs="+",
-        required=True,
+        nargs="*",
+        default=[],
         help="Snapshot JSON files or directories",
     )
+    parser.add_argument(
+        "--snapshots-manifest",
+        action="append",
+        default=[],
+        help=(
+            "Text file containing snapshot JSON files or directories, one per "
+            "line. Blank lines and # comments are ignored."
+        ),
+    )
     parser.add_argument("--output", help="Optional JSON output path")
+    parser.add_argument(
+        "--dataset-output",
+        help="Optional JSONL path for joined snapshot-label evaluation rows",
+    )
+    parser.add_argument(
+        "--include-dataset-rows",
+        action="store_true",
+        help="Include joined dataset rows in the printed/output JSON report",
+    )
     args = parser.parse_args()
+    snapshot_paths = list(args.snapshots) + _snapshot_paths_from_manifests(
+        args.snapshots_manifest
+    )
+    if not snapshot_paths:
+        parser.error("at least one --snapshots path or --snapshots-manifest is required")
 
-    report = evaluate_snapshots(args.db, args.snapshots)
+    report = evaluate_snapshots(
+        args.db,
+        snapshot_paths,
+        include_dataset_rows=bool(args.dataset_output or args.include_dataset_rows),
+    )
+    dataset_rows = report.get("evaluation_dataset_rows")
+    if args.dataset_output and isinstance(dataset_rows, list):
+        dataset_path = Path(args.dataset_output)
+        _write_dataset_jsonl(dataset_path, dataset_rows)
+        report["evaluation_dataset_output"] = str(dataset_path)
+        report["evaluation_dataset_rows_written"] = len(dataset_rows)
+        if not args.include_dataset_rows:
+            report.pop("evaluation_dataset_rows", None)
     text = json.dumps(report, indent=2, sort_keys=True)
     print(text)
     if args.output:

--- a/tests/test_accuracy_program.py
+++ b/tests/test_accuracy_program.py
@@ -69,6 +69,74 @@ def test_snapshot_excludes_result_labels_and_preserves_ev_contract():
     assert "actual_results" not in snapshot["predictions"][0]
 
 
+def test_snapshot_can_attach_report_only_calibration_without_reranking():
+    prediction_result = {
+        "race_id": "Race 4 - WRGL - 2026-05-21",
+        "model_version": "model-v1",
+        "predictions": [
+            {
+                "dog_clean_name": "Alpha Runner",
+                "box_number": 1,
+                "win_prob_norm": 0.64,
+                "predicted_rank": 1,
+            },
+            {
+                "dog_clean_name": "Beta Runner",
+                "box_number": 2,
+                "win_prob_norm": 0.25,
+                "predicted_rank": 2,
+            },
+            {
+                "dog_clean_name": "Gamma Runner",
+                "box_number": 3,
+                "win_prob_norm": 0.11,
+                "predicted_rank": 3,
+            },
+        ],
+    }
+
+    snapshot = build_prediction_snapshot(
+        prediction_result,
+        source_file_path="Race 4 - WRGL - 2026-05-21.csv",
+        lifecycle={"status": "upcoming_not_jumped"},
+        prediction_timestamp="2026-05-21T15:45:00",
+        report_only_calibration={
+            "algorithm": "power_normalize_per_race",
+            "alpha": 0.5,
+            "input_probability_key": "win_prob_norm",
+            "output_probability_key": "calibrated_win_prob_report_only",
+        },
+    )
+
+    rows = snapshot["predictions"]
+    assert [row["predicted_rank"] for row in rows] == [1, 2, 3]
+    assert [row["win_prob_norm"] for row in rows] == [0.64, 0.25, 0.11]
+    assert sum(row["calibrated_win_prob_report_only"] for row in rows) == pytest.approx(
+        1.0
+    )
+    assert [row["calibrated_predicted_rank_report_only"] for row in rows] == [
+        1,
+        2,
+        3,
+    ]
+    assert snapshot["report_only_calibration"] == {
+        "algorithm": "power_normalize_per_race",
+        "alpha": 0.5,
+        "input_probability_key": "win_prob_norm",
+        "output_probability_key": "calibrated_win_prob_report_only",
+        "output_rank_key": "calibrated_predicted_rank_report_only",
+        "status": "APPLIED_REPORT_ONLY",
+        "canonical_probabilities_unchanged": True,
+        "canonical_ranks_unchanged": True,
+        "uses_labels_at_runtime": False,
+        "uses_odds_at_runtime": False,
+        "model_artifact_written": False,
+        "registry_mutation_allowed": False,
+        "promotion_allowed": False,
+        "betting_allowed": False,
+    }
+
+
 def test_snapshot_ev_stays_null_without_valid_pre_jump_odds():
     snapshot = build_prediction_snapshot(
         {
@@ -630,6 +698,47 @@ def test_evaluation_checks_leakage_temporal_holdout_and_scores_market_metrics():
     assert metrics["top2"] == pytest.approx(1.0)
     assert metrics["probability_sum"]["max_abs_error"] == pytest.approx(0.0)
     assert metrics["roi_ev_by_decile"]
+
+
+def test_score_predictions_can_group_frozen_snapshot_instances_separately():
+    metrics = score_predictions(
+        [
+            {
+                "race_id": "R1",
+                "snapshot_instance_id": "R1|snapshot:a",
+                "dog_name": "A",
+                "win_prob_norm": 0.6,
+                "actual_win": 1,
+            },
+            {
+                "race_id": "R1",
+                "snapshot_instance_id": "R1|snapshot:a",
+                "dog_name": "B",
+                "win_prob_norm": 0.4,
+                "actual_win": 0,
+            },
+            {
+                "race_id": "R1",
+                "snapshot_instance_id": "R1|snapshot:b",
+                "dog_name": "A",
+                "win_prob_norm": 0.4,
+                "actual_win": 1,
+            },
+            {
+                "race_id": "R1",
+                "snapshot_instance_id": "R1|snapshot:b",
+                "dog_name": "B",
+                "win_prob_norm": 0.6,
+                "actual_win": 0,
+            },
+        ],
+        race_id_key="snapshot_instance_id",
+    )
+
+    assert metrics["races_evaluated"] == 2
+    assert metrics["top1"] == pytest.approx(0.5)
+    assert metrics["top2"] == pytest.approx(1.0)
+    assert metrics["winner_ranks"] == [1, 2]
 
 
 def test_market_implied_and_blend_are_normalized_experiment_helpers():

--- a/tests/test_odds_snapshot_readiness.py
+++ b/tests/test_odds_snapshot_readiness.py
@@ -9,7 +9,10 @@ import pytest
 
 from accuracy_program.odds_coverage import analyze_odds_coverage, normalize_dog_name
 from accuracy_program.snapshots import assert_no_result_fields, build_prediction_snapshot
-from scripts.evaluate_prediction_snapshots import evaluate_snapshots
+from scripts.evaluate_prediction_snapshots import (
+    _snapshot_paths_from_manifests,
+    evaluate_snapshots,
+)
 from sportsbet_odds_integrator import SportsbetOddsIntegrator
 
 
@@ -258,7 +261,70 @@ def test_prediction_snapshot_carries_odds_timestamp_provenance_and_readiness():
     }
     assert snapshot["predictions"][0]["odds_match_status"] == "valid_pre_jump_dog_odds"
     assert snapshot["snapshot_readiness"]["counts"]["missing_live_odds_count"] == 1
+    assert snapshot["snapshot_readiness"]["ev_readiness"]["status"] == "EV_NOT_READY"
+    assert snapshot["snapshot_readiness"]["ev_readiness"]["priced_runner_count"] == 1
+    assert snapshot["snapshot_readiness"]["ev_readiness"]["ev_eligible_runner_count"] == 1
+    assert snapshot["snapshot_readiness"]["ev_readiness"]["odds_exclusion_counts"] == {
+        "missing_live_odds": 1
+    }
     assert snapshot["snapshot_readiness"]["status"] == "READY"
+    assert_no_result_fields(snapshot)
+
+
+def test_ev_readiness_counts_untrusted_odds_without_exposing_ev():
+    snapshot = build_prediction_snapshot(
+        {
+            "race_id": "R1",
+            "model_version": "model-v1",
+            "predictions": [
+                {
+                    "dog_clean_name": "Alpha Runner",
+                    "box_number": 1,
+                    "win_prob_norm": 0.4,
+                    "predicted_rank": 1,
+                    "odds_win": 3.0,
+                    "odds_timestamp": "2026-05-24T09:55:00",
+                    "odds_source": "untrusted-book",
+                    "odds_source_url": "https://example.invalid/greyhound-racing/r1",
+                    "odds_race_id": "R1",
+                    "odds_dog_name": "Alpha Runner",
+                    "odds_box_number": 1,
+                    "odds_match_method": "race_id_box_name",
+                    "odds_match_confidence": 1.0,
+                },
+                {
+                    "dog_clean_name": "Beta Runner",
+                    "box_number": 2,
+                    "win_prob_norm": 0.6,
+                    "predicted_rank": 2,
+                    "quality_flags": ["missing_live_odds"],
+                },
+            ],
+        },
+        source_file_path="Race 1 - WPK - 2026-05-24.csv",
+        lifecycle={
+            "status": "upcoming_not_jumped",
+            "jump_datetime": "2026-05-24T10:30:00",
+        },
+        prediction_timestamp="2026-05-24T10:00:00",
+    )
+
+    invalid_runner = snapshot["predictions"][0]
+    ev_readiness = snapshot["snapshot_readiness"]["ev_readiness"]
+
+    assert invalid_runner["odds_match_status"] == "untrusted_source"
+    assert invalid_runner["odds_exclusion_reason"] == "untrusted_source"
+    assert invalid_runner["ev_win"] is None
+    assert ev_readiness["status"] == "EV_NOT_READY"
+    assert ev_readiness["runner_count"] == 2
+    assert ev_readiness["priced_runner_count"] == 1
+    assert ev_readiness["ev_eligible_runner_count"] == 0
+    assert ev_readiness["ev_present_runner_count"] == 0
+    assert ev_readiness["odds_exclusion_counts"] == {
+        "missing_live_odds": 1,
+        "untrusted_source": 1,
+    }
+    assert ev_readiness["requirements"]["ev_null_for_unpriced_or_ineligible"] is True
     assert_no_result_fields(snapshot)
 
 
@@ -570,6 +636,155 @@ def test_snapshot_evaluation_reports_missing_frozen_corpus(tmp_path):
     assert "result_free" in readiness["durable_pre_jump_snapshot_requirements"]
 
 
+def test_snapshot_evaluation_skips_non_snapshot_report_jsons(tmp_path):
+    db_path = tmp_path / "labels.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE race_metadata (
+            race_id TEXT PRIMARY KEY,
+            venue TEXT,
+            race_number INTEGER,
+            race_date TEXT,
+            results_status TEXT,
+            winner_name TEXT
+        );
+        CREATE TABLE dog_race_data (
+            race_id TEXT,
+            dog_name TEXT,
+            dog_clean_name TEXT,
+            box_number INTEGER,
+            finish_position INTEGER,
+            data_source TEXT
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO race_metadata VALUES ('Race 1 - WPK - 2026-05-24', 'WPK', 1, '2026-05-24', 'complete', 'Alpha')"
+    )
+    conn.executemany(
+        "INSERT INTO dog_race_data VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("Race 1 - WPK - 2026-05-24", "Alpha", "Alpha", 1, 1, "official"),
+            ("Race 1 - WPK - 2026-05-24", "Bravo", "Bravo", 2, 2, "official"),
+            ("Race 1 - WPK - 2026-05-24", "Charlie", "Charlie", 3, 3, "official"),
+            ("Race 1 - WPK - 2026-05-24", "Delta", "Delta", 4, 4, "official"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    snapshot = build_prediction_snapshot(
+        {
+            "race_id": "Race 1 - WPK - 2026-05-24",
+            "model_version": "model-v1",
+            "predictions": [
+                {"dog_clean_name": "Alpha", "box_number": 1, "win_prob_norm": 0.4},
+                {"dog_clean_name": "Bravo", "box_number": 2, "win_prob_norm": 0.3},
+                {"dog_clean_name": "Charlie", "box_number": 3, "win_prob_norm": 0.2},
+                {"dog_clean_name": "Delta", "box_number": 4, "win_prob_norm": 0.1},
+            ],
+        },
+        source_file_path="Race 1 - WPK - 2026-05-24.csv",
+        lifecycle={
+            "status": "upcoming_not_jumped",
+            "race_date": "2026-05-24",
+            "venue": "WPK",
+            "race_number": 1,
+        },
+        prediction_timestamp="2026-05-24T10:00:00",
+    )
+    snapshot_dir = tmp_path / "snapshots"
+    snapshot_dir.mkdir()
+    (snapshot_dir / "valid_snapshot.json").write_text(
+        json.dumps(snapshot),
+        encoding="utf-8",
+    )
+    (snapshot_dir / "evaluation_report.json").write_text(
+        json.dumps(
+            {
+                "status": "SUCCESS",
+                "failure_mode_diagnostics": {
+                    "races": [{"label_quality": "winner_name_only_result"}]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = evaluate_snapshots(str(db_path), [str(snapshot_dir)])
+
+    assert report["status"] == "SUCCESS"
+    assert report["json_files_scanned"] == 2
+    assert report["snapshot_files"] == 1
+    assert report["non_snapshot_artifacts_skipped"] == 1
+    assert report["snapshots_rejected"] == 0
+    assert report["runner_rows_scored"] == 4
+    readiness = report["snapshot_corpus_readiness"]
+    assert readiness["status"] == "READY"
+    assert readiness["json_files_scanned"] == 2
+    assert readiness["snapshot_files"] == 1
+    assert readiness["non_snapshot_artifacts_skipped"] == 1
+    assert readiness["skipped_non_snapshot_artifacts"] == [
+        {
+            "path": str(snapshot_dir / "evaluation_report.json"),
+            "reason": "not_prediction_snapshot_v1",
+        }
+    ]
+
+
+def test_snapshot_evaluator_reads_snapshot_manifest_paths(tmp_path):
+    manifest = tmp_path / "snapshots.txt"
+    manifest.write_text(
+        "\n".join(
+            [
+                "# generated clean corpus manifest",
+                "",
+                "artifacts/prediction_snapshots/2026-06-01/AP_K/race-1.json",
+                "artifacts/prediction_snapshots/2026-06-01/NOWRA/race-2.json",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert _snapshot_paths_from_manifests([str(manifest)]) == [
+        "artifacts/prediction_snapshots/2026-06-01/AP_K/race-1.json",
+        "artifacts/prediction_snapshots/2026-06-01/NOWRA/race-2.json",
+    ]
+
+
+def test_snapshot_evaluation_rejects_result_leaking_prediction_snapshot(tmp_path):
+    snapshot = build_prediction_snapshot(
+        {
+            "race_id": "Race 1 - WPK - 2026-05-24",
+            "model_version": "model-v1",
+            "predictions": [
+                {"dog_clean_name": "Alpha", "box_number": 1, "win_prob_norm": 0.4},
+                {"dog_clean_name": "Bravo", "box_number": 2, "win_prob_norm": 0.3},
+                {"dog_clean_name": "Charlie", "box_number": 3, "win_prob_norm": 0.2},
+                {"dog_clean_name": "Delta", "box_number": 4, "win_prob_norm": 0.1},
+            ],
+        },
+        source_file_path="Race 1 - WPK - 2026-05-24.csv",
+        lifecycle={"status": "upcoming_not_jumped"},
+        prediction_timestamp="2026-05-24T10:00:00",
+    )
+    snapshot["winner_name"] = "Alpha"
+    snapshot_path = tmp_path / "result_leaking_snapshot.json"
+    snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+    db_path = tmp_path / "labels.db"
+    sqlite3.connect(db_path).close()
+
+    report = evaluate_snapshots(str(db_path), [str(snapshot_path)])
+
+    assert report["status"] == "DATA_MISSING"
+    assert report["snapshot_files"] == 1
+    assert report["snapshots_rejected"] == 1
+    assert "result field leaked into snapshot" in report["rejected_snapshots"][0]["reason"]
+    assert report["snapshot_corpus_readiness"]["status"] == "NOT_READY"
+
+
 def test_snapshot_evaluation_links_results_and_scores_valid_pre_jump_odds_only(tmp_path):
     db_path = tmp_path / "labels.db"
     conn = sqlite3.connect(db_path)
@@ -698,15 +913,29 @@ def test_snapshot_evaluation_links_results_and_scores_valid_pre_jump_odds_only(t
         },
         prediction_timestamp="2026-05-24T10:00:00",
     )
+    snapshot["target_distance"] = "520m"
+    snapshot["target_grade"] = "Grade 5"
     snapshot_path = tmp_path / "snapshot.json"
     snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
 
-    report = evaluate_snapshots(str(db_path), [str(snapshot_path)])
+    report = evaluate_snapshots(
+        str(db_path),
+        [str(snapshot_path)],
+        include_dataset_rows=True,
+    )
 
     assert report["status"] == "SUCCESS"
     assert report["runner_rows_scored"] == 4
+    assert len(report["evaluation_dataset_rows"]) == 4
+    assert report["evaluation_dataset_rows"][0]["snapshot_path"] == str(snapshot_path)
+    assert report["evaluation_dataset_rows"][0]["target_grade"] == "Grade 5"
     assert report["metrics_by_arm"]["model_only"]["top1"] == pytest.approx(1.0)
     assert report["metrics_by_arm"]["model_only"]["winner_ranks"] == [1]
+    clean_official = report["clean_official_evaluation"]
+    assert clean_official["status"] == "SUCCESS"
+    assert clean_official["races_evaluated"] == 1
+    assert clean_official["runner_rows_evaluated"] == 4
+    assert clean_official["metrics_by_arm"]["model_only"]["top1"] == pytest.approx(1.0)
     assert report["ev_roi_coverage"]["status"] == "DATA_MISSING"
     assert report["ev_roi_coverage"]["reason"] == "partial_pre_jump_dog_level_odds"
     provenance = report["snapshot_provenance_report"]
@@ -726,6 +955,133 @@ def test_snapshot_evaluation_links_results_and_scores_valid_pre_jump_odds_only(t
     }
     assert provenance["odds_exclusion_reason_distribution"]["no_odds_row"] == 3
     assert provenance["target_distance_present_races"] == 1
+    diagnostics = report["failure_mode_diagnostics"]
+    assert diagnostics["grade_breakdown"]["Grade 5"]["races"] == 1
+    model_quality = report["model_quality_diagnosis"]
+    assert model_quality["clean_official_races_evaluated"] == 1
+    assert model_quality["retrain_gate"]["clean_official_evaluated_races"] == 1
+    assert model_quality["retrain_gate"]["status"] == "NOT_READY"
+    assert model_quality["retrain_gate"]["reason"] == (
+        "insufficient_clean_official_evaluated_corpus_for_leakage_safe_retrain"
+    )
+    assert model_quality["promotion_gate"]["action_taken"] == "none"
+
+
+def test_clean_official_evaluation_scores_duplicate_snapshot_instances_without_inflating_retrain_gate(tmp_path):
+    db_path = tmp_path / "labels.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE race_metadata (
+            race_id TEXT PRIMARY KEY,
+            venue TEXT,
+            race_number INTEGER,
+            race_date TEXT,
+            distance TEXT,
+            results_status TEXT,
+            winner_name TEXT
+        );
+        CREATE TABLE dog_race_data (
+            race_id TEXT,
+            dog_name TEXT,
+            dog_clean_name TEXT,
+            box_number INTEGER,
+            finish_position INTEGER,
+            data_source TEXT
+        );
+        """
+    )
+    race_id = "Race 1 - WPK - 2026-05-24"
+    conn.execute(
+        """
+        INSERT INTO race_metadata
+            (race_id, venue, race_number, race_date, results_status, winner_name)
+        VALUES (?, 'WPK', 1, '2026-05-24', 'complete', 'Alpha')
+        """,
+        (race_id,),
+    )
+    conn.executemany(
+        """
+        INSERT INTO dog_race_data
+            (race_id, dog_name, dog_clean_name, box_number, finish_position, data_source)
+        VALUES (?, ?, ?, ?, ?, 'official')
+        """,
+        [
+            (race_id, "Alpha", "Alpha", 1, 1),
+            (race_id, "Bravo", "Bravo", 2, 2),
+            (race_id, "Charlie", "Charlie", 3, 3),
+            (race_id, "Delta", "Delta", 4, 4),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    def snapshot_with_probs(probs: list[float], prediction_timestamp: str) -> dict:
+        snapshot = build_prediction_snapshot(
+            {
+                "race_id": race_id,
+                "model_version": "model-v1",
+                "predictions": [
+                    {
+                        "dog_clean_name": name,
+                        "box_number": box,
+                        "win_prob_norm": prob,
+                        "predicted_rank": rank,
+                    }
+                    for rank, (name, box, prob) in enumerate(
+                        zip(["Alpha", "Bravo", "Charlie", "Delta"], [1, 2, 3, 4], probs),
+                        start=1,
+                    )
+                ],
+            },
+            source_file_path="Race 1 - WPK - 2026-05-24.csv",
+            lifecycle={
+                "status": "upcoming_not_jumped",
+                "race_date": "2026-05-24",
+                "venue": "WPK",
+                "race_number": 1,
+                "jump_datetime": "2026-05-24T10:30:00",
+            },
+            prediction_timestamp=prediction_timestamp,
+        )
+        snapshot["target_distance"] = "520m"
+        snapshot["target_grade"] = "Grade 5"
+        return snapshot
+
+    snapshot_a = tmp_path / "snapshot_a.json"
+    snapshot_a.write_text(
+        json.dumps(snapshot_with_probs([0.6, 0.2, 0.15, 0.05], "2026-05-24T10:00:00")),
+        encoding="utf-8",
+    )
+    snapshot_b = tmp_path / "snapshot_b.json"
+    snapshot_b.write_text(
+        json.dumps(snapshot_with_probs([0.4, 0.3, 0.2, 0.1], "2026-05-24T10:05:00")),
+        encoding="utf-8",
+    )
+
+    report = evaluate_snapshots(
+        str(db_path),
+        [str(snapshot_a), str(snapshot_b)],
+        include_dataset_rows=True,
+    )
+
+    clean_official = report["clean_official_evaluation"]
+    assert clean_official["status"] == "SUCCESS"
+    assert clean_official["races_evaluated"] == 1
+    assert clean_official["snapshot_instances_evaluated"] == 2
+    assert clean_official["runner_rows_evaluated"] == 8
+    assert clean_official["excluded_reason_counts"] == {}
+    assert clean_official["metrics_by_arm"]["model_only"]["races_evaluated"] == 2
+    assert {row["snapshot_instance_id"] for row in report["evaluation_dataset_rows"]} == {
+        f"{race_id}|snapshot:{snapshot_a}",
+        f"{race_id}|snapshot:{snapshot_b}",
+    }
+
+    model_quality = report["model_quality_diagnosis"]
+    assert model_quality["clean_official_races_evaluated"] == 1
+    assert model_quality["clean_official_snapshot_instances_evaluated"] == 2
+    assert model_quality["retrain_gate"]["clean_official_evaluated_races"] == 1
+    assert model_quality["retrain_gate"]["status"] == "NOT_READY"
 
 
 def test_snapshot_evaluator_excludes_incomplete_runner_sets_even_if_labels_exist(tmp_path):
@@ -917,6 +1273,14 @@ def test_snapshot_evaluator_scores_partial_sportsbet_winner_only_labels(tmp_path
     assert report["label_quality_counts"] == {"partial_sportsbet_winner_only": 1}
     assert report["metrics_by_arm"]["model_only"]["top1"] == pytest.approx(1.0)
     assert report["metrics_by_arm"]["model_only"]["winner_ranks"] == [1]
+    clean_official = report["clean_official_evaluation"]
+    assert clean_official["status"] == "DATA_MISSING"
+    assert clean_official["races_evaluated"] == 0
+    assert clean_official["excluded_reason_counts"] == {
+        "finish_position_missing": 1,
+        "label_quality_not_official_or_complete": 1,
+        "result_detail_not_full_finish_position": 1,
+    }
     diagnostics = report["failure_mode_diagnostics"]
     assert diagnostics["winner_rank_by_race"] == {"Race 1 - WPK - 2026-05-25": 1}
     assert diagnostics["complete_vs_partial_labels"]["partial"]["races"] == 1

--- a/tests/test_probability_calibration.py
+++ b/tests/test_probability_calibration.py
@@ -1,0 +1,176 @@
+import pytest
+
+from accuracy_program.calibration import (
+    power_normalize_by_race,
+    power_normalize_prediction_group,
+)
+
+
+def test_power_normalize_by_race_is_additive_rank_preserving_and_label_free():
+    rows = [
+        {
+            "race_id": "Race 1",
+            "dog_name": "Alpha",
+            "box_number": 1,
+            "win_prob_norm": 0.64,
+            "actual_win": 0,
+            "odds": 12.0,
+        },
+        {
+            "race_id": "Race 1",
+            "dog_name": "Bravo",
+            "box_number": 2,
+            "win_prob_norm": 0.25,
+            "actual_win": 1,
+            "odds": 2.0,
+        },
+        {
+            "race_id": "Race 1",
+            "dog_name": "Charlie",
+            "box_number": 3,
+            "win_prob_norm": 0.11,
+            "actual_win": 0,
+            "odds": 8.0,
+        },
+        {
+            "race_id": "Race 2",
+            "dog_name": "Delta",
+            "box_number": 1,
+            "win_prob_norm": 0.4,
+        },
+        {
+            "race_id": "Race 2",
+            "dog_name": "Echo",
+            "box_number": 2,
+            "win_prob_norm": 0.35,
+        },
+        {
+            "race_id": "Race 2",
+            "dog_name": "Foxtrot",
+            "box_number": 3,
+            "win_prob_norm": 0.25,
+        },
+    ]
+
+    calibrated = power_normalize_by_race(
+        rows,
+        alpha=0.5,
+        output_key="calibrated_win_prob",
+    )
+
+    assert rows[0].get("calibrated_win_prob") is None
+    assert calibrated != rows
+    for race_id in {"Race 1", "Race 2"}:
+        race_rows = [row for row in calibrated if row["race_id"] == race_id]
+        assert sum(row["calibrated_win_prob"] for row in race_rows) == pytest.approx(
+            1.0
+        )
+        original_order = [
+            row["dog_name"]
+            for row in sorted(
+                [row for row in rows if row["race_id"] == race_id],
+                key=lambda row: row["win_prob_norm"],
+                reverse=True,
+            )
+        ]
+        calibrated_order = [
+            row["dog_name"]
+            for row in sorted(
+                race_rows,
+                key=lambda row: row["calibrated_win_prob"],
+                reverse=True,
+            )
+        ]
+        assert calibrated_order == original_order
+
+
+@pytest.mark.parametrize("alpha", [0, -1, float("nan")])
+def test_power_normalize_by_race_rejects_invalid_alpha(alpha):
+    with pytest.raises(ValueError, match="alpha_must_be_positive_finite"):
+        power_normalize_by_race(
+            [{"race_id": "Race 1", "win_prob_norm": 1.0}],
+            alpha=alpha,
+            output_key="calibrated_win_prob",
+        )
+
+
+def test_power_normalize_by_race_rejects_missing_race_groups():
+    with pytest.raises(ValueError, match="race_id_missing"):
+        power_normalize_by_race(
+            [{"win_prob_norm": 1.0}],
+            alpha=0.5,
+            output_key="calibrated_win_prob",
+        )
+
+
+def test_power_normalize_by_race_rejects_empty_prediction_groups():
+    with pytest.raises(ValueError, match="rows_missing"):
+        power_normalize_by_race(
+            [],
+            alpha=0.5,
+            output_key="calibrated_win_prob",
+        )
+
+
+def test_power_normalize_prediction_group_adds_report_only_fields():
+    predictions = [
+        {
+            "dog_name": "Alpha",
+            "box_number": 1,
+            "predicted_rank": 1,
+            "win_prob_norm": 0.64,
+            "actual_win": 0,
+            "odds": 12.0,
+        },
+        {
+            "dog_name": "Bravo",
+            "box_number": 2,
+            "predicted_rank": 2,
+            "win_prob_norm": 0.25,
+            "actual_win": 1,
+            "odds": 2.0,
+        },
+        {
+            "dog_name": "Charlie",
+            "box_number": 3,
+            "predicted_rank": 3,
+            "win_prob_norm": 0.11,
+            "actual_win": 0,
+            "odds": 8.0,
+        },
+    ]
+    without_labels_or_odds = [
+        {
+            "dog_name": row["dog_name"],
+            "box_number": row["box_number"],
+            "predicted_rank": row["predicted_rank"],
+            "win_prob_norm": row["win_prob_norm"],
+        }
+        for row in predictions
+    ]
+
+    calibrated = power_normalize_prediction_group(predictions, alpha=0.5)
+    calibrated_without_labels_or_odds = power_normalize_prediction_group(
+        without_labels_or_odds,
+        alpha=0.5,
+    )
+
+    assert predictions[0].get("calibrated_win_prob_report_only") is None
+    assert [row["predicted_rank"] for row in calibrated] == [1, 2, 3]
+    assert [row["win_prob_norm"] for row in calibrated] == [0.64, 0.25, 0.11]
+    assert sum(row["calibrated_win_prob_report_only"] for row in calibrated) == (
+        pytest.approx(1.0)
+    )
+    assert [row["calibrated_predicted_rank_report_only"] for row in calibrated] == [
+        1,
+        2,
+        3,
+    ]
+    assert [
+        row["calibrated_win_prob_report_only"] for row in calibrated
+    ] == pytest.approx(
+        [
+            row["calibrated_win_prob_report_only"]
+            for row in calibrated_without_labels_or_odds
+        ]
+    )


### PR DESCRIPTION
## Summary
- Add report-only probability calibration helpers for snapshot/evaluation paths.
- Add snapshot EV-readiness reporting without changing canonical ranks or probabilities.
- Teach snapshot evaluation to skip non-snapshot JSON artifacts, group duplicate snapshot instances explicitly, and report clean-official/model-quality diagnostics.
- Add focused tests for calibration, snapshot readiness, and snapshot manifest/evaluation behavior.

## Validation
- `git diff --check`
- `python -m py_compile accuracy_program/calibration.py accuracy_program/__init__.py accuracy_program/evaluation.py accuracy_program/snapshots.py scripts/evaluate_prediction_snapshots.py tests/test_accuracy_program.py tests/test_odds_snapshot_readiness.py tests/test_probability_calibration.py`
- `python -m pytest -q tests/test_probability_calibration.py tests/test_accuracy_program.py::test_snapshot_can_attach_report_only_calibration_without_reranking tests/test_accuracy_program.py::test_score_predictions_can_group_frozen_snapshot_instances_separately tests/test_odds_snapshot_readiness.py::test_ev_readiness_counts_untrusted_odds_without_exposing_ev tests/test_odds_snapshot_readiness.py::test_snapshot_evaluator_reads_snapshot_manifest_paths` (`11 passed`)

## Guardrails
- No DB, runtime, artifact, label, model registry, betting, or EV-action state was mutated.
- This is a draft PR and should not be merged until reviewed.