### PR TITLE
[codex] Accept hyphenated upcoming venue filenames

### DIFF
--- a/app.py
+++ b/app.py
@@ -6538,11 +6538,12 @@ def api_upcoming_races_csv():
                     race_date = parts[3]
                 else:
                     # Pattern C: "Race 1 - AP_K - 2025-08-04.csv" and similar
+                    venue_pattern = r"([A-Z0-9_/]+(?:-[A-Z0-9_/]+)*)"
                     pattern1 = (
-                        r"Race\s+(\d+)\s*-\s*([A-Z_/]+)\s*-\s*(\d{1,2}\s+\w+\s+\d{4})"
+                        rf"Race\s+(\d+)\s*-\s*{venue_pattern}\s*-\s*(\d{{1,2}}\s+\w+\s+\d{{4}})"
                     )
                     pattern2 = (
-                        r"Race\s+(\d+)\s*-\s*([A-Z_/]+)\s*-\s*(\d{4}-\d{2}-\d{2})"
+                        rf"Race\s+(\d+)\s*-\s*{venue_pattern}\s*-\s*(\d{{4}}-\d{{2}}-\d{{2}})"
                     )
                     match1 = re.search(pattern1, filename, re.IGNORECASE)
                     match2 = re.search(pattern2, filename, re.IGNORECASE)

--- a/app.py
+++ b/app.py
@@ -18224,7 +18224,7 @@ def _extract_csv_metadata(file_path):
 
     # Regex pattern to match: "Race {number} – {venue} – {date}.csv"
     # The en dash (–) is different from hyphen (-)
-    pattern = r"Race\s+(\d+)\s*[–-]\s*([A-Z_]+)\s*[–-]\s*(\d{4}-\d{2}-\d{2})\.csv"
+    pattern = r"Race\s+(\d+)\s*[–-]\s*([A-Z0-9_]+(?:-[A-Z0-9_]+)*)\s*[–-]\s*(\d{4}-\d{2}-\d{2})\.csv"
 
     match = re.match(pattern, filename, re.IGNORECASE)
     if match:

--- a/scripts/alias_upcoming_api_names_safe.py
+++ b/scripts/alias_upcoming_api_names_safe.py
@@ -19,7 +19,7 @@ RE_VENUE_UPCOMING = re.compile(
     r"Upcoming_([A-Z_]{2,5})_(\d{4}-\d{2}-\d{2})_(\d{1,2})", re.IGNORECASE
 )
 RE_API = re.compile(
-    r"^Race\s+(\d{1,2})\s*[–-]\s*([A-Z_]+)\s*[–-]\s*(\d{4}-\d{2}-\d{2})\.csv$",
+    r"^Race\s+(\d{1,2})\s*[–-]\s*([A-Z0-9_]+(?:-[A-Z0-9_]+)*)\s*[–-]\s*(\d{4}-\d{2}-\d{2})\.csv$",
     re.IGNORECASE,
 )
 

--- a/scripts/archive_past_upcoming.py
+++ b/scripts/archive_past_upcoming.py
@@ -35,7 +35,7 @@ from config.paths import ARCHIVE_DIR, UPCOMING_RACES_DIR
 log = get_component_logger()
 
 API_PATTERN = re.compile(
-    r"^Race\s+(\d{1,2})\s*[–-]\s*([A-Z_]+)\s*[–-]\s*(\d{4}-\d{2}-\d{2})\.csv$",
+    r"^Race\s+(\d{1,2})\s*[–-]\s*([A-Z0-9_]+(?:-[A-Z0-9_]+)*)\s*[–-]\s*(\d{4}-\d{2}-\d{2})\.csv$",
     re.IGNORECASE,
 )
 

--- a/scripts/normalize_upcoming_csvs.py
+++ b/scripts/normalize_upcoming_csvs.py
@@ -33,7 +33,10 @@ from typing import Dict, List, Optional, Tuple
 
 DATE_RE = re.compile(r"(\d{4}-\d{2}-\d{2})")
 # Filename contract: "Race {num} - {VENUE} - YYYY-MM-DD.csv" (hyphen or en dash)
-FILENAME_PATTERN = re.compile(r"^Race\s+(\d{1,2})\s*[–-]\s*([A-Z_]+)\s*[–-]\s*(\d{4}-\d{2}-\d{2})\.csv$", re.IGNORECASE)
+FILENAME_PATTERN = re.compile(
+    r"^Race\s+(\d{1,2})\s*[–-]\s*([A-Z0-9_]+(?:-[A-Z0-9_]+)*)\s*[–-]\s*(\d{4}-\d{2}-\d{2})\.csv$",
+    re.IGNORECASE,
+)
 
 
 @dataclass

--- a/scripts/normalize_upcoming_to_api_pattern.py
+++ b/scripts/normalize_upcoming_to_api_pattern.py
@@ -23,7 +23,7 @@ ARCHIVE_DIRS = [
 ]
 
 API_PATTERN = re.compile(
-    r"^Race\s+(\d{1,2})\s*[–-]\s*([A-Z_]+)\s*[–-]\s*(\d{4}-\d{2}-\d{2})\.csv$",
+    r"^Race\s+(\d{1,2})\s*[–-]\s*([A-Z0-9_]+(?:-[A-Z0-9_]+)*)\s*[–-]\s*(\d{4}-\d{2}-\d{2})\.csv$",
     re.IGNORECASE,
 )
 

--- a/scripts/validate_upcoming_races.py
+++ b/scripts/validate_upcoming_races.py
@@ -38,7 +38,7 @@ from config.logging_config import get_component_logger  # type: ignore
 log = get_component_logger()
 
 API_PATTERN = re.compile(
-    r"^Race\s+(\d{1,2})\s*[–-]\s*([A-Z_]+)\s*[–-]\s*(\d{4}-\d{2}-\d{2})\.csv$",
+    r"^Race\s+(\d{1,2})\s*[–-]\s*([A-Z0-9_]+(?:-[A-Z0-9_]+)*)\s*[–-]\s*(\d{4}-\d{2}-\d{2})\.csv$",
     re.IGNORECASE,
 )
 

--- a/tests/test_upcoming_filename_contract.py
+++ b/tests/test_upcoming_filename_contract.py
@@ -1,0 +1,90 @@
+from datetime import date
+
+from scripts import (
+    alias_upcoming_api_names_safe,
+    archive_past_upcoming,
+    normalize_upcoming_csvs,
+    normalize_upcoming_to_api_pattern,
+    validate_upcoming_races,
+)
+from upcoming_race_browser import UpcomingRaceBrowser
+from utils.csv_metadata import _extract_from_filename
+from utils.race_lifecycle import extract_target_metadata_from_filename
+
+
+HYPHENATED_VENUE_NAME = "Race 1 - LADBROKES-Q1-LAKESIDE - 2026-05-29.csv"
+
+
+class FixedDate(date):
+    @classmethod
+    def today(cls):
+        return date(2026, 5, 29)
+
+
+def test_hyphenated_alphanumeric_venue_filename_is_contract_compliant(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / HYPHENATED_VENUE_NAME
+    path.write_text(
+        "Dog Name|BOX\n"
+        "Alpha Runner|1\n"
+        "Bravo Runner|2\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(validate_upcoming_races, "date", FixedDate)
+
+    race_no, venue, race_date, problems = validate_upcoming_races.validate_filename(path)
+
+    assert problems == []
+    assert race_no == 1
+    assert venue == "LADBROKES-Q1-LAKESIDE"
+    assert race_date == date(2026, 5, 29)
+    assert validate_upcoming_races.validate_file(path, strict_future=False) == []
+
+    parsed_no, parsed_venue, parsed_date = archive_past_upcoming.parse_filename(path)
+    assert parsed_no == 1
+    assert parsed_venue == "LADBROKES-Q1-LAKESIDE"
+    assert parsed_date == date(2026, 5, 29)
+
+    assert normalize_upcoming_csvs.FILENAME_PATTERN.match(path.name).group(2) == (
+        "LADBROKES-Q1-LAKESIDE"
+    )
+    assert normalize_upcoming_to_api_pattern.extract_meta(path.name) == {
+        "race": 1,
+        "venue": "LADBROKES-Q1-LAKESIDE",
+        "date": "2026-05-29",
+    }
+    assert alias_upcoming_api_names_safe.extract_from_name(path.name) == (
+        1,
+        "LADBROKES-Q1-LAKESIDE",
+        "2026-05-29",
+    )
+    assert extract_target_metadata_from_filename(path)["venue"] == (
+        "LADBROKES-Q1-LAKESIDE"
+    )
+
+
+def test_legacy_filename_metadata_parsers_preserve_hyphenated_alphanumeric_venue(
+    tmp_path,
+):
+    browser = object.__new__(UpcomingRaceBrowser)
+    browser.base_url = "https://www.thedogs.com.au"
+    browser.upcoming_dir = str(tmp_path)
+    browser.venue_map = {}
+
+    info = browser.extract_race_info_from_csv_filename(
+        HYPHENATED_VENUE_NAME, "2026-05-29"
+    )
+
+    assert info is not None
+    assert info["race_number"] == 1
+    assert info["venue"] == "LADBROKES-Q1-LAKESIDE"
+    assert info["venue_name"] == "Ladbrokes Q1 Lakeside"
+    assert info["url"] == (
+        "https://www.thedogs.com.au/racing/ladbrokes-q1-lakeside/2026-05-29/1"
+    )
+    assert _extract_from_filename(HYPHENATED_VENUE_NAME) == {
+        "race_number": 1,
+        "venue": "LADBROKES-Q1-LAKESIDE",
+        "race_date": "2026-05-29",
+    }

--- a/tests/test_upcoming_races_csv_unit.py
+++ b/tests/test_upcoming_races_csv_unit.py
@@ -192,6 +192,27 @@ Test Dog Golf,4,30.1,Trainer Anderson""",
         assert race3["race_date"] == "2025-02-03"  # Extracted from filename
         assert race3["race_number"] == 3  # Extracted from filename
 
+    def test_upcoming_races_csv_preserves_hyphenated_alphanumeric_venue_from_filename(
+        self, client, test_app
+    ):
+        """Test API listing metadata for hyphenated/alphanumeric venue filenames."""
+        upcoming_dir = test_app.config["UPCOMING_DIR"]
+        filename = "Race 1 - LADBROKES-Q1-LAKESIDE - 2026-05-29.csv"
+        file_path = os.path.join(upcoming_dir, filename)
+        with open(file_path, "w", newline="") as f:
+            f.write("Dog Name,Box\nAlpha Runner,1\nBravo Runner,2\n")
+
+        response = client.get("/api/upcoming_races_csv")
+        assert response.status_code == 200
+
+        data = response.get_json()
+        race_by_filename = {race["filename"]: race for race in data["races"]}
+        race = race_by_filename[filename]
+
+        assert race["venue"] == "LADBROKES-Q1-LAKESIDE"
+        assert race["race_date"] == "2026-05-29"
+        assert race["race_number"] == 1
+
     def test_upcoming_races_csv_pagination(self, client, temp_upcoming_dir):
         """Test pagination functionality"""
         upcoming_dir, test_files = temp_upcoming_dir

--- a/upcoming_race_browser.py
+++ b/upcoming_race_browser.py
@@ -462,7 +462,10 @@ class UpcomingRaceBrowser:
         """Extract race information from CSV filename (e.g., 'Race 1 - BROKEN-HILL - 2025-07-27.csv')"""
         try:
             # Pattern: Race {number} - {venue} - {date}.csv
-            pattern = r"Race (\d+) - ([A-Z-]+) - (\d{4}-\d{2}-\d{2})\.csv"
+            pattern = (
+                r"Race\s+(\d+)\s*-\s*([A-Z0-9_]+(?:-[A-Z0-9_]+)*)\s*-\s*"
+                r"(\d{4}-\d{2}-\d{2})\.csv"
+            )
             match = re.match(pattern, filename)
 
             if not match:

--- a/utils/csv_metadata.py
+++ b/utils/csv_metadata.py
@@ -905,7 +905,9 @@ def _extract_from_filename(filename: str) -> Optional[Dict[str, Any]]:
     )  # Remove extension
 
     # Pattern 1: "Race 11 - TAREE - 2025-08-02" (ISO date format)
-    pattern1 = r"Race\s+(\d+)\s*-\s*([A-Z_]+)\s*-\s*(\d{4}-\d{2}-\d{2})"
+    venue_pattern = r"([A-Z0-9_]+(?:-[A-Z0-9_]+)*)"
+
+    pattern1 = rf"Race\s+(\d+)\s*-\s*{venue_pattern}\s*-\s*(\d{{4}}-\d{{2}}-\d{{2}})"
     match1 = re.search(pattern1, clean_name, re.IGNORECASE)
 
     if match1:
@@ -917,7 +919,7 @@ def _extract_from_filename(filename: str) -> Optional[Dict[str, Any]]:
         }
 
     # Pattern 2: "Race 5 - GEE - 08 July 2025" (human readable date)
-    pattern2 = r"Race\s+(\d+)\s*-\s*([A-Z_]+)\s*-\s*(\d{1,2})\s+(\w+)\s+(\d{4})"
+    pattern2 = rf"Race\s+(\d+)\s*-\s*{venue_pattern}\s*-\s*(\d{{1,2}})\s+(\w+)\s+(\d{{4}})"
     match2 = re.search(pattern2, clean_name, re.IGNORECASE)
 
     if match2:
@@ -933,7 +935,7 @@ def _extract_from_filename(filename: str) -> Optional[Dict[str, Any]]:
             }
 
     # Pattern 3: Try to extract just race number and venue if date parsing fails
-    pattern3 = r"Race\s+(\d+)\s*-\s*([A-Z_]+)"
+    pattern3 = rf"Race\s+(\d+)\s*-\s*{venue_pattern}"
     match3 = re.search(pattern3, clean_name, re.IGNORECASE)
 
     if match3:


### PR DESCRIPTION
## Summary
- Accept hyphenated/alphanumeric venue codes such as `LADBROKES-Q1-LAKESIDE` across upcoming-race filename parsers.
- Add a focused contract test that exercises validator, archive, normalization, aliasing, browser, and metadata filename parsers.

## Scope
This is a source/test-only salvage from the dirty checkout. It does not touch artifacts, outputs, upcoming race files, DB state, model registry, label state, betting paths, or PR #11 paths.

## Validation
- `git diff --check`
- temp-output `py_compile` for changed Python files
- `/tmp/greyhound-pytest-venv.v3qF3p/bin/python -m pytest --noconftest -q -p no:cacheprovider tests/test_upcoming_filename_contract.py`
- `/tmp/greyhound-pytest-venv.v3qF3p/bin/python -m pytest --noconftest -q -p no:cacheprovider tests/test_upcoming_race_time_mapping.py`

Note: base `pytest` was not installed; full repo conftest imports the Flask/analyzer stack, so focused pytest was run in a throwaway `/tmp` venv with `--noconftest` for this parser-only contract.