### PR TITLE
[codex] Add forward shadow result review tools

### DIFF
--- a/scripts/aggregate_forward_shadow_results.py
+++ b/scripts/aggregate_forward_shadow_results.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Aggregate forward shadow result joins across shadow batches.
+
+This is report-only. It reads existing forward-shadow result-join artifacts,
+deduplicates repeated race IDs, computes metrics on the selected unique joined
+races, and writes a fresh aggregate artifact. It does not write labels, DB rows,
+registry entries, models, production predictions, EV, or betting output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_STR = str(ROOT)
+sys.path = [path for path in sys.path if path != ROOT_STR]
+sys.path.insert(0, ROOT_STR)
+DEFAULT_EVIDENCE_ROOT = ROOT / "artifacts/full_evidence_orchestration_20260525"
+OUTPUT_PREFIX = "artifacts/full_evidence_orchestration_20260525/forward_shadow_result_aggregate_"
+PROBABILITY_COLUMN = "shadow_rf_calibrated_probability"
+FINAL_AGGREGATED = "FORWARD_SHADOW_RESULTS_AGGREGATED"
+FINAL_PARTIAL = "PARTIAL_AGGREGATE_PENDING_MORE_RESULTS"
+FINAL_WAITING = "WAITING_FOR_OFFICIAL_RESULTS"
+FINAL_UNSAFE = "BLOCKED_IDENTITY_MATCH_FAILURE"
+DEFAULT_PROTECTED_PATHS = (
+    ROOT / "greyhound_racing_data.db",
+    ROOT / "greyhound_racing_data_writable.db",
+    ROOT / "model_registry/best_metadata.json",
+    ROOT / "docs/model_contracts/v4_feature_contract.json",
+    ROOT / "artifacts/prediction_snapshots/manifest.jsonl",
+)
+SOURCE_SHADOW_RUN_NAME_RE = re.compile(r"^(daily_race_ingest_shadow_|forward_shadow_run_).+")
+
+from scripts.join_forward_shadow_results import (  # noqa: E402
+    clip_probability,
+    logistic_calibration_review,
+    probability_reliability_bins,
+)
+
+
+def relpath(path: Path | None) -> str | None:
+    if path is None:
+        return None
+    try:
+        return os.path.relpath(path.resolve(), ROOT.resolve())
+    except ValueError:
+        return str(path)
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def protected_hashes(paths: Sequence[Path] = DEFAULT_PROTECTED_PATHS) -> dict[str, str | None]:
+    return {relpath(path) or str(path): sha256_file(path) for path in paths}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            value = json.loads(line)
+            if isinstance(value, dict):
+                rows.append(value)
+    return rows
+
+
+def assert_output_dir_safe(output_dir: Path) -> Path:
+    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
+    try:
+        relative = logical.absolute().relative_to(ROOT.absolute())
+    except ValueError as exc:
+        raise ValueError("output_dir_must_be_inside_repo") from exc
+    if ".." in relative.parts:
+        raise ValueError("output_dir_must_not_contain_parent_traversal")
+    if not relative.as_posix().startswith(OUTPUT_PREFIX):
+        raise ValueError(f"output_dir_must_be_forward_shadow_result_aggregate_artifact:{relative}")
+    return logical.absolute()
+
+
+def discovered_result_join_dirs(evidence_root: Path) -> list[Path]:
+    return sorted(
+        item
+        for item in evidence_root.glob("forward_shadow_result_join_*")
+        if item.is_dir() and (item / "shadow_forward_metrics.json").exists()
+    )
+
+
+def source_shadow_run_key(source_shadow_run: object, *, fallback_join_dir: Path | None = None) -> str:
+    """Return a stable key for grouping result joins by source shadow run.
+
+    Result-join artifacts can refer to the same shadow run through different
+    path aliases, such as repo-relative `artifacts/...` paths and storage-root
+    relative paths. Known shadow run directory names are stable identifiers, so
+    use those before falling back to the previous raw path behavior.
+    """
+
+    text = str(source_shadow_run or "").strip()
+    if text:
+        normalized = text.replace("\\", "/").rstrip("/")
+        for part in reversed([part for part in normalized.split("/") if part]):
+            if SOURCE_SHADOW_RUN_NAME_RE.match(part):
+                return f"shadow_run_dir:{part}"
+
+        path = Path(text)
+        try:
+            logical = path if path.is_absolute() else ROOT / path
+            if logical.exists():
+                return f"path:{logical.resolve()}"
+        except OSError:
+            pass
+        return f"raw:{normalized}"
+
+    if fallback_join_dir is not None:
+        return f"join_dir:{fallback_join_dir.name}"
+    return "raw:"
+
+
+def result_join_dirs(evidence_root: Path) -> list[Path]:
+    latest_by_shadow_run: dict[str, Path] = {}
+    for join_dir in discovered_result_join_dirs(evidence_root):
+        metrics = load_json(join_dir / "shadow_forward_metrics.json")
+        source_key = source_shadow_run_key(metrics.get("source_shadow_run"), fallback_join_dir=join_dir)
+        latest_by_shadow_run[source_key] = join_dir
+    return sorted(latest_by_shadow_run.values())
+
+
+def race_key(value: Mapping[str, Any]) -> str:
+    return str(value.get("race_id") or "").strip()
+
+
+def grouped_joined_rows(join_dir: Path) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in read_jsonl(join_dir / "joined_shadow_predictions.jsonl"):
+        key = race_key(row)
+        if key:
+            grouped[key].append(row)
+    return dict(grouped)
+
+
+def selected_unique_joined_races(join_dirs: Sequence[Path]) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]]]:
+    selected: dict[str, list[dict[str, Any]]] = {}
+    duplicate_records: list[dict[str, Any]] = []
+    seen_sources: dict[str, list[str]] = defaultdict(list)
+    for join_dir in join_dirs:
+        for key, rows in grouped_joined_rows(join_dir).items():
+            if key in selected:
+                duplicate_records.append(
+                    {
+                        "race_id": key,
+                        "previous_sources": list(seen_sources[key]),
+                        "selected_source": relpath(join_dir),
+                        "selection_policy": "latest_join_artifact_per_unique_race",
+                    }
+                )
+            selected[key] = rows
+            seen_sources[key].append(relpath(join_dir) or str(join_dir))
+    return selected, duplicate_records
+
+
+def collect_pending_and_unsafe(join_dirs: Sequence[Path], selected_race_ids: set[str]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    pending_by_race: dict[str, dict[str, Any]] = {}
+    unsafe_by_race: dict[str, dict[str, Any]] = {}
+    for join_dir in join_dirs:
+        pending_path = join_dir / "pending_results.json"
+        if pending_path.exists():
+            for row in load_json(pending_path).get("pending_results") or []:
+                if isinstance(row, Mapping):
+                    key = race_key(row)
+                    if key and key not in selected_race_ids:
+                        record = dict(row)
+                        record["source_join_artifact"] = relpath(join_dir)
+                        pending_by_race[key] = record
+        unsafe_path = join_dir / "unsafe_result_matches.json"
+        if unsafe_path.exists():
+            for row in load_json(unsafe_path).get("unsafe_result_matches") or []:
+                if isinstance(row, Mapping):
+                    key = race_key(row) or str(row.get("race_url") or row.get("source_csv") or "")
+                    if key:
+                        record = dict(row)
+                        record["source_join_artifact"] = relpath(join_dir)
+                        unsafe_by_race[key] = record
+    return sorted(pending_by_race.values(), key=lambda row: str(row.get("race_id"))), sorted(
+        unsafe_by_race.values(), key=lambda row: str(row.get("race_id"))
+    )
+
+
+def safe_race_summary(race_id: str, rows: Sequence[Mapping[str, Any]]) -> dict[str, Any] | None:
+    winners = [row for row in rows if row.get("is_winner")]
+    if len(winners) != 1:
+        return None
+    winner = winners[0]
+    top_pick = sorted(rows, key=lambda row: int(row.get("predicted_rank") or 999))[0]
+    winner_rank = int(winner["predicted_rank"])
+    return {
+        "race_id": race_id,
+        "race_date": winner.get("race_date"),
+        "venue": winner.get("venue"),
+        "race_number": winner.get("race_number"),
+        "runner_count": len(rows),
+        "top_pick_box": top_pick.get("box"),
+        "top_pick_dog_name": top_pick.get("dog_name"),
+        "top_pick_won": bool(top_pick.get("is_winner")),
+        "winner_box": winner.get("box"),
+        "winner_predicted_rank": winner_rank,
+        "winner_in_top3": winner_rank <= 3,
+        "selected_result_url": winner.get("result_url"),
+    }
+
+
+def compute_aggregate_metrics(
+    *,
+    selected_by_race: Mapping[str, Sequence[Mapping[str, Any]]],
+    pending_count: int,
+    unsafe_count: int,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], list[dict[str, Any]]]:
+    safe_races = []
+    joined_rows = []
+    skipped = []
+    for key, rows in sorted(selected_by_race.items()):
+        summary = safe_race_summary(key, rows)
+        if summary is None:
+            skipped.append({"race_id": key, "reason": "winner_row_count_not_exactly_one"})
+            continue
+        safe_races.append(summary)
+        joined_rows.extend(dict(row) for row in rows)
+
+    labels = [1 if row.get("is_winner") else 0 for row in joined_rows]
+    probabilities = [float(row[PROBABILITY_COLUMN]) for row in joined_rows]
+    joined_by_race: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in joined_rows:
+        joined_by_race[str(row.get("race_id"))].append(row)
+
+    if safe_races:
+        winner_ranks = [int(row["winner_predicted_rank"]) for row in safe_races]
+        top1 = sum(1 for row in safe_races if row.get("top_pick_won")) / len(safe_races)
+        top3 = sum(1 for row in safe_races if row.get("winner_in_top3")) / len(safe_races)
+        brier = sum((probability - label) ** 2 for label, probability in zip(labels, probabilities)) / len(labels)
+        logloss = sum(
+            -math.log(clip_probability(float(next(row for row in rows if row.get("is_winner"))[PROBABILITY_COLUMN])))
+            for rows in joined_by_race.values()
+        ) / len(joined_by_race)
+        probability_sum_max_error = max(
+            abs(sum(float(row[PROBABILITY_COLUMN]) for row in rows) - 1.0)
+            for rows in joined_by_race.values()
+        )
+    else:
+        winner_ranks = []
+        top1 = top3 = brier = logloss = probability_sum_max_error = None
+
+    calibration_methods = sorted({str(row.get("calibration_method")) for row in joined_rows if row.get("calibration_method")})
+    tgr_values = sorted({bool(row.get("tgr_enabled")) for row in joined_rows})
+    metrics = {
+        "schema_version": "forward_shadow_aggregate_metrics_v1",
+        "status": "COMPUTED_FOR_UNIQUE_SAFE_JOINED_RACES" if safe_races else "NO_SAFE_JOINED_RACES",
+        "selection_policy": "latest_join_artifact_per_unique_race",
+        "safe_joined_race_count": len(safe_races),
+        "safe_joined_runner_count": len(joined_rows),
+        "pending_race_count": pending_count,
+        "unsafe_match_count": unsafe_count,
+        "top1": top1,
+        "top3": top3,
+        "winner_ranks": winner_ranks,
+        "mean_winner_rank": sum(winner_ranks) / len(winner_ranks) if winner_ranks else None,
+        "brier": brier,
+        "logloss": logloss,
+        "logloss_method": "mean_negative_log_calibrated_probability_assigned_to_winner_per_race",
+        "probability_sum_max_error_joined_races": probability_sum_max_error,
+        "joined_races": safe_races,
+        "calibration_methods": calibration_methods,
+        "tgr_enabled_values": tgr_values,
+    }
+    calibration = {
+        "schema_version": "forward_shadow_aggregate_calibration_review_v1",
+        "safe_joined_race_count": len(safe_races),
+        "safe_joined_runner_count": len(joined_rows),
+        "brier": metrics["brier"],
+        "logloss": metrics["logloss"],
+        "reliability_bins": probability_reliability_bins(labels, probabilities) if joined_rows else [],
+        "slope_intercept": (
+            logistic_calibration_review(labels, probabilities)
+            if joined_rows
+            else {"status": "no_safe_joined_rows", "slope": None, "intercept": None}
+        ),
+    }
+    top_pick_counts = Counter(str(row.get("top_pick_box")) for row in safe_races)
+    box_bias = {
+        "schema_version": "forward_shadow_aggregate_box_bias_review_v1",
+        "safe_joined_race_count": len(safe_races),
+        "safe_joined_top_pick_box_distribution": dict(sorted(top_pick_counts.items())),
+        "safe_joined_box_1_top_pick_share": top_pick_counts.get("1", 0) / len(safe_races) if safe_races else None,
+    }
+    return metrics, calibration, box_bias, skipped
+
+
+def final_status(metrics: Mapping[str, Any]) -> str:
+    safe = int(metrics.get("safe_joined_race_count") or 0)
+    pending = int(metrics.get("pending_race_count") or 0)
+    unsafe = int(metrics.get("unsafe_match_count") or 0)
+    if unsafe and not safe:
+        return FINAL_UNSAFE
+    if safe and not pending and not unsafe:
+        return FINAL_AGGREGATED
+    if safe:
+        return FINAL_PARTIAL
+    return FINAL_WAITING
+
+
+def build_aggregate_report(*, evidence_root: Path, generated_at: datetime | None = None) -> dict[str, Any]:
+    generated_at = generated_at or datetime.now().astimezone()
+    join_dirs = result_join_dirs(evidence_root)
+    selected, duplicates = selected_unique_joined_races(join_dirs)
+    pending, unsafe = collect_pending_and_unsafe(join_dirs, set(selected))
+    metrics, calibration, box_bias, skipped = compute_aggregate_metrics(
+        selected_by_race=selected,
+        pending_count=len(pending),
+        unsafe_count=len(unsafe),
+    )
+    return {
+        "schema_version": "forward_shadow_result_aggregate_v1",
+        "generated_at": generated_at.isoformat(),
+        "final_status": final_status(metrics),
+        "source_join_artifacts": [relpath(path) for path in join_dirs],
+        "source_join_artifact_count": len(join_dirs),
+        "discovered_join_artifact_count": len(discovered_result_join_dirs(evidence_root)),
+        "join_artifact_selection_policy": "latest_result_join_per_source_shadow_run",
+        "aggregate_forward_metrics": metrics,
+        "aggregate_calibration_review": calibration,
+        "aggregate_box_bias_review": box_bias,
+        "duplicate_joined_races": duplicates,
+        "duplicate_joined_race_count": len(duplicates),
+        "pending_results": {
+            "schema_version": "forward_shadow_aggregate_pending_results_v1",
+            "pending_race_count": len(pending),
+            "pending_results": pending,
+        },
+        "unsafe_result_matches": {
+            "schema_version": "forward_shadow_aggregate_unsafe_result_matches_v1",
+            "unsafe_match_count": len(unsafe),
+            "unsafe_result_matches": unsafe,
+        },
+        "skipped_joined_races": skipped,
+        "no_write_guarantees": {
+            "production_promotion": False,
+            "registry_mutation": False,
+            "production_pointer_update": False,
+            "production_prediction_write": False,
+            "db_write": False,
+            "label_write": False,
+            "tgr_enabled": False,
+            "betting_or_ev_output": False,
+        },
+    }
+
+
+def build_summary(report: Mapping[str, Any]) -> str:
+    metrics = report["aggregate_forward_metrics"]
+    return "\n".join(
+        [
+            "# Forward Shadow Result Aggregate",
+            "",
+            f"- Final status: `{report.get('final_status')}`",
+            f"- Source join artifacts: `{report.get('source_join_artifact_count')}`",
+            f"- Unique safe joined races: `{metrics.get('safe_joined_race_count')}`",
+            f"- Pending races: `{metrics.get('pending_race_count')}`",
+            f"- Unsafe matches: `{metrics.get('unsafe_match_count')}`",
+            f"- Duplicate joined races de-duplicated: `{report.get('duplicate_joined_race_count')}`",
+            f"- Top1: `{metrics.get('top1')}`",
+            f"- Top3: `{metrics.get('top3')}`",
+            f"- Mean winner rank: `{metrics.get('mean_winner_rank')}`",
+            f"- Brier: `{metrics.get('brier')}`",
+            f"- LogLoss: `{metrics.get('logloss')}`",
+            "",
+            "No production promotion, registry mutation, DB writes, label writes, TGR enablement, betting output, EV output, or production prediction overwrite was performed.",
+            "",
+        ]
+    )
+
+
+def run_aggregate(
+    *,
+    evidence_root: Path = DEFAULT_EVIDENCE_ROOT,
+    output_dir: Path | None = None,
+) -> dict[str, Any]:
+    generated_at = datetime.now().astimezone()
+    output_dir = output_dir or evidence_root / f"forward_shadow_result_aggregate_{generated_at.strftime('%Y%m%dT%H%M%S%z')}"
+    output_dir = assert_output_dir_safe(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=False)
+    protected_before = protected_hashes()
+    report = build_aggregate_report(evidence_root=evidence_root, generated_at=generated_at)
+    protected_after = protected_hashes()
+    report["protected_hashes_before"] = protected_before
+    report["protected_hashes_after"] = protected_after
+    report["protected_paths_unchanged"] = protected_before == protected_after
+    if not report["protected_paths_unchanged"]:
+        report["final_status"] = "BLOCKED_PROTECTED_PATH_MUTATION"
+
+    write_json(output_dir / "aggregate_forward_metrics.json", report["aggregate_forward_metrics"])
+    write_json(output_dir / "aggregate_calibration_review.json", report["aggregate_calibration_review"])
+    write_json(output_dir / "aggregate_box_bias_review.json", report["aggregate_box_bias_review"])
+    write_json(output_dir / "duplicate_joined_races.json", report["duplicate_joined_races"])
+    write_json(output_dir / "pending_results.json", report["pending_results"])
+    write_json(output_dir / "unsafe_result_matches.json", report["unsafe_result_matches"])
+    write_json(output_dir / "forward_shadow_result_aggregate_report.json", report)
+    write_text(output_dir / "SUMMARY.md", build_summary(report))
+    write_text(output_dir / "final_status.txt", str(report["final_status"]) + "\n")
+    return {
+        "output_dir": relpath(output_dir),
+        "final_status": report["final_status"],
+        "safe_joined_race_count": report["aggregate_forward_metrics"]["safe_joined_race_count"],
+        "pending_race_count": report["aggregate_forward_metrics"]["pending_race_count"],
+        "unsafe_match_count": report["aggregate_forward_metrics"]["unsafe_match_count"],
+        "duplicate_joined_race_count": report["duplicate_joined_race_count"],
+        "protected_paths_unchanged": report["protected_paths_unchanged"],
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence-root", type=Path, default=DEFAULT_EVIDENCE_ROOT)
+    parser.add_argument("--output-dir", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = run_aggregate(evidence_root=args.evidence_root, output_dir=args.output_dir)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/forward_shadow_status_report.py
+++ b/scripts/forward_shadow_status_report.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Build a rolling report-only status for forward shadow reliability.
+
+The report combines result-join metrics, sidecar metadata gates, live/training
+coverage, and activation-gate decisions into one evidence packet. It does not
+write predictions, labels, DB rows, registry entries, EV, betting output, or
+production model pointers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_EVIDENCE_ROOT = ROOT / "artifacts/full_evidence_orchestration_20260525"
+OUTPUT_PREFIX = "artifacts/full_evidence_orchestration_20260525/forward_shadow_status_"
+DEFAULT_PROTECTED_PATHS = (
+    ROOT / "greyhound_racing_data.db",
+    ROOT / "greyhound_racing_data_writable.db",
+    ROOT / "model_registry/best_metadata.json",
+    ROOT / "docs/model_contracts/v4_feature_contract.json",
+    ROOT / "artifacts/prediction_snapshots/manifest.jsonl",
+)
+EXPECTED_OFFICIAL_RACES = 214
+EXPECTED_OFFICIAL_DOG_ROWS = 1493
+DEFAULT_MIN_JOINED_RACES = 20
+
+STATUS_DB_BLOCKED = "BLOCKED_DB_STATE"
+STATUS_COLLECT_MORE = "CONTINUE_FORWARD_SHADOW_COLLECTION"
+STATUS_READY_REVIEW = "READY_FOR_FORWARD_SHADOW_REVIEW_REPORT_ONLY"
+STATUS_REVIEW_KEEP_QUARANTINED = "FORWARD_REVIEW_READY_KEEP_QUARANTINED"
+
+
+def relpath(path: Path | None) -> str | None:
+    if path is None:
+        return None
+    try:
+        return os.path.relpath(path.resolve(), ROOT.resolve())
+    except ValueError:
+        return str(path)
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def protected_hashes(paths: Sequence[Path] = DEFAULT_PROTECTED_PATHS) -> dict[str, str | None]:
+    return {relpath(path) or str(path): sha256_file(path) for path in paths}
+
+
+def db_state(db_path: Path) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "db_path": relpath(db_path),
+        "status": "FAIL",
+        "fail_reasons": [],
+    }
+    if not db_path.exists():
+        report["fail_reasons"].append("db_missing")
+        return report
+    try:
+        connection = sqlite3.connect(f"file:{db_path.resolve()}?mode=ro", uri=True)
+        try:
+            quick_check = connection.execute("PRAGMA quick_check").fetchone()[0]
+            official_races = connection.execute(
+                "SELECT count(DISTINCT race_id) FROM race_metadata "
+                "WHERE winner_source='thedogs_official'"
+            ).fetchone()[0]
+            official_dog_rows = connection.execute(
+                "SELECT count(*) FROM dog_race_data WHERE data_source='thedogs_official'"
+            ).fetchone()[0]
+        finally:
+            connection.close()
+    except Exception as exc:  # pragma: no cover - defensive artifact reporting
+        report["fail_reasons"].append(f"db_read_failed:{type(exc).__name__}")
+        return report
+    report.update(
+        {
+            "quick_check": quick_check,
+            "official_races": int(official_races),
+            "official_dog_rows": int(official_dog_rows),
+        }
+    )
+    if quick_check != "ok":
+        report["fail_reasons"].append("quick_check_not_ok")
+    if official_races != EXPECTED_OFFICIAL_RACES:
+        report["fail_reasons"].append("official_race_count_mismatch")
+    if official_dog_rows != EXPECTED_OFFICIAL_DOG_ROWS:
+        report["fail_reasons"].append("official_dog_row_count_mismatch")
+    if not report["fail_reasons"]:
+        report["status"] = "PASS"
+    return report
+
+
+def latest_artifact(root: Path, prefix: str, required_file: str) -> Path | None:
+    candidates = [
+        item
+        for item in root.glob(f"{prefix}*")
+        if item.is_dir() and (item / required_file).exists()
+    ]
+    return sorted(candidates)[-1] if candidates else None
+
+
+def load_json(path: Path | None) -> dict[str, Any] | None:
+    if path is None or not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def metric_summary(metrics: Mapping[str, Any] | None) -> dict[str, Any]:
+    metrics = metrics or {}
+    return {
+        "safe_joined_race_count": int(metrics.get("safe_joined_race_count") or 0),
+        "pending_race_count": int(metrics.get("pending_race_count") or 0),
+        "unsafe_match_count": int(metrics.get("unsafe_match_count") or 0),
+        "top1": metrics.get("top1"),
+        "top3": metrics.get("top3"),
+        "mean_winner_rank": metrics.get("mean_winner_rank"),
+        "brier": metrics.get("brier"),
+        "logloss": metrics.get("logloss"),
+        "probability_sum_max_error_joined_races": metrics.get(
+            "probability_sum_max_error_joined_races"
+        ),
+        "winner_ranks": metrics.get("winner_ranks") or [],
+    }
+
+
+def activation_summary(report: Mapping[str, Any] | None) -> dict[str, Any]:
+    report = report or {}
+    return {
+        "final_status": report.get("final_status"),
+        "activation_allowed_features": report.get("activation_allowed_features") or [],
+        "kept_quarantined_features": report.get("kept_quarantined_features") or [],
+    }
+
+
+def sidecar_summary(report: Mapping[str, Any] | None) -> dict[str, Any]:
+    report = report or {}
+    classification = report.get("classification") or {}
+    return {
+        "final_status": report.get("final_status"),
+        "eligible_count": classification.get("eligible_count"),
+        "malformed_count": classification.get("malformed_count"),
+        "stale_count": classification.get("stale_count"),
+        "prejump_sidecar_metadata_required": classification.get(
+            "prejump_sidecar_metadata_required"
+        ),
+    }
+
+
+def artifact_final_status(directory: Path | None) -> str | None:
+    if directory is None:
+        return None
+    path = directory / "final_status.txt"
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8").strip() or None
+
+
+def coverage_summary(
+    report: Mapping[str, Any] | None,
+    selected_metrics: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    report = report or {}
+    latest_metrics = (
+        dict(selected_metrics)
+        if selected_metrics is not None
+        else report.get("latest_forward_metrics_summary") or {}
+    )
+    return {
+        "final_status": report.get("final_status"),
+        "blocked_reasons": report.get("blocked_reasons") or [],
+        "latest_forward_metrics_summary": latest_metrics,
+        "training_feature_coverage": report.get("training_feature_coverage") or {},
+        "live_sidecar_feature_coverage": report.get("live_sidecar_feature_coverage") or {},
+    }
+
+
+def decide_status(
+    *,
+    db_report: Mapping[str, Any],
+    metrics: Mapping[str, Any],
+    activation: Mapping[str, Any],
+    min_joined_races: int,
+) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+    if db_report.get("status") != "PASS":
+        return STATUS_DB_BLOCKED, ["db_state_not_pass"]
+    if int(metrics.get("safe_joined_race_count") or 0) < min_joined_races:
+        reasons.append("safe_joined_race_count_below_review_min")
+    if int(metrics.get("pending_race_count") or 0) > 0:
+        reasons.append("pending_official_results_remain")
+    if int(metrics.get("unsafe_match_count") or 0) > 0:
+        reasons.append("unsafe_identity_matches_present")
+    probability_error = metrics.get("probability_sum_max_error_joined_races")
+    if probability_error is None or float(probability_error) > 1e-6:
+        reasons.append("probability_sum_error_not_pass")
+    kept_quarantined = activation.get("kept_quarantined_features") or []
+    if kept_quarantined:
+        reasons.append("features_remain_quarantined")
+    if reasons:
+        return STATUS_COLLECT_MORE, reasons
+    if kept_quarantined:
+        return STATUS_REVIEW_KEEP_QUARANTINED, reasons
+    return STATUS_READY_REVIEW, []
+
+
+def build_status_report(
+    *,
+    evidence_root: Path,
+    db_path: Path,
+    aggregate_result_dir: Path | None = None,
+    result_join_dir: Path | None = None,
+    sidecar_gate_dir: Path | None = None,
+    live_feature_audit_dir: Path | None = None,
+    activation_gate_dir: Path | None = None,
+    coverage_gap_dir: Path | None = None,
+    min_joined_races: int = DEFAULT_MIN_JOINED_RACES,
+    generated_at: datetime | None = None,
+) -> dict[str, Any]:
+    generated_at = generated_at or datetime.now().astimezone()
+    aggregate_result_dir = aggregate_result_dir or latest_artifact(
+        evidence_root, "forward_shadow_result_aggregate_", "aggregate_forward_metrics.json"
+    )
+    result_join_dir = result_join_dir or latest_artifact(
+        evidence_root, "forward_shadow_result_join_", "shadow_forward_metrics.json"
+    )
+    sidecar_gate_dir = sidecar_gate_dir or latest_artifact(
+        evidence_root, "prejump_sidecar_gate_audit_", "prejump_sidecar_gate_audit.json"
+    )
+    live_feature_audit_dir = live_feature_audit_dir or latest_artifact(
+        evidence_root,
+        "sidecar_target_metadata_live_feature_audit_",
+        "sidecar_target_metadata_live_feature_audit.json",
+    )
+    activation_gate_dir = activation_gate_dir or latest_artifact(
+        evidence_root, "shadow_feature_activation_gate_", "feature_activation_gate_report.json"
+    )
+    coverage_gap_dir = coverage_gap_dir or latest_artifact(
+        evidence_root,
+        "train_live_feature_coverage_gap_audit_",
+        "train_live_feature_coverage_gap_audit.json",
+    )
+
+    db_report = db_state(db_path)
+    if aggregate_result_dir is not None:
+        metrics = metric_summary(load_json(aggregate_result_dir / "aggregate_forward_metrics.json"))
+        result_metric_source = "aggregate_forward_metrics"
+    else:
+        metrics = metric_summary(
+            load_json(result_join_dir / "shadow_forward_metrics.json") if result_join_dir else None
+        )
+        result_metric_source = "latest_single_result_join"
+    activation = activation_summary(
+        load_json(activation_gate_dir / "feature_activation_gate_report.json")
+        if activation_gate_dir
+        else None
+    )
+    sidecar_gate = sidecar_summary(
+        load_json(sidecar_gate_dir / "prejump_sidecar_gate_audit.json")
+        if sidecar_gate_dir
+        else None
+    )
+    if not sidecar_gate.get("final_status"):
+        sidecar_gate["final_status"] = artifact_final_status(sidecar_gate_dir)
+    final_status, reasons = decide_status(
+        db_report=db_report,
+        metrics=metrics,
+        activation=activation,
+        min_joined_races=min_joined_races,
+    )
+    return {
+        "schema_version": "forward_shadow_status_report_v1",
+        "generated_at": generated_at.isoformat(),
+        "final_status": final_status,
+        "status_reasons": reasons,
+        "min_joined_races_for_review": min_joined_races,
+        "db_state": db_report,
+        "forward_metrics": metrics,
+        "activation_gate": activation,
+        "prejump_sidecar_gate": sidecar_gate,
+        "live_feature_audit": load_json(
+            live_feature_audit_dir / "sidecar_target_metadata_live_feature_audit.json"
+        )
+        if live_feature_audit_dir
+        else None,
+        "coverage_gap": coverage_summary(
+            load_json(coverage_gap_dir / "train_live_feature_coverage_gap_audit.json")
+            if coverage_gap_dir
+            else None,
+            selected_metrics=metrics,
+        ),
+        "source_dirs": {
+            "aggregate_result_dir": relpath(aggregate_result_dir),
+            "result_join_dir": relpath(result_join_dir),
+            "sidecar_gate_dir": relpath(sidecar_gate_dir),
+            "live_feature_audit_dir": relpath(live_feature_audit_dir),
+            "activation_gate_dir": relpath(activation_gate_dir),
+            "coverage_gap_dir": relpath(coverage_gap_dir),
+        },
+        "result_metric_source": result_metric_source,
+        "no_write_guarantees": {
+            "production_promotion": False,
+            "registry_mutation": False,
+            "production_pointer_update": False,
+            "production_prediction_write": False,
+            "db_write": False,
+            "label_write": False,
+            "tgr_enabled": False,
+            "betting_or_ev_output": False,
+        },
+    }
+
+
+def assert_output_dir_safe(output_dir: Path) -> Path:
+    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
+    try:
+        relative = logical.absolute().relative_to(ROOT.absolute())
+    except ValueError as exc:
+        raise ValueError("output_dir_must_be_inside_repo") from exc
+    if ".." in relative.parts:
+        raise ValueError("output_dir_must_not_contain_parent_traversal")
+    if not relative.as_posix().startswith(OUTPUT_PREFIX):
+        raise ValueError(f"output_dir_must_be_forward_shadow_status_artifact:{relative}")
+    return logical.absolute()
+
+
+def build_summary(report: Mapping[str, Any]) -> str:
+    metrics = report.get("forward_metrics") or {}
+    activation = report.get("activation_gate") or {}
+    lines = [
+        "# Forward Shadow Status",
+        "",
+        f"- Final status: `{report.get('final_status')}`",
+        f"- Reasons: `{report.get('status_reasons')}`",
+        f"- Safe joined races: `{metrics.get('safe_joined_race_count')}`",
+        f"- Pending races: `{metrics.get('pending_race_count')}`",
+        f"- Unsafe matches: `{metrics.get('unsafe_match_count')}`",
+        f"- Top1: `{metrics.get('top1')}`",
+        f"- Top3: `{metrics.get('top3')}`",
+        f"- Mean winner rank: `{metrics.get('mean_winner_rank')}`",
+        f"- Brier: `{metrics.get('brier')}`",
+        f"- LogLoss: `{metrics.get('logloss')}`",
+        f"- Quarantined features: `{activation.get('kept_quarantined_features')}`",
+        "",
+        "## Decision",
+        "- Continue collecting forward shadow results.",
+        "- Keep `quarantine_feature` for same-distance/same-grade timing fields.",
+        "- Do not promote, enable TGR, mutate registry, write DB labels, or write betting/EV outputs.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def run_status_report(
+    *,
+    evidence_root: Path = DEFAULT_EVIDENCE_ROOT,
+    output_dir: Path | None = None,
+    db_path: Path = ROOT / "greyhound_racing_data.db",
+    min_joined_races: int = DEFAULT_MIN_JOINED_RACES,
+) -> dict[str, Any]:
+    generated_at = datetime.now().astimezone()
+    output_dir = output_dir or evidence_root / f"forward_shadow_status_{generated_at.strftime('%Y%m%dT%H%M%S%z')}"
+    output_dir = assert_output_dir_safe(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=False)
+    protected_before = protected_hashes()
+    report = build_status_report(
+        evidence_root=evidence_root,
+        db_path=db_path,
+        min_joined_races=min_joined_races,
+        generated_at=generated_at,
+    )
+    protected_after = protected_hashes()
+    report["protected_hashes_before"] = protected_before
+    report["protected_hashes_after"] = protected_after
+    report["protected_paths_unchanged"] = protected_before == protected_after
+    if not report["protected_paths_unchanged"]:
+        report["final_status"] = "BLOCKED_PROTECTED_PATH_MUTATION"
+        report.setdefault("status_reasons", []).append("protected_paths_changed")
+    write_json(output_dir / "forward_shadow_status_report.json", report)
+    write_text(output_dir / "SUMMARY.md", build_summary(report))
+    write_text(output_dir / "final_status.txt", str(report["final_status"]) + "\n")
+    return {
+        "output_dir": relpath(output_dir),
+        "final_status": report["final_status"],
+        "status_reasons": report["status_reasons"],
+        "safe_joined_race_count": report["forward_metrics"]["safe_joined_race_count"],
+        "pending_race_count": report["forward_metrics"]["pending_race_count"],
+        "protected_paths_unchanged": report["protected_paths_unchanged"],
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence-root", type=Path, default=DEFAULT_EVIDENCE_ROOT)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--db", type=Path, default=ROOT / "greyhound_racing_data.db")
+    parser.add_argument("--min-joined-races", type=int, default=DEFAULT_MIN_JOINED_RACES)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = run_status_report(
+        evidence_root=args.evidence_root,
+        output_dir=args.output_dir,
+        db_path=args.db,
+        min_joined_races=args.min_joined_races,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/join_forward_shadow_results.py
+++ b/scripts/join_forward_shadow_results.py
@@ -1,0 +1,1376 @@
+#!/usr/bin/env python3
+"""Join forward shadow predictions to official TheDogs results.
+
+This command is report-only. It reads a completed shadow prediction artifact,
+looks up official TheDogs result pages, applies exact identity gates, computes
+metrics for safe joins, and writes a fresh shadow-only result-join artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import html
+import json
+import math
+import os
+import re
+import sqlite3
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+from urllib.parse import urlparse
+
+import requests
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_STR = str(ROOT)
+sys.path = [path for path in sys.path if path != ROOT_STR]
+sys.path.insert(0, ROOT_STR)
+
+from scripts.ingest_results_for_date import THEDOGS_PUBLIC_HEADERS  # noqa: E402
+from utils.race_lifecycle import extract_target_metadata_from_filename  # noqa: E402
+
+
+DEFAULT_OUTPUT_PARENT = ROOT / "artifacts/full_evidence_orchestration_20260525"
+DEFAULT_DB_PATH = ROOT / "greyhound_racing_data.db"
+DEFAULT_PROTECTED_PATHS = (
+    ROOT / "greyhound_racing_data.db",
+    ROOT / "greyhound_racing_data_writable.db",
+    ROOT / "model_registry/best_metadata.json",
+    ROOT / "docs/model_contracts/v4_feature_contract.json",
+    ROOT / "artifacts/prediction_snapshots/manifest.jsonl",
+)
+EXPECTED_OFFICIAL_RACES = 214
+EXPECTED_OFFICIAL_DOG_ROWS = 1493
+RESULT_JOIN_PREFIX = "artifacts/full_evidence_orchestration_20260525/forward_shadow_result_join_"
+PROBABILITY_COLUMN = "shadow_rf_calibrated_probability"
+NON_NAME_RESULT_BADGES = frozenset({"NBT"})
+SCRATCH_STATUSES = frozenset({"SCR", "L/SCR", "LSCR"})
+
+FINAL_STATUS_JOINED = "FORWARD_SHADOW_RESULTS_JOINED"
+FINAL_STATUS_WAITING = "WAITING_FOR_OFFICIAL_RESULTS"
+FINAL_STATUS_PARTIAL = "PARTIAL_JOIN_PENDING_MORE_RESULTS"
+FINAL_STATUS_IDENTITY_BLOCKED = "BLOCKED_IDENTITY_MATCH_FAILURE"
+FINAL_STATUS_DB_BLOCKED = "BLOCKED_DB_STATE"
+
+
+FetchHtml = Callable[[str], Mapping[str, Any]]
+
+
+def _rendered_text_from_fragment(markup: str) -> str:
+    try:
+        from bs4 import BeautifulSoup
+
+        return BeautifulSoup(markup or "", "html.parser").get_text(" ", strip=True)
+    except Exception:
+        cleaned = re.sub(r"<br\s*/?>", " ", str(markup or ""), flags=re.IGNORECASE)
+        cleaned = re.sub(r"<[^>]+>", " ", cleaned)
+        cleaned = html.unescape(cleaned)
+        return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def _rug_box_from_markup(markup: str) -> int | None:
+    for pattern in (
+        r"\brug[_-](?P<box>\d{1,2})\b",
+        r"\bbox[_-](?P<box>\d{1,2})\b",
+        r"\bdata-box=[\"'](?P<box>\d{1,2})[\"']",
+    ):
+        match = re.search(pattern, str(markup or ""), re.IGNORECASE)
+        if match:
+            return int(match.group("box"))
+    text_match = re.search(r"\b(?P<box>[1-8])\b", _rendered_text_from_fragment(markup))
+    return int(text_match.group("box")) if text_match else None
+
+
+def _finish_position_from_text(value: str) -> int | None:
+    match = re.search(r"\b(?P<position>\d{1,2})(?:st|nd|rd|th)?\b", str(value or ""), re.IGNORECASE)
+    if not match:
+        return None
+    position = int(match.group("position"))
+    return position if position > 0 else None
+
+
+def _terminal_status_from_text(value: str) -> str | None:
+    status = re.sub(r"\s+", " ", str(value or "").strip().upper())
+    if status in {"FELL", "SCR", "L/SCR", "LSCR", "DNF", "DISQ"}:
+        return status
+    return None
+
+
+def _clean_official_runner_name(value: str) -> str | None:
+    text = re.sub(r"\s+", " ", str(value or "").strip())
+    text = re.sub(r"^\s*\d{1,2}\s*[\.\):-]\s*", "", text)
+    text = re.sub(r"\s+\d{1,2}\.\d{2}\s+T:\s+.*$", "", text)
+    text = re.sub(r"\s+T:\s+.*$", "", text)
+    return text or None
+
+
+def thedogs_result_urls_from_race_url(url: str) -> list[str]:
+    parsed = urlparse(str(url or ""))
+    if not parsed.scheme or not parsed.netloc:
+        return []
+    base = parsed._replace(query="", fragment="").geturl().rstrip("/")
+    if not base:
+        return []
+    if base.endswith("/results"):
+        return [f"{base}?trial=false", base]
+    return [f"{base}/results?trial=false", f"{base}/results", f"{base}?trial=false", base]
+
+
+def parse_thedogs_result_html_runner_rows(markup: str) -> list[dict[str, Any]]:
+    if not str(markup or "").strip():
+        return []
+
+    try:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(markup or "", "html.parser")
+        rows: list[dict[str, Any]] = []
+        for row in soup.select("table.race-runners--result tr.race-runner"):
+            position_cell = row.select_one("td.race-runners__finish-position")
+            box_cell = row.select_one("td.race-runners__box")
+            name_cell = row.select_one("td.race-runners__name")
+            if box_cell is None or name_cell is None:
+                continue
+            position_text = position_cell.get_text(" ", strip=True) if position_cell else ""
+            box_number = _rug_box_from_markup(str(box_cell))
+            dog_name = _clean_official_runner_name(name_cell.get_text(" ", strip=True))
+            if box_number is None or not dog_name:
+                continue
+            rows.append(
+                {
+                    "box_number": box_number,
+                    "dog_name": dog_name,
+                    "finish_position": _finish_position_from_text(position_text),
+                    "status": _terminal_status_from_text(position_text),
+                }
+            )
+        return rows
+    except Exception:
+        rows = []
+        row_pattern = re.compile(
+            r"<tr\b(?=[^>]*\brace-runner\b)[^>]*>(?P<row>.*?)</tr>",
+            re.IGNORECASE | re.DOTALL,
+        )
+        cell_patterns = {
+            "position": re.compile(
+                r"<td\b(?=[^>]*\brace-runners__finish-position\b)[^>]*>(?P<value>.*?)</td>",
+                re.IGNORECASE | re.DOTALL,
+            ),
+            "box": re.compile(
+                r"<td\b(?=[^>]*\brace-runners__box\b)[^>]*>(?P<value>.*?)</td>",
+                re.IGNORECASE | re.DOTALL,
+            ),
+            "name": re.compile(
+                r"<td\b(?=[^>]*\brace-runners__name\b)[^>]*>(?P<value>.*?)</td>",
+                re.IGNORECASE | re.DOTALL,
+            ),
+        }
+        for row_match in row_pattern.finditer(str(markup or "")):
+            row_markup = row_match.group("row")
+            box_match = cell_patterns["box"].search(row_markup)
+            name_match = cell_patterns["name"].search(row_markup)
+            if not box_match or not name_match:
+                continue
+            position_match = cell_patterns["position"].search(row_markup)
+            position_text = (
+                _rendered_text_from_fragment(position_match.group("value"))
+                if position_match
+                else ""
+            )
+            box_number = _rug_box_from_markup(box_match.group("value"))
+            dog_name = _clean_official_runner_name(
+                _rendered_text_from_fragment(name_match.group("value"))
+            )
+            if box_number is None or not dog_name:
+                continue
+            rows.append(
+                {
+                    "box_number": box_number,
+                    "dog_name": dog_name,
+                    "finish_position": _finish_position_from_text(position_text),
+                    "status": _terminal_status_from_text(position_text),
+                }
+            )
+        return rows
+
+
+def thedogs_result_rows_present(markup: str) -> bool:
+    if not str(markup or "").strip():
+        return False
+    try:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(markup or "", "html.parser")
+        return bool(soup.select("table.race-runners--result tr.race-runner"))
+    except Exception:
+        return bool(
+            re.search(
+                r"<tr\b(?=[^>]*\brace-runner\b)",
+                str(markup or ""),
+                re.IGNORECASE | re.DOTALL,
+            )
+        )
+
+
+def now_id(now: datetime | None = None) -> str:
+    return (now or datetime.now().astimezone()).strftime("%Y%m%dT%H%M%S%z")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def write_json(path: Path, payload: object) -> None:
+    write_text(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def write_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def sha256_file(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def relpath(path: Path) -> str:
+    try:
+        return os.path.relpath(path.resolve(), ROOT.resolve())
+    except ValueError:
+        return str(path)
+
+
+def assert_result_join_output_dir_safe(output_dir: Path) -> Path:
+    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
+    try:
+        relative = logical.absolute().relative_to(ROOT.absolute())
+    except ValueError as exc:
+        raise ValueError("output_dir_must_be_inside_repo") from exc
+    if ".." in relative.parts:
+        raise ValueError("output_dir_must_not_contain_parent_traversal")
+    if not relative.as_posix().startswith(RESULT_JOIN_PREFIX):
+        raise ValueError(f"output_dir_must_be_forward_shadow_result_join_artifact:{relative}")
+    return logical.absolute()
+
+
+def unique_default_output_dir(output_parent: Path, generated_at: datetime) -> Path:
+    base = output_parent / f"forward_shadow_result_join_{now_id(generated_at)}"
+    output_dir = assert_result_join_output_dir_safe(base)
+    if not output_dir.exists():
+        return output_dir
+    for index in range(1, 1000):
+        candidate = assert_result_join_output_dir_safe(Path(f"{base}_{index:03d}"))
+        if not candidate.exists():
+            return candidate
+    raise RuntimeError("forward_shadow_result_join_output_dir_collision_exhausted")
+
+
+def verify_db_state(db_path: Path) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "schema_version": "forward_shadow_result_join_db_state_v1",
+        "db_path": relpath(db_path),
+        "expected_official_races": EXPECTED_OFFICIAL_RACES,
+        "expected_official_dog_rows": EXPECTED_OFFICIAL_DOG_ROWS,
+        "status": "FAIL",
+        "fail_reasons": [],
+    }
+    if not db_path.exists():
+        report["fail_reasons"].append("db_missing")
+        return report
+
+    try:
+        report["sha256"] = sha256_file(db_path)
+        connection = sqlite3.connect(f"file:{db_path.resolve()}?mode=ro", uri=True)
+        try:
+            quick_check = connection.execute("PRAGMA quick_check").fetchone()[0]
+            official_races = connection.execute(
+                "SELECT count(DISTINCT race_id) FROM race_metadata "
+                "WHERE winner_source='thedogs_official'"
+            ).fetchone()[0]
+            official_dog_rows = connection.execute(
+                "SELECT count(*) FROM dog_race_data "
+                "WHERE data_source='thedogs_official'"
+            ).fetchone()[0]
+        finally:
+            connection.close()
+    except Exception as exc:  # pragma: no cover - defensive artifact reporting
+        report["fail_reasons"].append(f"db_read_failed:{exc!r}")
+        return report
+
+    report.update(
+        {
+            "quick_check": quick_check,
+            "official_races": official_races,
+            "official_dog_rows": official_dog_rows,
+        }
+    )
+    if quick_check != "ok":
+        report["fail_reasons"].append("quick_check_not_ok")
+    if official_races != EXPECTED_OFFICIAL_RACES:
+        report["fail_reasons"].append("official_race_count_mismatch")
+    if official_dog_rows != EXPECTED_OFFICIAL_DOG_ROWS:
+        report["fail_reasons"].append("official_dog_row_count_mismatch")
+    if not report["fail_reasons"]:
+        report["status"] = "PASS"
+    return report
+
+
+def protected_path_hashes(paths: Sequence[Path] | None = None) -> dict[str, str | None]:
+    paths = DEFAULT_PROTECTED_PATHS if paths is None else paths
+    return {relpath(path): sha256_file(path) for path in paths}
+
+
+def normalize_result_identity_name(value: object) -> str:
+    text = re.sub(r"\s+", " ", str(value or "").strip())
+    text = re.sub(r"^\s*\d{1,2}\s*[\.)\-:]\s*", "", text)
+    changed = True
+    while changed:
+        changed = False
+        for badge in NON_NAME_RESULT_BADGES:
+            updated = re.sub(rf"\s+{re.escape(badge)}\s*$", "", text, flags=re.IGNORECASE)
+            if updated != text:
+                text = updated.strip()
+                changed = True
+    return re.sub(r"[^a-z0-9]+", "", text.casefold())
+
+
+def display_name_without_result_badges(value: object) -> str:
+    text = re.sub(r"\s+", " ", str(value or "").strip())
+    text = re.sub(r"^\s*\d{1,2}\s*[\.)\-:]\s*", "", text)
+    for badge in NON_NAME_RESULT_BADGES:
+        text = re.sub(rf"\s+{re.escape(badge)}\s*$", "", text, flags=re.IGNORECASE)
+    return text.strip()
+
+
+def clip_probability(value: float) -> float:
+    return min(max(float(value), 1e-15), 1.0 - 1e-15)
+
+
+def parse_current_time(value: str | None) -> datetime:
+    if not value:
+        return datetime.now().astimezone()
+    text = value.strip()
+    if len(text) >= 5 and text[-5] in {"+", "-"} and text[-4:].isdigit():
+        text = f"{text[:-5]}{text[-5:-2]}:{text[-2:]}"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        return parsed.astimezone()
+    return parsed
+
+
+def parse_datetime(value: object) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+
+
+def date_from_thedogs_url(url: str) -> str | None:
+    match = re.search(r"/racing/[^/]+/(\d{4}-\d{2}-\d{2})/", str(url or ""))
+    return match.group(1) if match else None
+
+
+def base_url_without_query(url: str) -> str:
+    parsed = urlparse(str(url or ""))
+    return parsed._replace(query="", fragment="").geturl().rstrip("/")
+
+
+def official_result_candidate_urls(race_url: str | None) -> list[str]:
+    if not race_url:
+        return []
+    candidates = [
+        race_url,
+        base_url_without_query(race_url),
+        *thedogs_result_urls_from_race_url(race_url),
+    ]
+    output: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            output.append(candidate)
+    return output
+
+
+def default_fetch_html(url: str) -> Mapping[str, Any]:
+    session = requests.Session()
+    session.trust_env = False
+    try:
+        response = session.get(
+            url,
+            headers=THEDOGS_PUBLIC_HEADERS,
+            timeout=20,
+            allow_redirects=True,
+        )
+        return {
+            "url": url,
+            "final_url": response.url,
+            "status_code": response.status_code,
+            "text": response.text or "",
+            "error": None,
+        }
+    except Exception as exc:  # pragma: no cover - network-dependent
+        return {
+            "url": url,
+            "final_url": None,
+            "status_code": None,
+            "text": "",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+
+def load_shadow_predictions(shadow_run_dir: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    predictions_path = shadow_run_dir / "shadow_predictions.csv"
+    predictions: list[dict[str, Any]] = []
+    malformed_rows: list[dict[str, Any]] = []
+    with predictions_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        for line_number, row in enumerate(csv.DictReader(handle), start=2):
+            parsed = dict(row)
+            try:
+                parsed["box"] = int(parsed["box"])
+                parsed["predicted_rank"] = int(parsed["predicted_rank"])
+                parsed[PROBABILITY_COLUMN] = float(parsed[PROBABILITY_COLUMN])
+                parsed["shadow_rf_uncalibrated_probability"] = float(
+                    parsed["shadow_rf_uncalibrated_probability"]
+                )
+            except (TypeError, ValueError, KeyError) as exc:
+                malformed_rows.append(
+                    {
+                        "line_number": line_number,
+                        "race_id": parsed.get("race_id"),
+                        "dog_name": parsed.get("dog_name"),
+                        "reason": "invalid_prediction_row_numeric_field",
+                        "error": f"{type(exc).__name__}: {exc}",
+                        "row": parsed,
+                    }
+                )
+                continue
+            predictions.append(parsed)
+    return predictions, malformed_rows
+
+
+def race_key_from_metadata(meta: Mapping[str, Any], fallback_filename: str | None = None) -> str | None:
+    filename = meta.get("filename") or fallback_filename
+    if filename:
+        stem = Path(str(filename)).stem
+        if re.match(r"^Race\s+\d+\s+-\s+.+\s+-\s+\d{4}-\d{2}-\d{2}$", stem, re.I):
+            return stem
+
+    info = meta.get("race_info") or {}
+    venue = info.get("venue") or meta.get("venue")
+    race_number = info.get("race_number") or meta.get("race_number")
+    race_date = info.get("date") or meta.get("race_date")
+    if venue and race_number and race_date:
+        return f"Race {int(race_number)} - {str(venue).upper()} - {race_date}"
+    return None
+
+
+def load_shadow_race_metadata(
+    shadow_run_dir: Path,
+    refresh_metadata_path: Path | None = None,
+) -> dict[str, dict[str, Any]]:
+    race_meta: dict[str, dict[str, Any]] = {}
+    for meta_path in sorted((shadow_run_dir / "eligible_inputs").glob("source_*/*.metadata.json")):
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        race_id = race_key_from_metadata(meta)
+        if not race_id:
+            continue
+        info = meta.get("race_info") or {}
+        filename = str(meta.get("filename") or meta_path.name.replace(".metadata.json", ""))
+        filename_meta = extract_target_metadata_from_filename(filename)
+        race_meta[race_id] = {
+            "race_id": race_id,
+            "source_metadata_path": relpath(meta_path),
+            "source_csv_path": relpath(meta_path.with_name(meta_path.name.replace(".metadata.json", ""))),
+            "race_url": meta.get("race_url") or meta.get("metadata_source_url") or info.get("url"),
+            "venue": info.get("venue") or filename_meta.get("venue"),
+            "race_number": int(info.get("race_number") or filename_meta.get("race_number")),
+            "race_date": info.get("date") or filename_meta.get("race_date"),
+            "race_time": info.get("race_time"),
+            "metadata_is_leakage_safe": meta.get("metadata_is_leakage_safe"),
+            "canonical_runner_alignment": (
+                dict(meta.get("canonical_runner_alignment"))
+                if isinstance(meta.get("canonical_runner_alignment"), Mapping)
+                else None
+            ),
+            "runner_completeness_after_canonical_alignment": (
+                dict(meta.get("runner_completeness_after_canonical_alignment"))
+                if isinstance(meta.get("runner_completeness_after_canonical_alignment"), Mapping)
+                else None
+            ),
+        }
+
+    if refresh_metadata_path and refresh_metadata_path.exists():
+        refresh = json.loads(refresh_metadata_path.read_text(encoding="utf-8"))
+        for item in refresh.get("selected_races") or []:
+            race_url = str(item.get("race_url") or "")
+            race_date = item.get("race_date") or date_from_thedogs_url(race_url)
+            venue = item.get("venue")
+            race_number = item.get("race_number")
+            if not (race_date and venue and race_number):
+                continue
+            race_id = f"Race {int(race_number)} - {str(venue).upper()} - {race_date}"
+            race_meta.setdefault(race_id, {"race_id": race_id})
+            race_meta[race_id].update(
+                {
+                    "race_url": race_url or race_meta[race_id].get("race_url"),
+                    "venue": str(venue).upper(),
+                    "race_number": int(race_number),
+                    "race_date": race_date,
+                    "jump_datetime": item.get("jump_datetime"),
+                    "refresh_source_path": relpath(refresh_metadata_path),
+                }
+            )
+    return race_meta
+
+
+def classify_result_identity_join(
+    *,
+    race_id: str,
+    prediction_rows: Sequence[Mapping[str, Any]],
+    official_rows: Sequence[Mapping[str, Any]],
+    race_url: str | None = None,
+    result_url: str | None = None,
+) -> dict[str, Any]:
+    by_box: dict[int, Mapping[str, Any]] = {}
+    duplicate_boxes: list[int] = []
+    for official in official_rows:
+        box = int(official.get("box_number") or 0)
+        if not box:
+            continue
+        if box in by_box:
+            duplicate_boxes.append(box)
+        by_box[box] = official
+
+    expected_boxes = {int(row.get("box") or 0) for row in prediction_rows}
+    official_boxes = set(by_box)
+    missing_predicted_boxes = sorted(expected_boxes - official_boxes)
+    extra_official_boxes = sorted(official_boxes - expected_boxes)
+
+    allowed_extra_scratched: list[dict[str, Any]] = []
+    disallowed_extra: list[dict[str, Any]] = []
+    for box in extra_official_boxes:
+        official = by_box[box]
+        status = str(official.get("status") or "").upper()
+        item = {
+            "box": box,
+            "status": status,
+            "dog_name": official.get("dog_name"),
+        }
+        if status in SCRATCH_STATUSES:
+            allowed_extra_scratched.append(item)
+        else:
+            disallowed_extra.append(item)
+
+    name_mismatches: list[dict[str, Any]] = []
+    for prediction in prediction_rows:
+        box = int(prediction.get("box") or 0)
+        official = by_box.get(box)
+        if official is None:
+            continue
+        prediction_identity = normalize_result_identity_name(prediction.get("dog_name"))
+        official_identity = normalize_result_identity_name(official.get("dog_name"))
+        if prediction_identity != official_identity:
+            name_mismatches.append(
+                {
+                    "box": box,
+                    "prediction_dog_name": prediction.get("dog_name"),
+                    "official_dog_name": official.get("dog_name"),
+                    "official_dog_name_after_badge_strip": display_name_without_result_badges(
+                        official.get("dog_name")
+                    ),
+                    "prediction_identity": prediction_identity,
+                    "official_identity": official_identity,
+                }
+            )
+
+    winners = [
+        official
+        for official in official_rows
+        if official.get("finish_position") == 1
+        and int(official.get("box_number") or 0) in expected_boxes
+    ]
+
+    identity_errors: list[str] = []
+    if duplicate_boxes:
+        identity_errors.append("duplicate_official_boxes")
+    if missing_predicted_boxes:
+        identity_errors.append("missing_predicted_boxes_in_official_result")
+    if disallowed_extra:
+        identity_errors.append("extra_official_non_scratch_boxes_outside_prediction_set")
+    if name_mismatches:
+        identity_errors.append("dog_name_mismatch_after_exact_badge_stripping")
+    if len(winners) != 1:
+        identity_errors.append("winner_count_not_exactly_one")
+
+    status = "UNSAFE_QUARANTINED" if identity_errors else "SAFE_EXACT_BOX_AND_NAME_MATCH"
+    return {
+        "race_id": race_id,
+        "status": status,
+        "identity_errors": identity_errors,
+        "race_url": race_url,
+        "result_url": result_url,
+        "official_runner_rows": [dict(row) for row in official_rows],
+        "duplicate_official_boxes": duplicate_boxes,
+        "missing_predicted_boxes": missing_predicted_boxes,
+        "extra_official_boxes": extra_official_boxes,
+        "allowed_extra_scratched_official_boxes": allowed_extra_scratched,
+        "disallowed_extra_official_boxes": disallowed_extra,
+        "name_mismatches": name_mismatches,
+        "winner_count": len(winners),
+        "winner_box": int(winners[0]["box_number"]) if len(winners) == 1 else None,
+    }
+
+
+def joined_rows_for_safe_race(
+    *,
+    race_meta: Mapping[str, Any],
+    prediction_rows: Sequence[Mapping[str, Any]],
+    identity: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    official_by_box = {
+        int(row["box_number"]): row for row in identity.get("official_runner_rows", [])
+    }
+    winner_box = int(identity["winner_box"])
+    winner_rank = None
+    joined_rows: list[dict[str, Any]] = []
+    for prediction in sorted(prediction_rows, key=lambda row: int(row.get("predicted_rank") or 999)):
+        box = int(prediction["box"])
+        official = official_by_box[box]
+        is_winner = box == winner_box
+        if is_winner:
+            winner_rank = int(prediction["predicted_rank"])
+        joined_rows.append(
+            {
+                "race_id": race_meta.get("race_id"),
+                "race_date": race_meta.get("race_date"),
+                "venue": race_meta.get("venue"),
+                "race_number": race_meta.get("race_number"),
+                "jump_datetime": race_meta.get("jump_datetime"),
+                "race_url": race_meta.get("race_url"),
+                "result_url": identity.get("result_url"),
+                "box": box,
+                "dog_name": prediction.get("dog_name"),
+                "official_dog_name": official.get("dog_name"),
+                "official_dog_name_after_badge_strip": display_name_without_result_badges(
+                    official.get("dog_name")
+                ),
+                "finish_position": official.get("finish_position"),
+                "is_winner": is_winner,
+                "predicted_rank": int(prediction["predicted_rank"]),
+                "shadow_rf_calibrated_probability": float(prediction[PROBABILITY_COLUMN]),
+                "shadow_rf_uncalibrated_probability": float(
+                    prediction["shadow_rf_uncalibrated_probability"]
+                ),
+                "calibration_method": prediction.get("calibration_method"),
+                "tgr_enabled": str(prediction.get("tgr_enabled")).lower() == "true",
+                "identity_match_status": "exact_box_and_normalized_name",
+                "identity_name_badge_strip": sorted(NON_NAME_RESULT_BADGES),
+                "allowed_extra_scratched_official_boxes": identity.get(
+                    "allowed_extra_scratched_official_boxes", []
+                ),
+            }
+        )
+
+    top_pick = sorted(prediction_rows, key=lambda row: int(row.get("predicted_rank") or 999))[0]
+    summary = {
+        "race_id": race_meta.get("race_id"),
+        "winner_box": winner_box,
+        "winner_predicted_rank": winner_rank,
+        "runner_count": len(prediction_rows),
+        "top_pick_box": int(top_pick["box"]),
+        "top_pick_dog_name": top_pick.get("dog_name"),
+        "top_pick_won": winner_rank == 1,
+        "winner_in_top3": bool(winner_rank is not None and winner_rank <= 3),
+    }
+    return joined_rows, summary
+
+
+def probability_reliability_bins(labels: Sequence[int], probabilities: Sequence[float]) -> list[dict[str, Any]]:
+    bins = []
+    for index in range(10):
+        start = index / 10
+        end = (index + 1) / 10
+        members = [
+            (label, probability)
+            for label, probability in zip(labels, probabilities)
+            if probability >= start and (probability < end or (end == 1.0 and probability <= end))
+        ]
+        if members:
+            labels_in_bin = [label for label, _ in members]
+            probs_in_bin = [probability for _, probability in members]
+            bins.append(
+                {
+                    "bin_start": start,
+                    "bin_end": end,
+                    "count": len(members),
+                    "mean_predicted_probability": sum(probs_in_bin) / len(probs_in_bin),
+                    "observed_rate": sum(labels_in_bin) / len(labels_in_bin),
+                }
+            )
+        else:
+            bins.append(
+                {
+                    "bin_start": start,
+                    "bin_end": end,
+                    "count": 0,
+                    "mean_predicted_probability": None,
+                    "observed_rate": None,
+                }
+            )
+    return bins
+
+
+def logistic_calibration_review(labels: Sequence[int], probabilities: Sequence[float]) -> dict[str, Any]:
+    positive = sum(labels)
+    negative = len(labels) - positive
+    if len(labels) < 30 or positive < 5 or negative < 5:
+        return {
+            "status": "insufficient_sample",
+            "sample_size": len(labels),
+            "positive_labels": positive,
+            "negative_labels": negative,
+            "minimum_required": {
+                "sample_size": 30,
+                "positive_labels": 5,
+                "negative_labels": 5,
+            },
+            "slope": None,
+            "intercept": None,
+        }
+
+    logits = [math.log(clip_probability(p) / (1.0 - clip_probability(p))) for p in probabilities]
+    if len(set(round(logit, 12) for logit in logits)) < 2:
+        return {
+            "status": "insufficient_probability_variation",
+            "sample_size": len(labels),
+            "positive_labels": positive,
+            "negative_labels": negative,
+            "slope": None,
+            "intercept": None,
+        }
+
+    intercept = 0.0
+    slope = 1.0
+    for _ in range(50):
+        g0 = g1 = h00 = h01 = h11 = 0.0
+        for logit, label in zip(logits, labels):
+            eta = max(min(intercept + slope * logit, 35.0), -35.0)
+            mean = 1.0 / (1.0 + math.exp(-eta))
+            weight = max(mean * (1.0 - mean), 1e-9)
+            diff = label - mean
+            g0 += diff
+            g1 += diff * logit
+            h00 += weight
+            h01 += weight * logit
+            h11 += weight * logit * logit
+        determinant = h00 * h11 - h01 * h01
+        if abs(determinant) < 1e-12:
+            return {
+                "status": "singular_fit",
+                "sample_size": len(labels),
+                "positive_labels": positive,
+                "negative_labels": negative,
+                "slope": None,
+                "intercept": None,
+            }
+        delta_intercept = (g0 * h11 - g1 * h01) / determinant
+        delta_slope = (h00 * g1 - h01 * g0) / determinant
+        intercept += delta_intercept
+        slope += delta_slope
+        if abs(delta_intercept) + abs(delta_slope) < 1e-8:
+            break
+
+    return {
+        "status": "computed",
+        "sample_size": len(labels),
+        "positive_labels": positive,
+        "negative_labels": negative,
+        "intercept": intercept,
+        "slope": slope,
+        "method": "logistic_regression_on_logit_probability",
+    }
+
+
+def metric_reports(
+    *,
+    shadow_run_dir: Path,
+    manifest: Mapping[str, Any],
+    predictions_by_race: Mapping[str, Sequence[Mapping[str, Any]]],
+    safe_races: Sequence[Mapping[str, Any]],
+    joined_rows: Sequence[Mapping[str, Any]],
+    pending_count: int,
+    unsafe_count: int,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    labels = [1 if row.get("is_winner") else 0 for row in joined_rows]
+    probabilities = [float(row[PROBABILITY_COLUMN]) for row in joined_rows]
+    joined_by_race: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in joined_rows:
+        joined_by_race[str(row.get("race_id"))].append(row)
+
+    if safe_races:
+        winner_ranks = [int(row["winner_predicted_rank"]) for row in safe_races]
+        top1 = sum(1 for row in safe_races if row.get("top_pick_won")) / len(safe_races)
+        top3 = sum(1 for row in safe_races if row.get("winner_in_top3")) / len(safe_races)
+        brier = sum((probability - label) ** 2 for label, probability in zip(labels, probabilities)) / len(
+            labels
+        )
+        logloss = sum(
+            -math.log(
+                clip_probability(
+                    float(next(row for row in rows if row.get("is_winner"))[PROBABILITY_COLUMN])
+                )
+            )
+            for rows in joined_by_race.values()
+        ) / len(joined_by_race)
+        probability_sum_max_error = max(
+            abs(sum(float(row[PROBABILITY_COLUMN]) for row in rows) - 1.0)
+            for rows in joined_by_race.values()
+        )
+        metrics = {
+            "schema_version": "forward_shadow_metrics_v1",
+            "status": "COMPUTED_FOR_SAFE_JOINED_RACES",
+            "source_shadow_run": relpath(shadow_run_dir),
+            "safe_joined_race_count": len(safe_races),
+            "safe_joined_runner_count": len(joined_rows),
+            "pending_race_count": pending_count,
+            "unsafe_match_count": unsafe_count,
+            "top1": top1,
+            "top3": top3,
+            "winner_ranks": winner_ranks,
+            "mean_winner_rank": sum(winner_ranks) / len(winner_ranks),
+            "brier": brier,
+            "logloss": logloss,
+            "logloss_method": "mean_negative_log_calibrated_probability_assigned_to_winner_per_race",
+            "probability_sum_max_error_joined_races": probability_sum_max_error,
+            "joined_races": list(safe_races),
+            "calibration_method": manifest.get("calibration_method"),
+            "all_missing_train_policy": manifest.get("all_missing_train_policy"),
+            "tgr_enabled": manifest.get("tgr_enabled"),
+        }
+    else:
+        metrics = {
+            "schema_version": "forward_shadow_metrics_v1",
+            "status": "NO_SAFE_JOINED_RACES",
+            "source_shadow_run": relpath(shadow_run_dir),
+            "safe_joined_race_count": 0,
+            "safe_joined_runner_count": 0,
+            "pending_race_count": pending_count,
+            "unsafe_match_count": unsafe_count,
+            "top1": None,
+            "top3": None,
+            "winner_ranks": [],
+            "mean_winner_rank": None,
+            "brier": None,
+            "logloss": None,
+            "probability_sum_max_error_joined_races": None,
+            "joined_races": [],
+            "calibration_method": manifest.get("calibration_method"),
+            "all_missing_train_policy": manifest.get("all_missing_train_policy"),
+            "tgr_enabled": manifest.get("tgr_enabled"),
+        }
+
+    calibration = {
+        "schema_version": "forward_shadow_calibration_review_v1",
+        "source_shadow_run": relpath(shadow_run_dir),
+        "safe_joined_race_count": len(safe_races),
+        "safe_joined_runner_count": len(joined_rows),
+        "calibration_method": manifest.get("calibration_method"),
+        "brier": metrics.get("brier"),
+        "logloss": metrics.get("logloss"),
+        "reliability_bins": (
+            probability_reliability_bins(labels, probabilities) if joined_rows else []
+        ),
+        "slope_intercept": (
+            logistic_calibration_review(labels, probabilities)
+            if joined_rows
+            else {"status": "no_safe_joined_rows", "slope": None, "intercept": None}
+        ),
+    }
+
+    all_top_picks = [
+        sorted(rows, key=lambda row: int(row.get("predicted_rank") or 999))[0]
+        for rows in predictions_by_race.values()
+        if rows
+    ]
+    all_top_pick_counts = Counter(str(row.get("box")) for row in all_top_picks)
+    joined_top_pick_counts = Counter(str(row.get("top_pick_box")) for row in safe_races)
+    box_bias = {
+        "schema_version": "forward_shadow_box_bias_review_v1",
+        "source_shadow_run": relpath(shadow_run_dir),
+        "all_shadow_race_count": len(predictions_by_race),
+        "all_shadow_top_pick_box_distribution": dict(
+            sorted(all_top_pick_counts.items(), key=lambda item: int(item[0]))
+        ),
+        "all_shadow_box_1_top_pick_share": (
+            all_top_pick_counts.get("1", 0) / len(all_top_picks) if all_top_picks else None
+        ),
+        "safe_joined_race_count": len(safe_races),
+        "safe_joined_top_pick_box_distribution": dict(
+            sorted(joined_top_pick_counts.items(), key=lambda item: int(item[0]))
+        ),
+        "safe_joined_box_1_top_pick_share": (
+            joined_top_pick_counts.get("1", 0) / len(safe_races) if safe_races else None
+        ),
+    }
+    return metrics, calibration, box_bias
+
+
+def final_status_for_counts(safe_count: int, pending_count: int, unsafe_count: int) -> str:
+    if safe_count and not pending_count and not unsafe_count:
+        return FINAL_STATUS_JOINED
+    if safe_count and (pending_count or unsafe_count):
+        return FINAL_STATUS_PARTIAL
+    if unsafe_count and not pending_count:
+        return FINAL_STATUS_IDENTITY_BLOCKED
+    return FINAL_STATUS_WAITING
+
+
+def build_summary(
+    *,
+    shadow_run_dir: Path,
+    generated_at: datetime,
+    final_status: str,
+    db_before: Mapping[str, Any] | None,
+    db_after: Mapping[str, Any] | None,
+    protected_unchanged: bool,
+    metrics: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+) -> str:
+    lines = [
+        "# Forward Shadow Result Join",
+        "",
+        f"- Source shadow run: `{relpath(shadow_run_dir)}`",
+        f"- Generated at: `{generated_at.isoformat()}`",
+        f"- Final verdict: `{final_status}`",
+        f"- Safe joined races: `{metrics.get('safe_joined_race_count')}`",
+        f"- Safe joined runner rows: `{metrics.get('safe_joined_runner_count')}`",
+        f"- Pending races: `{metrics.get('pending_race_count')}`",
+        f"- Unsafe/quarantined result matches: `{metrics.get('unsafe_match_count')}`",
+        f"- DB state before/after: `{db_before}` / `{db_after}`",
+        f"- Protected paths unchanged: `{protected_unchanged}`",
+        f"- Calibration: `{manifest.get('calibration_method')}`",
+        f"- All-missing-train policy: `{manifest.get('all_missing_train_policy')}`",
+        f"- TGR enabled: `{manifest.get('tgr_enabled')}`",
+        "",
+        "## Metrics",
+    ]
+    if metrics.get("safe_joined_race_count"):
+        lines.extend(
+            [
+                f"- Top1: `{metrics.get('top1')}`",
+                f"- Top3: `{metrics.get('top3')}`",
+                f"- Mean winner rank: `{metrics.get('mean_winner_rank')}`",
+                f"- Brier: `{metrics.get('brier')}`",
+                f"- LogLoss: `{metrics.get('logloss')}`",
+                f"- Winner ranks: `{metrics.get('winner_ranks')}`",
+            ]
+        )
+    else:
+        lines.append("- Metrics not computed because no race passed the safe identity join gate.")
+    lines.extend(
+        [
+            "",
+            "## Identity Policy",
+            "- Race identity came from the shadow source sidecars and TheDogs race URLs.",
+            "- Runner identity required exact box and exact normalized dog name. Fuzzy-only matches were not accepted.",
+            "- Known non-name result badges were stripped before exact comparison and recorded in the identity report.",
+            "- Extra official scratched boxes outside the prediction field were allowed only with an official scratch status.",
+            "",
+            "## Stop State",
+            "- Stopped after result reporting.",
+            "- No production promotion, registry mutation, pointer update, TGR enablement, betting/EV output, DB writes, or label writes were performed.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def join_forward_shadow_results(
+    *,
+    shadow_run_dir: Path,
+    output_parent: Path = DEFAULT_OUTPUT_PARENT,
+    output_dir: Path | None = None,
+    refresh_metadata_path: Path | None = None,
+    db_path: Path = DEFAULT_DB_PATH,
+    current_time: datetime | None = None,
+    fetch_html: FetchHtml = default_fetch_html,
+    verify_db: bool = True,
+) -> dict[str, Any]:
+    generated_at = current_time or datetime.now().astimezone()
+    shadow_run_dir = shadow_run_dir.resolve()
+    output_dir = (
+        assert_result_join_output_dir_safe(output_dir)
+        if output_dir is not None
+        else unique_default_output_dir(output_parent, generated_at)
+    )
+    output_dir.mkdir(parents=True, exist_ok=False)
+
+    db_before = verify_db_state(db_path) if verify_db else None
+    if verify_db and (not db_before or db_before.get("status") != "PASS"):
+        write_text(output_dir / "final_status.txt", FINAL_STATUS_DB_BLOCKED + "\n")
+        write_json(
+            output_dir / "identity_match_report.json",
+            {
+                "schema_version": "forward_shadow_identity_match_report_v2",
+                "generated_at": generated_at.isoformat(),
+                "source_shadow_run": relpath(shadow_run_dir),
+                "db_state_before": db_before,
+                "summary": {"verdict": FINAL_STATUS_DB_BLOCKED},
+            },
+        )
+        return {
+            "output_dir": relpath(output_dir),
+            "verdict": FINAL_STATUS_DB_BLOCKED,
+            "db_state_before": db_before,
+        }
+
+    protected_before = protected_path_hashes()
+    manifest = json.loads((shadow_run_dir / "shadow_manifest.json").read_text(encoding="utf-8"))
+    predictions, malformed_prediction_rows = load_shadow_predictions(shadow_run_dir)
+    predictions_by_race: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in predictions:
+        predictions_by_race[str(row["race_id"])].append(row)
+    for rows in predictions_by_race.values():
+        rows.sort(key=lambda row: int(row.get("predicted_rank") or 999))
+
+    race_meta = load_shadow_race_metadata(shadow_run_dir, refresh_metadata_path)
+    joined_rows: list[dict[str, Any]] = []
+    safe_races: list[dict[str, Any]] = []
+    pending_results: list[dict[str, Any]] = []
+    unsafe_matches: list[dict[str, Any]] = []
+    race_attempts: list[dict[str, Any]] = []
+
+    for race_id in sorted(predictions_by_race):
+        rows = predictions_by_race[race_id]
+        meta = dict(race_meta.get(race_id, {"race_id": race_id}))
+        meta["race_id"] = race_id
+        race_url = meta.get("race_url")
+        jump_datetime = parse_datetime(meta.get("jump_datetime"))
+        attempt: dict[str, Any] = {
+            "race_id": race_id,
+            "race_url": race_url,
+            "venue": meta.get("venue"),
+            "race_number": meta.get("race_number"),
+            "race_date": meta.get("race_date"),
+            "jump_datetime": meta.get("jump_datetime"),
+            "prediction_runner_count": len(rows),
+            "prejump_runner_alignment": {
+                "canonical_runner_alignment_status": (
+                    (meta.get("canonical_runner_alignment") or {}).get("status")
+                    if isinstance(meta.get("canonical_runner_alignment"), Mapping)
+                    else None
+                ),
+                "canonical_runner_set_status": (
+                    (meta.get("canonical_runner_alignment") or {}).get(
+                        "canonical_runner_set_status"
+                    )
+                    if isinstance(meta.get("canonical_runner_alignment"), Mapping)
+                    else None
+                ),
+                "canonical_runner_count": (
+                    (meta.get("canonical_runner_alignment") or {}).get("canonical_runner_count")
+                    if isinstance(meta.get("canonical_runner_alignment"), Mapping)
+                    else None
+                ),
+                "canonical_prediction_runner_count": (
+                    (meta.get("canonical_runner_alignment") or {}).get(
+                        "prediction_runner_count"
+                    )
+                    if isinstance(meta.get("canonical_runner_alignment"), Mapping)
+                    else None
+                ),
+                "remapped_participants": (
+                    (meta.get("canonical_runner_alignment") or {}).get("remapped_participants")
+                    if isinstance(meta.get("canonical_runner_alignment"), Mapping)
+                    else []
+                ),
+                "dropped_participants": (
+                    (meta.get("canonical_runner_alignment") or {}).get("dropped_participants")
+                    if isinstance(meta.get("canonical_runner_alignment"), Mapping)
+                    else []
+                ),
+                "runner_completeness_after_canonical_alignment": meta.get(
+                    "runner_completeness_after_canonical_alignment"
+                ),
+            },
+            "lookup_urls": [],
+            "result_status": None,
+            "identity_status": None,
+        }
+        if not race_url:
+            attempt["result_status"] = "NO_RACE_URL"
+            attempt["identity_status"] = "PENDING_OFFICIAL_RESULT"
+            pending_results.append(
+                {
+                    "race_id": race_id,
+                    "status": "PENDING_OFFICIAL_OUTCOME",
+                    "reason": "no_race_url_available_for_lookup",
+                    "metadata": meta,
+                }
+            )
+            race_attempts.append(attempt)
+            continue
+
+        official_rows: list[dict[str, Any]] = []
+        result_url = None
+        lookup_error = None
+        for candidate_url in official_result_candidate_urls(str(race_url)):
+            response = fetch_html(candidate_url)
+            text = str(response.get("text") or "")
+            lookup = {
+                "url": candidate_url,
+                "final_url": response.get("final_url"),
+                "status_code": response.get("status_code"),
+                "content_length": len(text),
+                "result_rows_present": False,
+                "parsed_runner_rows": 0,
+                "error": response.get("error"),
+            }
+            lookup_error = response.get("error") or lookup_error
+            parsed = parse_thedogs_result_html_runner_rows(text)
+            lookup["result_rows_present"] = bool(thedogs_result_rows_present(text))
+            lookup["parsed_runner_rows"] = len(parsed)
+            attempt["lookup_urls"].append(lookup)
+            if lookup["result_rows_present"] and parsed:
+                official_rows = [dict(row) for row in parsed]
+                result_url = candidate_url
+                break
+
+        if not official_rows:
+            reason = "official_result_rows_not_present"
+            if jump_datetime and generated_at < jump_datetime:
+                reason = "race_not_jumped_at_join_time"
+            attempt["result_status"] = "OFFICIAL_RESULT_NOT_AVAILABLE"
+            attempt["identity_status"] = "PENDING_OFFICIAL_RESULT"
+            pending_results.append(
+                {
+                    "race_id": race_id,
+                    "status": "PENDING_OFFICIAL_OUTCOME",
+                    "reason": reason,
+                    "race_url": race_url,
+                    "jump_datetime": meta.get("jump_datetime"),
+                    "lookup_error": lookup_error,
+                }
+            )
+            race_attempts.append(attempt)
+            continue
+
+        attempt["result_status"] = "OFFICIAL_RESULT_ROWS_FOUND"
+        attempt["winning_result_url"] = result_url
+        identity = classify_result_identity_join(
+            race_id=race_id,
+            prediction_rows=rows,
+            official_rows=official_rows,
+            race_url=str(race_url),
+            result_url=result_url,
+        )
+        attempt.update(
+            {
+                "identity_status": identity["status"],
+                "identity_errors": identity["identity_errors"],
+                "official_runner_rows": identity["official_runner_rows"],
+                "duplicate_official_boxes": identity["duplicate_official_boxes"],
+                "missing_predicted_boxes": identity["missing_predicted_boxes"],
+                "extra_official_boxes": identity["extra_official_boxes"],
+                "allowed_extra_scratched_official_boxes": identity[
+                    "allowed_extra_scratched_official_boxes"
+                ],
+                "disallowed_extra_official_boxes": identity["disallowed_extra_official_boxes"],
+                "name_mismatches": identity["name_mismatches"],
+                "winner_count": identity["winner_count"],
+            }
+        )
+        if identity["status"] != "SAFE_EXACT_BOX_AND_NAME_MATCH":
+            unsafe_matches.append(
+                {
+                    "race_id": race_id,
+                    "status": "UNSAFE_RESULT_MATCH_QUARANTINED",
+                    "reason": identity["identity_errors"],
+                    "race_url": race_url,
+                    "winning_result_url": result_url,
+                    "missing_predicted_boxes": identity["missing_predicted_boxes"],
+                    "allowed_extra_scratched_official_boxes": identity[
+                        "allowed_extra_scratched_official_boxes"
+                    ],
+                    "disallowed_extra_official_boxes": identity[
+                        "disallowed_extra_official_boxes"
+                    ],
+                    "name_mismatches": identity["name_mismatches"],
+                    "official_runner_rows": identity["official_runner_rows"],
+                    "prejump_runner_alignment": attempt["prejump_runner_alignment"],
+                }
+            )
+            race_attempts.append(attempt)
+            continue
+
+        race_joined_rows, race_summary = joined_rows_for_safe_race(
+            race_meta=meta,
+            prediction_rows=rows,
+            identity=identity,
+        )
+        joined_rows.extend(race_joined_rows)
+        safe_races.append(race_summary)
+        race_attempts.append(attempt)
+
+    metrics, calibration, box_bias = metric_reports(
+        shadow_run_dir=shadow_run_dir,
+        manifest=manifest,
+        predictions_by_race=predictions_by_race,
+        safe_races=safe_races,
+        joined_rows=joined_rows,
+        pending_count=len(pending_results),
+        unsafe_count=len(unsafe_matches),
+    )
+    final_status = final_status_for_counts(
+        len(safe_races), len(pending_results), len(unsafe_matches)
+    )
+    db_after = verify_db_state(db_path) if verify_db else None
+    protected_after = protected_path_hashes()
+    protected_unchanged = protected_before == protected_after
+    if verify_db and (
+        not db_after or db_after.get("status") != "PASS" or db_after != db_before
+    ):
+        final_status = FINAL_STATUS_DB_BLOCKED
+
+    identity_report = {
+        "schema_version": "forward_shadow_identity_match_report_v2",
+        "generated_at": generated_at.isoformat(),
+        "source_shadow_run": relpath(shadow_run_dir),
+        "identity_policy": {
+            "race_match": "source sidecar race_url plus date venue race_number metadata",
+            "runner_match": "exact box and exact normalized dog name for every predicted runner",
+            "fuzzy_matching_allowed": False,
+            "normalization": "casefold whitespace/punctuation normalization with deterministic stripping of known non-name result badges only",
+            "stripped_non_name_badges": sorted(NON_NAME_RESULT_BADGES),
+            "extra_official_boxes": "allowed only when official terminal status is SCR/L-SCR/LSCR and box was absent from the pre-jump prediction field",
+            "nonwinner_missing_finish_position": "allowed after exact runner identity and exactly one official winner are established",
+            "prejump_runner_set": "prediction sidecars may carry canonical pre-jump final-starter alignment evidence; it is reported with every race attempt and unsafe match",
+        },
+        "shadow_manifest_summary": {
+            "prediction_rows": manifest.get("prediction_rows"),
+            "race_count": manifest.get("race_count"),
+            "calibration_method": manifest.get("calibration_method"),
+            "all_missing_train_policy": manifest.get("all_missing_train_policy"),
+            "tgr_enabled": manifest.get("tgr_enabled"),
+            "output_mode": manifest.get("output_mode"),
+        },
+        "db_state_before": db_before,
+        "db_state_after": db_after,
+        "protected_hashes_before": protected_before,
+        "protected_hashes_after": protected_after,
+        "protected_paths_unchanged": protected_unchanged,
+        "summary": {
+            "safe_joined_race_count": len(safe_races),
+            "safe_joined_runner_count": len(joined_rows),
+            "pending_race_count": len(pending_results),
+            "unsafe_match_count": len(unsafe_matches),
+            "malformed_prediction_row_count": len(malformed_prediction_rows),
+            "verdict": final_status,
+        },
+        "malformed_prediction_rows": malformed_prediction_rows,
+        "race_attempts": race_attempts,
+    }
+
+    write_jsonl(output_dir / "joined_shadow_predictions.jsonl", joined_rows)
+    write_json(output_dir / "shadow_forward_metrics.json", metrics)
+    write_json(output_dir / "identity_match_report.json", identity_report)
+    write_json(
+        output_dir / "malformed_prediction_rows.json",
+        {
+            "schema_version": "forward_shadow_malformed_prediction_rows_v1",
+            "malformed_prediction_row_count": len(malformed_prediction_rows),
+            "malformed_prediction_rows": malformed_prediction_rows,
+        },
+    )
+    write_json(
+        output_dir / "pending_results.json",
+        {
+            "schema_version": "forward_shadow_pending_results_v1",
+            "pending_race_count": len(pending_results),
+            "pending_results": pending_results,
+        },
+    )
+    write_json(
+        output_dir / "unsafe_result_matches.json",
+        {
+            "schema_version": "forward_shadow_unsafe_result_matches_v1",
+            "unsafe_match_count": len(unsafe_matches),
+            "unsafe_result_matches": unsafe_matches,
+        },
+    )
+    write_json(output_dir / "calibration_review.json", calibration)
+    write_json(output_dir / "box_bias_review.json", box_bias)
+    write_text(
+        output_dir / "SUMMARY.md",
+        build_summary(
+            shadow_run_dir=shadow_run_dir,
+            generated_at=generated_at,
+            final_status=final_status,
+            db_before=db_before,
+            db_after=db_after,
+            protected_unchanged=protected_unchanged,
+            metrics=metrics,
+            manifest=manifest,
+        ),
+    )
+    write_text(output_dir / "final_status.txt", final_status + "\n")
+
+    return {
+        "output_dir": relpath(output_dir),
+        "verdict": final_status,
+        "safe_joined_race_count": len(safe_races),
+        "safe_joined_runner_count": len(joined_rows),
+        "pending_race_count": len(pending_results),
+        "unsafe_match_count": len(unsafe_matches),
+        "malformed_prediction_row_count": len(malformed_prediction_rows),
+        "metrics": metrics,
+        "db_state_before": db_before,
+        "db_state_after": db_after,
+        "protected_paths_unchanged": protected_unchanged,
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--shadow-run-dir", required=True, type=Path)
+    parser.add_argument("--output-parent", default=DEFAULT_OUTPUT_PARENT, type=Path)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--refresh-metadata", type=Path)
+    parser.add_argument("--db", default=DEFAULT_DB_PATH, type=Path)
+    parser.add_argument("--current-time", help="ISO timestamp used for pending race-time decisions")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = join_forward_shadow_results(
+        shadow_run_dir=args.shadow_run_dir,
+        output_parent=args.output_parent,
+        output_dir=args.output_dir,
+        refresh_metadata_path=args.refresh_metadata,
+        db_path=args.db,
+        current_time=parse_current_time(args.current_time),
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report.get("verdict") != FINAL_STATUS_DB_BLOCKED else 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/run_forward_shadow_challenger_calibration.py
+++ b/scripts/run_forward_shadow_challenger_calibration.py
@@ -1,0 +1,792 @@
+#!/usr/bin/env python3
+"""Train report-only calibration challengers from exact-joined shadow results.
+
+This worker is intentionally detached from production. It reads deduplicated
+forward-shadow result joins, fits only additive probability-calibration
+parameters on exact official joins, and writes challenger artifacts under the
+evidence directory. It never mutates the model registry, DB labels, production
+models, prediction snapshots, EV output, or betting output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import sys
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_STR = str(ROOT)
+sys.path = [path for path in sys.path if path != ROOT_STR]
+sys.path.insert(0, ROOT_STR)
+
+from accuracy_program.calibration import power_normalize_by_race  # noqa: E402
+from scripts.aggregate_forward_shadow_results import (  # noqa: E402
+    DEFAULT_EVIDENCE_ROOT,
+    grouped_joined_rows,
+    read_jsonl,
+    result_join_dirs,
+    selected_unique_joined_races,
+)
+from scripts.join_forward_shadow_results import (  # noqa: E402
+    clip_probability,
+    logistic_calibration_review,
+    probability_reliability_bins,
+)
+
+
+OUTPUT_PREFIX = (
+    "artifacts/full_evidence_orchestration_20260525/"
+    "forward_shadow_challenger_calibration_"
+)
+DEFAULT_PROTECTED_PATHS = (
+    ROOT / "greyhound_racing_data.db",
+    ROOT / "greyhound_racing_data_writable.db",
+    ROOT / "model_registry/best_metadata.json",
+    ROOT / "docs/model_contracts/v4_feature_contract.json",
+    ROOT / "artifacts/prediction_snapshots/manifest.jsonl",
+)
+DEFAULT_ALPHA_GRID = (
+    0.40,
+    0.50,
+    0.60,
+    0.75,
+    0.90,
+    1.00,
+    1.10,
+    1.25,
+    1.50,
+    1.75,
+    2.00,
+    2.40,
+    3.00,
+)
+BASELINE_ALPHA = 1.0
+
+FINAL_READY = "CHALLENGER_CALIBRATION_REPORT_ONLY_READY_FOR_REVIEW"
+FINAL_BLOCKED = "CHALLENGER_CALIBRATION_BLOCKED_KEEP_BASELINE"
+FINAL_NO_SAFE_JOINS = "CHALLENGER_CALIBRATION_NO_SAFE_JOINED_RACES"
+
+
+@dataclass(frozen=True)
+class ChallengerThresholds:
+    min_total_safe_joined_races: int = 100
+    min_train_races: int = 40
+    min_eval_races: int = 20
+    max_probability_sum_error: float = 1e-6
+    metric_tolerance: float = 0.0
+    train_fraction: float = 0.8
+
+
+def relpath(path: Path | None) -> str | None:
+    if path is None:
+        return None
+    try:
+        return os.path.relpath(path.resolve(), ROOT.resolve())
+    except ValueError:
+        return str(path)
+
+
+def now_id(now: datetime | None = None) -> str:
+    return (now or datetime.now().astimezone()).strftime("%Y%m%dT%H%M%S%z")
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(dict(row), sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def protected_hashes(paths: Sequence[Path] = DEFAULT_PROTECTED_PATHS) -> dict[str, str | None]:
+    return {relpath(path) or str(path): sha256_file(path) for path in paths}
+
+
+def assert_output_dir_safe(output_dir: Path) -> Path:
+    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
+    try:
+        relative = logical.absolute().relative_to(ROOT.absolute())
+    except ValueError as exc:
+        raise ValueError("output_dir_must_be_inside_repo") from exc
+    if ".." in relative.parts:
+        raise ValueError("output_dir_must_not_contain_parent_traversal")
+    if not relative.as_posix().startswith(OUTPUT_PREFIX):
+        raise ValueError(
+            f"output_dir_must_be_forward_shadow_challenger_calibration_artifact:{relative}"
+        )
+    return logical.absolute()
+
+
+def unique_dir(base: Path) -> Path:
+    if not base.exists():
+        return base
+    for index in range(1, 1000):
+        candidate = Path(f"{base}_{index:03d}")
+        if not candidate.exists():
+            return candidate
+    raise RuntimeError(f"output_dir_collision_exhausted:{base}")
+
+
+def finite_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(parsed) or math.isinf(parsed):
+        return None
+    return parsed
+
+
+def race_key(row: Mapping[str, Any]) -> str:
+    return str(row.get("race_id") or "").strip()
+
+
+def race_sort_key(rows: Sequence[Mapping[str, Any]]) -> tuple[str, str, int, str]:
+    first = rows[0] if rows else {}
+    race_number = first.get("race_number")
+    try:
+        parsed_number = int(race_number)
+    except (TypeError, ValueError):
+        parsed_number = 999
+    return (
+        str(first.get("race_date") or ""),
+        str(first.get("jump_datetime") or ""),
+        parsed_number,
+        race_key(first),
+    )
+
+
+def validate_exact_joined_race(
+    race_id: str,
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    input_probability_key: str,
+    max_probability_sum_error: float,
+) -> tuple[list[dict[str, Any]] | None, list[str]]:
+    reasons: list[str] = []
+    if not rows:
+        return None, ["race_rows_missing"]
+    winners = [row for row in rows if row.get("is_winner") is True]
+    if len(winners) != 1:
+        reasons.append("winner_row_count_not_exactly_one")
+    boxes = [row.get("box") for row in rows]
+    if len(set(boxes)) != len(boxes):
+        reasons.append("duplicate_box_in_joined_rows")
+    for row in rows:
+        if race_key(row) != race_id:
+            reasons.append("mixed_race_id_in_group")
+            break
+        if row.get("identity_match_status") != "exact_box_and_normalized_name":
+            reasons.append("non_exact_identity_match_status")
+            break
+        probability = finite_float(row.get(input_probability_key))
+        if probability is None:
+            reasons.append(f"{input_probability_key}_missing_or_invalid")
+            break
+        if probability < 0:
+            reasons.append(f"{input_probability_key}_negative")
+            break
+        if bool(row.get("tgr_enabled")):
+            reasons.append("tgr_enabled_joined_row")
+            break
+    probability_sum = sum(
+        finite_float(row.get(input_probability_key)) or 0.0 for row in rows
+    )
+    if abs(probability_sum - 1.0) > max_probability_sum_error:
+        reasons.append("probability_sum_error_exceeds_threshold")
+    if reasons:
+        return None, list(dict.fromkeys(reasons))
+
+    cleaned: list[dict[str, Any]] = []
+    for row in rows:
+        item = dict(row)
+        item[input_probability_key] = float(item[input_probability_key])
+        item["is_winner"] = bool(item["is_winner"])
+        cleaned.append(item)
+    return cleaned, []
+
+
+def collect_candidate_races(
+    *,
+    evidence_root: Path,
+    input_probability_key: str,
+    max_probability_sum_error: float,
+) -> tuple[list[list[dict[str, Any]]], list[dict[str, Any]], list[str]]:
+    join_dirs = result_join_dirs(evidence_root)
+    selected, duplicates = selected_unique_joined_races(join_dirs)
+    safe_races: list[list[dict[str, Any]]] = []
+    rejected: list[dict[str, Any]] = []
+    for key, rows in sorted(selected.items()):
+        cleaned, reasons = validate_exact_joined_race(
+            key,
+            rows,
+            input_probability_key=input_probability_key,
+            max_probability_sum_error=max_probability_sum_error,
+        )
+        if cleaned is None:
+            rejected.append(
+                {
+                    "race_id": key,
+                    "reasons": reasons,
+                    "row_count": len(rows),
+                }
+            )
+            continue
+        safe_races.append(cleaned)
+    safe_races.sort(key=race_sort_key)
+    return safe_races, rejected, [str(item.get("race_id")) for item in duplicates]
+
+
+def flatten(races: Sequence[Sequence[Mapping[str, Any]]]) -> list[dict[str, Any]]:
+    return [dict(row) for rows in races for row in rows]
+
+
+def top_pick(rows: Sequence[Mapping[str, Any]], probability_key: str) -> Mapping[str, Any]:
+    return sorted(
+        rows,
+        key=lambda row: (-float(row[probability_key]), int(row.get("box") or 999), str(row.get("dog_name") or "")),
+    )[0]
+
+
+def winner(rows: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
+    winners = [row for row in rows if row.get("is_winner") is True]
+    if len(winners) != 1:
+        raise ValueError("winner_row_count_not_exactly_one")
+    return winners[0]
+
+
+def rank_of_winner(rows: Sequence[Mapping[str, Any]], probability_key: str) -> int:
+    ranked = sorted(
+        rows,
+        key=lambda row: (-float(row[probability_key]), int(row.get("box") or 999), str(row.get("dog_name") or "")),
+    )
+    for index, row in enumerate(ranked, start=1):
+        if row.get("is_winner") is True:
+            return index
+    raise ValueError("winner_missing_from_ranked_rows")
+
+
+def metric_summary(races: Sequence[Sequence[Mapping[str, Any]]], probability_key: str) -> dict[str, Any]:
+    if not races:
+        return {
+            "safe_joined_race_count": 0,
+            "safe_joined_runner_count": 0,
+            "top1": None,
+            "top3": None,
+            "mean_winner_rank": None,
+            "brier": None,
+            "logloss": None,
+            "probability_sum_max_error_joined_races": None,
+            "box1_top_pick_share": None,
+            "reliability_bins": [],
+            "calibration_slope_intercept": {
+                "status": "no_safe_joined_rows",
+                "slope": None,
+                "intercept": None,
+            },
+        }
+
+    labels: list[int] = []
+    probabilities: list[float] = []
+    winner_ranks: list[int] = []
+    top1_count = 0
+    top3_count = 0
+    top_pick_boxes: Counter[str] = Counter()
+    probability_sum_errors: list[float] = []
+    logloss_values: list[float] = []
+
+    for rows in races:
+        race_probabilities = [float(row[probability_key]) for row in rows]
+        probability_sum_errors.append(abs(sum(race_probabilities) - 1.0))
+        top = top_pick(rows, probability_key)
+        win = winner(rows)
+        winner_rank = rank_of_winner(rows, probability_key)
+        winner_ranks.append(winner_rank)
+        if bool(top.get("is_winner")):
+            top1_count += 1
+        if winner_rank <= 3:
+            top3_count += 1
+        top_pick_boxes[str(top.get("box"))] += 1
+        logloss_values.append(-math.log(clip_probability(float(win[probability_key]))))
+        for row in rows:
+            labels.append(1 if row.get("is_winner") else 0)
+            probabilities.append(float(row[probability_key]))
+
+    brier = sum((probability - label) ** 2 for label, probability in zip(labels, probabilities)) / len(labels)
+    return {
+        "safe_joined_race_count": len(races),
+        "safe_joined_runner_count": len(labels),
+        "top1": top1_count / len(races),
+        "top3": top3_count / len(races),
+        "winner_ranks": winner_ranks,
+        "mean_winner_rank": sum(winner_ranks) / len(winner_ranks),
+        "brier": brier,
+        "logloss": sum(logloss_values) / len(logloss_values),
+        "probability_sum_max_error_joined_races": max(probability_sum_errors),
+        "box1_top_pick_share": top_pick_boxes.get("1", 0) / len(races),
+        "top_pick_box_distribution": dict(sorted(top_pick_boxes.items())),
+        "reliability_bins": probability_reliability_bins(labels, probabilities),
+        "calibration_slope_intercept": logistic_calibration_review(labels, probabilities),
+    }
+
+
+def apply_alpha(
+    races: Sequence[Sequence[Mapping[str, Any]]],
+    *,
+    alpha: float,
+    input_probability_key: str,
+    output_probability_key: str,
+) -> list[list[dict[str, Any]]]:
+    rows = flatten(races)
+    calibrated = power_normalize_by_race(
+        rows,
+        alpha=alpha,
+        input_key=input_probability_key,
+        output_key=output_probability_key,
+        race_key="race_id",
+    )
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in calibrated:
+        grouped[race_key(row)].append(row)
+    return [grouped[race_key(rows[0])] for rows in races]
+
+
+def alpha_metric_grid(
+    races: Sequence[Sequence[Mapping[str, Any]]],
+    *,
+    alpha_grid: Sequence[float],
+    input_probability_key: str,
+) -> list[dict[str, Any]]:
+    output_key = "challenger_probability"
+    results = []
+    for alpha in alpha_grid:
+        calibrated = apply_alpha(
+            races,
+            alpha=alpha,
+            input_probability_key=input_probability_key,
+            output_probability_key=output_key,
+        )
+        metrics = metric_summary(calibrated, output_key)
+        results.append(
+            {
+                "alpha": alpha,
+                "metrics": {
+                    key: value
+                    for key, value in metrics.items()
+                    if key
+                    not in {
+                        "reliability_bins",
+                        "calibration_slope_intercept",
+                        "winner_ranks",
+                        "top_pick_box_distribution",
+                    }
+                },
+            }
+        )
+    return sorted(
+        results,
+        key=lambda row: (
+            float(row["metrics"]["logloss"]),
+            float(row["metrics"]["brier"]),
+            abs(float(row["alpha"]) - BASELINE_ALPHA),
+        ),
+    )
+
+
+def split_races(
+    races: Sequence[Sequence[Mapping[str, Any]]],
+    *,
+    train_fraction: float,
+) -> tuple[list[list[dict[str, Any]]], list[list[dict[str, Any]]]]:
+    if not races:
+        return [], []
+    if not (0 < train_fraction < 1):
+        raise ValueError("train_fraction_must_be_between_0_and_1")
+    split_index = int(len(races) * train_fraction)
+    split_index = min(max(split_index, 1), len(races) - 1)
+    return [list(rows) for rows in races[:split_index]], [list(rows) for rows in races[split_index:]]
+
+
+def activation_blockers(
+    *,
+    total_races: int,
+    train_races: int,
+    eval_races: int,
+    baseline_eval_metrics: Mapping[str, Any],
+    candidate_eval_metrics: Mapping[str, Any],
+    thresholds: ChallengerThresholds,
+    protected_paths_unchanged: bool,
+) -> list[str]:
+    blockers: list[str] = []
+    if total_races <= 0:
+        blockers.append("no_safe_exact_joined_races")
+    if total_races < thresholds.min_total_safe_joined_races:
+        blockers.append("safe_joined_race_count_below_min_total")
+    if train_races < thresholds.min_train_races:
+        blockers.append("train_race_count_below_min")
+    if eval_races < thresholds.min_eval_races:
+        blockers.append("eval_race_count_below_min")
+    if not protected_paths_unchanged:
+        blockers.append("protected_paths_changed")
+    max_error = candidate_eval_metrics.get("probability_sum_max_error_joined_races")
+    if max_error is None or float(max_error) > thresholds.max_probability_sum_error:
+        blockers.append("candidate_probability_sum_error_failed")
+
+    comparisons = (
+        ("top1", "higher_or_equal"),
+        ("top3", "higher_or_equal"),
+        ("mean_winner_rank", "lower_or_equal"),
+        ("brier", "lower_or_equal"),
+        ("logloss", "lower_or_equal"),
+    )
+    for key, direction in comparisons:
+        baseline_value = baseline_eval_metrics.get(key)
+        candidate_value = candidate_eval_metrics.get(key)
+        if baseline_value is None or candidate_value is None:
+            blockers.append(f"metric_missing:{key}")
+            continue
+        baseline = float(baseline_value)
+        candidate = float(candidate_value)
+        if direction == "higher_or_equal" and candidate + thresholds.metric_tolerance < baseline:
+            blockers.append(f"metric_regressed:{key}")
+        if direction == "lower_or_equal" and candidate > baseline + thresholds.metric_tolerance:
+            blockers.append(f"metric_regressed:{key}")
+    return list(dict.fromkeys(blockers))
+
+
+def report_only_prediction_rows(
+    races: Sequence[Sequence[Mapping[str, Any]]],
+    *,
+    alpha: float,
+    input_probability_key: str,
+) -> list[dict[str, Any]]:
+    output_key = "challenger_calibrated_probability_report_only"
+    calibrated = apply_alpha(
+        races,
+        alpha=alpha,
+        input_probability_key=input_probability_key,
+        output_probability_key=output_key,
+    )
+    rows = []
+    for race_rows in calibrated:
+        ranked = sorted(
+            race_rows,
+            key=lambda row: (-float(row[output_key]), int(row.get("box") or 999), str(row.get("dog_name") or "")),
+        )
+        rank_by_identity = {
+            (race_key(row), row.get("box"), row.get("dog_name")): index
+            for index, row in enumerate(ranked, start=1)
+        }
+        for row in race_rows:
+            item = {
+                "race_id": row.get("race_id"),
+                "race_date": row.get("race_date"),
+                "venue": row.get("venue"),
+                "race_number": row.get("race_number"),
+                "box": row.get("box"),
+                "dog_name": row.get("dog_name"),
+                "is_winner": bool(row.get("is_winner")),
+                input_probability_key: row.get(input_probability_key),
+                output_key: row.get(output_key),
+                "challenger_predicted_rank_report_only": rank_by_identity[
+                    (race_key(row), row.get("box"), row.get("dog_name"))
+                ],
+                "identity_match_status": row.get("identity_match_status"),
+            }
+            rows.append(item)
+    return rows
+
+
+def build_report(
+    *,
+    evidence_root: Path,
+    input_probability_key: str,
+    alpha_grid: Sequence[float],
+    thresholds: ChallengerThresholds,
+    generated_at: datetime | None = None,
+    protected_before: Mapping[str, str | None] | None = None,
+    protected_after: Mapping[str, str | None] | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    generated_at = generated_at or datetime.now().astimezone()
+    protected_before = dict(protected_before or protected_hashes())
+    safe_races, rejected_races, duplicate_race_ids = collect_candidate_races(
+        evidence_root=evidence_root,
+        input_probability_key=input_probability_key,
+        max_probability_sum_error=thresholds.max_probability_sum_error,
+    )
+    train_races, eval_races = split_races(
+        safe_races,
+        train_fraction=thresholds.train_fraction,
+    ) if len(safe_races) >= 2 else (safe_races, [])
+
+    if not safe_races:
+        protected_after = dict(protected_after or protected_hashes())
+        report = {
+            "schema_version": "forward_shadow_challenger_calibration_v1",
+            "generated_at": generated_at.isoformat(),
+            "final_status": FINAL_NO_SAFE_JOINS,
+            "input_probability_key": input_probability_key,
+            "safe_exact_joined_race_count": 0,
+            "safe_exact_joined_runner_count": 0,
+            "rejected_joined_races": rejected_races,
+            "activation_blockers": ["no_safe_exact_joined_races"],
+            "protected_hashes_before": protected_before,
+            "protected_hashes_after": protected_after,
+            "protected_paths_unchanged": protected_before == protected_after,
+            "no_write_guarantees": no_write_guarantees(),
+        }
+        return report, []
+
+    training_grid = alpha_metric_grid(
+        train_races,
+        alpha_grid=alpha_grid,
+        input_probability_key=input_probability_key,
+    )
+    best_alpha = float(training_grid[0]["alpha"])
+    baseline_train = metric_summary(
+        apply_alpha(
+            train_races,
+            alpha=BASELINE_ALPHA,
+            input_probability_key=input_probability_key,
+            output_probability_key="baseline_probability",
+        ),
+        "baseline_probability",
+    )
+    baseline_eval = metric_summary(
+        apply_alpha(
+            eval_races,
+            alpha=BASELINE_ALPHA,
+            input_probability_key=input_probability_key,
+            output_probability_key="baseline_probability",
+        ),
+        "baseline_probability",
+    )
+    candidate_train = metric_summary(
+        apply_alpha(
+            train_races,
+            alpha=best_alpha,
+            input_probability_key=input_probability_key,
+            output_probability_key="candidate_probability",
+        ),
+        "candidate_probability",
+    )
+    candidate_eval_races = apply_alpha(
+        eval_races,
+        alpha=best_alpha,
+        input_probability_key=input_probability_key,
+        output_probability_key="candidate_probability",
+    )
+    candidate_eval = metric_summary(candidate_eval_races, "candidate_probability")
+    protected_after = dict(protected_after or protected_hashes())
+    blockers = activation_blockers(
+        total_races=len(safe_races),
+        train_races=len(train_races),
+        eval_races=len(eval_races),
+        baseline_eval_metrics=baseline_eval,
+        candidate_eval_metrics=candidate_eval,
+        thresholds=thresholds,
+        protected_paths_unchanged=protected_before == protected_after,
+    )
+    final_status = FINAL_BLOCKED if blockers else FINAL_READY
+    report = {
+        "schema_version": "forward_shadow_challenger_calibration_v1",
+        "generated_at": generated_at.isoformat(),
+        "final_status": final_status,
+        "input_probability_key": input_probability_key,
+        "calibration_family": "per_race_power_normalization",
+        "candidate_alpha": best_alpha,
+        "baseline_alpha": BASELINE_ALPHA,
+        "alpha_selection_metric": "train_logloss_then_train_brier",
+        "alpha_grid_results_train": training_grid,
+        "safe_exact_joined_race_count": len(safe_races),
+        "safe_exact_joined_runner_count": len(flatten(safe_races)),
+        "train_race_count": len(train_races),
+        "eval_race_count": len(eval_races),
+        "split_policy": {
+            "method": "chronological_by_race_date_jump_datetime_race_number_race_id",
+            "train_fraction": thresholds.train_fraction,
+        },
+        "baseline_train_metrics": baseline_train,
+        "candidate_train_metrics": candidate_train,
+        "baseline_eval_metrics": baseline_eval,
+        "candidate_eval_metrics": candidate_eval,
+        "activation_blockers": blockers,
+        "thresholds": asdict(thresholds),
+        "rejected_joined_races": rejected_races,
+        "duplicate_joined_race_ids_seen": duplicate_race_ids,
+        "source_join_artifact_selection_policy": (
+            "latest_result_join_per_source_shadow_run_then_latest_join_artifact_per_unique_race"
+        ),
+        "report_only": True,
+        "production_activation_allowed": False,
+        "protected_hashes_before": protected_before,
+        "protected_hashes_after": protected_after,
+        "protected_paths_unchanged": protected_before == protected_after,
+        "no_write_guarantees": no_write_guarantees(),
+    }
+    return report, report_only_prediction_rows(
+        safe_races,
+        alpha=best_alpha,
+        input_probability_key=input_probability_key,
+    )
+
+
+def no_write_guarantees() -> dict[str, bool]:
+    return {
+        "production_promotion": False,
+        "registry_mutation": False,
+        "production_pointer_update": False,
+        "active_model_replacement": False,
+        "production_prediction_write": False,
+        "db_write": False,
+        "label_write": False,
+        "canonical_schema_mutation": False,
+        "tgr_enabled": False,
+        "betting_or_ev_output": False,
+    }
+
+
+def build_summary(report: Mapping[str, Any]) -> str:
+    return "\n".join(
+        [
+            "# Forward Shadow Challenger Calibration",
+            "",
+            f"- Final status: `{report.get('final_status')}`",
+            f"- Safe exact joined races: `{report.get('safe_exact_joined_race_count')}`",
+            f"- Train races: `{report.get('train_race_count')}`",
+            f"- Eval races: `{report.get('eval_race_count')}`",
+            f"- Candidate alpha: `{report.get('candidate_alpha')}`",
+            f"- Activation blockers: `{len(report.get('activation_blockers') or [])}`",
+            f"- Protected paths unchanged: `{report.get('protected_paths_unchanged')}`",
+            "",
+            "This is report-only. No production model, registry, DB, label, snapshot, EV, or betting output was written.",
+            "",
+        ]
+    )
+
+
+def run_challenger_calibration(
+    *,
+    evidence_root: Path = DEFAULT_EVIDENCE_ROOT,
+    output_dir: Path | None = None,
+    input_probability_key: str = "shadow_rf_calibrated_probability",
+    alpha_grid: Sequence[float] = DEFAULT_ALPHA_GRID,
+    thresholds: ChallengerThresholds = ChallengerThresholds(),
+) -> dict[str, Any]:
+    generated_at = datetime.now().astimezone()
+    output_dir = output_dir or evidence_root / f"forward_shadow_challenger_calibration_{now_id(generated_at)}"
+    output_dir = unique_dir(assert_output_dir_safe(output_dir))
+    output_dir.mkdir(parents=True, exist_ok=False)
+    protected_before = protected_hashes()
+    report, prediction_rows = build_report(
+        evidence_root=evidence_root,
+        input_probability_key=input_probability_key,
+        alpha_grid=alpha_grid,
+        thresholds=thresholds,
+        generated_at=generated_at,
+        protected_before=protected_before,
+    )
+    write_json(output_dir / "challenger_calibration_report.json", report)
+    write_json(output_dir / "challenger_activation_gate.json", {
+        "schema_version": "forward_shadow_challenger_activation_gate_v1",
+        "final_status": report["final_status"],
+        "activation_blockers": report.get("activation_blockers") or [],
+        "production_activation_allowed": False,
+        "report_only": True,
+    })
+    write_jsonl(output_dir / "challenger_predictions_report_only.jsonl", prediction_rows)
+    write_text(output_dir / "SUMMARY.md", build_summary(report))
+    write_text(output_dir / "final_status.txt", str(report["final_status"]) + "\n")
+    return {
+        "output_dir": relpath(output_dir),
+        "final_status": report["final_status"],
+        "safe_exact_joined_race_count": report.get("safe_exact_joined_race_count"),
+        "train_race_count": report.get("train_race_count"),
+        "eval_race_count": report.get("eval_race_count"),
+        "candidate_alpha": report.get("candidate_alpha"),
+        "activation_blockers": report.get("activation_blockers") or [],
+        "protected_paths_unchanged": report.get("protected_paths_unchanged"),
+    }
+
+
+def parse_alpha_grid(text: str | None) -> tuple[float, ...]:
+    if not text:
+        return DEFAULT_ALPHA_GRID
+    values = []
+    for part in text.split(","):
+        value = finite_float(part.strip())
+        if value is None or value <= 0:
+            raise ValueError("alpha_grid_values_must_be_positive_finite")
+        values.append(value)
+    if not values:
+        raise ValueError("alpha_grid_missing_values")
+    return tuple(dict.fromkeys(values))
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence-root", type=Path, default=DEFAULT_EVIDENCE_ROOT)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--input-probability-key", default="shadow_rf_calibrated_probability")
+    parser.add_argument("--alpha-grid")
+    parser.add_argument("--min-total-safe-joined-races", type=int, default=100)
+    parser.add_argument("--min-train-races", type=int, default=40)
+    parser.add_argument("--min-eval-races", type=int, default=20)
+    parser.add_argument("--train-fraction", type=float, default=0.8)
+    parser.add_argument("--metric-tolerance", type=float, default=0.0)
+    parser.add_argument("--max-probability-sum-error", type=float, default=1e-6)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    thresholds = ChallengerThresholds(
+        min_total_safe_joined_races=args.min_total_safe_joined_races,
+        min_train_races=args.min_train_races,
+        min_eval_races=args.min_eval_races,
+        max_probability_sum_error=args.max_probability_sum_error,
+        metric_tolerance=args.metric_tolerance,
+        train_fraction=args.train_fraction,
+    )
+    result = run_challenger_calibration(
+        evidence_root=args.evidence_root,
+        output_dir=args.output_dir,
+        input_probability_key=args.input_probability_key,
+        alpha_grid=parse_alpha_grid(args.alpha_grid),
+        thresholds=thresholds,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_aggregate_forward_shadow_results.py
+++ b/tests/test_aggregate_forward_shadow_results.py
@@ -1,0 +1,207 @@
+import json
+from datetime import datetime
+from pathlib import Path
+
+from scripts import aggregate_forward_shadow_results as aggregate
+
+
+def _write_json(path: Path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _runner(race_id, box, rank, prob, winner=False):
+    return {
+        "race_id": race_id,
+        "race_date": "2026-06-08",
+        "venue": "TEST",
+        "race_number": int(race_id.rsplit(" ", 1)[-1]),
+        "box": box,
+        "dog_name": f"Dog {box}",
+        "predicted_rank": rank,
+        "shadow_rf_calibrated_probability": prob,
+        "calibration_method": "power_gamma_2.4",
+        "tgr_enabled": False,
+        "is_winner": winner,
+        "result_url": f"https://example.test/{race_id}",
+    }
+
+
+def _write_join_dir(root: Path, name: str, joined_rows, pending_ids=(), source_shadow_run=None, unsafe_rows=()):
+    join_dir = root / name
+    _write_json(
+        join_dir / "shadow_forward_metrics.json",
+        {"safe_joined_race_count": 1, "source_shadow_run": source_shadow_run},
+    )
+    _write_jsonl(join_dir / "joined_shadow_predictions.jsonl", joined_rows)
+    _write_json(
+        join_dir / "pending_results.json",
+        {
+            "pending_race_count": len(pending_ids),
+            "pending_results": [
+                {"race_id": race_id, "status": "PENDING_OFFICIAL_OUTCOME"}
+                for race_id in pending_ids
+            ],
+        },
+    )
+    _write_json(join_dir / "unsafe_result_matches.json", {"unsafe_result_matches": list(unsafe_rows)})
+    return join_dir
+
+
+def test_aggregate_deduplicates_joined_races_with_latest_artifact_selection(tmp_path):
+    _write_join_dir(
+        tmp_path,
+        "forward_shadow_result_join_20260608T120000+1000",
+        [
+            _runner("Race 1", 1, 1, 0.6, winner=False),
+            _runner("Race 1", 2, 2, 0.4, winner=True),
+            _runner("Race 2", 1, 1, 0.7, winner=True),
+            _runner("Race 2", 2, 2, 0.3, winner=False),
+        ],
+        pending_ids=["Race 3"],
+    )
+    _write_join_dir(
+        tmp_path,
+        "forward_shadow_result_join_20260608T121000+1000",
+        [
+            _runner("Race 1", 1, 2, 0.2, winner=False),
+            _runner("Race 1", 2, 1, 0.8, winner=True),
+        ],
+        pending_ids=["Race 3"],
+    )
+
+    report = aggregate.build_aggregate_report(
+        evidence_root=tmp_path,
+        generated_at=datetime.fromisoformat("2026-06-08T12:30:00+10:00"),
+    )
+
+    metrics = report["aggregate_forward_metrics"]
+    assert report["final_status"] == "PARTIAL_AGGREGATE_PENDING_MORE_RESULTS"
+    assert metrics["safe_joined_race_count"] == 2
+    assert metrics["pending_race_count"] == 1
+    assert metrics["unsafe_match_count"] == 0
+    assert metrics["top1"] == 1.0
+    assert metrics["winner_ranks"] == [1, 1]
+    assert report["duplicate_joined_race_count"] == 1
+    duplicate = report["duplicate_joined_races"][0]
+    assert duplicate["selected_source"].endswith("forward_shadow_result_join_20260608T121000+1000")
+    assert len(duplicate["previous_sources"]) == 1
+    assert duplicate["previous_sources"][0].endswith("forward_shadow_result_join_20260608T120000+1000")
+    assert duplicate["selected_source"] not in duplicate["previous_sources"]
+    assert report["pending_results"]["pending_results"][0]["race_id"] == "Race 3"
+
+
+def test_output_guard_rejects_non_shadow_aggregate_paths():
+    try:
+        aggregate.assert_output_dir_safe(Path("model_registry/forward_shadow_result_aggregate_bad"))
+    except ValueError as exc:
+        assert "output_dir_must_be_forward_shadow_result_aggregate_artifact" in str(exc)
+    else:
+        raise AssertionError("expected output path guard to reject production path")
+
+
+def test_aggregate_uses_latest_join_per_source_shadow_run(tmp_path):
+    _write_join_dir(
+        tmp_path,
+        "forward_shadow_result_join_20260608T120000+1000",
+        [],
+        source_shadow_run="daily_shadow_a",
+        unsafe_rows=[{"race_id": "Race 1", "status": "UNSAFE_RESULT_MATCH_QUARANTINED"}],
+    )
+    _write_join_dir(
+        tmp_path,
+        "forward_shadow_result_join_20260608T121000+1000",
+        [
+            _runner("Race 1", 1, 1, 0.7, winner=True),
+            _runner("Race 1", 2, 2, 0.3, winner=False),
+        ],
+        source_shadow_run="daily_shadow_a",
+    )
+
+    report = aggregate.build_aggregate_report(
+        evidence_root=tmp_path,
+        generated_at=datetime.fromisoformat("2026-06-08T12:30:00+10:00"),
+    )
+
+    assert report["discovered_join_artifact_count"] == 2
+    assert report["source_join_artifact_count"] == 1
+    assert report["aggregate_forward_metrics"]["safe_joined_race_count"] == 1
+    assert report["unsafe_result_matches"]["unsafe_match_count"] == 0
+
+
+def test_aggregate_collapses_storage_and_repo_aliases_for_same_daily_shadow_run(tmp_path):
+    source_name = "daily_race_ingest_shadow_20260608T202503+1000_urgent_nearjump"
+    _write_join_dir(
+        tmp_path,
+        "forward_shadow_result_join_20260608T120000+1000",
+        [],
+        pending_ids=["Race 1"],
+        source_shadow_run=f"artifacts/full_evidence_orchestration_20260525/{source_name}",
+        unsafe_rows=[{"race_id": "Race 2", "status": "UNSAFE_RESULT_MATCH_QUARANTINED"}],
+    )
+    _write_join_dir(
+        tmp_path,
+        "forward_shadow_result_join_20260608T121000+1000",
+        [
+            _runner("Race 1", 1, 1, 0.7, winner=True),
+            _runner("Race 1", 2, 2, 0.3, winner=False),
+        ],
+        source_shadow_run=(
+            "../../../greyhound_racing_collector_storage/artifacts/"
+            f"full_evidence_orchestration_20260525/{source_name}"
+        ),
+    )
+
+    report = aggregate.build_aggregate_report(
+        evidence_root=tmp_path,
+        generated_at=datetime.fromisoformat("2026-06-08T12:30:00+10:00"),
+    )
+
+    assert report["discovered_join_artifact_count"] == 2
+    assert report["source_join_artifact_count"] == 1
+    assert report["aggregate_forward_metrics"]["safe_joined_race_count"] == 1
+    assert report["aggregate_forward_metrics"]["pending_race_count"] == 0
+    assert report["unsafe_result_matches"]["unsafe_match_count"] == 0
+
+
+def test_aggregate_keeps_distinct_daily_shadow_runs_separate(tmp_path):
+    _write_join_dir(
+        tmp_path,
+        "forward_shadow_result_join_20260608T120000+1000",
+        [
+            _runner("Race 1", 1, 1, 0.7, winner=True),
+            _runner("Race 1", 2, 2, 0.3, winner=False),
+        ],
+        source_shadow_run=(
+            "artifacts/full_evidence_orchestration_20260525/"
+            "daily_race_ingest_shadow_20260608T202503+1000_urgent_nearjump"
+        ),
+    )
+    _write_join_dir(
+        tmp_path,
+        "forward_shadow_result_join_20260608T121000+1000",
+        [
+            _runner("Race 2", 1, 1, 0.6, winner=False),
+            _runner("Race 2", 2, 2, 0.4, winner=True),
+        ],
+        source_shadow_run=(
+            "artifacts/full_evidence_orchestration_20260525/"
+            "daily_race_ingest_shadow_20260608T202922+1000_urgent_nearjump_second_pass"
+        ),
+    )
+
+    report = aggregate.build_aggregate_report(
+        evidence_root=tmp_path,
+        generated_at=datetime.fromisoformat("2026-06-08T12:30:00+10:00"),
+    )
+
+    assert report["source_join_artifact_count"] == 2
+    assert report["aggregate_forward_metrics"]["safe_joined_race_count"] == 2

--- a/tests/test_forward_shadow_challenger_calibration.py
+++ b/tests/test_forward_shadow_challenger_calibration.py
@@ -1,0 +1,162 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts import run_forward_shadow_challenger_calibration as challenger
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _runner(
+    race_id: str,
+    box: int,
+    dog_name: str,
+    probability: float,
+    *,
+    is_winner: bool = False,
+    identity_status: str = "exact_box_and_normalized_name",
+) -> dict:
+    return {
+        "race_id": race_id,
+        "race_date": "2026-06-08",
+        "venue": "TEST",
+        "race_number": int(race_id.rsplit(" ", 1)[-1]),
+        "box": box,
+        "dog_name": dog_name,
+        "identity_match_status": identity_status,
+        "is_winner": is_winner,
+        "shadow_rf_calibrated_probability": probability,
+        "shadow_rf_uncalibrated_probability": probability,
+        "calibration_method": "power_gamma_2.4",
+        "tgr_enabled": False,
+    }
+
+
+def _safe_race(race_id: str, *, winner_box: int = 1) -> list[dict]:
+    return [
+        _runner(race_id, 1, f"{race_id} Alpha", 0.60, is_winner=winner_box == 1),
+        _runner(race_id, 2, f"{race_id} Bravo", 0.25, is_winner=winner_box == 2),
+        _runner(race_id, 3, f"{race_id} Charlie", 0.15, is_winner=winner_box == 3),
+    ]
+
+
+def _join_dir(evidence_root: Path, name: str, source_shadow_run: str, rows: list[dict]) -> Path:
+    join_dir = evidence_root / name
+    _write_json(
+        join_dir / "shadow_forward_metrics.json",
+        {
+            "schema_version": "forward_shadow_metrics_v1",
+            "source_shadow_run": source_shadow_run,
+        },
+    )
+    _write_jsonl(join_dir / "joined_shadow_predictions.jsonl", rows)
+    return join_dir
+
+
+def test_challenger_uses_only_exact_joined_races_and_writes_report_only(tmp_path, monkeypatch):
+    monkeypatch.setattr(challenger, "ROOT", tmp_path)
+    monkeypatch.setattr(challenger, "DEFAULT_PROTECTED_PATHS", ())
+    evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
+    safe_rows = _safe_race("Race 1")
+    safe_rows.extend(_safe_race("Race 2", winner_box=2))
+    unsafe_rows = [
+        _runner(
+            "Race 3",
+            1,
+            "Race 3 Alpha",
+            0.70,
+            is_winner=True,
+            identity_status="fuzzy_name_only",
+        ),
+        _runner("Race 3", 2, "Race 3 Bravo", 0.30),
+    ]
+    _join_dir(
+        evidence_root,
+        "forward_shadow_result_join_20260608T120000+1000",
+        "daily_race_ingest_shadow_a",
+        safe_rows + unsafe_rows,
+    )
+    output_dir = (
+        evidence_root / "forward_shadow_challenger_calibration_20260608T120100+1000"
+    )
+
+    result = challenger.run_challenger_calibration(
+        evidence_root=evidence_root,
+        output_dir=output_dir,
+        alpha_grid=(1.0,),
+        thresholds=challenger.ChallengerThresholds(
+            min_total_safe_joined_races=2,
+            min_train_races=1,
+            min_eval_races=1,
+            train_fraction=0.5,
+        ),
+    )
+
+    assert result["final_status"] == challenger.FINAL_READY
+    report = json.loads((output_dir / "challenger_calibration_report.json").read_text())
+    assert report["safe_exact_joined_race_count"] == 2
+    assert report["production_activation_allowed"] is False
+    assert report["no_write_guarantees"]["db_write"] is False
+    assert report["no_write_guarantees"]["registry_mutation"] is False
+    assert report["rejected_joined_races"] == [
+        {
+            "race_id": "Race 3",
+            "reasons": ["non_exact_identity_match_status"],
+            "row_count": 2,
+        }
+    ]
+    predictions = [
+        json.loads(line)
+        for line in (output_dir / "challenger_predictions_report_only.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert {row["race_id"] for row in predictions} == {"Race 1", "Race 2"}
+    assert all(
+        row["identity_match_status"] == "exact_box_and_normalized_name"
+        for row in predictions
+    )
+
+
+def test_challenger_blocks_activation_when_sample_is_below_threshold(tmp_path, monkeypatch):
+    monkeypatch.setattr(challenger, "ROOT", tmp_path)
+    monkeypatch.setattr(challenger, "DEFAULT_PROTECTED_PATHS", ())
+    evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
+    _join_dir(
+        evidence_root,
+        "forward_shadow_result_join_20260608T120000+1000",
+        "daily_race_ingest_shadow_a",
+        _safe_race("Race 1") + _safe_race("Race 2", winner_box=2),
+    )
+
+    report, _ = challenger.build_report(
+        evidence_root=evidence_root,
+        input_probability_key="shadow_rf_calibrated_probability",
+        alpha_grid=(1.0,),
+        thresholds=challenger.ChallengerThresholds(
+            min_total_safe_joined_races=3,
+            min_train_races=2,
+            min_eval_races=2,
+            train_fraction=0.5,
+        ),
+        generated_at=datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc),
+        protected_before={},
+        protected_after={},
+    )
+
+    assert report["final_status"] == challenger.FINAL_BLOCKED
+    assert "safe_joined_race_count_below_min_total" in report["activation_blockers"]
+    assert "train_race_count_below_min" in report["activation_blockers"]
+    assert "eval_race_count_below_min" in report["activation_blockers"]
+    assert report["report_only"] is True

--- a/tests/test_forward_shadow_status_report.py
+++ b/tests/test_forward_shadow_status_report.py
@@ -1,0 +1,149 @@
+import json
+from datetime import datetime
+
+from scripts import forward_shadow_status_report as status
+
+
+def _db_report(state="PASS"):
+    return {"status": state}
+
+
+def _metrics(**overrides):
+    payload = {
+        "safe_joined_race_count": 25,
+        "pending_race_count": 0,
+        "unsafe_match_count": 0,
+        "probability_sum_max_error_joined_races": 0.0,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _activation(**overrides):
+    payload = {"kept_quarantined_features": []}
+    payload.update(overrides)
+    return payload
+
+
+def test_status_collects_more_when_joined_sample_is_too_small():
+    final_status, reasons = status.decide_status(
+        db_report=_db_report(),
+        metrics=_metrics(safe_joined_race_count=4, pending_race_count=12),
+        activation=_activation(kept_quarantined_features=["same_distance_same_grade_best_time"]),
+        min_joined_races=20,
+    )
+
+    assert final_status == "CONTINUE_FORWARD_SHADOW_COLLECTION"
+    assert "safe_joined_race_count_below_review_min" in reasons
+    assert "pending_official_results_remain" in reasons
+    assert "features_remain_quarantined" in reasons
+
+
+def test_status_blocks_on_db_failure():
+    final_status, reasons = status.decide_status(
+        db_report=_db_report("FAIL"),
+        metrics=_metrics(),
+        activation=_activation(),
+        min_joined_races=20,
+    )
+
+    assert final_status == "BLOCKED_DB_STATE"
+    assert reasons == ["db_state_not_pass"]
+
+
+def test_status_ready_for_report_only_review_when_sample_and_gates_pass():
+    final_status, reasons = status.decide_status(
+        db_report=_db_report(),
+        metrics=_metrics(),
+        activation=_activation(),
+        min_joined_races=20,
+    )
+
+    assert final_status == "READY_FOR_FORWARD_SHADOW_REVIEW_REPORT_ONLY"
+    assert reasons == []
+
+
+def test_metric_summary_handles_missing_metrics():
+    summary = status.metric_summary(None)
+
+    assert summary["safe_joined_race_count"] == 0
+    assert summary["pending_race_count"] == 0
+    assert summary["winner_ranks"] == []
+
+
+def test_artifact_final_status_reads_status_file(tmp_path):
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    (artifact / "final_status.txt").write_text("READY\n", encoding="utf-8")
+
+    assert status.artifact_final_status(artifact) == "READY"
+
+
+def test_status_prefers_aggregate_metrics_over_latest_single_join(tmp_path, monkeypatch):
+    aggregate_dir = tmp_path / "forward_shadow_result_aggregate_20260608T123000+1000"
+    aggregate_dir.mkdir()
+    (aggregate_dir / "aggregate_forward_metrics.json").write_text(
+        json.dumps(
+            {
+                "safe_joined_race_count": 6,
+                "pending_race_count": 10,
+                "unsafe_match_count": 0,
+                "probability_sum_max_error_joined_races": 0.0,
+                "winner_ranks": [7, 1, 5, 5, 2, 8],
+            }
+        ),
+        encoding="utf-8",
+    )
+    single_dir = tmp_path / "forward_shadow_result_join_20260608T124000+1000"
+    single_dir.mkdir()
+    (single_dir / "shadow_forward_metrics.json").write_text(
+        json.dumps(
+            {
+                "safe_joined_race_count": 1,
+                "pending_race_count": 10,
+                "unsafe_match_count": 0,
+                "probability_sum_max_error_joined_races": 0.0,
+                "winner_ranks": [5],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(status, "db_state", lambda _path: {"status": "PASS"})
+
+    report = status.build_status_report(
+        evidence_root=tmp_path,
+        db_path=tmp_path / "db.sqlite",
+        min_joined_races=20,
+        generated_at=datetime.fromisoformat("2026-06-08T12:45:00+10:00"),
+    )
+
+    assert report["result_metric_source"] == "aggregate_forward_metrics"
+    assert report["forward_metrics"]["safe_joined_race_count"] == 6
+    assert report["coverage_gap"]["latest_forward_metrics_summary"][
+        "safe_joined_race_count"
+    ] == 6
+    assert report["source_dirs"]["aggregate_result_dir"].endswith(
+        "forward_shadow_result_aggregate_20260608T123000+1000"
+    )
+
+
+def test_coverage_summary_uses_selected_forward_metrics_over_stale_audit_metrics():
+    summary = status.coverage_summary(
+        {
+            "latest_forward_metrics_summary": {
+                "safe_joined_race_count": 4,
+                "pending_race_count": 12,
+            },
+            "blocked_reasons": ["features_remain_quarantined"],
+        },
+        selected_metrics={
+            "safe_joined_race_count": 7,
+            "pending_race_count": 9,
+        },
+    )
+
+    assert summary["latest_forward_metrics_summary"] == {
+        "safe_joined_race_count": 7,
+        "pending_race_count": 9,
+    }
+    assert summary["blocked_reasons"] == ["features_remain_quarantined"]

--- a/tests/test_join_forward_shadow_results.py
+++ b/tests/test_join_forward_shadow_results.py
@@ -1,0 +1,384 @@
+import csv
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts import join_forward_shadow_results as joiner
+
+
+def _prediction(
+    race_id: str,
+    dog_name: str,
+    box: int,
+    probability: float,
+    rank: int,
+) -> dict:
+    return {
+        "race_id": race_id,
+        "dog_name": dog_name,
+        "box": box,
+        "shadow_rf_uncalibrated_probability": probability,
+        "shadow_rf_calibrated_probability": probability,
+        "predicted_rank": rank,
+        "calibration_method": "power_gamma_2.4",
+        "model_version": "test-shadow",
+        "model_source": "artifacts/test/model.joblib",
+        "tgr_enabled": False,
+        "output_mode": "shadow_only",
+    }
+
+
+def _official(
+    box: int,
+    dog_name: str,
+    finish_position: int | None,
+    status: str | None = None,
+) -> dict:
+    return {
+        "box_number": box,
+        "dog_name": dog_name,
+        "finish_position": finish_position,
+        "status": status,
+    }
+
+
+def _result_html(rows: list[dict]) -> str:
+    body = []
+    for row in rows:
+        position = row["status"] or (
+            f"{row['finish_position']}st"
+            if row["finish_position"] == 1
+            else f"{row['finish_position']}th"
+            if row["finish_position"] is not None
+            else ""
+        )
+        body.append(
+            "<tr class=\"race-runner\">"
+            f"<td class=\"race-runners__finish-position\">{position}</td>"
+            f"<td class=\"race-runners__box\"><input name=\"rug_{row['box_number']}\" /></td>"
+            f"<td class=\"race-runners__name\">{row['dog_name']}</td>"
+            "</tr>"
+        )
+    return "<table class=\"race-runners--result\">" + "".join(body) + "</table>"
+
+
+def _write_shadow_run(root: Path, races: dict[str, list[dict]]) -> Path:
+    shadow_dir = root / "shadow"
+    shadow_dir.mkdir()
+    manifest = {
+        "prediction_rows": sum(len(rows) for rows in races.values()),
+        "race_count": len(races),
+        "calibration_method": "power_gamma_2.4",
+        "all_missing_train_policy": "quarantine_feature",
+        "tgr_enabled": False,
+        "output_mode": "shadow_only",
+    }
+    (shadow_dir / "shadow_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    with (shadow_dir / "shadow_predictions.csv").open("w", encoding="utf-8", newline="") as handle:
+        fieldnames = [
+            "race_id",
+            "dog_name",
+            "box",
+            "shadow_rf_uncalibrated_probability",
+            "shadow_rf_calibrated_probability",
+            "predicted_rank",
+            "calibration_method",
+            "model_version",
+            "model_source",
+            "tgr_enabled",
+            "output_mode",
+        ]
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for rows in races.values():
+            for row in rows:
+                writer.writerow(row)
+
+    for index, race_id in enumerate(races, start=1):
+        source = shadow_dir / "eligible_inputs" / f"source_{index:04d}"
+        source.mkdir(parents=True)
+        csv_path = source / f"{race_id}.csv"
+        csv_path.write_text("Dog Name|BOX\n", encoding="utf-8")
+        race_number = race_id.split(" - ")[0].replace("Race ", "")
+        venue = race_id.split(" - ")[1]
+        race_date = race_id.split(" - ")[2]
+        metadata = {
+            "filename": csv_path.name,
+            "race_url": f"https://www.thedogs.com.au/racing/test/{race_date}/{race_number}/test?trial=false",
+            "race_info": {
+                "date": race_date,
+                "venue": venue,
+                "race_number": race_number,
+                "url": f"https://www.thedogs.com.au/racing/test/{race_date}/{race_number}/test?trial=false",
+            },
+            "metadata_is_leakage_safe": True,
+            "runner_completeness_after_canonical_alignment": {
+                "status": "COMPLETE",
+                "runner_count": len(races[race_id]),
+                "boxes": [row["box"] for row in races[race_id]],
+                "participants": [
+                    {"box_number": row["box"], "dog_name": row["dog_name"]}
+                    for row in races[race_id]
+                ],
+            },
+            "canonical_runner_alignment": {
+                "schema_version": "canonical_runner_alignment_v1",
+                "status": "aligned",
+                "reason": None,
+                "canonical_runner_set_status": "available",
+                "canonical_runner_count": len(races[race_id]),
+                "prediction_runner_count": len(races[race_id]),
+                "remapped_participants": [],
+                "dropped_participants": [],
+            },
+        }
+        csv_path.with_name(csv_path.name + ".metadata.json").write_text(
+            json.dumps(metadata),
+            encoding="utf-8",
+        )
+    return shadow_dir
+
+
+def test_normalized_identity_strips_badges_and_punctuation_without_fuzzy_matching():
+    assert joiner.normalize_result_identity_name("Shank's Pony NBT") == (
+        joiner.normalize_result_identity_name("Shanks Pony")
+    )
+    assert joiner.normalize_result_identity_name("Alpha Runner") != (
+        joiner.normalize_result_identity_name("Alfa Runner")
+    )
+
+
+def test_classify_safe_join_allows_extra_official_scratch_and_unplaced_nonwinners():
+    predictions = [
+        _prediction("Race 5 - TRA - 2026-06-08", "Minter Blinder", 1, 0.6, 1),
+        _prediction("Race 5 - TRA - 2026-06-08", "Shanks Pony", 5, 0.3, 2),
+        _prediction("Race 5 - TRA - 2026-06-08", "Little Thief", 8, 0.1, 3),
+    ]
+    official_rows = [
+        _official(1, "Minter Blinder", 1),
+        _official(5, "Shank's Pony", 2),
+        _official(8, "Little Thief NBT", None),
+        _official(2, "King Cherry NBT", None, "SCR"),
+    ]
+
+    report = joiner.classify_result_identity_join(
+        race_id="Race 5 - TRA - 2026-06-08",
+        prediction_rows=predictions,
+        official_rows=official_rows,
+    )
+
+    assert report["status"] == "SAFE_EXACT_BOX_AND_NAME_MATCH"
+    assert report["winner_box"] == 1
+    assert report["allowed_extra_scratched_official_boxes"] == [
+        {"box": 2, "dog_name": "King Cherry NBT", "status": "SCR"}
+    ]
+
+
+def test_classify_join_rejects_fuzzy_name_mismatch():
+    predictions = [_prediction("Race 1 - TEST - 2026-06-08", "Alpha Runner", 1, 1.0, 1)]
+    official_rows = [_official(1, "Alfa Runner", 1)]
+
+    report = joiner.classify_result_identity_join(
+        race_id="Race 1 - TEST - 2026-06-08",
+        prediction_rows=predictions,
+        official_rows=official_rows,
+    )
+
+    assert report["status"] == "UNSAFE_QUARANTINED"
+    assert "dog_name_mismatch_after_exact_badge_stripping" in report["identity_errors"]
+
+
+def test_join_forward_shadow_results_writes_partial_artifact_with_stub_fetcher(tmp_path, monkeypatch):
+    monkeypatch.setattr(joiner, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        joiner,
+        "DEFAULT_PROTECTED_PATHS",
+        (tmp_path / "greyhound_racing_data.db",),
+    )
+    races = {
+        "Race 1 - TEST - 2026-06-08": [
+            _prediction("Race 1 - TEST - 2026-06-08", "Alpha Runner", 1, 0.7, 1),
+            _prediction("Race 1 - TEST - 2026-06-08", "Bravo Runner", 2, 0.3, 2),
+        ],
+        "Race 2 - TEST - 2026-06-08": [
+            _prediction("Race 2 - TEST - 2026-06-08", "Charlie Runner", 1, 0.55, 1),
+            _prediction("Race 2 - TEST - 2026-06-08", "Delta Runner", 2, 0.45, 2),
+        ],
+    }
+    shadow_dir = _write_shadow_run(tmp_path, races)
+    output_dir = (
+        tmp_path
+        / "artifacts/full_evidence_orchestration_20260525/"
+        "forward_shadow_result_join_20260608T120000+1000"
+    )
+
+    def fetch_html(url: str) -> dict:
+        if "/1/" in url:
+            return {
+                "url": url,
+                "final_url": url,
+                "status_code": 200,
+                "text": _result_html(
+                    [
+                        _official(1, "Alpha Runner", 1),
+                        _official(2, "Bravo Runner NBT", None),
+                    ]
+                ),
+                "error": None,
+            }
+        return {
+            "url": url,
+            "final_url": url,
+            "status_code": 200,
+            "text": "<html>No results yet</html>",
+            "error": None,
+        }
+
+    result = joiner.join_forward_shadow_results(
+        shadow_run_dir=shadow_dir,
+        output_dir=output_dir,
+        current_time=datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc),
+        fetch_html=fetch_html,
+        verify_db=False,
+    )
+
+    assert result["verdict"] == "PARTIAL_JOIN_PENDING_MORE_RESULTS"
+    assert result["safe_joined_race_count"] == 1
+    assert result["pending_race_count"] == 1
+    assert result["unsafe_match_count"] == 0
+    assert (output_dir / "joined_shadow_predictions.jsonl").read_text(encoding="utf-8").count("\n") == 2
+    metrics = json.loads((output_dir / "shadow_forward_metrics.json").read_text(encoding="utf-8"))
+    assert metrics["top1"] == 1.0
+    identity_report = json.loads(
+        (output_dir / "identity_match_report.json").read_text(encoding="utf-8")
+    )
+    assert identity_report["race_attempts"][0]["prejump_runner_alignment"][
+        "canonical_runner_alignment_status"
+    ] == "aligned"
+    assert json.loads((output_dir / "pending_results.json").read_text(encoding="utf-8"))[
+        "pending_race_count"
+    ] == 1
+
+
+def test_join_forward_shadow_results_quarantines_malformed_prediction_rows(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(joiner, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        joiner,
+        "DEFAULT_PROTECTED_PATHS",
+        (tmp_path / "greyhound_racing_data.db",),
+    )
+    shadow_dir = _write_shadow_run(
+        tmp_path,
+        {
+            "Race 1 - TEST - 2026-06-08": [
+                _prediction("Race 1 - TEST - 2026-06-08", "Alpha Runner", 1, 0.7, 1),
+                _prediction("Race 1 - TEST - 2026-06-08", "Bravo Runner", 2, 0.3, 2),
+            ]
+        },
+    )
+    with (shadow_dir / "shadow_predictions.csv").open("a", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            [
+                "Race 1 - TEST - 2026-06-08",
+                "Broken Runner",
+                "",
+                "0.1",
+                "0.1",
+                "",
+                "power_gamma_2.4",
+                "test-shadow",
+                "artifacts/test/model.joblib",
+                "False",
+                "shadow_only",
+            ]
+        )
+
+    output_dir = (
+        tmp_path
+        / "artifacts/full_evidence_orchestration_20260525/"
+        "forward_shadow_result_join_20260608T121500+1000"
+    )
+
+    result = joiner.join_forward_shadow_results(
+        shadow_run_dir=shadow_dir,
+        output_dir=output_dir,
+        current_time=datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc),
+        fetch_html=lambda _url: {
+            "url": _url,
+            "final_url": _url,
+            "status_code": 200,
+            "text": _result_html(
+                [
+                    _official(1, "Alpha Runner", 1),
+                    _official(2, "Bravo Runner", 2),
+                ]
+            ),
+            "error": None,
+        },
+        verify_db=False,
+    )
+
+    assert result["verdict"] == "FORWARD_SHADOW_RESULTS_JOINED"
+    assert result["safe_joined_race_count"] == 1
+    assert result["malformed_prediction_row_count"] == 1
+    malformed = json.loads(
+        (output_dir / "malformed_prediction_rows.json").read_text(encoding="utf-8")
+    )
+    assert malformed["malformed_prediction_row_count"] == 1
+    assert malformed["malformed_prediction_rows"][0]["dog_name"] == "Broken Runner"
+    identity_report = json.loads(
+        (output_dir / "identity_match_report.json").read_text(encoding="utf-8")
+    )
+    assert identity_report["summary"]["malformed_prediction_row_count"] == 1
+
+
+def test_unique_default_output_dir_adds_suffix_for_existing_generated_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(joiner, "ROOT", tmp_path)
+    generated_at = datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc)
+    existing = (
+        tmp_path
+        / "artifacts/full_evidence_orchestration_20260525/"
+        "forward_shadow_result_join_20260608T120000+0000"
+    )
+    existing.mkdir(parents=True)
+
+    output_dir = joiner.unique_default_output_dir(
+        tmp_path / "artifacts/full_evidence_orchestration_20260525",
+        generated_at,
+    )
+
+    assert output_dir.name == "forward_shadow_result_join_20260608T120000+0000_001"
+
+
+def test_explicit_output_dir_still_fails_when_existing(tmp_path, monkeypatch):
+    monkeypatch.setattr(joiner, "ROOT", tmp_path)
+    monkeypatch.setattr(joiner, "DEFAULT_PROTECTED_PATHS", (tmp_path / "greyhound_racing_data.db",))
+    shadow_dir = _write_shadow_run(
+        tmp_path,
+        {
+            "Race 1 - TEST - 2026-06-08": [
+                _prediction("Race 1 - TEST - 2026-06-08", "Alpha Runner", 1, 1.0, 1)
+            ]
+        },
+    )
+    output_dir = (
+        tmp_path
+        / "artifacts/full_evidence_orchestration_20260525/"
+        "forward_shadow_result_join_20260608T120000+1000"
+    )
+    output_dir.mkdir(parents=True)
+
+    try:
+        joiner.join_forward_shadow_results(
+            shadow_run_dir=shadow_dir,
+            output_dir=output_dir,
+            fetch_html=lambda _url: {"text": "", "status_code": 200, "error": None},
+            verify_db=False,
+        )
+    except FileExistsError:
+        pass
+    else:
+        raise AssertionError("expected explicit existing output_dir to fail closed")


### PR DESCRIPTION
## Summary

Adds a report-only forward-shadow result review toolkit:

- join shadow predictions to official TheDogs results with exact identity gates
- aggregate repeated forward-shadow result joins by source shadow run
- run report-only challenger calibration from exact joined races
- summarize forward-shadow readiness from join, aggregate, sidecar, coverage, and activation evidence

The tools write only guarded report artifacts under explicit `artifacts/full_evidence_orchestration_20260525/forward_shadow_*` output prefixes when invoked. They do not mutate model registry state, DB labels, production model pointers, prediction snapshots, EV output, betting output, or runtime data.

## Validation

- `/tmp/greyhound-forward-shadow-result-review-venv/bin/python -m pytest --noconftest --no-cov tests/test_join_forward_shadow_results.py tests/test_aggregate_forward_shadow_results.py tests/test_forward_shadow_challenger_calibration.py tests/test_forward_shadow_status_report.py` -> 21 passed
- `/tmp/greyhound-forward-shadow-result-review-venv/bin/python -m py_compile scripts/join_forward_shadow_results.py scripts/aggregate_forward_shadow_results.py scripts/run_forward_shadow_challenger_calibration.py scripts/forward_shadow_status_report.py` -> passed
- `git diff --cached --check` -> passed before commit

## Scope Boundaries

Excluded merged PR #9/#11/#12 duplicates, artifacts, outputs, upcoming race files, DB/runtime/data state, model registry state, betting/label state, systemd/autopilot deployment files, and destructive cleanup/deletion changes.
