### PR TITLE
fix(greyhound): pin shadow scorer sklearn runtime

### DIFF
--- a/scripts/daily_race_ingest_shadow_orchestrator.py
+++ b/scripts/daily_race_ingest_shadow_orchestrator.py
@@ -68,7 +68,10 @@ DEFAULT_OUTPUT_PARENT = ROOT / "artifacts/full_evidence_orchestration_20260525"
 DEFAULT_INPUT_DIRS = (ROOT / "upcoming_races",)
 DEFAULT_ALL_MISSING_TRAIN_POLICY = "quarantine_feature"
 DEFAULT_SCORE_COMMAND_MODE = "auto"
-UV_SCORE_LIVE_PACKAGES = ("joblib", "scikit-learn", "numpy")
+# The locked shadow RandomForest artifact was pickled with sklearn 1.7.2.
+# Floating scikit-learn breaks live scoring when uv resolves a newer version.
+SHADOW_MODEL_SKLEARN_VERSION = "1.7.2"
+UV_SCORE_LIVE_PACKAGES = ("joblib", f"scikit-learn=={SHADOW_MODEL_SKLEARN_VERSION}", "numpy")
 DAILY_OUTPUT_PREFIX = "artifacts/full_evidence_orchestration_20260525/daily_race_ingest_shadow_"
 EXPECTED_OFFICIAL_RACES = 214
 EXPECTED_OFFICIAL_DOG_ROWS = 1493

--- a/tests/test_daily_race_ingest_shadow_orchestrator.py
+++ b/tests/test_daily_race_ingest_shadow_orchestrator.py
@@ -920,7 +920,8 @@ def test_score_live_command_auto_falls_back_to_uv_when_current_python_lacks_ml_d
     assert command[:2] == ["/usr/bin/uv", "run"]
     assert "--with" in command
     assert "joblib" in command
-    assert "scikit-learn" in command
+    assert "scikit-learn" not in command
+    assert f"scikit-learn=={orchestrator.SHADOW_MODEL_SKLEARN_VERSION}" in command
     assert "numpy" in command
     assert "python" in command
     assert command[command.index("python") + 1].endswith(


### PR DESCRIPTION
## Summary
- pin the uv score-live scikit-learn dependency to 1.7.2, matching the locked shadow RandomForest pickle
- add a regression assertion so the daemon/orchestrator no longer emits floating scikit-learn

## Validation
- python3 -m py_compile scripts/daily_race_ingest_shadow_orchestrator.py tests/test_daily_race_ingest_shadow_orchestrator.py
- uv run --with 'scikit-learn==1.7.2' --with joblib --with numpy python -c 'import sklearn; print(sklearn.__version__)'
- uv run --python 3.11 --with-requirements requirements/all.in python -m pytest -q tests/test_daily_race_ingest_shadow_orchestrator.py
- uv run --python 3.11 --with-requirements requirements/all.in python -m pytest -q tests/test_shadow_autopilot_daemon.py tests/test_daily_race_ingest_shadow_orchestrator.py
- live checkout single regression test passed
- shadow-only score-live validation produced 102 prediction rows with protected paths unchanged

No promotion, registry mutation, DB write, label write, TGR enablement, betting/EV output, or production prediction overwrite.