### PR TITLE
[codex] Keep generated runtime service command stable

### DIFF
--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -1102,8 +1102,9 @@ def service_file_text(
 ) -> str:
     script_path = repo_path / "scripts/shadow_autopilot_daemon.py"
     service_python = python_path or Path("/usr/bin/python3")
+    evidence_root_segment = " ".join(optional_path_cli_args("--evidence-root", evidence_root))
+    evidence_root_segment = f"{evidence_root_segment} " if evidence_root_segment else ""
     explicit_path_args = [
-        *optional_path_cli_args("--evidence-root", evidence_root),
         *optional_path_cli_args("--db", db_path),
         *shadow_model_cli_args(shadow_model),
         *optional_path_cli_args("--lock-path", lock_path),
@@ -1128,6 +1129,7 @@ def service_file_text(
             "Environment=PATH=/home/l4nd0/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
             (
                 f"ExecStart={service_python} {script_path} run-once "
+                f"{evidence_root_segment}"
                 "--days-ahead 1 --refresh-limit 16 "
                 f"{explicit_path_segment}"
                 "--enable-autonomous-odds-capture "
@@ -1178,8 +1180,9 @@ def odds_capture_service_file_text(
 ) -> str:
     script_path = repo_path / "scripts/shadow_autopilot_daemon.py"
     service_python = python_path or Path("/usr/bin/python3")
+    evidence_root_segment = " ".join(optional_path_cli_args("--evidence-root", evidence_root))
+    evidence_root_segment = f"{evidence_root_segment} " if evidence_root_segment else ""
     explicit_path_args = [
-        *optional_path_cli_args("--evidence-root", evidence_root),
         *optional_path_cli_args("--db", db_path),
         *optional_path_cli_args("--lock-path", lock_path),
         *optional_path_cli_args("--state-path", state_path),
@@ -1202,6 +1205,7 @@ def odds_capture_service_file_text(
             "Environment=PATH=/home/l4nd0/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
             (
                 f"ExecStart={service_python} {script_path} run-odds-capture-once "
+                f"{evidence_root_segment}"
                 "--days-ahead 1 "
                 f"--refresh-limit {refresh_limit} "
                 f"--odds-capture-refresh-limit {refresh_limit} "

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -4242,6 +4242,7 @@ def test_service_and_timer_define_15_minute_oneshot_cycle():
         "--evidence-root /runtime/artifacts/full_evidence_orchestration_20260525"
         in service
     )
+    assert service.index("--evidence-root") < service.index("--days-ahead")
     assert "--shadow-model /models/stage2/shadow_randomforest_model.joblib" in service
     assert "--db /data/greyhound_racing_data.db" in service
     assert "--lock-path /runtime/shared-shadow-autopilot.lock" in service
@@ -4282,6 +4283,7 @@ def test_odds_capture_service_and_timer_define_minutely_locked_lane():
         "--evidence-root /runtime/artifacts/full_evidence_orchestration_20260525"
         in service
     )
+    assert service.index("--evidence-root") < service.index("--days-ahead")
     assert "--db /data/greyhound_racing_data.db" in service
     assert "--lock-path /runtime/shared-shadow-autopilot.lock" in service
     assert "--state-path /runtime/odds_capture_state.json" in service
@@ -4329,6 +4331,7 @@ def test_write_odds_capture_service_files_preserves_db_and_lock(tmp_path):
         "--evidence-root /runtime/artifacts/full_evidence_orchestration_20260525"
         in service
     )
+    assert service.index("--evidence-root") < service.index("--days-ahead")
     assert "--db /data/greyhound_racing_data.db" in service
     assert "--lock-path /runtime/shared-shadow-autopilot.lock" in service
     assert f"OnCalendar={daemon.DEFAULT_ODDS_CAPTURE_ONLY_TIMER_ON_CALENDAR}" in timer
@@ -6488,6 +6491,7 @@ def test_write_service_files_preserves_shadow_model_pin(tmp_path):
         "--evidence-root /runtime/artifacts/full_evidence_orchestration_20260525"
         in service
     )
+    assert service.index("--evidence-root") < service.index("--days-ahead")
     assert "--shadow-model /models/stage2/shadow_randomforest_model.joblib" in service
     assert "--db /data/greyhound_racing_data.db" in service
     assert "--lock-path /runtime/shared-shadow-autopilot.lock" in service


### PR DESCRIPTION
## Summary

Keeps generated shadow-autopilot systemd commands stable with the installed/static service templates.

PR #20 fixed the generator to include the runtime interpreter and external evidence root. A live writer smoke then showed the generated command was functionally correct but reordered `--evidence-root` after `--days-ahead`, which still dirtied the worktree compared with the installed service files.

## Changes

- Emit `--evidence-root` before `--days-ahead` for both main and odds-only generated systemd commands.
- Add regression assertions that generated main and odds-only services keep `--evidence-root` before `--days-ahead`.

## Validation

- `python -m py_compile scripts/shadow_autopilot_daemon.py tests/test_shadow_autopilot_daemon.py`: pass
- `git diff --check`: pass
- Direct generator-order probe: pass

Local runtime venv still does not have `pytest` installed (`No module named pytest`), so full pytest coverage is left to CI.

## Safety

No model, registry, label, betting/EV, training, or production promotion changes. This only stabilizes generated systemd template text.