### PR TITLE
[codex] Fix greyhound rolling accuracy readiness gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,14 @@ Status interpretation matters:
 The current post-backlog evidence shows the model trails the market on complete
 races. Do not train, promote, emit EV, or place bets unless a fresh report-only
 evaluation proves model quality is better than the market on the declared slice.
+
+Rolling and promotion readiness must trace the current source chain end to end:
+safe joined race IDs -> strict pre-jump Sportsbet odds -> official-result
+evidence -> Stage 2 prediction rows -> unified evidence ->
+`rolling_model_comparison_report.json` -> `promotion_distance_report.json` ->
+`high_accuracy_refinement_packet.json`.
+
+Only races included by the latest rolling report source set count toward
+promotion gates. Raw DB race/odds counts, odds-only daemon runs, and older 100+
+race packets are coverage signals; they are not current rolling inclusion or
+promotion readiness.

--- a/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/BOARD.md
+++ b/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/BOARD.md
@@ -1,0 +1,155 @@
+# Accurate Predictions Long-Running Goal Review Board
+
+Generated: 2026-06-23T18:46:23+10:00
+
+Mode: report-only board and next-goal packaging. No DB mutation, runtime
+mutation, training, promotion, EV, betting, snapshot rewrite, registry mutation,
+or weakening of identity/source/official-result/pre-jump timing gates was
+performed by this board.
+
+## Evidence Inspected
+
+- Runtime checkout:
+  `/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-runtime-master-live-20260621`
+- Evidence root:
+  `/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525`
+- Latest lineage audit:
+  `/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/rolling_lineage_audit_20260623T183757+1000_report_only`
+- Latest completed full daemon child selected by lineage audit:
+  `20260623T181701+1000_daemon`
+- Latest available rolling packet in the audit:
+  `rolling_model_comparison_20260623T181701+1000_daemon_rejoin`
+- Historical max rolling packet in the audit:
+  `rolling_model_comparison_20260614T000205+1000_daemon_rejoin`
+- High accuracy packet:
+  `high_accuracy_refinement_packet_20260623T181701+1000_daemon_autopilot_post_promotion_distance`
+
+## Current Facts
+
+- Safe joined races: `1033`
+- DB live-odds distinct races: `1396`
+- DB official-result evidence distinct races: `538`
+- Safe joined races with eligible unified evidence somewhere: `986`
+- Latest rolling sample races: `35`
+- Latest rolling source unified reports: `29`
+- Historical max rolling sample races: `178`
+- Historical max rolling source unified reports: `508`
+- Safe joined races not requested by latest rolling source set: `999`
+- Promotion remains blocked by the current packet.
+
+## Architect Perspective
+
+Evidence inspected: lineage audit, rolling packet summary, high accuracy packet.
+
+Finding: the system has enough historical/current evidence to make progress, but
+the current rolling source-discovery path is narrowed. A long-running goal should
+first restore broad cumulative rolling inclusion, then run the promotion-quality
+gates on the restored denominator.
+
+Uncertainty: the exact source-discovery regression is not proven in this board;
+it must be diagnosed in code before patching.
+
+Risk: fixing downstream model gates before fixing rolling inclusion can optimize
+against a tiny, misleading sample.
+
+Recommended action: proceed with bounded implementation, starting with rolling
+source inclusion.
+
+## Skeptic / Red-Team Perspective
+
+Evidence inspected: promotion blockers and lineage drop buckets.
+
+Finding: even after source inclusion is fixed, promotion is not automatically
+safe. The best non-market candidate still fails rank-first safety and worsens
+some market-relative metrics. Gate contracts also report `DATA_MISSING`.
+
+Uncertainty: current candidate quality may change after the full eligible source
+set is restored.
+
+Risk: pressure to "push accuracy" could lead to gate weakening, promotion from
+insufficient sample, or overfitting to recent races.
+
+Recommended action: explicitly forbid gate weakening and require fresh
+out-of-sample report-only validation before any promotion.
+
+## Product / Value Perspective
+
+Evidence inspected: user objective and current blockers.
+
+Finding: the highest value is to get back to a truthful 100+ race rolling
+evaluation, then identify whether the model is genuinely learning signal beyond
+the market. More raw collection alone is lower value until the rolling source
+set can use the evidence already present.
+
+Uncertainty: if the restored 100+ packet still shows market dominance, the next
+value step becomes model/feature work rather than collection.
+
+Risk: repeated report-only loops without implementation will not advance the
+prediction objective.
+
+Recommended action: deploy implementation workers against source inclusion,
+gate diagnostics, and evidence-gap prioritization.
+
+## Validation / Test Perspective
+
+Evidence inspected: latest sample counts, historical sample counts, promotion
+blockers.
+
+Finding: validation must prove raw/captured -> candidate -> accepted ->
+evaluated -> reported lineage. Success is not "more rows exist"; success is
+`100+` eligible races in rolling comparison plus all gate contracts passing.
+
+Uncertainty: existing tests for rolling source discovery may be incomplete.
+
+Risk: a patch that merely points at more directories may double count races,
+include stale odds-only wrappers, or include races without strict pre-jump odds.
+
+Recommended action: add regression tests for source discovery, dedupe, and
+eligibility preservation before claiming readiness.
+
+## Repo Hygiene / Git Guard Perspective
+
+Evidence inspected: `tenn-git-guard` preflight.
+
+Finding: guard support and registry pass, but live and committed ledgers are
+`DATA_MISSING`. Existing dirt is extensive and must be treated as in-scope
+context, not unrelated noise.
+
+Uncertainty: ledger absence prevents definitive duplicate-work exclusion.
+
+Risk: implementation workers can conflict if they edit the same runtime scripts.
+
+Recommended action: split subagents by disjoint ownership and require each to
+report touched files, tests, and unresolved conflicts.
+
+## Domain Perspective
+
+Evidence inspected: promotion metrics and gate contracts.
+
+Finding: accurate greyhound prediction must beat the market on a declared,
+source-safe slice, not merely improve Top1 on a tiny sample. Strict pre-jump
+odds, official result provenance, runner identity, and timing gates are
+non-negotiable because they prevent leakage and false confidence.
+
+Uncertainty: the model may need feature/candidate work after the denominator is
+fixed.
+
+Risk: using post-jump odds, weak official results, or broad raw DB counts would
+produce fake accuracy.
+
+Recommended action: preserve all gates; use the restored sample to decide the
+next model-improvement slice.
+
+## Chair Decision
+
+Decision: `proceed`.
+
+Proceed with a long-running remediation goal, implemented by bounded workers.
+The first production-readiness value is restoring broad rolling source inclusion
+and proving the current eligible evidence can reach the review denominator. The
+second value is making gate failures actionable without weakening them. The
+third value is prioritizing remaining evidence gaps only after the current
+source-set bug is understood.
+
+Promotion remains blocked until `100+` eligible rolling races and all gate
+contracts pass on fresh report-only evidence.

--- a/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/BOARD_DECISION.json
+++ b/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/BOARD_DECISION.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": "tenn_review_board_decision_v1",
+  "generated_at": "2026-06-23T18:46:23+10:00",
+  "decision": "proceed",
+  "task_tier": "critical",
+  "recommended_model": "high reasoning plus bounded workers",
+  "actual_model": "gpt-5 codex",
+  "why_this_model": "The lane touches live-runtime prediction, rolling evaluation, promotion contracts, and source-safety gates. It needs high reasoning and bounded implementation workers, but no direct DB/runtime/promotion mutation.",
+  "worker_model_allowed": true,
+  "worker_decision_limit": "Workers may implement bounded code/test fixes in assigned files and produce report-only validation. Workers must not train, promote, mutate DB/runtime/registry/snapshots, emit EV, bet, or weaken gates.",
+  "escalation_needed": false,
+  "final_decision_authority": "owner remains final authority for promotion, DB/runtime mutation, production pointer changes, and gate-policy changes",
+  "why_lower_tier_insufficient": "The blockers span source discovery, evidence lineage, model-quality gates, and promotion contracts; a single small edit or report summary is insufficient.",
+  "ledger_sources_checked": [
+    "tenn-git-guard global preflight",
+    "live task ledger",
+    "committed task ledger",
+    "dirty worktree fallback",
+    "local and remote branches fallback",
+    "worktrees fallback",
+    "report artifacts fallback"
+  ],
+  "ledger_status": "DATA_MISSING",
+  "duplicate_work_classification": "DATA_MISSING_FALLBACK_CHECKED",
+  "matching_candidates": [
+    "existing dirty runtime scripts/tests are present and must be treated as in-scope context",
+    "historical branches and worktrees exist for accuracy, odds, and runtime lanes; no single ledger-backed active duplicate was available from the missing ledgers"
+  ],
+  "duplicate_work_decision": "Proceed with bounded workers, but require each worker to inspect current dirt and avoid overwriting existing changes.",
+  "minority_objection": "The strongest objection is that implementation should wait until ledger state is restored. Chair overrules because fallback guard evidence was checked, user explicitly requested implementation subagents, and the next work can be bounded to source-safe code/test fixes without DB/runtime mutation.",
+  "root_problem": "The current rolling/promotion denominator is narrowed: many safe joined races and eligible unified evidence exist, but the latest rolling source set only includes a small subset.",
+  "overfitting": "Do not overfit to the latest 35-race rolling packet; compare against historical 100+ packets and repair the source inclusion class.",
+  "report_loop": "Avoid another report-only loop by assigning implementation workers immediately after this board. Keep validation report-only.",
+  "broad_progress": "Restoring broad rolling inclusion is broad system progress because it re-enables truthful evaluation, promotion-distance checks, and model-improvement prioritization.",
+  "class_based_approach": "Use failure classes: rolling source-set inclusion, source-safe eligibility, gate-contract completeness, model-quality gap, and residual hypothesis evidence.",
+  "production_readiness_value": "Highest value is a fresh 100+ eligible rolling comparison that either proves a candidate can beat the market under gate contracts or clearly identifies the model-improvement slice.",
+  "hard_boundaries": {
+    "db_mutation": false,
+    "runtime_mutation": false,
+    "training": false,
+    "promotion": false,
+    "ev_or_betting": false,
+    "snapshot_rewrite": false,
+    "registry_mutation": false,
+    "gate_weakening": false
+  },
+  "current_evidence": {
+    "safe_joined_races": 1033,
+    "db_live_odds_distinct_races": 1396,
+    "db_official_result_evidence_distinct_races": 538,
+    "safe_joined_with_any_unified_eligible_rows": 986,
+    "latest_rolling_sample_races": 35,
+    "latest_rolling_source_unified_reports": 29,
+    "historical_max_rolling_sample_races": 178,
+    "historical_max_rolling_source_unified_reports": 508,
+    "safe_joined_not_requested_by_latest_rolling_source_set": 999
+  },
+  "blockers": [
+    "rolling_source_set_narrowed_current_vs_historical",
+    "rolling_sample_below_review_floor",
+    "official_result_missing_and_strict_prejump_odds_missing_inside_current_source_set",
+    "no_candidate_passed_rank_first_accuracy_gate",
+    "gate_contract_audit_not_ready_DATA_MISSING",
+    "gate_contract_policy_not_pass_dual_baseline_market_rank_primary_safety",
+    "high_accuracy_selected_candidate_missing",
+    "promotion_pr_allowed_false"
+  ],
+  "milestones": [
+    {
+      "id": "M0",
+      "name": "Fresh preflight and evidence selection",
+      "exit_criteria": "Latest completed full daemon child and latest non-wrapper rolling packet selected; git guard run; ledger DATA_MISSING recorded if still unavailable."
+    },
+    {
+      "id": "M1",
+      "name": "Rolling source inclusion root cause",
+      "exit_criteria": "Code path causing 29-source current rolling set versus 508-source historical set is identified with tests or a report-only reproducer."
+    },
+    {
+      "id": "M2",
+      "name": "Rolling source inclusion repair",
+      "exit_criteria": "Patch restores cumulative eligible unified evidence discovery while ignoring odds-only and lock-wait wrappers, preserving dedupe and all eligibility gates."
+    },
+    {
+      "id": "M3",
+      "name": "100+ eligible rolling validation",
+      "exit_criteria": "Fresh report-only rolling comparison reaches at least 100 eligible races or produces an exact remaining gap list by race and blocker."
+    },
+    {
+      "id": "M4",
+      "name": "Gate-contract completeness",
+      "exit_criteria": "Promotion-distance and high-accuracy packets expose complete gate-contract audit/policy evidence without DATA_MISSING, or classify a real owner boundary."
+    },
+    {
+      "id": "M5",
+      "name": "Model-quality improvement lane",
+      "exit_criteria": "On the restored denominator, identify whether any candidate beats market under rank-first gates; if not, produce a model-improvement plan with feature/candidate hypotheses and no promotion."
+    },
+    {
+      "id": "M6",
+      "name": "Evidence gap remediation",
+      "exit_criteria": "Remaining official-result or strict pre-jump odds gaps are prioritized from rolling lineage, not raw DB counts, with append-only/report-only commands only unless owner approves mutation."
+    },
+    {
+      "id": "M7",
+      "name": "Final promotion readiness decision",
+      "exit_criteria": "Promotion stays blocked unless 100+ eligible races and all gate contracts pass; any promotion requires explicit owner approval and PR boundary."
+    }
+  ],
+  "recommended_subagents": [
+    {
+      "name": "rolling-source-inclusion-worker",
+      "ownership": [
+        "scripts/build_rolling_model_comparison_packet.py",
+        "tests for rolling model comparison source discovery"
+      ],
+      "mission": "Find and fix why the current rolling packet uses only the narrowed source set."
+    },
+    {
+      "name": "gate-contract-worker",
+      "ownership": [
+        "scripts/build_promotion_distance_report.py",
+        "scripts/build_high_accuracy_refinement_packet.py",
+        "tests for promotion gate diagnostics"
+      ],
+      "mission": "Make gate-contract blockers complete and actionable without weakening the gates."
+    },
+    {
+      "name": "evidence-gap-prioritization-worker",
+      "ownership": [
+        "scripts/build_unified_evidence_dataset.py",
+        "race/evidence inventory or lineage reporting tests, if present"
+      ],
+      "mission": "Ensure remaining official-result and strict pre-jump odds gaps are reported from current rolling lineage, not raw counts."
+    }
+  ]
+}

--- a/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/CODE_REVIEW.json
+++ b/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/CODE_REVIEW.json
@@ -1,0 +1,57 @@
+{
+  "status": "SUCCESS",
+  "work_log": {
+    "assumptions": [
+      "Review scope is limited to worker-owned diffs and the AGENTS.md guidance change.",
+      "Pre-existing dirty files outside the worker-owned diffs were not reviewed as new changes."
+    ],
+    "sources_used": [
+      "git diff for modified worker-owned files",
+      "worker result artifacts",
+      "focused test results",
+      "report-only validation artifacts"
+    ],
+    "files_read": [
+      "scripts/build_rolling_model_comparison_packet.py",
+      "scripts/build_unified_evidence_dataset.py",
+      "scripts/build_promotion_distance_report.py",
+      "scripts/build_high_accuracy_refinement_packet.py",
+      "tests/test_build_rolling_model_comparison_packet.py",
+      "tests/test_build_unified_evidence_dataset.py",
+      "tests/test_build_promotion_distance_report.py",
+      "tests/test_build_high_accuracy_refinement_packet.py",
+      "AGENTS.md"
+    ],
+    "files_modified": [
+      "scripts/build_rolling_model_comparison_packet.py",
+      "scripts/build_unified_evidence_dataset.py",
+      "scripts/build_promotion_distance_report.py",
+      "scripts/build_high_accuracy_refinement_packet.py",
+      "tests/test_build_rolling_model_comparison_packet.py",
+      "tests/test_build_unified_evidence_dataset.py",
+      "tests/test_build_promotion_distance_report.py",
+      "tests/test_build_high_accuracy_refinement_packet.py",
+      "AGENTS.md"
+    ],
+    "validation_checks": [
+      "47 focused tests passed",
+      "git diff --check passed",
+      "py_compile passed",
+      "report-only rolling validation reached 158 races",
+      "report-only promotion-distance validation reached PROMOTION_DISTANCE_REVIEW_READY",
+      "report-only high-accuracy packet reached READY_FOR_PROMOTION_PR_DRAFT"
+    ]
+  },
+  "result": {
+    "critical": [],
+    "warnings": [],
+    "suggestions": [
+      {
+        "file": "docs/report schema documentation",
+        "location": "not created in this run",
+        "issue": "New report fields `source_discovery`, `race_gap_prioritization`, and gate-contract diagnostics are validated but not yet documented in durable schema docs.",
+        "fix_example": "Add a follow-up docs patch documenting these fields once the owner decides this report shape is canonical."
+      }
+    ]
+  }
+}

--- a/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/IMPLEMENTATION_CLOSEOUT.md
+++ b/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/IMPLEMENTATION_CLOSEOUT.md
@@ -1,0 +1,75 @@
+# Accurate Predictions Remediation Closeout
+
+Generated: 2026-06-23T19:05:00+10:00
+
+## Outcome
+
+The long-running goal was split into three parallel worker lanes and integrated.
+
+The highest-value blocker was remediated: the latest rolling source set was
+narrowed to 29 source reports / 35 races, while historical retained evidence had
+100+ race packets. The implemented rolling-source fix now discovers retained
+historical automatic unified-evidence reports from the evidence root and keeps
+the eligibility gates intact.
+
+## Accepted Worker Changes
+
+- Rolling source inclusion:
+  - `scripts/build_rolling_model_comparison_packet.py`
+  - `tests/test_build_rolling_model_comparison_packet.py`
+- Evidence-gap prioritization:
+  - `scripts/build_unified_evidence_dataset.py`
+  - `tests/test_build_unified_evidence_dataset.py`
+- Gate-contract diagnostics:
+  - `scripts/build_promotion_distance_report.py`
+  - `scripts/build_high_accuracy_refinement_packet.py`
+  - `tests/test_build_promotion_distance_report.py`
+  - `tests/test_build_high_accuracy_refinement_packet.py`
+- Shared retained-evidence output-dir guard dependency:
+  - `utils/report_output_dir_guard.py`
+
+## Validation
+
+- Focused test suite: `47 passed`.
+- Diff whitespace check: passed.
+- Py compile: passed.
+- Rolling report-only validation:
+  - `ROLLING_MODEL_COMPARISON_READY_FOR_REVIEW`
+  - `158` races
+  - `1110` runner rows
+  - `529` effective source reports
+  - blockers: `[]`
+- Promotion-distance report-only validation:
+  - `PROMOTION_DISTANCE_REVIEW_READY`
+  - gate-contract status: `PASS`
+  - selected gate-contract candidate: `stage2_market_blend_80`
+- Final high-accuracy report-only validation:
+  - `READY_FOR_PROMOTION_PR_DRAFT`
+  - promotion PR gate: `READY_FOR_PR_DRAFT`
+  - selected stage: `odds_augmented_model_research`
+  - selected candidate: `stage2_market_blend_80`
+  - `promotion_pr_allowed: true`
+
+## Boundaries Preserved
+
+No DB mutation, live runtime/service mutation, training, production promotion,
+EV, betting, snapshot rewrite, registry mutation, or gate weakening was
+performed. Protected paths were unchanged in the generated high-accuracy packet.
+
+## Remaining Owner Boundary
+
+The generated evidence says the candidate is ready for a promotion PR draft, not
+that production has been promoted. Any actual promotion remains owner-reviewed
+and PR-boundary controlled.
+
+## Docs Impact
+
+- `docs_impact`: `DOCS_FOLLOWUP`
+- `docs_checked`: `AGENTS.md`, board artifacts, worker result artifacts, changed
+  report builders and tests
+- `docs_changed`: `AGENTS.md`
+- `docs_followup`: document canonical schemas for `source_discovery`,
+  `race_gap_prioritization`, and gate-contract diagnostic fields if these report
+  shapes become permanent
+- `reason`: behavior and report schemas changed; operator guidance was updated,
+  durable schema docs are still a follow-up

--- a/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/NEXT_GOAL.md
+++ b/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/NEXT_GOAL.md
@@ -1,0 +1,113 @@
+# Fresh Session Long-Running Goal
+
+Use this `/goal` in a fresh session:
+
+```text
+/goal
+Work in /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-runtime-master-live-20260621.
+
+Read these artifacts first:
+- artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/BOARD.md
+- artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/BOARD_DECISION.json
+- artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/NEXT_GOAL.md
+- /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/rolling_lineage_audit_20260623T183757+1000_report_only/SUMMARY.md
+- /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/rolling_lineage_audit_20260623T183757+1000_report_only/rolling_lineage_audit_report.json
+
+Act as an orchestrator of bounded implementation subagents. Start with
+tenn-git-guard preflight. If ledger scripts/data are missing, record
+DATA_MISSING and continue with fallback git/artifact checks. Treat existing
+dirt as in-scope context; do not revert it.
+
+Mission:
+Remediate as many Greyhound prediction-readiness blockers as possible while
+preserving source-safety. Push toward accurate predictions by restoring a
+truthful 100+ race rolling comparison first, then using that denominator to
+decide whether candidate model work can beat the market.
+
+Hard boundaries:
+- No DB mutation without explicit owner approval.
+- No live runtime/service mutation without explicit owner approval.
+- No training, promotion, EV, betting, snapshot rewrite, registry mutation, or
+  production pointer update.
+- Do not weaken identity, source, official-result, strict pre-jump timing,
+  dual-baseline market-rank safety, or promotion PR gates.
+- Validation may write report-only artifacts and tests.
+
+Known current facts:
+- Latest completed full daemon child from the lineage audit:
+  20260623T181701+1000_daemon.
+- Latest rolling packet in the audit:
+  rolling_model_comparison_20260623T181701+1000_daemon_rejoin.
+- Historical max rolling packet:
+  rolling_model_comparison_20260614T000205+1000_daemon_rejoin.
+- Safe joined races: 1033.
+- DB live-odds distinct races: 1396.
+- DB official-result evidence distinct races: 538.
+- Safe joined races with eligible unified evidence somewhere: 986.
+- Latest rolling sample races: 35.
+- Latest rolling source unified reports: 29.
+- Historical max rolling sample races: 178.
+- Historical max rolling source unified reports: 508.
+- Main lineage drop: 999 safe joined races are not requested by the latest
+  rolling source set.
+
+Milestones:
+M0. Fresh preflight and latest evidence selection.
+    Select the latest completed full daemon child. Ignore odds-only and
+    lock-wait wrappers for accuracy report-only validation. Reconfirm the latest
+    rolling/rejoin packet and historical 100+ packet.
+
+M1. Rolling source inclusion root cause.
+    Diagnose why current rolling source discovery uses 29 source reports while
+    historical ready packets used 508. Identify the exact code path, filter,
+    directory scope, manifest field, or wrapper-selection rule causing the
+    narrowed denominator.
+
+M2. Rolling source inclusion repair.
+    Patch the rolling comparison source discovery so it can include cumulative
+    eligible unified evidence from the retained evidence root, while preserving:
+    dedupe by race ID, official-result provenance, strict pre-jump odds,
+    Stage 2 prediction availability, and wrapper exclusions.
+
+M3. 100+ eligible rolling validation.
+    Run focused tests and a report-only rolling validation. Success is at least
+    100 eligible rolling races. If still below 100, produce an exact race-level
+    gap list classified by source-set missing, official-result missing,
+    strict-prejump-odds missing, Stage 2 missing, identity mismatch, or other
+    gate.
+
+M4. Gate-contract completeness.
+    Fix promotion-distance/high-accuracy diagnostics so gate contract audit and
+    policy blockers are explicit and not ambiguous DATA_MISSING unless evidence
+    is truly unavailable. Do not weaken gates.
+
+M5. Model-quality decision on restored denominator.
+    Once 100+ eligible races exist, compare candidates against market and
+    baseline on the declared rank-first gates. If no candidate passes, produce a
+    concrete model-improvement plan with feature/candidate hypotheses, tests,
+    and no promotion.
+
+M6. Evidence gap remediation plan.
+    Only after M1-M3, prioritize any remaining official-result or strict
+    pre-jump odds collection gaps from the rolling lineage, not raw DB counts.
+    Keep collection/appends approval-gated.
+
+M7. Final readiness gate.
+    Stop with promotion still blocked unless all are true:
+    - 100+ eligible rolling races
+    - official-result and pre-jump timing gates pass
+    - candidate beats market/baseline under declared gates
+    - gate-contract audit/policy pass
+    - promotion PR boundary allows owner-reviewed promotion
+
+Subagent deployment guidance:
+1. rolling-source-inclusion-worker owns rolling source discovery and tests.
+2. gate-contract-worker owns promotion-distance/high-accuracy diagnostics and
+   tests.
+3. evidence-gap-prioritization-worker owns lineage/gap reporting improvements
+   and tests.
+
+Each worker must report touched files, tests run, blockers, and whether any
+existing dirty file constrained their patch. Integrate only coherent, reviewed
+changes.
+```

--- a/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/STATE.md
+++ b/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/STATE.md
@@ -1,0 +1,105 @@
+# Accurate Predictions Remediation State
+
+Generated: 2026-06-23T18:46:23+10:00
+
+## Mode
+
+Implementation orchestration has started after review-board decision
+`proceed`.
+
+## Guard
+
+- Guard runner: `/home/l4nd0/.agents/skills/tenn-git-guard/scripts/tenn_git_guard.py`
+- Guard support: `PASS`
+- Registry status: `PASS`
+- Ledger status: `DATA_MISSING`
+- Duplicate work classification: `DATA_MISSING_FALLBACK_CHECKED`
+- Existing dirt: present and in-scope. Workers must not revert it.
+
+## Worker Routing
+
+- Task tier: `critical`
+- Recommended model: high reasoning plus bounded workers
+- Worker decision limit: workers may patch assigned code/tests only; the main
+  orchestrator owns final integration, validation, and readiness claims.
+- Escalation needed: no owner escalation yet, provided workers stay inside
+  assigned scopes and hard boundaries.
+
+## Active Workers
+
+| Worker | Agent ID | Lane | Assigned Write Scope | Result Path |
+| --- | --- | --- | --- | --- |
+| Helmholtz | `019ef3aa-e361-7313-b477-7f4f8d2e0b2e` | rolling source inclusion | `scripts/build_rolling_model_comparison_packet.py`, focused rolling tests | `workers/rolling_source_inclusion/WORKER_RESULT.md` |
+| Nash | `019ef3ab-8339-7a71-b8aa-dc8840493661` | gate-contract diagnostics | `scripts/build_promotion_distance_report.py`, `scripts/build_high_accuracy_refinement_packet.py`, focused gate tests | `workers/gate_contract/WORKER_RESULT.md` |
+| Nietzsche | `019ef3ab-ca52-72f0-8f4d-84fba9bb60cd` | evidence-gap prioritization | `scripts/build_unified_evidence_dataset.py`, `scripts/forward_shadow_status_report.py` only if needed, focused evidence-gap tests | `workers/evidence_gap_prioritization/WORKER_RESULT.md` |
+
+## Worker Results
+
+| Worker | Status | Integration Decision | Key Result |
+| --- | --- | --- | --- |
+| Helmholtz | completed | accepted for validation | Restored cumulative rolling source discovery from retained evidence root; latest 29 explicit reports expand to 529 effective reports and 158 eligible rolling races. |
+| Nash | completed | accepted for validation | Gate-contract diagnostics now separate `DATA_MISSING`, `SOURCE_NOT_READY`, and `POLICY_FAILED`; high-accuracy packets carry promotion-distance gate-contract diagnostics. |
+| Nietzsche | completed | accepted for validation | Unified evidence reports now emit `race_gap_prioritization` from the source/dataset race set with `raw_db_count_basis: false`. |
+
+## Integrated Validation
+
+- Focused combined tests:
+  `uv run --with-requirements requirements/requirements.lock --with pytest pytest tests/test_build_rolling_model_comparison_packet.py tests/test_build_unified_evidence_dataset.py tests/test_build_promotion_distance_report.py tests/test_build_high_accuracy_refinement_packet.py -q`
+  - Result: `47 passed in 33.67s`.
+- Diff check:
+  `git diff --cached --check`
+  - Result: passed.
+- Py compile:
+  `python3 -m py_compile scripts/build_rolling_model_comparison_packet.py scripts/build_unified_evidence_dataset.py scripts/build_promotion_distance_report.py scripts/build_high_accuracy_refinement_packet.py utils/report_output_dir_guard.py tests/test_build_rolling_model_comparison_packet.py tests/test_build_unified_evidence_dataset.py tests/test_build_promotion_distance_report.py tests/test_build_high_accuracy_refinement_packet.py`
+  - Result: passed.
+- Report-only rolling validation:
+  `/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/rolling_model_comparison_20260623T190354+1000_orchestrator_validation_report_only`
+  - Status: `ROLLING_MODEL_COMPARISON_READY_FOR_REVIEW`
+  - Effective source reports: `529`
+  - Sample races: `158`
+  - Sample runner rows: `1110`
+  - Blockers: `[]`
+- Report-only promotion-distance validation:
+  `/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/promotion_distance_report_20260623T190354+1000_orchestrator_validation_report_only_001`
+  - Status: `PROMOTION_DISTANCE_REVIEW_READY`
+  - Promotion ready in report-only packet: `true`
+  - Gate-contract candidate: `stage2_market_blend_80`
+  - Gate-contract status: `PASS`
+- Report-only final high-accuracy validation:
+  `/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/high_accuracy_refinement_packet_20260623T190354+1000_orchestrator_validation_post_promotion_distance_report_only`
+  - Status: `READY_FOR_PROMOTION_PR_DRAFT`
+  - Promotion PR gate: `READY_FOR_PR_DRAFT`
+  - Selected stage: `odds_augmented_model_research`
+  - Selected candidate: `stage2_market_blend_80`
+  - `promotion_pr_allowed`: `true`
+  - Protected paths unchanged: `true`
+  - No registry, DB, label, snapshot, EV, betting, TGR, production pointer, or production promotion write was performed.
+
+## Hard Boundaries
+
+- No DB mutation.
+- No live runtime/service mutation.
+- No training.
+- No promotion.
+- No EV or betting.
+- No snapshot rewrite.
+- No registry mutation.
+- No weakening identity, source, official-result, strict pre-jump timing, dual
+  baseline market-rank safety, or promotion PR gates.
+
+## Integration Rules
+
+1. Wait for worker outputs.
+2. Review every patch before applying or accepting it.
+3. Integrate one coherent change at a time.
+4. Run focused tests for the integrated change.
+5. Update this state with accepted/revised/parked/discarded worker status.
+6. Promotion remains blocked unless the full `NEXT_GOAL.md` final readiness gate
+   is satisfied.
+
+## Current Closeout State
+
+The implementation now satisfies the report-only evidence portion of the final
+readiness gate: `100+` eligible rolling races and gate-contract pass were
+validated in generated artifacts. No production promotion was performed. Any
+actual promotion remains owner-reviewed and PR-boundary controlled.

--- a/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/workers/evidence_gap_prioritization/WORKER_RESULT.md
+++ b/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/workers/evidence_gap_prioritization/WORKER_RESULT.md
@@ -1,0 +1,121 @@
+# Evidence Gap Prioritization Worker Result
+
+Generated: 2026-06-23
+
+## Scope
+
+Worker: `evidence-gap-prioritization-worker`
+
+Allowed write scope used:
+
+- `scripts/build_unified_evidence_dataset.py`
+- `tests/test_build_unified_evidence_dataset.py`
+- This worker result artifact
+
+`scripts/forward_shadow_status_report.py` was already dirty before this worker and was not edited by this worker.
+
+Hard boundaries preserved:
+
+- No DB mutation.
+- No live runtime or service mutation.
+- No training.
+- No promotion.
+- No EV or betting output.
+- No snapshot, registry, manifest, or gate-policy mutation.
+
+## Guard
+
+- Repo: `/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-runtime-master-live-20260621`
+- Branch: `codex/runtime-master-live-20260621`
+- HEAD: `c96363fbcd708bba78ecfb69e4bc4dacb183d867`
+- Upstream/base: `origin/codex/runtime-master-live-20260621`
+- Guard runner: `/home/l4nd0/.agents/skills/tenn-git-guard/scripts/tenn_git_guard.py`
+- Guard support: `PASS`
+- Registry status: `PASS`
+- Ledger status: `DATA_MISSING`
+- Duplicate work classification: `DATA_MISSING_FALLBACK_CHECKED`
+- Final guard decision: `warning`
+
+Existing dirty files were treated as in-scope context and were not reverted.
+
+## Implementation
+
+Added race-level source-aware gap reporting to `unified_evidence_dataset_report.json` under:
+
+- `race_gap_prioritization`
+
+The new report object records:
+
+- `raw_db_count_basis: false`
+- source basis, using `join_eligibility_packet_accepted_race_ids` when available and falling back to dataset race IDs
+- source and dataset race counts
+- source-set missing race count
+- sample-blocking gap count
+- primary gap class counts
+- all gap class counts
+- top gap race IDs and compact top gap rows
+
+Gap classes now separate:
+
+- `source_set_missing`
+- `identity_mismatch`
+- `official_result_missing`
+- `strict_prejump_odds_missing`
+- `stage2_missing`
+- `other_gate`
+
+Also added per-race rejected identity context in joined-shadow official-result audits via `rejected_race_ids_by_reason`, so unsafe identity joins can be classified as `identity_mismatch` instead of being flattened into generic official-result absence.
+
+`SUMMARY.md` now surfaces the race gap source basis, raw DB count basis, class counts, and top gap race IDs.
+
+## Root Cause Improved
+
+The reporting problem was that official-result and strict pre-jump odds gaps could be read as raw/global DB shortages, even when the rolling lineage blocker was the current source set. The new report classifies gaps from the current source/dataset race set and explicitly marks `raw_db_count_basis` as false.
+
+This does not repair rolling source discovery. It makes the remaining gap classes actionable once rolling source inclusion is restored, and it prevents source-set misses from being mixed with official-result or strict-odds collection gaps.
+
+## Tests Run
+
+Passed:
+
+- `python3 -m py_compile scripts/build_unified_evidence_dataset.py tests/test_build_unified_evidence_dataset.py`
+- `uv run --isolated --with pytest pytest --noconftest tests/test_build_unified_evidence_dataset.py -q`
+  - Result: `16 passed`
+- `uv run --isolated --with pytest --with requests pytest --noconftest tests/test_build_rolling_model_comparison_packet.py tests/test_build_promotion_distance_report.py -q`
+  - Result: `13 passed`
+- `uv run --isolated --with pytest pytest --noconftest tests/test_build_high_accuracy_refinement_packet.py -q`
+  - Result: `18 passed`
+- `git diff --check -- scripts/build_unified_evidence_dataset.py tests/test_build_unified_evidence_dataset.py`
+
+Validation environment notes:
+
+- `python3 -m pytest ...` could not run because system Python has no `pytest`.
+- `uv run --with pytest pytest ...` with repo conftest hit unrelated app dependency imports (`flask`, then `flask_compress`).
+- Focused script tests were run with `--noconftest` to avoid unrelated Flask app startup.
+
+## Code Review
+
+Review result: no critical findings, warnings, or suggestions found in the worker-owned diff after focused validation.
+
+Review checks covered:
+
+- additive schema shape
+- no gate weakening
+- no DB/runtime/registry write path
+- identity mismatch classification does not accept rejected rows
+- source-set race IDs are normalized
+- focused downstream consumers still pass
+
+## Docs Impact
+
+- `docs_impact`: `DOCS_FOLLOWUP`
+- `docs_checked`: board artifacts, `scripts/build_unified_evidence_dataset.py`, downstream rolling/promotion/high-accuracy tests
+- `docs_changed`: none
+- `docs_followup`: document `race_gap_prioritization` schema and summary fields in the durable evidence/report schema docs if this report shape becomes canonical
+- `reason`: report artifact shape changed, but durable docs are outside this worker write scope
+
+## Remaining Blockers
+
+- Rolling source inclusion is still the upstream blocker for the current lineage: the reviewed audit showed 999 safe joined races not requested by the latest rolling source set.
+- This worker did not edit rolling source discovery, promotion-distance, high-accuracy, runtime, service, DB, or registry code.
+- Full repo pytest with `tests/conftest.py` was not run because it requires unrelated Flask app dependencies in this environment.

--- a/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/workers/gate_contract/WORKER_RESULT.md
+++ b/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/workers/gate_contract/WORKER_RESULT.md
@@ -1,0 +1,85 @@
+# Gate Contract Worker Result
+
+Generated: 2026-06-23
+
+## Scope
+
+Worker: `gate-contract-worker`
+
+Edited only:
+- `scripts/build_promotion_distance_report.py`
+- `scripts/build_high_accuracy_refinement_packet.py`
+- `tests/test_build_promotion_distance_report.py`
+- `tests/test_build_high_accuracy_refinement_packet.py`
+- this worker result artifact
+
+No DB mutation, live runtime/service mutation, training, promotion, EV/betting,
+snapshot rewrite, registry mutation, or gate weakening was performed.
+
+## Result
+
+Promotion-distance gate diagnostics now distinguish:
+- `DATA_MISSING`: true missing audit inputs, such as absent candidate metrics or
+  missing primary/market baselines.
+- `SOURCE_NOT_READY`: evidence exists, but the rolling source is not evaluable
+  for the gate yet, such as collecting status, non-unified sample, unmet sample
+  floor, or fewer than 100 rolling races.
+- `POLICY_FAILED`: the source is evaluable, but the declared
+  `dual_baseline_market_rank_primary_safety` policy has no passing candidate.
+
+The high-accuracy PR gate now carries promotion-distance blockers and the
+promotion-distance gate-contract diagnostic summary even when no candidate
+passed the rank-first gate. This keeps `promotion_pr_allowed=False` conservative
+while making the cause actionable.
+
+## Diagnostics Added
+
+`promotion_distance_report.json` now includes these fields under
+`gate_contract_candidate`:
+- `audit_classification`
+- `policy_evaluation_status`
+- `data_missing_reasons`
+- `source_not_ready_reasons`
+- `policy_failure_reasons`
+- `candidate_policy_blocker_counts`
+- `candidate_gate_matrix_row_count`
+- `candidate_metrics_key_count`
+- rolling status/scope/floor/sample fields used for classification
+
+`high_accuracy_refinement_packet.json` now preserves the promotion-distance
+`gate_contract_candidate` summary and includes compact diagnostics under
+`promotion_pr_gate.promotion_distance_gate_contract`.
+
+## Tests Run
+
+Command:
+
+```bash
+uv run --with-requirements requirements/requirements.lock --with pytest pytest tests/test_build_promotion_distance_report.py tests/test_build_high_accuracy_refinement_packet.py -q
+```
+
+Result:
+
+```text
+22 passed in 14.95s
+```
+
+Additional check:
+
+```bash
+git diff --check -- scripts/build_promotion_distance_report.py scripts/build_high_accuracy_refinement_packet.py tests/test_build_promotion_distance_report.py tests/test_build_high_accuracy_refinement_packet.py
+```
+
+Result: passed with no whitespace errors.
+
+## Remaining Blockers
+
+- Existing generated artifacts still show their old ambiguous diagnostics until
+  promotion-distance and high-accuracy packets are rerun.
+- Promotion remains blocked. This worker did not restore the narrowed rolling
+  source set, increase the rolling denominator to 100+ races, train a candidate,
+  promote a model, or change the dual-baseline market-rank safety policy.
+- Current known blockers remain actionable rather than cleared:
+  `no_candidate_passed_rank_first_accuracy_gate`, high-accuracy selected
+  candidate missing when no stage passes, rolling sample below review floor, and
+  `promotion_pr_allowed=False`.

--- a/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/workers/rolling_source_inclusion/WORKER_RESULT.md
+++ b/artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/workers/rolling_source_inclusion/WORKER_RESULT.md
@@ -1,0 +1,105 @@
+# Rolling Source Inclusion Worker Result
+
+Generated: 2026-06-23
+
+## Scope
+
+- Worker: `rolling-source-inclusion-worker`
+- Task card: `artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/NEXT_GOAL.md`
+- Allowed code scope used:
+  - `scripts/build_rolling_model_comparison_packet.py`
+  - `tests/test_build_rolling_model_comparison_packet.py`
+- No DB mutation, live runtime/service mutation, training, promotion, EV/betting, snapshot rewrite, registry mutation, or gate weakening was performed.
+
+## Root Cause
+
+The rolling comparison script only evaluated the explicit `--unified-evidence-report`
+paths handed to it. The latest rolling packet therefore stayed narrowed to the
+29 current/backlog source reports already present in its invocation.
+
+Older retained unified-evidence reports were also effectively undiscoverable from
+the live runtime checkout because many historical reports store `dataset_jsonl`
+as a repo-relative `artifacts/...` path from the evidence-producing checkout.
+The rolling script resolved those paths against the live runtime checkout, not
+against the retained evidence root's repo, so broad historical reports appeared
+dataset-missing even though their datasets still existed under the retained root.
+
+## Fix
+
+- Added retained-root-aware dataset path resolution for historical
+  `dataset_jsonl` values.
+- Added in-script cumulative historical unified-evidence discovery from
+  `--evidence-root`, capped at the existing historical limit of 500 automatic
+  reports.
+- Preserved source safety filters:
+  - final status must be `UNIFIED_EVIDENCE_DATASET_BUILT`
+  - `unified_evidence_eligible_rows` must be positive
+  - dataset JSONL must exist after retained-root resolution
+  - manual, probe, validation, odds-only, and lock-wait wrapper names are ignored
+- Preserved existing race-level gates in `collect_race_groups`; expanded reports
+  still must pass official-result availability, prediction availability,
+  full unified-evidence eligibility, winner-count, and race-id dedupe checks.
+- Preserved existing explicit input order semantics so later explicit reports
+  still win race-id dedupe.
+- Added `source_discovery` counts to the rolling report and summary.
+
+## Files Changed
+
+- `scripts/build_rolling_model_comparison_packet.py`
+- `tests/test_build_rolling_model_comparison_packet.py`
+- `artifacts/full_evidence_orchestration_20260525/accurate_predictions_long_running_goal_review_board_20260623T184623+1000_report_only/workers/rolling_source_inclusion/WORKER_RESULT.md`
+
+Pre-existing dirty edits in `scripts/build_rolling_model_comparison_packet.py`
+for retained output-dir guards were preserved and not reverted.
+
+## Tests Run
+
+```bash
+uv run --with pytest --with flask --with flask-compress --with flask-cors --with pyyaml --with matplotlib --with seaborn --with scikit-learn --with pandas --with requests --with joblib pytest tests/test_build_rolling_model_comparison_packet.py -q
+```
+
+Result: `9 passed in 0.25s`
+
+```bash
+python3 -m py_compile scripts/build_rolling_model_comparison_packet.py tests/test_build_rolling_model_comparison_packet.py
+```
+
+Result: pass
+
+```bash
+git diff --check -- scripts/build_rolling_model_comparison_packet.py tests/test_build_rolling_model_comparison_packet.py
+```
+
+Result: pass
+
+## Report-Only Validation
+
+Command class: rebuilt rolling comparison from the latest narrowed
+`rolling_model_comparison_20260623T181701+1000_daemon_rejoin` source list using
+the retained evidence root:
+
+```bash
+python3 scripts/build_rolling_model_comparison_packet.py \
+  --evidence-root /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525 \
+  --output-dir /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/rolling_model_comparison_20260623Trolling_source_inclusion_worker_validation \
+  --unified-evidence-report <29 latest source reports>
+```
+
+Output:
+
+- Final status: `ROLLING_MODEL_COMPARISON_READY_FOR_REVIEW`
+- Explicit source reports: `29`
+- Historical reports discovered: `500`
+- Effective source reports: `529`
+- Sample race count: `158`
+- Minimum races for review: `100`
+- Sample floor met: `true`
+- Races needed for review: `0`
+- Blockers: `[]`
+- Output dir: `/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/rolling_model_comparison_20260623Trolling_source_inclusion_worker_validation`
+
+## Remaining Blockers
+
+No blocker remains for this worker's assigned source-inclusion scope. Promotion
+is still not implied or allowed; downstream gate-contract and model-quality
+workers must evaluate the restored denominator under their own scopes.

--- a/scripts/build_high_accuracy_refinement_packet.py
+++ b/scripts/build_high_accuracy_refinement_packet.py
@@ -28,12 +28,14 @@ sys.path = [path for path in sys.path if path != ROOT_STR]
 sys.path.insert(0, ROOT_STR)
 
 from scripts import build_promotion_gate_contract_audit_packet as gate_contract_audit  # noqa: E402
+from utils.report_output_dir_guard import assert_prefixed_report_output_dir  # noqa: E402
 
 
 OUTPUT_PREFIX = (
     "artifacts/full_evidence_orchestration_20260525/"
     "high_accuracy_refinement_packet_"
 )
+OUTPUT_ARTIFACT_PREFIX = "high_accuracy_refinement_packet_"
 DEFAULT_OUTPUT_PARENT = ROOT / "artifacts/full_evidence_orchestration_20260525"
 DEFAULT_PROTECTED_PATHS = (
     ROOT / "greyhound_racing_data.db",
@@ -149,17 +151,19 @@ def protected_hashes(paths: Sequence[Path] = DEFAULT_PROTECTED_PATHS) -> dict[st
     return {relpath(path) or str(path): sha256_file(path) for path in paths}
 
 
-def assert_output_dir_safe(output_dir: Path) -> Path:
-    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
-    try:
-        relative = logical.absolute().relative_to(ROOT.absolute())
-    except ValueError as exc:
-        raise ValueError("output_dir_must_be_inside_repo") from exc
-    if ".." in relative.parts:
-        raise ValueError("output_dir_must_not_contain_parent_traversal")
-    if not relative.as_posix().startswith(OUTPUT_PREFIX):
-        raise ValueError(f"output_dir_must_be_high_accuracy_refinement_packet:{relative}")
-    return logical.absolute()
+def assert_output_dir_safe(
+    output_dir: Path,
+    *,
+    evidence_root: Path | None = None,
+) -> Path:
+    return assert_prefixed_report_output_dir(
+        output_dir,
+        repo_root=ROOT,
+        repo_prefix=OUTPUT_PREFIX,
+        artifact_prefix=OUTPUT_ARTIFACT_PREFIX,
+        prefix_error="output_dir_must_be_high_accuracy_refinement_packet",
+        evidence_root=evidence_root,
+    )
 
 
 def unique_dir(base: Path) -> Path:
@@ -1475,6 +1479,7 @@ def promotion_distance_summary(
     market_benchmark = mapping(report.get("market_benchmark"))
     predeclared_residual = mapping(report.get("predeclared_residual_candidate"))
     rolling_sample = mapping(report.get("rolling_sample"))
+    gate_contract_candidate = mapping(report.get("gate_contract_candidate"))
     official_result_coverage = promotion_distance_official_result_coverage_summary(
         report,
         rolling_sample,
@@ -1544,6 +1549,7 @@ def promotion_distance_summary(
         "best_non_market_minus_market": dict(
             mapping(market_benchmark.get("best_non_market_minus_market"))
         ),
+        "gate_contract_candidate": dict(gate_contract_candidate),
         "predeclared_residual_candidate_key": predeclared_residual.get(
             "candidate_key"
         ),
@@ -1566,6 +1572,41 @@ def promotion_distance_summary(
             mapping(predeclared_residual.get("candidate_minus_market"))
         ),
         "no_write_guarantees": mapping(report.get("no_write_guarantees")),
+    }
+
+
+def promotion_distance_gate_contract_diagnostics(
+    promotion_distance: Mapping[str, Any],
+) -> dict[str, Any]:
+    gate_contract = mapping(promotion_distance.get("gate_contract_candidate"))
+    if not gate_contract:
+        return {}
+    return {
+        "status": gate_contract.get("status"),
+        "audit_final_status": gate_contract.get("audit_final_status"),
+        "audit_classification": gate_contract.get("audit_classification"),
+        "policy_key": gate_contract.get("policy_key"),
+        "policy_status": gate_contract.get("policy_status"),
+        "policy_evaluation_status": gate_contract.get("policy_evaluation_status"),
+        "selected_candidate": gate_contract.get("selected_candidate"),
+        "audit_selected_candidate": gate_contract.get("audit_selected_candidate"),
+        "data_missing_reasons": string_list(gate_contract.get("data_missing_reasons")),
+        "source_not_ready_reasons": string_list(
+            gate_contract.get("source_not_ready_reasons")
+        ),
+        "policy_failure_reasons": string_list(
+            gate_contract.get("policy_failure_reasons")
+        ),
+        "candidate_policy_blocker_counts": int_count_mapping(
+            gate_contract.get("candidate_policy_blocker_counts")
+        ),
+        "candidate_gate_matrix_row_count": finite_int(
+            gate_contract.get("candidate_gate_matrix_row_count")
+        ),
+        "candidate_metrics_key_count": finite_int(
+            gate_contract.get("candidate_metrics_key_count")
+        ),
+        "blockers": string_list(gate_contract.get("blockers")),
     }
 
 
@@ -1856,9 +1897,7 @@ def promotion_pr_gate(
     selected = passing[-1] if passing else None
     distance = mapping(promotion_distance)
     if (
-        selected
-        and selected.get("stage") == "odds_augmented_model_research"
-        and distance
+        distance
         and distance.get("status") != "NOT_RUN"
         and distance.get("promotion_ready") is not True
     ):
@@ -1867,6 +1906,7 @@ def promotion_pr_gate(
             f"promotion_distance_blocker:{blocker}"
             for blocker in string_list(distance.get("blockers"))
         )
+    gate_contract_diagnostics = promotion_distance_gate_contract_diagnostics(distance)
     ready = bool(selected and not blockers)
     return {
         "schema_version": "promotion_pr_only_gate_v1",
@@ -1874,6 +1914,7 @@ def promotion_pr_gate(
         "selected_stage": selected.get("stage") if selected else None,
         "selected_candidate": selected.get("candidate_key") if selected else None,
         "blockers": blockers,
+        "promotion_distance_gate_contract": gate_contract_diagnostics,
         "pull_request_boundary": {
             "promotion_pr_allowed": ready,
             "direct_local_switch_allowed": False,
@@ -2069,6 +2110,9 @@ def build_summary(packet: Mapping[str, Any]) -> str:
     unified_summary = mapping(packet.get("unified_evidence_summary"))
     backlog_summary = mapping(packet.get("backlog_unified_evidence_summary"))
     promotion_distance = mapping(packet.get("promotion_distance_summary"))
+    promotion_gate_contract = mapping(
+        promotion_distance.get("gate_contract_candidate")
+    ) or mapping(pr_gate.get("promotion_distance_gate_contract"))
     unified_official_result = mapping(
         unified_summary.get("official_result_coverage")
     )
@@ -2150,6 +2194,11 @@ def build_summary(packet: Mapping[str, Any]) -> str:
         f"- Backlog aggregation scope: `{backlog_summary.get('aggregation_scope')}`",
         f"- Promotion distance: `{promotion_distance.get('status') or 'NOT_RUN'}`",
         f"- Promotion distance blockers: `{promotion_distance.get('blockers')}`",
+        f"- Promotion distance gate-contract audit classification: `{promotion_gate_contract.get('audit_classification')}`",
+        f"- Promotion distance gate-contract policy evaluation: `{promotion_gate_contract.get('policy_evaluation_status')}`",
+        f"- Promotion distance gate-contract data-missing reasons: `{promotion_gate_contract.get('data_missing_reasons')}`",
+        f"- Promotion distance gate-contract source-not-ready reasons: `{promotion_gate_contract.get('source_not_ready_reasons')}`",
+        f"- Promotion distance gate-contract policy failure reasons: `{promotion_gate_contract.get('policy_failure_reasons')}`",
         f"- Promotion distance source exclusion reasons: `{promotion_distance.get('source_exclusion_reason_counts')}`",
         f"- Promotion distance official-result missing race IDs: `{promotion_distance.get('source_official_result_evidence_db_missing_race_ids')}`",
         f"- Promotion distance official-result runner path count: `{promotion_official_result.get('runner_path_count')}`",
@@ -2253,6 +2302,7 @@ def run_refinement_packet(
     timing_aligned_rerun_plan_path: Path | None = None,
     timing_aligned_rerun_execution_status_path: Path | None = None,
     output_dir: Path | None = None,
+    evidence_root: Path | None = None,
     thresholds: AccuracyGateThresholds = AccuracyGateThresholds(),
 ) -> dict[str, Any]:
     if not any(
@@ -2274,7 +2324,7 @@ def run_refinement_packet(
         raise ValueError("at_least_one_source_report_required")
     generated_at = datetime.now().astimezone()
     output_dir = output_dir or DEFAULT_OUTPUT_PARENT / f"high_accuracy_refinement_packet_{now_id(generated_at)}"
-    output_dir = unique_dir(assert_output_dir_safe(output_dir))
+    output_dir = unique_dir(assert_output_dir_safe(output_dir, evidence_root=evidence_root))
     output_dir.mkdir(parents=True, exist_ok=False)
     protected_before = protected_hashes()
     reserve_substitution_manual_review_path = (
@@ -2358,6 +2408,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--timing-aligned-rerun-plan", type=Path)
     parser.add_argument("--timing-aligned-rerun-execution-status", type=Path)
     parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--evidence-root", type=Path, default=DEFAULT_OUTPUT_PARENT)
     parser.add_argument("--min-safe-joined-races", type=int, default=100)
     parser.add_argument("--min-top1-delta", type=float, default=0.02)
     parser.add_argument("--min-top3-delta", type=float, default=0.0)
@@ -2400,6 +2451,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         timing_aligned_rerun_plan_path=args.timing_aligned_rerun_plan,
         timing_aligned_rerun_execution_status_path=args.timing_aligned_rerun_execution_status,
         output_dir=args.output_dir,
+        evidence_root=args.evidence_root,
         thresholds=thresholds,
     )
     print(json.dumps(result, indent=2, sort_keys=True))

--- a/scripts/build_promotion_distance_report.py
+++ b/scripts/build_promotion_distance_report.py
@@ -16,6 +16,7 @@ import json
 import math
 import os
 import sys
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -27,11 +28,14 @@ sys.path = [path for path in sys.path if path != ROOT_STR]
 sys.path.insert(0, ROOT_STR)
 
 from scripts import build_promotion_gate_contract_audit_packet as gate_contract_audit  # noqa: E402
+from utils.report_output_dir_guard import assert_prefixed_report_output_dir  # noqa: E402
 
+DEFAULT_EVIDENCE_ROOT = ROOT / "artifacts/full_evidence_orchestration_20260525"
 OUTPUT_PREFIX = (
     "artifacts/full_evidence_orchestration_20260525/"
     "promotion_distance_report_"
 )
+OUTPUT_ARTIFACT_PREFIX = "promotion_distance_report_"
 REPORT_FILE = "promotion_distance_report.json"
 SUMMARY_FILE = "SUMMARY.md"
 MIN_ROLLING_RACES_FOR_REVIEW = 100
@@ -77,17 +81,19 @@ def relpath(path: Path | None) -> str | None:
         return str(path)
 
 
-def assert_output_dir_safe(output_dir: Path) -> Path:
-    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
-    try:
-        relative = logical.absolute().relative_to(ROOT.absolute())
-    except ValueError as exc:
-        raise ValueError("output_dir_must_be_inside_repo") from exc
-    if ".." in relative.parts:
-        raise ValueError("output_dir_must_not_contain_parent_traversal")
-    if not relative.as_posix().startswith(OUTPUT_PREFIX):
-        raise ValueError(f"output_dir_must_be_promotion_distance_report:{relative}")
-    return logical.absolute()
+def assert_output_dir_safe(
+    output_dir: Path,
+    *,
+    evidence_root: Path | None = None,
+) -> Path:
+    return assert_prefixed_report_output_dir(
+        output_dir,
+        repo_root=ROOT,
+        repo_prefix=OUTPUT_PREFIX,
+        artifact_prefix=OUTPUT_ARTIFACT_PREFIX,
+        prefix_error="output_dir_must_be_promotion_distance_report",
+        evidence_root=evidence_root,
+    )
 
 
 def unique_dir(base: Path) -> Path:
@@ -180,6 +186,118 @@ def metric_gap_to_target(delta: float | None, target: float) -> float | None:
     return max(0.0, target - delta)
 
 
+def mapping_list(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [mapping(item) for item in value if isinstance(item, Mapping)]
+
+
+def first_present(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def gate_contract_audit_diagnostics(
+    *,
+    audit: Mapping[str, Any],
+    rolling: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    selected_candidate: Any,
+    row: Mapping[str, Any],
+    min_rolling_races: int,
+) -> dict[str, Any]:
+    audit_final_status = str(audit.get("final_status") or "DATA_MISSING")
+    rolling_summary = mapping(audit.get("rolling_report_summary"))
+    rolling_status = first_present(
+        rolling_summary.get("final_status"),
+        rolling.get("final_status"),
+    )
+    sample_scope = first_present(
+        rolling_summary.get("sample_scope"),
+        rolling.get("sample_scope"),
+    )
+    sample_floor_met = first_present(
+        rolling_summary.get("sample_floor_met"),
+        rolling.get("sample_floor_met"),
+    )
+    sample_race_count = finite_int(
+        first_present(
+            rolling_summary.get("sample_race_count"),
+            rolling.get("sample_race_count"),
+        )
+    )
+    data_missing_reasons = string_list(audit.get("blockers"))
+    source_not_ready_reasons: list[str] = []
+    if rolling_status != gate_contract_audit.ROLLING_READY_STATUS:
+        source_not_ready_reasons.append(
+            f"rolling_report_status_not_ready:{rolling_status or 'missing'}"
+        )
+    if sample_scope != "unified":
+        source_not_ready_reasons.append(
+            f"sample_scope_not_unified:{sample_scope or 'missing'}"
+        )
+    if sample_floor_met is not True:
+        source_not_ready_reasons.append("sample_floor_not_met")
+    if sample_race_count < min_rolling_races:
+        source_not_ready_reasons.append("rolling_sample_below_review_floor")
+
+    policy_key = str(policy.get("policy_key") or PROMOTION_GATE_CONTRACT_POLICY)
+    candidate_rows = mapping_list(audit.get("candidate_gate_matrix"))
+    policy_blocker_counts: Counter[str] = Counter()
+    for candidate_row in candidate_rows:
+        blocker_text = str(candidate_row.get(f"{policy_key}_blockers") or "")
+        for blocker in (item for item in blocker_text.split(";") if item):
+            policy_blocker_counts[blocker] += 1
+    selected_blocker_text = str(row.get(f"{policy_key}_blockers") or "")
+    selected_policy_blockers = [
+        item for item in selected_blocker_text.split(";") if item
+    ]
+
+    policy_status = str(policy.get("status") or "MISSING")
+    if data_missing_reasons:
+        audit_classification = "DATA_MISSING"
+    elif source_not_ready_reasons:
+        audit_classification = "SOURCE_NOT_READY"
+    elif policy_status != "PASS":
+        audit_classification = "POLICY_FAILED"
+    elif audit_final_status != "REPORT_ONLY_GATE_CHANGE_CANDIDATE":
+        audit_classification = "AUDIT_STATUS_NOT_READY"
+    else:
+        audit_classification = "PASS"
+
+    if audit_classification in {"DATA_MISSING", "SOURCE_NOT_READY"}:
+        policy_evaluation_status = "NOT_EVALUABLE"
+        policy_failure_reasons: list[str] = []
+    elif policy_status == "PASS":
+        policy_evaluation_status = "PASS"
+        policy_failure_reasons = []
+    else:
+        policy_evaluation_status = "FAILED"
+        policy_failure_reasons = list(
+            dict.fromkeys(selected_policy_blockers or sorted(policy_blocker_counts))
+        )
+
+    candidate_metrics_by_key = mapping(rolling.get("candidate_metrics_by_key"))
+    return {
+        "audit_classification": audit_classification,
+        "policy_evaluation_status": policy_evaluation_status,
+        "data_missing_reasons": list(dict.fromkeys(data_missing_reasons)),
+        "source_not_ready_reasons": list(dict.fromkeys(source_not_ready_reasons)),
+        "policy_failure_reasons": policy_failure_reasons,
+        "candidate_policy_blocker_counts": dict(sorted(policy_blocker_counts.items())),
+        "candidate_gate_matrix_row_count": len(candidate_rows),
+        "candidate_metrics_key_count": len(candidate_metrics_by_key),
+        "selected_candidate_gate_matrix_row_found": bool(row),
+        "selected_candidate_from_high_accuracy": selected_candidate,
+        "rolling_report_status": rolling_status,
+        "rolling_sample_scope": sample_scope,
+        "rolling_sample_floor_met": sample_floor_met,
+        "rolling_sample_race_count": sample_race_count,
+    }
+
+
 def high_accuracy_gate_contract_blockers(high_gate: Mapping[str, Any]) -> list[str]:
     blockers: list[str] = []
     if high_gate.get("status") != "READY_FOR_PR_DRAFT":
@@ -203,6 +321,7 @@ def gate_contract_candidate_summary(
     rolling: Mapping[str, Any],
     high_gate: Mapping[str, Any],
     target_top1_margin_vs_market: float,
+    min_rolling_races: int,
 ) -> dict[str, Any]:
     audit = gate_contract_audit.build_report(
         rolling_report=rolling,
@@ -232,13 +351,38 @@ def gate_contract_candidate_summary(
     row = mapping(row)
     blocker_text = str(row.get(f"{PROMOTION_GATE_CONTRACT_POLICY}_blockers") or "")
     candidate_blockers = [item for item in blocker_text.split(";") if item]
+    diagnostics = gate_contract_audit_diagnostics(
+        audit=audit,
+        rolling=rolling,
+        policy=policy,
+        selected_candidate=selected_candidate,
+        row=row,
+        min_rolling_races=min_rolling_races,
+    )
     blockers: list[str] = []
-    if audit.get("final_status") != "REPORT_ONLY_GATE_CHANGE_CANDIDATE":
-        blockers.append(
-            f"gate_contract_audit_not_ready:{audit.get('final_status')}"
-        )
+    audit_classification = str(
+        diagnostics.get("audit_classification") or "DATA_MISSING"
+    )
+    policy_evaluation_status = str(
+        diagnostics.get("policy_evaluation_status") or "NOT_EVALUABLE"
+    )
+    if audit_classification in {"DATA_MISSING", "SOURCE_NOT_READY"}:
+        blockers.append(f"gate_contract_audit_not_ready:{audit_classification}")
+    elif (
+        audit.get("final_status") != "REPORT_ONLY_GATE_CHANGE_CANDIDATE"
+        and audit_classification != "POLICY_FAILED"
+    ):
+        blockers.append(f"gate_contract_audit_not_ready:{audit.get('final_status')}")
     if policy.get("status") != "PASS":
-        blockers.append(f"gate_contract_policy_not_pass:{PROMOTION_GATE_CONTRACT_POLICY}")
+        if policy_evaluation_status == "NOT_EVALUABLE":
+            blockers.append(
+                "gate_contract_policy_not_evaluable:"
+                f"{PROMOTION_GATE_CONTRACT_POLICY}:{audit_classification}"
+            )
+        else:
+            blockers.append(
+                f"gate_contract_policy_failed:{PROMOTION_GATE_CONTRACT_POLICY}"
+            )
     if not selected_candidate:
         blockers.append("high_accuracy_selected_candidate_missing")
     if selected_candidate and not row:
@@ -248,16 +392,36 @@ def gate_contract_candidate_summary(
             "high_accuracy_selected_candidate_not_audit_selected:"
             f"{selected_candidate}!={audit_candidate}"
         )
-    blockers.extend(candidate_blockers)
+    if policy_evaluation_status != "NOT_EVALUABLE":
+        blockers.extend(candidate_blockers)
     top1_delta = finite_float(row.get("market_top1_delta"))
     return {
         "schema_version": "promotion_distance_gate_contract_candidate_v1",
         "status": "PASS" if not blockers else "BLOCKED",
         "audit_final_status": audit.get("final_status"),
+        "audit_classification": diagnostics.get("audit_classification"),
         "policy_key": PROMOTION_GATE_CONTRACT_POLICY,
         "policy_status": policy.get("status"),
+        "policy_evaluation_status": diagnostics.get("policy_evaluation_status"),
         "selected_candidate": selected_candidate,
         "audit_selected_candidate": audit_candidate,
+        "data_missing_reasons": diagnostics.get("data_missing_reasons"),
+        "source_not_ready_reasons": diagnostics.get("source_not_ready_reasons"),
+        "policy_failure_reasons": diagnostics.get("policy_failure_reasons"),
+        "candidate_policy_blocker_counts": diagnostics.get(
+            "candidate_policy_blocker_counts"
+        ),
+        "candidate_gate_matrix_row_count": diagnostics.get(
+            "candidate_gate_matrix_row_count"
+        ),
+        "candidate_metrics_key_count": diagnostics.get("candidate_metrics_key_count"),
+        "selected_candidate_gate_matrix_row_found": diagnostics.get(
+            "selected_candidate_gate_matrix_row_found"
+        ),
+        "rolling_report_status": diagnostics.get("rolling_report_status"),
+        "rolling_sample_scope": diagnostics.get("rolling_sample_scope"),
+        "rolling_sample_floor_met": diagnostics.get("rolling_sample_floor_met"),
+        "rolling_sample_race_count": diagnostics.get("rolling_sample_race_count"),
         "candidate_minus_market": {
             "top1": top1_delta,
             "top3": finite_float(row.get("market_top3_delta")),
@@ -335,13 +499,14 @@ def build_report(
     pre_race_gated_report_path: Path,
     high_accuracy_gate_path: Path,
     output_dir: Path,
+    evidence_root: Path | None = None,
     generated_at: datetime | None = None,
     min_rolling_races: int = MIN_ROLLING_RACES_FOR_REVIEW,
     min_residual_triggered_races: int = MIN_RESIDUAL_TRIGGERED_RACES_FOR_DIRECTIONAL_READ,
     target_top1_margin_vs_market: float = TARGET_TOP1_MARGIN_VS_MARKET,
 ) -> dict[str, Any]:
     generated_at = generated_at or datetime.now().astimezone()
-    output_dir = unique_dir(assert_output_dir_safe(output_dir))
+    output_dir = unique_dir(assert_output_dir_safe(output_dir, evidence_root=evidence_root))
     output_dir.mkdir(parents=True, exist_ok=False)
 
     rolling = load_json(rolling_report_path)
@@ -370,6 +535,7 @@ def build_report(
         rolling=rolling,
         high_gate=high_gate,
         target_top1_margin_vs_market=target_top1_margin_vs_market,
+        min_rolling_races=min_rolling_races,
     )
     gate_contract_passed = gate_contract_candidate.get("status") == "PASS"
 
@@ -540,7 +706,13 @@ def summary_markdown(report: Mapping[str, Any]) -> str:
             f"- Best non-market top1 gap to target margin: `{market.get('best_non_market_top1_margin_gap')}`",
             f"- Gate-contract candidate: `{gate_contract.get('selected_candidate')}`",
             f"- Gate-contract candidate status: `{gate_contract.get('status')}`",
+            f"- Gate-contract audit classification: `{gate_contract.get('audit_classification')}`",
+            f"- Gate-contract policy evaluation: `{gate_contract.get('policy_evaluation_status')}`",
             f"- Gate-contract policy: `{gate_contract.get('policy_key')}`",
+            f"- Gate-contract data-missing reasons: `{gate_contract.get('data_missing_reasons')}`",
+            f"- Gate-contract source-not-ready reasons: `{gate_contract.get('source_not_ready_reasons')}`",
+            f"- Gate-contract policy failure reasons: `{gate_contract.get('policy_failure_reasons')}`",
+            f"- Gate-contract candidate policy blocker counts: `{gate_contract.get('candidate_policy_blocker_counts')}`",
             f"- Gate-contract candidate minus market: `{gate_contract.get('candidate_minus_market')}`",
             f"- Gate-contract top1 gap to target margin: `{gate_contract.get('top1_margin_gap_to_target')}`",
             f"- Gate-contract blockers: `{gate_contract.get('blockers')}`",
@@ -564,21 +736,21 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--pre-race-gated-report", type=Path, required=True)
     parser.add_argument("--high-accuracy-gate", type=Path, required=True)
     parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--evidence-root", type=Path, default=DEFAULT_EVIDENCE_ROOT)
     return parser.parse_args(argv)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     output_dir = args.output_dir or (
-        ROOT
-        / "artifacts/full_evidence_orchestration_20260525"
-        / f"promotion_distance_report_{now_id()}"
+        DEFAULT_EVIDENCE_ROOT / f"promotion_distance_report_{now_id()}"
     )
     report = build_report(
         rolling_report_path=args.rolling_report,
         pre_race_gated_report_path=args.pre_race_gated_report,
         high_accuracy_gate_path=args.high_accuracy_gate,
         output_dir=output_dir,
+        evidence_root=args.evidence_root,
     )
     print(json.dumps(report, indent=2, sort_keys=True))
     return 0

--- a/scripts/build_rolling_model_comparison_packet.py
+++ b/scripts/build_rolling_model_comparison_packet.py
@@ -28,6 +28,7 @@ sys.path = [path for path in sys.path if path != ROOT_STR]
 sys.path.insert(0, ROOT_STR)
 
 from scripts.join_forward_shadow_results import logistic_calibration_review  # noqa: E402
+from utils.report_output_dir_guard import assert_prefixed_report_output_dir  # noqa: E402
 
 
 DEFAULT_EVIDENCE_ROOT = ROOT / "artifacts/full_evidence_orchestration_20260525"
@@ -35,12 +36,14 @@ OUTPUT_PREFIX = (
     "artifacts/full_evidence_orchestration_20260525/"
     "rolling_model_comparison_"
 )
+OUTPUT_ARTIFACT_PREFIX = "rolling_model_comparison_"
 REPORT_FILE = "rolling_model_comparison_report.json"
 SUMMARY_FILE = "SUMMARY.md"
 CANDIDATE_CSV_FILE = "candidate_metrics.csv"
 MARKET_RESIDUAL_CASES_CSV_FILE = "market_residual_cases.csv"
 MARKET_RESIDUAL_RUNNER_MATRIX_CSV_FILE = "market_residual_runner_matrix.csv"
 MIN_RACES_FOR_REVIEW = 100
+DEFAULT_HISTORICAL_UNIFIED_EVIDENCE_REPORT_LIMIT = 500
 POWER_GAMMAS = (0.85, 1.2, 1.5, 2.0)
 BLEND_MARKET_WEIGHTS = tuple(weight / 100 for weight in range(5, 100, 5))
 NO_WRITE_GUARANTEES = {
@@ -73,17 +76,19 @@ def relpath(path: Path | None) -> str | None:
         return str(path)
 
 
-def assert_output_dir_safe(output_dir: Path) -> Path:
-    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
-    try:
-        relative = logical.absolute().relative_to(ROOT.absolute())
-    except ValueError as exc:
-        raise ValueError("output_dir_must_be_inside_repo") from exc
-    if ".." in relative.parts:
-        raise ValueError("output_dir_must_not_contain_parent_traversal")
-    if not relative.as_posix().startswith(OUTPUT_PREFIX):
-        raise ValueError(f"output_dir_must_be_rolling_model_comparison:{relative}")
-    return logical.absolute()
+def assert_output_dir_safe(
+    output_dir: Path,
+    *,
+    evidence_root: Path | None = None,
+) -> Path:
+    return assert_prefixed_report_output_dir(
+        output_dir,
+        repo_root=ROOT,
+        repo_prefix=OUTPUT_PREFIX,
+        artifact_prefix=OUTPUT_ARTIFACT_PREFIX,
+        prefix_error="output_dir_must_be_rolling_model_comparison",
+        evidence_root=evidence_root,
+    )
 
 
 def unique_dir(base: Path) -> Path:
@@ -154,6 +159,36 @@ def output_manifest(output_dir: Path) -> dict[str, Any]:
         "output_dir": relpath(output_dir),
         "files": files,
     }
+
+
+def evidence_repo_root(evidence_root: Path | None) -> Path | None:
+    if evidence_root is None:
+        return None
+    root = evidence_root.resolve()
+    if root.name == "full_evidence_orchestration_20260525" and root.parent.name == "artifacts":
+        return root.parent.parent
+    return root
+
+
+def resolve_report_relative_path(
+    report_path: Path,
+    path_value: Any,
+    *,
+    evidence_root: Path | None = None,
+) -> Path:
+    path = Path(str(path_value))
+    if path.is_absolute():
+        return path
+    candidates: list[Path] = []
+    repo_root = evidence_repo_root(evidence_root)
+    if repo_root is not None:
+        candidates.append(repo_root / path)
+    candidates.append(ROOT / path)
+    candidates.append(report_path.parent / path)
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0] if candidates else report_path.parent / path
 
 
 def finite_float(value: Any) -> float | None:
@@ -418,22 +453,128 @@ def candidate_specs() -> list[dict[str, Any]]:
     return specs
 
 
-def report_dataset_path(report_path: Path, report: Mapping[str, Any]) -> Path | None:
+def report_dataset_path(
+    report_path: Path,
+    report: Mapping[str, Any],
+    *,
+    evidence_root: Path | None = None,
+) -> Path | None:
     dataset = report.get("dataset_jsonl")
-    if not dataset:
-        return None
-    path = Path(str(dataset))
-    if path.is_absolute():
-        return path
-    rooted = ROOT / path
-    if rooted.exists():
-        return rooted
-    return report_path.parent / path
+    if dataset:
+        return resolve_report_relative_path(
+            report_path,
+            dataset,
+            evidence_root=evidence_root,
+        )
+    fallback = report_path.parent / "unified_evidence_dataset.jsonl"
+    return fallback if fallback.exists() else None
+
+
+def unified_report_eligible_rows(report: Mapping[str, Any]) -> int:
+    return safe_int(report.get("unified_evidence_eligible_rows"))
+
+
+def is_automatic_unified_evidence_report_path(report_path: Path) -> bool:
+    dirname = report_path.parent.name
+    if (
+        "_manual" in dirname
+        or "_probe" in dirname
+        or "_validation" in dirname
+        or "_odds_only" in dirname
+        or "_lock_wait" in dirname
+    ):
+        return False
+    if "_daemon_autopilot" in dirname:
+        return True
+    marker = "_daemon_rejoin_"
+    if marker not in dirname:
+        return False
+    suffix = dirname.rsplit(marker, 1)[1]
+    return len(suffix) >= 3 and suffix[:3].isdigit() and (
+        len(suffix) == 3 or suffix[3] == "_"
+    )
+
+
+def historical_unified_evidence_report_paths(
+    evidence_root: Path,
+    *,
+    exclude_paths: Sequence[Path] = (),
+    max_reports: int = DEFAULT_HISTORICAL_UNIFIED_EVIDENCE_REPORT_LIMIT,
+) -> list[Path]:
+    excluded = {path.resolve() for path in exclude_paths if path.exists()}
+    candidates: list[Path] = []
+    for report_path in sorted(
+        evidence_root.glob("unified_evidence_dataset_*/unified_evidence_dataset_report.json")
+    ):
+        if not is_automatic_unified_evidence_report_path(report_path):
+            continue
+        if report_path.exists() and report_path.resolve() in excluded:
+            continue
+        report = load_json(report_path)
+        if not report or report.get("final_status") != "UNIFIED_EVIDENCE_DATASET_BUILT":
+            continue
+        if unified_report_eligible_rows(report) <= 0:
+            continue
+        dataset_path = report_dataset_path(
+            report_path,
+            report,
+            evidence_root=evidence_root,
+        )
+        if dataset_path is None or not dataset_path.exists():
+            continue
+        candidates.append(report_path)
+    return candidates[-max_reports:] if max_reports > 0 else candidates
+
+
+def unique_report_paths(paths: Sequence[Path]) -> list[Path]:
+    unique: dict[str, Path] = {}
+    for path in paths:
+        try:
+            key = str(path.resolve()) if path.exists() else path.as_posix()
+        except OSError:
+            key = path.as_posix()
+        if key in unique:
+            del unique[key]
+        unique[key] = path
+    return list(unique.values())
+
+
+def resolve_unified_evidence_report_paths(
+    report_paths: Sequence[Path],
+    *,
+    evidence_root: Path | None = None,
+    historical_limit: int = DEFAULT_HISTORICAL_UNIFIED_EVIDENCE_REPORT_LIMIT,
+) -> tuple[list[Path], dict[str, Any]]:
+    explicit_paths = list(report_paths)
+    historical_paths: list[Path] = []
+    if evidence_root is not None and evidence_root.exists():
+        historical_paths = historical_unified_evidence_report_paths(
+            evidence_root,
+            exclude_paths=explicit_paths,
+            max_reports=historical_limit,
+        )
+    resolved_paths = unique_report_paths([*historical_paths, *explicit_paths])
+    return resolved_paths, {
+        "schema_version": "rolling_model_source_discovery_v1",
+        "evidence_root": relpath(evidence_root),
+        "explicit_report_count": len(explicit_paths),
+        "historical_report_limit": historical_limit,
+        "historical_report_count": len(historical_paths),
+        "effective_report_count": len(resolved_paths),
+        "historical_first_report_path": relpath(historical_paths[0])
+        if historical_paths
+        else None,
+        "historical_last_report_path": relpath(historical_paths[-1])
+        if historical_paths
+        else None,
+    }
 
 
 def collect_race_groups(
     report_paths: Sequence[Path],
     *,
+    evidence_root: Path | None = None,
+    source_discovery: Mapping[str, Any] | None = None,
     sample_scope: str,
     dedupe_race_id: bool,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
@@ -442,7 +583,11 @@ def collect_race_groups(
     source_reports: list[dict[str, Any]] = []
     for source_index, report_path in enumerate(report_paths):
         report = load_json(report_path)
-        dataset_path = report_dataset_path(report_path, report)
+        dataset_path = report_dataset_path(
+            report_path,
+            report,
+            evidence_root=evidence_root,
+        )
         official_audit = mapping(report.get("official_result_evidence_db_audit"))
         source_reports.append(
             {
@@ -538,6 +683,7 @@ def collect_race_groups(
         "skipped_race_counts": dict(sorted(skipped.items())),
         "dedupe_race_id": dedupe_race_id,
         "sample_scope": sample_scope,
+        "source_discovery": dict(source_discovery or {}),
     }
 
 
@@ -1620,6 +1766,7 @@ def build_report(
         "market_residual_runner_matrix_csv": relpath(
             output_dir / MARKET_RESIDUAL_RUNNER_MATRIX_CSV_FILE
         ),
+        "source_discovery": collection.get("source_discovery") or {},
         "source_unified_evidence_reports": [relpath(path) for path in report_paths],
         "sample_scope": collection.get("sample_scope"),
         "dedupe_race_id": collection.get("dedupe_race_id"),
@@ -1887,12 +2034,16 @@ def write_market_residual_runner_matrix_csv(
 
 def summary_markdown(report: Mapping[str, Any]) -> str:
     official_result = report.get("official_result_coverage") or {}
+    source_discovery = report.get("source_discovery") or {}
     return "\n".join(
         [
             "# Rolling Model Comparison",
             "",
             f"Final status: `{report.get('final_status')}`",
             "",
+            f"- Source discovery explicit reports: `{source_discovery.get('explicit_report_count')}`",
+            f"- Source discovery historical reports: `{source_discovery.get('historical_report_count')}`",
+            f"- Source discovery effective reports: `{source_discovery.get('effective_report_count')}`",
             f"- Sample scope: `{report.get('sample_scope')}`",
             f"- Dedupe race id: `{report.get('dedupe_race_id')}`",
             f"- Sample races: `{report.get('sample_race_count')}` / `{report.get('minimum_races_for_review')}`",
@@ -1938,23 +2089,30 @@ def build_comparison(
     *,
     unified_evidence_report_paths: Sequence[Path],
     output_dir: Path,
+    evidence_root: Path | None = None,
     sample_scope: str = "unified",
     dedupe_race_id: bool = True,
     min_races_for_review: int = MIN_RACES_FOR_REVIEW,
     generated_at: datetime | None = None,
 ) -> dict[str, Any]:
     generated_at = generated_at or datetime.now().astimezone()
-    output_dir = unique_dir(assert_output_dir_safe(output_dir))
+    output_dir = unique_dir(assert_output_dir_safe(output_dir, evidence_root=evidence_root))
     output_dir.mkdir(parents=True, exist_ok=False)
-    race_groups, collection = collect_race_groups(
+    effective_report_paths, source_discovery = resolve_unified_evidence_report_paths(
         unified_evidence_report_paths,
+        evidence_root=evidence_root,
+    )
+    race_groups, collection = collect_race_groups(
+        effective_report_paths,
+        evidence_root=evidence_root,
+        source_discovery=source_discovery,
         sample_scope=sample_scope,
         dedupe_race_id=dedupe_race_id,
     )
     metrics = [evaluate_candidate(race_groups, spec) for spec in candidate_specs()]
     report = build_report(
         generated_at=generated_at,
-        report_paths=unified_evidence_report_paths,
+        report_paths=effective_report_paths,
         race_groups=race_groups,
         collection=collection,
         candidate_metrics=metrics,
@@ -2000,6 +2158,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         required=True,
     )
     parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--evidence-root", type=Path, default=DEFAULT_EVIDENCE_ROOT)
     parser.add_argument(
         "--sample-scope",
         choices=("unified", "label"),
@@ -2020,6 +2179,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     report = build_comparison(
         unified_evidence_report_paths=args.unified_evidence_report,
         output_dir=output_dir,
+        evidence_root=args.evidence_root,
         sample_scope=args.sample_scope,
         dedupe_race_id=not args.no_dedupe_race_id,
         min_races_for_review=args.min_races_for_review,

--- a/scripts/build_unified_evidence_dataset.py
+++ b/scripts/build_unified_evidence_dataset.py
@@ -28,10 +28,12 @@ sys.path = [path for path in sys.path if path != ROOT_STR]
 sys.path.insert(0, ROOT_STR)
 
 from utils.runner_completeness import normalise_runner_name  # noqa: E402
+from utils.report_output_dir_guard import assert_prefixed_report_output_dir  # noqa: E402
 
 
 DEFAULT_EVIDENCE_ROOT = ROOT / "artifacts/full_evidence_orchestration_20260525"
 OUTPUT_PREFIX = "artifacts/full_evidence_orchestration_20260525/unified_evidence_dataset_"
+OUTPUT_ARTIFACT_PREFIX = "unified_evidence_dataset_"
 DATASET_FILE = "unified_evidence_dataset.jsonl"
 CSV_FILE = "unified_evidence_dataset.csv"
 REPORT_FILE = "unified_evidence_dataset_report.json"
@@ -41,6 +43,22 @@ ACCEPTED_DOG_LEVEL_ODDS_LEVELS = {"dog", "runner"}
 POST_RACE_SOURCE_URL_TOKENS = {"dividend", "payout", "result", "results"}
 JOINED_SHADOW_EXACT_IDENTITY_STATUS = "exact_box_and_normalized_name"
 OFFICIAL_RESULT_EVIDENCE_DB_SOURCE = "official_result_evidence_db"
+GAP_CLASS_PRIORITY = (
+    "source_set_missing",
+    "identity_mismatch",
+    "official_result_missing",
+    "strict_prejump_odds_missing",
+    "stage2_missing",
+    "other_gate",
+)
+GAP_CLASS_ACTIONS = {
+    "source_set_missing": "restore_rolling_source_set_inclusion",
+    "identity_mismatch": "inspect_identity_match_or_join_artifact",
+    "official_result_missing": "capture_or_join_official_result",
+    "strict_prejump_odds_missing": "collect_strict_prejump_odds",
+    "stage2_missing": "rebuild_stage2_shadow_predictions",
+    "other_gate": "inspect_other_unified_evidence_gate",
+}
 NO_WRITE_GUARANTEES = {
     "training": False,
     "production_promotion": False,
@@ -71,17 +89,19 @@ def relpath(path: Path | None) -> str | None:
         return str(path)
 
 
-def assert_output_dir_safe(output_dir: Path) -> Path:
-    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
-    try:
-        relative = logical.absolute().relative_to(ROOT.absolute())
-    except ValueError as exc:
-        raise ValueError("output_dir_must_be_inside_repo") from exc
-    if ".." in relative.parts:
-        raise ValueError("output_dir_must_not_contain_parent_traversal")
-    if not relative.as_posix().startswith(OUTPUT_PREFIX):
-        raise ValueError(f"output_dir_must_be_unified_evidence_dataset_artifact:{relative}")
-    return logical.absolute()
+def assert_output_dir_safe(
+    output_dir: Path,
+    *,
+    evidence_root: Path | None = None,
+) -> Path:
+    return assert_prefixed_report_output_dir(
+        output_dir,
+        repo_root=ROOT,
+        repo_prefix=OUTPUT_PREFIX,
+        artifact_prefix=OUTPUT_ARTIFACT_PREFIX,
+        prefix_error="output_dir_must_be_unified_evidence_dataset_artifact",
+        evidence_root=evidence_root,
+    )
 
 
 def unique_dir(base: Path) -> Path:
@@ -195,6 +215,232 @@ def official_result_coverage_summary(
         "missing_exclusion_count": int(
             exclusion_reason_counts.get("official_result_missing") or 0
         ),
+    }
+
+
+def accepted_source_race_ids(
+    join_eligibility_packet_audits: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    return sorted(
+        {
+            str(race_id).strip()
+            for audit in join_eligibility_packet_audits
+            for race_id in audit.get("accepted_race_ids") or []
+            if str(race_id or "").strip()
+        }
+    )
+
+
+def joined_identity_mismatch_context(
+    joined_shadow_prediction_audits: Sequence[Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    context: dict[str, dict[str, Any]] = {}
+    for audit in joined_shadow_prediction_audits:
+        reason_map = audit.get("rejected_race_ids_by_reason") or {}
+        if not isinstance(reason_map, Mapping):
+            continue
+        path = audit.get("path")
+        for reason, race_ids in reason_map.items():
+            if str(reason) != "identity_match_not_exact_box_and_normalized_name":
+                continue
+            if not isinstance(race_ids, Sequence) or isinstance(race_ids, (str, bytes)):
+                continue
+            for race_id in race_ids:
+                race_key = str(race_id or "").strip()
+                if not race_key:
+                    continue
+                entry = context.setdefault(
+                    race_key,
+                    {
+                        "identity_mismatch_reasons": set(),
+                        "identity_mismatch_source_paths": set(),
+                    },
+                )
+                entry["identity_mismatch_reasons"].add(str(reason))
+                if path:
+                    entry["identity_mismatch_source_paths"].add(str(path))
+    return {
+        race_id: {
+            "identity_mismatch_reasons": sorted(value["identity_mismatch_reasons"]),
+            "identity_mismatch_source_paths": sorted(value["identity_mismatch_source_paths"]),
+        }
+        for race_id, value in sorted(context.items())
+    }
+
+
+def is_odds_detail_reason(reason: str) -> bool:
+    return reason.startswith("odds_") or reason.startswith("unsupported_sportsbet_box_source")
+
+
+def build_race_gap_prioritization(
+    *,
+    rows: Sequence[Mapping[str, Any]],
+    join_eligibility_packet_audits: Sequence[Mapping[str, Any]],
+    joined_shadow_prediction_audits: Sequence[Mapping[str, Any]],
+    top_limit: int = 20,
+) -> dict[str, Any]:
+    rows_by_race: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in rows:
+        race_id = str(row.get("race_id") or "").strip()
+        if race_id:
+            rows_by_race[race_id].append(row)
+
+    dataset_race_ids = set(rows_by_race)
+    source_race_ids = set(accepted_source_race_ids(join_eligibility_packet_audits))
+    source_race_id_source = (
+        "join_eligibility_packet_accepted_race_ids"
+        if source_race_ids
+        else "dataset_race_ids"
+    )
+    if not source_race_ids:
+        source_race_ids = set(dataset_race_ids)
+
+    identity_context = joined_identity_mismatch_context(joined_shadow_prediction_audits)
+    source_race_ids.update(identity_context)
+    source_race_ids.update(dataset_race_ids)
+
+    gap_class_counts = {gap_class: 0 for gap_class in GAP_CLASS_PRIORITY}
+    primary_gap_class_counts = {gap_class: 0 for gap_class in GAP_CLASS_PRIORITY}
+    gap_rows: list[dict[str, Any]] = []
+
+    for race_id in sorted(source_race_ids):
+        race_rows = rows_by_race.get(race_id, [])
+        row_count = len(race_rows)
+        reason_counts = Counter()
+        for row in race_rows:
+            reason_counts.update(
+                str(reason)
+                for reason in row.get("excluded_from_unified_reason") or []
+                if str(reason or "").strip()
+            )
+
+        if row_count == 0:
+            gap_classes = ["source_set_missing"]
+            official_missing_rows = 0
+            strict_missing_rows = 0
+            stage2_missing_rows = 0
+            primary_missing_rows = 0
+            unified_missing_rows = 0
+            official_complete = False
+            strict_complete = False
+            stage2_complete = False
+            primary_complete = False
+            unified_complete = False
+            race_date = None
+            venue = None
+            race_number = None
+        else:
+            official_rows = sum(1 for row in race_rows if row.get("official_result_available"))
+            strict_rows = sum(1 for row in race_rows if row.get("strict_prejump_odds_available"))
+            stage2_rows = sum(1 for row in race_rows if row.get("stage2_prediction_available"))
+            primary_rows = sum(1 for row in race_rows if row.get("primary_prediction_available"))
+            unified_rows = sum(1 for row in race_rows if row.get("unified_evidence_eligible"))
+            official_missing_rows = max(0, row_count - official_rows)
+            strict_missing_rows = max(0, row_count - strict_rows)
+            stage2_missing_rows = max(0, row_count - stage2_rows)
+            primary_missing_rows = max(0, row_count - primary_rows)
+            unified_missing_rows = max(0, row_count - unified_rows)
+            official_complete = row_count > 0 and official_missing_rows == 0
+            strict_complete = row_count > 0 and strict_missing_rows == 0
+            stage2_complete = row_count > 0 and stage2_missing_rows == 0
+            primary_complete = row_count > 0 and primary_missing_rows == 0
+            unified_complete = row_count > 0 and unified_missing_rows == 0
+            race_date = next((row.get("race_date") for row in race_rows if row.get("race_date")), None)
+            venue = next((row.get("venue") for row in race_rows if row.get("venue")), None)
+            race_number = next(
+                (row.get("race_number") for row in race_rows if row.get("race_number") is not None),
+                None,
+            )
+
+            gap_classes = []
+            if race_id in identity_context and not official_complete:
+                gap_classes.append("identity_mismatch")
+            if not official_complete:
+                gap_classes.append("official_result_missing")
+            if not strict_complete:
+                gap_classes.append("strict_prejump_odds_missing")
+            if not stage2_complete:
+                gap_classes.append("stage2_missing")
+            other_reasons = [
+                reason
+                for reason in sorted(reason_counts)
+                if reason
+                not in {
+                    "official_result_missing",
+                    "strict_prejump_odds_missing",
+                    "stage2_shadow_prediction_missing",
+                }
+                and not (
+                    "strict_prejump_odds_missing" in gap_classes
+                    and is_odds_detail_reason(reason)
+                )
+            ]
+            if primary_missing_rows or (unified_missing_rows and not gap_classes) or other_reasons:
+                gap_classes.append("other_gate")
+
+        gap_classes = [gap_class for gap_class in GAP_CLASS_PRIORITY if gap_class in gap_classes]
+        if not gap_classes:
+            continue
+
+        for gap_class in gap_classes:
+            gap_class_counts[gap_class] += 1
+        primary_gap_class = gap_classes[0]
+        primary_gap_class_counts[primary_gap_class] += 1
+        identity_details = identity_context.get(race_id) or {}
+        gap_rows.append(
+            {
+                "race_id": race_id,
+                "race_date": race_date,
+                "venue": venue,
+                "race_number": race_number,
+                "primary_gap_class": primary_gap_class,
+                "gap_class": primary_gap_class,
+                "gap_classes": gap_classes,
+                "recommended_action": GAP_CLASS_ACTIONS[primary_gap_class],
+                "source_set_present": row_count > 0,
+                "row_count": row_count,
+                "official_result_missing_rows": official_missing_rows,
+                "strict_prejump_odds_missing_rows": strict_missing_rows,
+                "stage2_missing_rows": stage2_missing_rows,
+                "primary_prediction_missing_rows": primary_missing_rows,
+                "unified_evidence_missing_rows": unified_missing_rows,
+                "official_result_complete": official_complete,
+                "strict_prejump_odds_complete": strict_complete,
+                "stage2_complete": stage2_complete,
+                "primary_prediction_complete": primary_complete,
+                "unified_evidence_complete": unified_complete,
+                "excluded_from_unified_reason_counts": dict(sorted(reason_counts.items())),
+                "identity_mismatch_reasons": identity_details.get("identity_mismatch_reasons") or [],
+                "identity_mismatch_source_paths": (
+                    identity_details.get("identity_mismatch_source_paths") or []
+                ),
+            }
+        )
+
+    priority = {gap_class: index for index, gap_class in enumerate(GAP_CLASS_PRIORITY)}
+    gap_rows.sort(
+        key=lambda row: (
+            priority.get(str(row.get("primary_gap_class")), len(priority)),
+            -int(row.get("unified_evidence_missing_rows") or 0),
+            str(row.get("race_id") or ""),
+        )
+    )
+    return {
+        "schema_version": "unified_evidence_race_gap_prioritization_v1",
+        "scope": "source_set_or_dataset_race_level_gaps",
+        "lineage_basis": source_race_id_source,
+        "raw_db_count_basis": False,
+        "source_race_id_source": source_race_id_source,
+        "source_race_count": len(source_race_ids),
+        "dataset_race_count": len(dataset_race_ids),
+        "source_set_missing_race_count": sum(
+            1 for race_id in source_race_ids if race_id not in dataset_race_ids
+        ),
+        "sample_blocking_gap_count": len(gap_rows),
+        "primary_gap_class_counts": dict(sorted(primary_gap_class_counts.items())),
+        "gap_class_counts": dict(sorted(gap_class_counts.items())),
+        "top_gap_race_ids": [row["race_id"] for row in gap_rows[:top_limit]],
+        "top_gap_races": gap_rows[:top_limit],
     }
 
 
@@ -646,40 +892,47 @@ def joined_shadow_official_results(
     for path in joined_paths:
         rows = load_jsonl(path)
         rejection_reasons = Counter()
+        rejected_race_ids_by_reason: dict[str, set[str]] = defaultdict(set)
         accepted_rows = 0
         duplicate_rows = 0
         for item in rows:
-            if item.get("identity_match_status") != JOINED_SHADOW_EXACT_IDENTITY_STATUS:
-                rejection_reasons["identity_match_not_exact_box_and_normalized_name"] += 1
-                continue
             race_id = str(item.get("race_id") or "").strip()
+
+            def reject(reason: str) -> None:
+                rejection_reasons[reason] += 1
+                if race_id:
+                    rejected_race_ids_by_reason[reason].add(race_id)
+
+            if item.get("identity_match_status") != JOINED_SHADOW_EXACT_IDENTITY_STATUS:
+                reject("identity_match_not_exact_box_and_normalized_name")
+                continue
             box_number = parse_int(
                 item.get("box_number") if item.get("box_number") not in (None, "") else item.get("box")
             )
             dog_name = item.get("dog_name") or item.get("official_dog_name")
             if not race_id:
-                rejection_reasons["race_id_missing"] += 1
+                reject("race_id_missing")
                 continue
             if box_number is None:
-                rejection_reasons["box_number_missing"] += 1
+                reject("box_number_missing")
                 continue
             if not normalize_name(dog_name):
-                rejection_reasons["dog_name_missing"] += 1
+                reject("dog_name_missing")
                 continue
             finish_position = parse_int(item.get("finish_position"))
             if finish_position is None or finish_position <= 0:
-                rejection_reasons["finish_position_invalid"] += 1
+                reject("finish_position_invalid")
                 continue
             is_winner = parse_json_bool(item.get("is_winner"))
             if is_winner is None:
-                rejection_reasons["is_winner_not_json_bool"] += 1
+                reject("is_winner_not_json_bool")
                 continue
             if is_winner != (finish_position == 1):
-                rejection_reasons["finish_position_winner_flag_conflict"] += 1
+                reject("finish_position_winner_flag_conflict")
                 continue
             source_url = item.get("result_url") or item.get("source_url") or item.get("race_url")
             if not str(source_url or "").strip():
-                rejection_reasons["result_source_url_missing"] += 1
+                reject("result_source_url_missing")
                 continue
             key = runner_key(race_id, box_number, dog_name)
             result = {
@@ -703,7 +956,7 @@ def joined_shadow_official_results(
                     existing.get("finish_position") != result.get("finish_position")
                     or existing.get("is_winner") != result.get("is_winner")
                 ):
-                    rejection_reasons["duplicate_joined_result_conflict"] += 1
+                    reject("duplicate_joined_result_conflict")
                     continue
                 duplicate_rows += 1
                 continue
@@ -717,6 +970,10 @@ def joined_shadow_official_results(
                 "duplicate_rows": duplicate_rows,
                 "rejected_rows": sum(rejection_reasons.values()),
                 "rejection_reason_counts": dict(sorted(rejection_reasons.items())),
+                "rejected_race_ids_by_reason": {
+                    reason: sorted(race_ids)
+                    for reason, race_ids in sorted(rejected_race_ids_by_reason.items())
+                },
             }
         )
     return results, audits
@@ -1178,6 +1435,11 @@ def build_report(
         official_result_evidence_db_audit=official_result_evidence_db_audit,
         exclusion_reason_counts=exclusion_counts,
     )
+    race_gap_prioritization = build_race_gap_prioritization(
+        rows=rows,
+        join_eligibility_packet_audits=join_eligibility_packet_audits,
+        joined_shadow_prediction_audits=joined_shadow_prediction_audits,
+    )
     return {
         "schema_version": "unified_evidence_dataset_report_v1",
         "generated_at": generated_at.isoformat(),
@@ -1193,6 +1455,7 @@ def build_report(
         "official_result_runner_paths": [relpath(path) for path in official_result_runner_paths],
         "official_result_evidence_db_audit": dict(official_result_evidence_db_audit),
         "official_result_coverage": official_result_coverage,
+        "race_gap_prioritization": race_gap_prioritization,
         "joined_shadow_prediction_paths": [relpath(path) for path in joined_shadow_prediction_paths],
         "joined_shadow_prediction_audits": list(joined_shadow_prediction_audits),
         "joined_shadow_prediction_rows_seen": sum(
@@ -1305,6 +1568,11 @@ def summary_markdown(report: Mapping[str, Any]) -> str:
         if isinstance(report.get("official_result_coverage"), Mapping)
         else {}
     )
+    race_gap_prioritization = (
+        report.get("race_gap_prioritization")
+        if isinstance(report.get("race_gap_prioritization"), Mapping)
+        else {}
+    )
     return "\n".join(
         [
             "# Unified Evidence Dataset",
@@ -1339,10 +1607,25 @@ def summary_markdown(report: Mapping[str, Any]) -> str:
             f"- Stage 2-evaluation eligible rows: `{report.get('stage2_evaluation_eligible_rows')}`",
             f"- Odds-evaluation eligible rows: `{report.get('odds_evaluation_eligible_rows')}`",
             f"- Unified-evidence eligible rows: `{report.get('unified_evidence_eligible_rows')}`",
+            f"- Race gap source basis: `{race_gap_prioritization.get('source_race_id_source')}`",
+            f"- Race gap raw DB count basis: `{race_gap_prioritization.get('raw_db_count_basis')}`",
+            f"- Race gap source races: `{race_gap_prioritization.get('source_race_count')}`",
+            f"- Race gap sample-blocking races: `{race_gap_prioritization.get('sample_blocking_gap_count')}`",
+            f"- Race gap primary class counts: `{race_gap_prioritization.get('primary_gap_class_counts')}`",
+            f"- Race gap all class counts: `{race_gap_prioritization.get('gap_class_counts')}`",
+            f"- Race gap top race IDs: `{race_gap_prioritization.get('top_gap_race_ids')}`",
             "",
             "## Exclusions",
             "",
             json.dumps(report.get("exclusion_reason_counts") or {}, indent=2, sort_keys=True),
+            "",
+            "## Race Gap Prioritization",
+            "",
+            json.dumps(
+                race_gap_prioritization.get("top_gap_races") or [],
+                indent=2,
+                sort_keys=True,
+            ),
             "",
             "## Rejected Live Odds Candidate Reasons",
             "",
@@ -1363,6 +1646,7 @@ def build_dataset(
     shadow_run_dir: Path,
     db_path: Path,
     output_dir: Path,
+    evidence_root: Path | None = None,
     official_result_runner_paths: Sequence[Path] = (),
     joined_shadow_prediction_paths: Sequence[Path] = (),
     join_eligibility_packet_paths: Sequence[Path] = (),
@@ -1370,7 +1654,7 @@ def build_dataset(
     generated_at: datetime | None = None,
 ) -> dict[str, Any]:
     generated_at = generated_at or datetime.now().astimezone()
-    output_dir = unique_dir(assert_output_dir_safe(output_dir))
+    output_dir = unique_dir(assert_output_dir_safe(output_dir, evidence_root=evidence_root))
     output_dir.mkdir(parents=True, exist_ok=False)
     prediction_info = load_prediction_rows(shadow_run_dir)
     eligible_race_ids, join_eligibility_audits = join_eligibility_packet_audit(
@@ -1433,6 +1717,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--shadow-run-dir", type=Path, required=True)
     parser.add_argument("--db", type=Path, default=ROOT / "greyhound_racing_data.db")
+    parser.add_argument("--evidence-root", type=Path, default=DEFAULT_EVIDENCE_ROOT)
     parser.add_argument("--output-dir", type=Path)
     parser.add_argument("--official-result-runners-jsonl", action="append", type=Path, default=[])
     parser.add_argument("--joined-shadow-predictions-jsonl", action="append", type=Path, default=[])
@@ -1452,6 +1737,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         shadow_run_dir=args.shadow_run_dir,
         db_path=args.db,
         output_dir=output_dir,
+        evidence_root=args.evidence_root,
         official_result_runner_paths=args.official_result_runners_jsonl,
         joined_shadow_prediction_paths=args.joined_shadow_predictions_jsonl,
         join_eligibility_packet_paths=args.join_eligibility_packet,

--- a/tests/test_build_high_accuracy_refinement_packet.py
+++ b/tests/test_build_high_accuracy_refinement_packet.py
@@ -602,6 +602,85 @@ def test_rolling_gate_contract_can_select_non_rank_first_market_safe_candidate()
     )
 
 
+def test_promotion_pr_gate_carries_gate_contract_diagnostics_without_candidate():
+    promotion_distance_report = {
+        "final_status": "PROMOTION_DISTANCE_BLOCKED",
+        "promotion_ready": False,
+        "blockers": [
+            "gate_contract_candidate_blocker:gate_contract_audit_not_ready:SOURCE_NOT_READY",
+            (
+                "gate_contract_candidate_blocker:gate_contract_policy_not_evaluable:"
+                "dual_baseline_market_rank_primary_safety:SOURCE_NOT_READY"
+            ),
+        ],
+        "rolling_sample": {
+            "sample_race_count": 33,
+            "sample_runner_rows": 222,
+            "minimum_races_for_review": 100,
+        },
+        "gate_contract_candidate": {
+            "status": "BLOCKED",
+            "audit_final_status": "DATA_MISSING",
+            "audit_classification": "SOURCE_NOT_READY",
+            "policy_key": "dual_baseline_market_rank_primary_safety",
+            "policy_status": "BLOCKED",
+            "policy_evaluation_status": "NOT_EVALUABLE",
+            "data_missing_reasons": [],
+            "source_not_ready_reasons": [
+                "rolling_report_status_not_ready:ROLLING_MODEL_COMPARISON_COLLECTING",
+                "sample_floor_not_met",
+                "rolling_sample_below_review_floor",
+            ],
+            "policy_failure_reasons": [],
+            "candidate_policy_blocker_counts": {
+                "source_status_not_ready:ROLLING_MODEL_COMPARISON_COLLECTING": 3
+            },
+            "selected_candidate": None,
+            "audit_selected_candidate": None,
+            "blockers": [
+                "gate_contract_audit_not_ready:SOURCE_NOT_READY",
+                (
+                    "gate_contract_policy_not_evaluable:"
+                    "dual_baseline_market_rank_primary_safety:SOURCE_NOT_READY"
+                ),
+                "high_accuracy_selected_candidate_missing",
+            ],
+        },
+    }
+
+    result = packet.build_packet(
+        promotion_distance_report=promotion_distance_report,
+        generated_at=datetime(2026, 6, 23, 9, 10, tzinfo=timezone.utc),
+        protected_before={},
+        protected_after={},
+    )
+
+    pr_gate = result["promotion_pr_gate"]
+    assert pr_gate["status"] == "BLOCKED"
+    assert "no_candidate_passed_rank_first_accuracy_gate" in pr_gate["blockers"]
+    assert "promotion_distance_not_ready:PROMOTION_DISTANCE_BLOCKED" in (
+        pr_gate["blockers"]
+    )
+    assert (
+        "promotion_distance_blocker:"
+        "gate_contract_candidate_blocker:gate_contract_audit_not_ready:SOURCE_NOT_READY"
+    ) in pr_gate["blockers"]
+    assert pr_gate["promotion_distance_gate_contract"]["audit_classification"] == (
+        "SOURCE_NOT_READY"
+    )
+    assert pr_gate["promotion_distance_gate_contract"]["policy_evaluation_status"] == (
+        "NOT_EVALUABLE"
+    )
+    assert result["promotion_distance_summary"]["gate_contract_candidate"][
+        "audit_classification"
+    ] == "SOURCE_NOT_READY"
+    summary = packet.build_summary(result)
+    assert (
+        "Promotion distance gate-contract audit classification: `SOURCE_NOT_READY`"
+        in summary
+    )
+
+
 def test_collecting_rolling_comparison_does_not_bypass_latest_odds_gate():
     odds_gate_report = {
         "status": packet.ODDS_RESEARCH_BLOCKED_PROVENANCE,

--- a/tests/test_build_promotion_distance_report.py
+++ b/tests/test_build_promotion_distance_report.py
@@ -236,6 +236,233 @@ def test_promotion_distance_report_quantifies_blocked_accuracy_path(
     assert (output_dir / "output_manifest.json").exists()
 
 
+def test_gate_contract_diagnostics_classify_source_not_ready_separately(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(distance, "ROOT", tmp_path)
+    primary = _candidate(
+        candidate_key="primary_shadow",
+        family="baseline",
+        top1=0.30,
+        top3=0.60,
+        mean_winner_rank=3.0,
+        brier=0.80,
+        logloss=1.70,
+        slope=1.0,
+        intercept=0.0,
+        box1=0.16,
+    )
+    market = _candidate(
+        candidate_key="market_only_implied",
+        family="market_only",
+        top1=0.44,
+        top3=0.80,
+        mean_winner_rank=2.35,
+        brier=0.70,
+        logloss=1.50,
+        slope=0.90,
+        intercept=-0.10,
+        box1=0.20,
+    )
+    candidate = _candidate(
+        candidate_key="stage2_market_blend_85",
+        top1=0.448,
+        top3=0.816,
+        mean_winner_rank=2.27,
+        brier=0.69,
+        logloss=1.48,
+        slope=0.95,
+        intercept=0.05,
+        box1=0.21,
+    )
+    rolling = _write_json(
+        tmp_path / "rolling_collecting.json",
+        {
+            "final_status": "ROLLING_MODEL_COMPARISON_COLLECTING",
+            "sample_scope": "unified",
+            "sample_floor_met": False,
+            "sample_race_count": 33,
+            "sample_runner_rows": 222,
+            "minimum_races_for_review": 100,
+            "best_candidate_key": "stage2_market_blend_85",
+            "best_non_market_candidate_key": "stage2_market_blend_85",
+            "best_non_market_minus_market": {"top1": 0.008},
+            "rank_first_sort": ["stage2_market_blend_85"],
+            "baseline_metrics": primary,
+            "market_metrics": market,
+            "candidate_metrics_by_key": {
+                "primary_shadow": primary,
+                "market_only_implied": market,
+                "stage2_market_blend_85": candidate,
+            },
+        },
+    )
+    gated = _write_json(
+        tmp_path / "gated.json",
+        {"predeclared_residual_candidate": {"triggered_race_count": 0}},
+    )
+    gate = _write_json(
+        tmp_path / "gate.json",
+        {
+            "status": "BLOCKED",
+            "blockers": ["no_candidate_passed_rank_first_accuracy_gate"],
+            "pull_request_boundary": {"promotion_pr_allowed": False},
+        },
+    )
+
+    report = distance.build_report(
+        rolling_report_path=rolling,
+        pre_race_gated_report_path=gated,
+        high_accuracy_gate_path=gate,
+        output_dir=(
+            tmp_path
+            / "artifacts/full_evidence_orchestration_20260525"
+            / "promotion_distance_report_source_not_ready_test"
+        ),
+        generated_at=datetime(2026, 6, 23, 9, 0, tzinfo=timezone.utc),
+    )
+
+    contract = report["gate_contract_candidate"]
+    assert contract["audit_final_status"] == "DATA_MISSING"
+    assert contract["audit_classification"] == "SOURCE_NOT_READY"
+    assert contract["policy_evaluation_status"] == "NOT_EVALUABLE"
+    assert contract["data_missing_reasons"] == []
+    assert "rolling_report_status_not_ready:ROLLING_MODEL_COMPARISON_COLLECTING" in (
+        contract["source_not_ready_reasons"]
+    )
+    assert "sample_floor_not_met" in contract["source_not_ready_reasons"]
+    assert "rolling_sample_below_review_floor" in contract["source_not_ready_reasons"]
+    assert "gate_contract_audit_not_ready:SOURCE_NOT_READY" in contract["blockers"]
+    assert (
+        "gate_contract_policy_not_evaluable:"
+        "dual_baseline_market_rank_primary_safety:SOURCE_NOT_READY"
+    ) in contract["blockers"]
+    assert not any(
+        str(blocker).startswith("gate_contract_policy_failed")
+        for blocker in contract["blockers"]
+    )
+    summary = (
+        tmp_path
+        / "artifacts/full_evidence_orchestration_20260525"
+        / "promotion_distance_report_source_not_ready_test"
+        / "SUMMARY.md"
+    ).read_text(encoding="utf-8")
+    assert "Gate-contract audit classification: `SOURCE_NOT_READY`" in summary
+
+
+def test_gate_contract_diagnostics_classify_ready_source_policy_failure(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(distance, "ROOT", tmp_path)
+    primary = _candidate(
+        candidate_key="primary_shadow",
+        family="baseline",
+        top1=0.30,
+        top3=0.60,
+        mean_winner_rank=3.0,
+        brier=0.80,
+        logloss=1.70,
+        slope=1.0,
+        intercept=0.0,
+        box1=0.16,
+    )
+    market = _candidate(
+        candidate_key="market_only_implied",
+        family="market_only",
+        top1=0.44,
+        top3=0.80,
+        mean_winner_rank=2.35,
+        brier=0.70,
+        logloss=1.50,
+        slope=0.90,
+        intercept=-0.10,
+        box1=0.20,
+    )
+    failing = _candidate(
+        candidate_key="stage2_market_blend_20",
+        top1=0.42,
+        top3=0.78,
+        mean_winner_rank=2.45,
+        brier=0.74,
+        logloss=1.58,
+        slope=0.20,
+        intercept=-1.20,
+        box1=0.24,
+    )
+    rolling = _write_json(
+        tmp_path / "rolling_ready_policy_failed.json",
+        {
+            "final_status": "ROLLING_MODEL_COMPARISON_READY_FOR_REVIEW",
+            "sample_scope": "unified",
+            "sample_floor_met": True,
+            "sample_race_count": 120,
+            "sample_runner_rows": 840,
+            "minimum_races_for_review": 100,
+            "best_candidate_key": "stage2_market_blend_20",
+            "best_non_market_candidate_key": "stage2_market_blend_20",
+            "best_non_market_minus_market": {"top1": -0.02},
+            "rank_first_sort": ["stage2_market_blend_20"],
+            "baseline_metrics": primary,
+            "market_metrics": market,
+            "candidate_metrics_by_key": {
+                "primary_shadow": primary,
+                "market_only_implied": market,
+                "stage2_market_blend_20": failing,
+            },
+        },
+    )
+    gated = _write_json(
+        tmp_path / "gated.json",
+        {"predeclared_residual_candidate": {"triggered_race_count": 0}},
+    )
+    gate = _write_json(
+        tmp_path / "gate_ready.json",
+        {
+            "status": "READY_FOR_PR_DRAFT",
+            "selected_stage": "odds_augmented_model_research",
+            "selected_candidate": "stage2_market_blend_20",
+            "blockers": [],
+            "pull_request_boundary": {
+                "promotion_pr_allowed": True,
+                "direct_local_switch_allowed": False,
+                "local_registry_mutation_allowed": False,
+                "production_pointer_update_allowed": False,
+                "requires_human_pr_review": True,
+            },
+        },
+    )
+
+    report = distance.build_report(
+        rolling_report_path=rolling,
+        pre_race_gated_report_path=gated,
+        high_accuracy_gate_path=gate,
+        output_dir=(
+            tmp_path
+            / "artifacts/full_evidence_orchestration_20260525"
+            / "promotion_distance_report_policy_failed_test"
+        ),
+        generated_at=datetime(2026, 6, 23, 9, 5, tzinfo=timezone.utc),
+    )
+
+    contract = report["gate_contract_candidate"]
+    assert contract["audit_classification"] == "POLICY_FAILED"
+    assert contract["policy_evaluation_status"] == "FAILED"
+    assert contract["data_missing_reasons"] == []
+    assert contract["source_not_ready_reasons"] == []
+    assert "gate_contract_policy_failed:dual_baseline_market_rank_primary_safety" in (
+        contract["blockers"]
+    )
+    assert "metric_delta_below_min:top1" in contract["policy_failure_reasons"]
+    assert (
+        contract["candidate_policy_blocker_counts"]["metric_delta_below_min:top1"]
+        >= 1
+    )
+    assert "gate_contract_audit_not_ready:DATA_MISSING" not in contract["blockers"]
+    assert report["promotion_ready"] is False
+
+
 def test_gate_contract_candidate_can_make_promotion_distance_review_ready(
     tmp_path,
     monkeypatch,

--- a/tests/test_build_rolling_model_comparison_packet.py
+++ b/tests/test_build_rolling_model_comparison_packet.py
@@ -82,6 +82,142 @@ def _write_dataset(
     return report_path
 
 
+def test_evidence_root_expands_current_input_to_historical_automatic_sources(
+    tmp_path,
+    monkeypatch,
+):
+    runtime_root = tmp_path / "runtime"
+    retained_repo = tmp_path / "retained"
+    runtime_root.mkdir()
+    retained_repo.mkdir()
+    evidence_root = retained_repo / "artifacts/full_evidence_orchestration_20260525"
+    monkeypatch.setattr(comparison, "ROOT", runtime_root)
+
+    older = _write_dataset(
+        retained_repo,
+        "unified_evidence_dataset_20260613T151711+1000_daemon_autopilot_backlog_001",
+        [
+            _row(
+                race_id="Race 1 - BEN - 2026-06-13",
+                dog="A",
+                box=1,
+                winner=True,
+                primary=0.7,
+                stage2=0.8,
+                odds=2.0,
+            ),
+            _row(
+                race_id="Race 1 - BEN - 2026-06-13",
+                dog="B",
+                box=2,
+                primary=0.3,
+                stage2=0.2,
+                odds=4.0,
+            ),
+        ],
+    )
+    _write_dataset(
+        retained_repo,
+        "unified_evidence_dataset_20260613T151711+1000_daemon_autopilot_backlog_manual_001",
+        [
+            _row(
+                race_id="Race manual - BEN - 2026-06-13",
+                dog="M",
+                box=1,
+                winner=True,
+            ),
+            _row(race_id="Race manual - BEN - 2026-06-13", dog="N", box=2),
+        ],
+    )
+    partial = _write_dataset(
+        retained_repo,
+        "unified_evidence_dataset_20260613T151711+1000_daemon_rejoin_001",
+        [
+            _row(
+                race_id="Race partial - BEN - 2026-06-13",
+                dog="P",
+                box=1,
+                winner=True,
+                unified=True,
+            ),
+            _row(
+                race_id="Race partial - BEN - 2026-06-13",
+                dog="Q",
+                box=2,
+                unified=False,
+                odds=None,
+            ),
+        ],
+    )
+    _write_dataset(
+        retained_repo,
+        "unified_evidence_dataset_20260613T151711+1000_daemon_rejoin_002",
+        [
+            _row(
+                race_id="Race empty - BEN - 2026-06-13",
+                dog="E",
+                box=1,
+                winner=True,
+            ),
+            _row(race_id="Race empty - BEN - 2026-06-13", dog="F", box=2),
+        ],
+        report_extra={"final_status": "UNIFIED_EVIDENCE_DATASET_EMPTY"},
+    )
+    latest = _write_dataset(
+        retained_repo,
+        "unified_evidence_dataset_20260623T181701+1000_daemon_rejoin_001",
+        [
+            _row(
+                race_id="Race 2 - BEN - 2026-06-23",
+                dog="C",
+                box=1,
+                winner=True,
+                primary=0.6,
+                stage2=0.7,
+                odds=2.4,
+            ),
+            _row(
+                race_id="Race 2 - BEN - 2026-06-23",
+                dog="D",
+                box=2,
+                primary=0.4,
+                stage2=0.3,
+                odds=3.5,
+            ),
+        ],
+    )
+
+    assert comparison.report_dataset_path(
+        older,
+        comparison.load_json(older),
+        evidence_root=evidence_root,
+    ).exists()
+
+    report = comparison.build_comparison(
+        unified_evidence_report_paths=[latest],
+        evidence_root=evidence_root,
+        output_dir=evidence_root / "rolling_model_comparison_expanded",
+        min_races_for_review=2,
+        generated_at=datetime(2026, 6, 23, 9, 0, tzinfo=timezone.utc),
+    )
+
+    assert report["final_status"] == "ROLLING_MODEL_COMPARISON_READY_FOR_REVIEW"
+    assert report["sample_race_count"] == 2
+    assert report["skipped_race_counts"] == {
+        "race_not_fully_unified_evidence_eligible": 1
+    }
+    assert report["source_discovery"]["explicit_report_count"] == 1
+    assert report["source_discovery"]["historical_report_count"] == 2
+    assert report["source_discovery"]["effective_report_count"] == 3
+    assert len(report["source_reports"]) == 3
+    source_paths = report["source_unified_evidence_reports"]
+    assert any(older.parent.name in path for path in source_paths)
+    assert any(partial.parent.name in path for path in source_paths)
+    assert any(latest.parent.name in path for path in source_paths)
+    assert not any("_manual_" in path for path in source_paths)
+    assert not any("daemon_rejoin_002" in path for path in source_paths)
+
+
 def test_rolling_comparison_evaluates_stage2_market_and_blends(tmp_path, monkeypatch):
     monkeypatch.setattr(comparison, "ROOT", tmp_path)
     rows = [

--- a/tests/test_build_unified_evidence_dataset.py
+++ b/tests/test_build_unified_evidence_dataset.py
@@ -1233,6 +1233,248 @@ def test_joined_shadow_predictions_reject_non_exact_identity_rows(tmp_path, monk
     assert "official_result_missing" in rows[0]["excluded_from_unified_reason"]
 
 
+def test_race_gap_prioritization_uses_source_lineage_not_raw_db_counts(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(dataset, "ROOT", tmp_path)
+    shadow_dir = tmp_path / "daily"
+
+    def prediction(race_id: str, dog_name: str) -> dict:
+        return {
+            "race_id": race_id,
+            "dog_name": dog_name,
+            "box": 1,
+            "predicted_rank": 1,
+            "shadow_rf_calibrated_probability": 0.31,
+        }
+
+    ready = "Race 1 - WPK - 2026-06-10"
+    official_missing = "Race 2 - WPK - 2026-06-10"
+    odds_missing = "Race 3 - WPK - 2026-06-10"
+    stage2_missing = "Race 4 - WPK - 2026-06-10"
+    identity_mismatch = "Race 5 - WPK - 2026-06-10"
+    source_set_missing = "Race 6 - WPK - 2026-06-10"
+    other_gate = "Race 7 - WPK - 2026-06-10"
+    dog_by_race = {
+        ready: "Ready Runner",
+        official_missing: "Official Missing Runner",
+        odds_missing: "Odds Missing Runner",
+        stage2_missing: "Stage Two Missing Runner",
+        identity_mismatch: "Identity Mismatch Runner",
+        source_set_missing: "Source Missing Runner",
+        other_gate: "Other Gate Runner",
+    }
+
+    primary_predictions = [
+        prediction(ready, dog_by_race[ready]),
+        prediction(official_missing, dog_by_race[official_missing]),
+        prediction(odds_missing, dog_by_race[odds_missing]),
+        prediction(stage2_missing, dog_by_race[stage2_missing]),
+        prediction(identity_mismatch, dog_by_race[identity_mismatch]),
+    ]
+    stage2_predictions = [
+        {
+            **prediction(race_id, dog_by_race[race_id]),
+            "schema_version": "stage2_shadow_prediction_v1",
+            "stage2_challenger_key": "shadow_calibrated_rf_power_gamma_2_4",
+        }
+        for race_id in [
+            ready,
+            official_missing,
+            odds_missing,
+            identity_mismatch,
+            other_gate,
+        ]
+    ]
+    _write_jsonl(shadow_dir / "shadow_predictions.jsonl", primary_predictions)
+    _write_jsonl(shadow_dir / "stage2_shadow_predictions.jsonl", stage2_predictions)
+
+    runner_path = tmp_path / "official_result_runners.jsonl"
+    _write_jsonl(
+        runner_path,
+        [
+            {
+                "race_id": race_id,
+                "box_number": 1,
+                "dog_name": dog_by_race[race_id],
+                "finish_position": 1,
+                "source": "thedogs_official",
+                "source_url": (
+                    "https://www.thedogs.com.au/racing/"
+                    f"wentworth-park/2026-06-10/{index}/results"
+                ),
+            }
+            for index, race_id in enumerate(
+                [ready, odds_missing, stage2_missing, other_gate],
+                start=1,
+            )
+        ],
+    )
+
+    joined_path = tmp_path / "joined_shadow_predictions.jsonl"
+    _write_jsonl(
+        joined_path,
+        [
+            {
+                "race_id": identity_mismatch,
+                "dog_name": dog_by_race[identity_mismatch],
+                "official_dog_name": "Different Runner",
+                "box": 1,
+                "finish_position": 1,
+                "is_winner": True,
+                "identity_match_status": "dog_name_mismatch_after_exact_badge_stripping",
+                "result_url": "https://www.thedogs.com.au/racing/wentworth-park/2026-06-10/5/results",
+            }
+        ],
+    )
+
+    odds_path = tmp_path / "shadow_odds_snapshot.jsonl"
+    _write_jsonl(
+        odds_path,
+        [
+            {
+                "schema_version": "shadow_odds_snapshot_runner_v1",
+                "race_id": race_id,
+                "dog_name": dog_by_race[race_id],
+                "box": 1,
+                "odds_match_status": "valid_pre_jump_dog_odds",
+                "odds_provenance_status": "complete",
+                "ev_calculation_status": "DISABLED_REPORT_ONLY_NO_EV_OUTPUT",
+                "ev_win": None,
+                "race_context": {
+                    "venue": "WPK",
+                    "race_number": int(race_id.split()[1]),
+                    "race_date": "2026-06-10",
+                    "race_time": "15:00",
+                },
+                "odds_snapshot": {
+                    "market_odds_win": 2.8,
+                    "market_type": "win",
+                    "odds_timestamp": "2026-06-10T14:30:00+10:00",
+                    "odds_level": "dog",
+                    "odds_captured_before_feature_freeze": True,
+                    "odds_captured_before_jump": True,
+                    "odds_captured_before_prediction": True,
+                    "odds_provenance": {
+                        "source": "sportsbet",
+                        "source_table": "live_odds",
+                        "source_url": (
+                            "https://www.sportsbet.com.au/greyhound-racing/"
+                            "australia-nz/wentworth-park/race-1"
+                        ),
+                        "capture_mode": "autonomous_prejump_t30m",
+                        "sportsbet_box_source": "runner_text",
+                        "sportsbet_raw_runner_text": f"1. {dog_by_race[race_id]}",
+                        "odds_box_number": 1,
+                        "odds_dog_name": dog_by_race[race_id].upper(),
+                        "odds_race_id": race_id,
+                    },
+                },
+            }
+            for race_id in [
+                ready,
+                official_missing,
+                stage2_missing,
+                identity_mismatch,
+                other_gate,
+            ]
+        ],
+    )
+
+    packet_path = tmp_path / "join_eligibility.json"
+    packet_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "live_odds_backlog_join_eligibility_packet_v1",
+                "diagnostic_only": True,
+                "join_authorized": False,
+                "db_write_performed": False,
+                "races": [
+                    {
+                        "race_id": race_id,
+                        "eligibility_status": "JOIN_ELIGIBLE_REPORT_ONLY",
+                        "blockers": [],
+                        "join_authorized": False,
+                        "db_write_performed": False,
+                    }
+                    for race_id in dog_by_race
+                ],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    db_path = _make_db(tmp_path)
+    _remove_official_result_rows(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DELETE FROM live_odds")
+
+    report = dataset.build_dataset(
+        shadow_run_dir=shadow_dir,
+        db_path=db_path,
+        output_dir=tmp_path
+        / "artifacts/full_evidence_orchestration_20260525/unified_evidence_dataset_gap_priority",
+        official_result_runner_paths=[runner_path],
+        joined_shadow_prediction_paths=[joined_path],
+        join_eligibility_packet_paths=[packet_path],
+        odds_jsonl_paths=[odds_path],
+        generated_at=datetime.fromisoformat("2026-06-10T15:30:00+10:00"),
+    )
+
+    gap = report["race_gap_prioritization"]
+    assert gap["source_race_id_source"] == "join_eligibility_packet_accepted_race_ids"
+    assert gap["raw_db_count_basis"] is False
+    assert gap["source_race_count"] == 7
+    assert gap["dataset_race_count"] == 6
+    assert gap["source_set_missing_race_count"] == 1
+    assert gap["primary_gap_class_counts"] == {
+        "identity_mismatch": 1,
+        "official_result_missing": 1,
+        "other_gate": 1,
+        "source_set_missing": 1,
+        "stage2_missing": 1,
+        "strict_prejump_odds_missing": 1,
+    }
+    assert gap["gap_class_counts"] == {
+        "identity_mismatch": 1,
+        "official_result_missing": 2,
+        "other_gate": 1,
+        "source_set_missing": 1,
+        "stage2_missing": 1,
+        "strict_prejump_odds_missing": 1,
+    }
+    assert gap["top_gap_race_ids"] == [
+        source_set_missing,
+        identity_mismatch,
+        official_missing,
+        odds_missing,
+        stage2_missing,
+        other_gate,
+    ]
+    top_by_race = {row["race_id"]: row for row in gap["top_gap_races"]}
+    assert top_by_race[source_set_missing]["primary_gap_class"] == "source_set_missing"
+    assert top_by_race[source_set_missing]["source_set_present"] is False
+    assert top_by_race[identity_mismatch]["gap_classes"] == [
+        "identity_mismatch",
+        "official_result_missing",
+    ]
+    assert top_by_race[identity_mismatch]["identity_mismatch_reasons"] == [
+        "identity_match_not_exact_box_and_normalized_name"
+    ]
+    assert top_by_race[official_missing]["primary_gap_class"] == "official_result_missing"
+    assert top_by_race[odds_missing]["primary_gap_class"] == "strict_prejump_odds_missing"
+    assert top_by_race[stage2_missing]["primary_gap_class"] == "stage2_missing"
+    assert top_by_race[other_gate]["primary_gap_class"] == "other_gate"
+
+    summary = (
+        tmp_path
+        / "artifacts/full_evidence_orchestration_20260525/unified_evidence_dataset_gap_priority/SUMMARY.md"
+    ).read_text(encoding="utf-8")
+    assert "- Race gap raw DB count basis: `False`" in summary
+    assert f"- Race gap top race IDs: `{gap['top_gap_race_ids']}`" in summary
+
+
 def test_valid_strict_odds_do_not_inherit_stale_candidate_exclusions(tmp_path, monkeypatch):
     monkeypatch.setattr(dataset, "ROOT", tmp_path)
     shadow_dir = tmp_path / "daily"

--- a/utils/report_output_dir_guard.py
+++ b/utils/report_output_dir_guard.py
@@ -1,0 +1,41 @@
+"""Shared output-directory guard for report-only artifact builders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def assert_prefixed_report_output_dir(
+    output_dir: Path,
+    *,
+    repo_root: Path,
+    repo_prefix: str,
+    artifact_prefix: str,
+    prefix_error: str,
+    evidence_root: Path | None = None,
+) -> Path:
+    logical = output_dir if output_dir.is_absolute() else repo_root / output_dir
+    candidate = logical.absolute()
+    repo_base = repo_root.absolute()
+    try:
+        relative = candidate.relative_to(repo_base)
+    except ValueError as exc:
+        if evidence_root is None:
+            raise ValueError("output_dir_must_be_inside_repo") from exc
+    else:
+        if ".." in relative.parts:
+            raise ValueError("output_dir_must_not_contain_parent_traversal")
+        if relative.as_posix().startswith(repo_prefix):
+            return candidate
+        raise ValueError(f"{prefix_error}:{relative}")
+
+    evidence_base = evidence_root if evidence_root.is_absolute() else repo_root / evidence_root
+    try:
+        relative = candidate.relative_to(evidence_base.absolute())
+    except ValueError as exc:
+        raise ValueError("output_dir_must_be_inside_repo_or_evidence_root") from exc
+    if ".." in relative.parts:
+        raise ValueError("output_dir_must_not_contain_parent_traversal")
+    if relative.parts and relative.parts[0].startswith(artifact_prefix):
+        return candidate
+    raise ValueError(f"{prefix_error}:{relative}")


### PR DESCRIPTION
## Summary

Fixes the greyhound report-only accuracy readiness lane so the rolling/promotion packets use the cumulative full-evidence sample instead of only the latest daemon child packet.

Changes included:
- Restore retained evidence-root discovery for rolling model comparison.
- Add source-aware race gap prioritization to unified evidence output.
- Add clearer promotion-distance gate-contract diagnostics for `DATA_MISSING`, `SOURCE_NOT_READY`, and `POLICY_FAILED` states.
- Preserve promotion-distance gate-contract diagnostics in the high-accuracy packet.
- Add durable AGENTS guidance explaining that the rolling/promotion denominator is the safe eligible prediction/result/odds sample, not raw race inventory.
- Commit the review-board closeout bundle and worker results for this lane.

## Root Cause

The live daemon was producing full prediction artifacts, but the validation path was undercounting safe races because it selected the latest completed full daemon child and did not automatically include the retained historical full-evidence packets. That made the rolling sample look smaller than the available race evidence and kept the promotion contract ambiguous.

## Validation

- `uv run --with-requirements requirements/requirements.lock --with pytest pytest tests/test_build_rolling_model_comparison_packet.py tests/test_build_unified_evidence_dataset.py tests/test_build_promotion_distance_report.py tests/test_build_high_accuracy_refinement_packet.py -q`
  - `47 passed in 33.67s`
- `git diff --cached --check`
- `python3 -m py_compile scripts/build_rolling_model_comparison_packet.py scripts/build_unified_evidence_dataset.py scripts/build_promotion_distance_report.py scripts/build_high_accuracy_refinement_packet.py utils/report_output_dir_guard.py tests/test_build_rolling_model_comparison_packet.py tests/test_build_unified_evidence_dataset.py tests/test_build_promotion_distance_report.py tests/test_build_high_accuracy_refinement_packet.py`
- Report-only rolling validation: `158` races / `1110` runner rows, `ROLLING_MODEL_COMPARISON_READY_FOR_REVIEW`
- Report-only promotion-distance validation: `PROMOTION_DISTANCE_REVIEW_READY`, gate contract `PASS`
- Report-only high-accuracy packet: `READY_FOR_PROMOTION_PR_DRAFT`

## Safety Boundary

This PR is a draft for owner review. It does not perform production promotion and does not mutate the DB, runtime service state, training outputs, registry, EV/betting surfaces, snapshots, or production model pointers.

Tenn git guard result before publish: `warning` due to missing live and committed ledger files; fallback artifact/git checks completed and registry status was `PASS`.