### PR TITLE
[codex] Lock rolling candidate denominators

### DIFF
--- a/scripts/build_promotion_gate_contract_audit_packet.py
+++ b/scripts/build_promotion_gate_contract_audit_packet.py
@@ -42,6 +42,9 @@ OUTPUT_MANIFEST_FILE = "output_manifest.json"
 ROLLING_READY_STATUS = "ROLLING_MODEL_COMPARISON_READY_FOR_REVIEW"
 MARKET_ONLY_CANDIDATE_KEYS = {"market_only_implied"}
 BASELINE_CANDIDATE_KEYS = {"primary_shadow", "champion_baseline"}
+CANDIDATE_DENOMINATOR_MISMATCH_BLOCKER = (
+    "candidate_denominator_mismatch_primary_shadow"
+)
 
 
 @dataclass(frozen=True)
@@ -217,6 +220,24 @@ def calibration_distance(metrics: Mapping[str, Any]) -> float | None:
     return abs(slope - 1.0) + abs(intercept)
 
 
+def denominator_mismatches_primary(
+    candidate: Mapping[str, Any],
+    rolling_report: Mapping[str, Any],
+) -> bool:
+    if candidate.get("baseline_denominator_match") is True:
+        return False
+    if candidate.get("baseline_denominator_match") is False:
+        return True
+    primary = mapping(rolling_report.get("baseline_metrics"))
+    primary_count = race_count(primary)
+    candidate_count = race_count(candidate)
+    primary_hash = str(primary.get("evaluated_race_ids_hash") or "")
+    candidate_hash = str(candidate.get("evaluated_race_ids_hash") or "")
+    if primary_count <= 0 or candidate_count <= 0 or not primary_hash or not candidate_hash:
+        return False
+    return primary_count != candidate_count or primary_hash != candidate_hash
+
+
 def delta(
     baseline: Mapping[str, Any],
     candidate: Mapping[str, Any],
@@ -290,6 +311,8 @@ def add_common_candidate_blockers(
         blockers.append("market_only_candidate_not_promotable")
     if is_baseline_candidate(candidate_key):
         blockers.append("baseline_candidate_not_promotable")
+    if denominator_mismatches_primary(candidate, rolling_report):
+        blockers.append(CANDIDATE_DENOMINATOR_MISMATCH_BLOCKER)
     if race_count(candidate) < thresholds.min_safe_joined_races:
         blockers.append("candidate_race_sample_below_min")
     sum_error = probability_sum_error(candidate)
@@ -607,6 +630,8 @@ def candidate_gate_row(
         "candidate_key": candidate_key,
         "family": candidate.get("family"),
         "status": candidate.get("status"),
+        "baseline_denominator_match": candidate.get("baseline_denominator_match"),
+        "evaluated_race_ids_hash": candidate.get("evaluated_race_ids_hash"),
         "rank_first_order": rank_lookup.get(candidate_key),
         "race_count": race_count(candidate),
         "top1": metric(candidate, "top1"),
@@ -827,6 +852,8 @@ def compact_metrics(metrics: Mapping[str, Any]) -> dict[str, Any]:
         "brier": metric(metrics, "brier"),
         "logloss": metric(metrics, "logloss"),
         "box1_top_pick_share": metric(metrics, "box1_top_pick_share"),
+        "baseline_denominator_match": metrics.get("baseline_denominator_match"),
+        "evaluated_race_ids_hash": metrics.get("evaluated_race_ids_hash"),
         "calibration_distance": calibration_distance(metrics),
         "probability_sum_max_error_joined_races": probability_sum_error(metrics),
     }

--- a/scripts/build_rolling_model_comparison_packet.py
+++ b/scripts/build_rolling_model_comparison_packet.py
@@ -46,6 +46,10 @@ MIN_RACES_FOR_REVIEW = 100
 DEFAULT_HISTORICAL_UNIFIED_EVIDENCE_REPORT_LIMIT = 500
 POWER_GAMMAS = (0.85, 1.2, 1.5, 2.0)
 BLEND_MARKET_WEIGHTS = tuple(weight / 100 for weight in range(5, 100, 5))
+REFINED_BLEND_MARKET_WEIGHTS = (0.63, 0.66, 0.89, 0.91)
+CANDIDATE_DENOMINATOR_MISMATCH_BLOCKER = (
+    "candidate_denominator_mismatch_primary_shadow"
+)
 NO_WRITE_GUARANTEES = {
     "training": False,
     "production_promotion": False,
@@ -791,6 +795,8 @@ def compact_candidate_metrics(metrics: Mapping[str, Any]) -> dict[str, Any]:
             "family",
             "status",
             "race_count",
+            "evaluated_race_ids_hash",
+            "baseline_denominator_match",
             "top1",
             "top3",
             "mean_winner_rank",
@@ -820,6 +826,37 @@ def is_market_only_candidate(metrics: Mapping[str, Any]) -> bool:
         str(metrics.get("candidate_key") or "") == "market_only_implied"
         or str(metrics.get("family") or "") == "market_only"
     )
+
+
+def with_baseline_denominator_guard(
+    metrics: Mapping[str, Any],
+    *,
+    baseline: Mapping[str, Any],
+) -> dict[str, Any]:
+    guarded = dict(metrics)
+    if guarded.get("status") != "EVALUATED":
+        return guarded
+    baseline_count = safe_int(baseline.get("race_count"))
+    baseline_hash = str(baseline.get("evaluated_race_ids_hash") or "")
+    candidate_count = safe_int(guarded.get("race_count"))
+    candidate_hash = str(guarded.get("evaluated_race_ids_hash") or "")
+    denominator_match = (
+        bool(baseline)
+        and baseline.get("status") == "EVALUATED"
+        and candidate_count == baseline_count
+        and bool(candidate_hash)
+        and candidate_hash == baseline_hash
+    )
+    guarded["baseline_denominator_candidate_key"] = "primary_shadow"
+    guarded["baseline_denominator_race_count"] = baseline_count if baseline else None
+    guarded["baseline_denominator_race_ids_hash"] = baseline_hash or None
+    guarded["baseline_denominator_match"] = denominator_match
+    if not denominator_match:
+        blockers = list(guarded.get("blockers") or [])
+        if CANDIDATE_DENOMINATOR_MISMATCH_BLOCKER not in blockers:
+            blockers.append(CANDIDATE_DENOMINATOR_MISMATCH_BLOCKER)
+        guarded["blockers"] = blockers
+    return guarded
 
 
 def metric_delta(
@@ -1619,6 +1656,55 @@ def build_residual_hypothesis_backtests(
     return results
 
 
+def build_refined_blend_frontier_backtests(
+    race_groups: Sequence[Mapping[str, Any]],
+    *,
+    baseline_metrics: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for weight in REFINED_BLEND_MARKET_WEIGHTS:
+        weight_percent = int(round(weight * 100))
+        spec = {
+            "candidate_key": f"stage2_market_blend_{weight_percent}",
+            "family": "report_only_refined_odds_augmented_blend",
+            "market_weight": weight,
+            "score_function": (
+                lambda rows, weight=weight: blend_scores(
+                    rows,
+                    model_key="stage2_shadow_probability",
+                    market_weight=weight,
+                )
+            ),
+        }
+        metrics = with_baseline_denominator_guard(
+            evaluate_candidate(race_groups, spec),
+            baseline=baseline_metrics,
+        )
+        blockers = ["report_only_refined_frontier_not_promotion_eligible"]
+        if metrics.get("baseline_denominator_match") is False:
+            blockers.append(CANDIDATE_DENOMINATOR_MISMATCH_BLOCKER)
+        results.append(
+            {
+                "schema_version": "rolling_model_refined_blend_frontier_backtest_v1",
+                "candidate_key": spec["candidate_key"],
+                "family": spec["family"],
+                "status": (
+                    "REPORT_ONLY_EVALUATED"
+                    if metrics.get("status") == "EVALUATED"
+                    else metrics.get("status")
+                ),
+                "selection_basis": (
+                    "small_refined_frontier_around_prior_stage2_market_blend_candidates"
+                ),
+                "promotion_eligible": False,
+                "market_weight": weight,
+                "metrics": compact_candidate_metrics(metrics),
+                "blockers": blockers,
+            }
+        )
+    return results
+
+
 def build_report(
     *,
     generated_at: datetime,
@@ -1629,14 +1715,33 @@ def build_report(
     min_races_for_review: int,
     output_dir: Path,
 ) -> dict[str, Any]:
-    evaluated = [item for item in candidate_metrics if item.get("status") == "EVALUATED"]
+    raw_evaluated = [
+        item for item in candidate_metrics if item.get("status") == "EVALUATED"
+    ]
+    raw_baseline = next(
+        (item for item in raw_evaluated if item.get("candidate_key") == "primary_shadow"),
+        {},
+    )
+    guarded_candidate_metrics = [
+        with_baseline_denominator_guard(item, baseline=raw_baseline)
+        for item in candidate_metrics
+    ]
+    evaluated = [
+        item for item in guarded_candidate_metrics if item.get("status") == "EVALUATED"
+    ]
     baseline = next(
         (item for item in evaluated if item.get("candidate_key") == "primary_shadow"),
         {},
     )
-    best = max(evaluated, key=candidate_sort_key) if evaluated else {}
+    rankable = [
+        item for item in evaluated if item.get("baseline_denominator_match") is True
+    ]
+    denominator_mismatches = [
+        item for item in evaluated if item.get("baseline_denominator_match") is False
+    ]
+    best = max(rankable, key=candidate_sort_key) if rankable else {}
     best_non_baseline = max(
-        [item for item in evaluated if item.get("candidate_key") != "primary_shadow"],
+        [item for item in rankable if item.get("candidate_key") != "primary_shadow"],
         key=candidate_sort_key,
         default={},
     )
@@ -1644,8 +1749,11 @@ def build_report(
         (item for item in evaluated if is_market_only_candidate(item)),
         {},
     )
+    rankable_market = (
+        market if market.get("baseline_denominator_match") is True else {}
+    )
     best_non_market = max(
-        [item for item in evaluated if not is_market_only_candidate(item)],
+        [item for item in rankable if not is_market_only_candidate(item)],
         key=candidate_sort_key,
         default={},
     )
@@ -1828,7 +1936,17 @@ def build_report(
         "skipped_race_counts": collection.get("skipped_race_counts") or {},
         "sample_race_count": sample_race_count,
         "sample_runner_rows": sum(len(race.get("runner_rows") or []) for race in race_groups),
-        "candidate_count": len(candidate_metrics),
+        "candidate_count": len(guarded_candidate_metrics),
+        "rankable_candidate_count": len(rankable),
+        "candidate_denominator_mismatch_count": len(denominator_mismatches),
+        "candidate_denominator_mismatch_keys": [
+            item.get("candidate_key") for item in denominator_mismatches
+        ],
+        "baseline_denominator": {
+            "candidate_key": "primary_shadow",
+            "race_count": baseline.get("race_count"),
+            "evaluated_race_ids_hash": baseline.get("evaluated_race_ids_hash"),
+        },
         "minimum_races_for_review": min_races_for_review,
         "sample_floor_met": sample_floor_met,
         "races_needed_for_review": max(0, min_races_for_review - sample_race_count),
@@ -1855,8 +1973,8 @@ def build_report(
             )
         },
         "best_non_market_minus_market": (
-            slice_metric_delta(market, best_non_market)
-            if market and best_non_market
+            slice_metric_delta(rankable_market, best_non_market)
+            if rankable_market and best_non_market
             else {}
         ),
         "best_non_market_minus_baseline": (
@@ -1865,11 +1983,12 @@ def build_report(
             else {}
         ),
         "candidate_metrics_by_key": {
-            str(item.get("candidate_key")): dict(item) for item in candidate_metrics
+            str(item.get("candidate_key")): dict(item)
+            for item in guarded_candidate_metrics
         },
         "rank_first_sort": [
             item.get("candidate_key")
-            for item in sorted(evaluated, key=candidate_sort_key, reverse=True)
+            for item in sorted(rankable, key=candidate_sort_key, reverse=True)
         ],
         "edge_diagnostics": build_edge_diagnostics(
             race_groups,
@@ -1894,6 +2013,10 @@ def build_report(
         "residual_hypothesis_backtests": build_residual_hypothesis_backtests(
             race_groups,
         ),
+        "refined_blend_frontier_backtests": build_refined_blend_frontier_backtests(
+            race_groups,
+            baseline_metrics=baseline,
+        ),
         "ev_metrics_used_for_promotion": False,
         "ev_improved": False,
         "no_write_guarantees": dict(NO_WRITE_GUARANTEES),
@@ -1914,6 +2037,10 @@ def write_candidate_csv(path: Path, candidate_metrics: Sequence[Mapping[str, Any
         "logloss",
         "box1_top_pick_share",
         "probability_sum_max_error_joined_races",
+        "evaluated_race_ids_hash",
+        "baseline_denominator_match",
+        "baseline_denominator_race_count",
+        "baseline_denominator_race_ids_hash",
         "calibration_status",
         "calibration_slope",
         "calibration_intercept",
@@ -2069,6 +2196,9 @@ def summary_markdown(report: Mapping[str, Any]) -> str:
             f"- Official-result runner path count: `{official_result.get('runner_path_count')}`",
             f"- Official-result runner paths source field: `{official_result.get('runner_paths_source_field')}`",
             f"- Candidate count: `{report.get('candidate_count')}`",
+            f"- Rankable candidate count: `{report.get('rankable_candidate_count')}`",
+            f"- Candidate denominator mismatch count: `{report.get('candidate_denominator_mismatch_count')}`",
+            f"- Candidate denominator mismatch keys: `{report.get('candidate_denominator_mismatch_keys')}`",
             f"- Best candidate: `{report.get('best_candidate_key')}`",
             f"- Best non-baseline candidate: `{report.get('best_non_baseline_candidate_key')}`",
             f"- Best non-market candidate: `{report.get('best_non_market_candidate_key')}`",
@@ -2078,6 +2208,7 @@ def summary_markdown(report: Mapping[str, Any]) -> str:
             f"- Market residual case rows: `{report.get('market_residual_case_count')}`",
             f"- Market residual runner matrix rows: `{report.get('market_residual_runner_matrix_row_count')}`",
             f"- Residual hypothesis backtests: `{len(report.get('residual_hypothesis_backtests') or [])}`",
+            f"- Refined blend frontier backtests: `{len(report.get('refined_blend_frontier_backtests') or [])}`",
             "",
             "No training, production promotion, registry mutation, production pointer update, DB write, label write, odds write, betting/EV action, snapshot rewrite, manifest rewrite, or TGR enablement was performed.",
             "",

--- a/tests/test_build_promotion_gate_contract_audit_packet.py
+++ b/tests/test_build_promotion_gate_contract_audit_packet.py
@@ -19,12 +19,14 @@ def _metrics(
     intercept: float = 0.0,
     box1: float = 0.16,
     status: str = "EVALUATED",
+    evaluated_race_ids_hash: str = "trusted_race_hash",
 ) -> dict:
     return {
         "candidate_key": candidate_key,
         "family": family,
         "status": status,
         "race_count": races,
+        "evaluated_race_ids_hash": evaluated_race_ids_hash,
         "top1": top1,
         "top3": top3,
         "mean_winner_rank": mean_winner_rank,
@@ -192,6 +194,44 @@ def test_strict_market_and_dual_pass_emit_report_only_gate_change_candidate():
     assert dual["status"] == "PASS"
     assert report["no_write_guarantees"]["production_promotion"] is False
     assert "separate reviewed implementation" in report["recommended_next_action"]
+
+
+def test_denominator_mismatch_candidate_is_not_gate_eligible():
+    sparse = _metrics(
+        candidate_key="stage2_sparse_candidate",
+        races=60,
+        evaluated_race_ids_hash="sparse_race_hash",
+        top1=0.50,
+        top3=0.82,
+        mean_winner_rank=2.20,
+        brier=0.68,
+        logloss=1.48,
+        slope=0.98,
+        intercept=0.02,
+        box1=0.20,
+    )
+    rolling_report = _rolling_report(
+        {"stage2_sparse_candidate": sparse},
+        ["stage2_sparse_candidate"],
+    )
+
+    report = packet.build_report(
+        rolling_report=rolling_report,
+        generated_at=datetime(2026, 6, 18, 5, 0, tzinfo=timezone.utc),
+    )
+
+    row = {
+        item["candidate_key"]: item
+        for item in report["candidate_gate_matrix"]
+    }["stage2_sparse_candidate"]
+    assert row["market_relative_rank_safe_box_cap_only_status"] == "BLOCKED"
+    assert "candidate_denominator_mismatch_primary_shadow" in row[
+        "market_relative_rank_safe_box_cap_only_blockers"
+    ]
+    assert _policy(
+        report, "market_relative_rank_safe_box_cap_only"
+    )["status"] == "BLOCKED"
+    assert report["final_status"] == "KEEP_BASELINE_GATE_VALID"
 
 
 def test_missing_market_baseline_is_data_missing():

--- a/tests/test_build_rolling_model_comparison_packet.py
+++ b/tests/test_build_rolling_model_comparison_packet.py
@@ -401,6 +401,7 @@ def test_rolling_comparison_evaluates_stage2_market_and_blends(tmp_path, monkeyp
     assert "stage2_market_blend_50" in report["candidate_metrics_by_key"]
     assert "stage2_market_blend_55" in report["candidate_metrics_by_key"]
     assert "stage2_market_blend_95" in report["candidate_metrics_by_key"]
+    assert "stage2_market_blend_63" not in report["candidate_metrics_by_key"]
     assert "stage2_uncalibrated_market_blend_50" in report["candidate_metrics_by_key"]
     assert "stage2_uncalibrated_market_blend_55" in report["candidate_metrics_by_key"]
     assert "stage2_uncalibrated_market_blend_95" in report["candidate_metrics_by_key"]
@@ -423,6 +424,24 @@ def test_rolling_comparison_evaluates_stage2_market_and_blends(tmp_path, monkeyp
     )
     assert len(report["residual_hypothesis_backtests"]) == 1
     assert report["residual_hypothesis_backtests"][0]["promotion_eligible"] is False
+    frontier = {
+        item["candidate_key"]: item
+        for item in report["refined_blend_frontier_backtests"]
+    }
+    assert set(frontier) == {
+        "stage2_market_blend_63",
+        "stage2_market_blend_66",
+        "stage2_market_blend_89",
+        "stage2_market_blend_91",
+    }
+    assert frontier["stage2_market_blend_63"]["status"] == "REPORT_ONLY_EVALUATED"
+    assert frontier["stage2_market_blend_63"]["promotion_eligible"] is False
+    assert frontier["stage2_market_blend_63"]["metrics"][
+        "baseline_denominator_match"
+    ] is True
+    assert "report_only_refined_frontier_not_promotion_eligible" in frontier[
+        "stage2_market_blend_63"
+    ]["blockers"]
     assert report["edge_diagnostics"]["schema_version"] == (
         "rolling_model_edge_diagnostics_v1"
     )
@@ -450,6 +469,65 @@ def test_rolling_comparison_evaluates_stage2_market_and_blends(tmp_path, monkeyp
     assert "candidate_minus_market_probability" in residual_matrix[0]
     assert "stage2_shadow_uncalibrated_probability_norm" in residual_matrix[0]
     assert (output_dir / "SUMMARY.md").exists()
+
+
+def test_ranked_candidates_must_match_primary_denominator(tmp_path, monkeypatch):
+    monkeypatch.setattr(comparison, "ROOT", tmp_path)
+    rows = [
+        _row(race_id="Race 1 - BEN - 2026-06-10", dog="A", box=1, winner=True, primary=0.2, stage2=0.2, odds=6.0),
+        _row(race_id="Race 1 - BEN - 2026-06-10", dog="B", box=2, primary=0.7, stage2=0.7, odds=2.0),
+        _row(race_id="Race 1 - BEN - 2026-06-10", dog="C", box=3, primary=0.1, stage2=0.1, odds=8.0),
+        _row(race_id="Race 2 - BEN - 2026-06-10", dog="D", box=1, winner=True, primary=0.2, stage2=0.2, odds=6.0),
+        _row(race_id="Race 2 - BEN - 2026-06-10", dog="E", box=2, primary=0.7, stage2=0.7, odds=2.0),
+        _row(race_id="Race 2 - BEN - 2026-06-10", dog="F", box=3, primary=0.1, stage2=0.1, odds=8.0),
+    ]
+    report_path = _write_dataset(
+        tmp_path,
+        "unified_evidence_dataset_sparse_candidate",
+        rows,
+    )
+    original_candidate_specs = comparison.candidate_specs
+
+    def sparse_perfect_scores(candidate_rows):
+        if candidate_rows and candidate_rows[0].get("race_id") == "Race 1 - BEN - 2026-06-10":
+            return [0.8 if row.get("is_winner") else 0.1 for row in candidate_rows]
+        return None
+
+    def candidate_specs_with_sparse():
+        return [
+            *original_candidate_specs(),
+            {
+                "candidate_key": "sparse_perfect_candidate",
+                "family": "test_sparse_candidate",
+                "score_function": sparse_perfect_scores,
+            },
+        ]
+
+    monkeypatch.setattr(comparison, "candidate_specs", candidate_specs_with_sparse)
+
+    report = comparison.build_comparison(
+        unified_evidence_report_paths=[report_path],
+        output_dir=(
+            tmp_path
+            / "artifacts/full_evidence_orchestration_20260525"
+            / "rolling_model_comparison_sparse_candidate"
+        ),
+        min_races_for_review=2,
+        generated_at=datetime(2026, 6, 10, 1, 0, tzinfo=timezone.utc),
+    )
+
+    sparse = report["candidate_metrics_by_key"]["sparse_perfect_candidate"]
+    assert sparse["status"] == "EVALUATED"
+    assert sparse["race_count"] == 1
+    assert sparse["baseline_denominator_match"] is False
+    assert "candidate_denominator_mismatch_primary_shadow" in sparse["blockers"]
+    assert report["candidate_denominator_mismatch_keys"] == [
+        "sparse_perfect_candidate"
+    ]
+    assert report["best_candidate_key"] != "sparse_perfect_candidate"
+    assert report["best_non_baseline_candidate_key"] != "sparse_perfect_candidate"
+    assert report["best_non_market_candidate_key"] != "sparse_perfect_candidate"
+    assert "sparse_perfect_candidate" not in report["rank_first_sort"]
 
 
 def test_unified_scope_excludes_partial_odds_races(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- ranked/readiness candidates now must match primary_shadow race count and evaluated race-id hash
- promotion gate blocks denominator mismatches
- refined blend frontier 63/66/89/91 is report-only and not promotion eligible
- trusted denominator evaluation: 168 races / 1151 runner rows from latest retained rolling report
- validation: ................                                                         [100%]
16 passed in 0.44s passed (16 passed)
- no runtime/DB/training/promotion/EV/betting/backfill actions were run