### PR TITLE
[codex] Fix PR25 approved append source selection

### DIFF
--- a/scripts/shadow_autopilot_v1.py
+++ b/scripts/shadow_autopilot_v1.py
@@ -44,7 +44,7 @@ DEFAULT_ODDS_CAPTURE_MIN_MINUTES = 0.0
 DEFAULT_ODDS_CAPTURE_MAX_MINUTES = 60.0
 DEFAULT_ODDS_CAPTURE_REFRESH_LIMIT = 8
 DEFAULT_AUTONOMOUS_ODDS_CAPTURE_LIMIT: int | None = None
-DEFAULT_HISTORICAL_UNIFIED_EVIDENCE_REPORT_LIMIT = 500
+DEFAULT_HISTORICAL_UNIFIED_EVIDENCE_REPORT_LIMIT = 600
 DEFAULT_RESULT_BACKLOG_LIMIT = 128
 DEFAULT_RESULT_BACKLOG_SHADOW_RUN_LIMIT = 200
 DEFAULT_RESULT_BACKLOG_LOOKBACK_DAYS = 2
@@ -2158,6 +2158,14 @@ def unified_report_dataset_path(report_path: Path, report: Mapping[str, Any]) ->
         rooted_dataset_path = ROOT / dataset_path
         if rooted_dataset_path.exists():
             return rooted_dataset_path
+        for parent in report_path.parents:
+            parent_relative_path = parent / dataset_path
+            if parent_relative_path.exists():
+                return parent_relative_path
+        if dataset_path.name == "unified_evidence_dataset.jsonl":
+            adjacent_dataset_path = report_path.parent / dataset_path.name
+            if adjacent_dataset_path.exists():
+                return adjacent_dataset_path
         return report_path.parent / dataset_path
     return report_path.parent / "unified_evidence_dataset.jsonl"
 
@@ -2175,6 +2183,8 @@ def is_automatic_unified_evidence_report_path(report_path: Path) -> bool:
     if "_manual" in dirname or "_probe" in dirname or "_validation" in dirname:
         return False
     if "_daemon_autopilot" in dirname:
+        return True
+    if "_live_db_approved_append_" in dirname:
         return True
     marker = "_daemon_rejoin_"
     if marker not in dirname:

--- a/tests/test_shadow_autopilot_v1.py
+++ b/tests/test_shadow_autopilot_v1.py
@@ -13,7 +13,7 @@ def test_autopilot_default_min_joined_races_matches_review_target():
     assert autopilot.DEFAULT_ODDS_CAPTURE_MIN_MINUTES == 0.0
     assert autopilot.DEFAULT_ODDS_CAPTURE_MAX_MINUTES == 60.0
     assert autopilot.DEFAULT_ODDS_CAPTURE_REFRESH_LIMIT == 8
-    assert autopilot.DEFAULT_HISTORICAL_UNIFIED_EVIDENCE_REPORT_LIMIT == 500
+    assert autopilot.DEFAULT_HISTORICAL_UNIFIED_EVIDENCE_REPORT_LIMIT == 600
     assert args.target_joined_races == 100
     assert args.min_joined_races == 100
     assert args.odds_capture_min_minutes == 0.0
@@ -3733,6 +3733,10 @@ def test_historical_unified_evidence_reports_use_automatic_daemon_evidence_only(
         "unified_evidence_dataset_20260610T191153+1000_daemon_rejoin_007",
         23,
     )
+    approved_append = write_report(
+        "unified_evidence_dataset_live_db_approved_append_20260701T0630p1000_01",
+        31,
+    )
     write_report(
         "unified_evidence_dataset_20260610T191153+1000_daemon_rejoin_bridge_validation_007",
         27,
@@ -3754,8 +3758,44 @@ def test_historical_unified_evidence_reports_use_automatic_daemon_evidence_only(
 
     reports = autopilot.historical_unified_evidence_report_paths(evidence_root)
 
-    assert reports == [older, newer, rejoin]
-    assert autopilot.best_unified_evidence_report_path(reports) == rejoin
+    assert reports == [older, newer, rejoin, approved_append]
+    assert autopilot.best_unified_evidence_report_path(reports) == approved_append
+
+
+def test_historical_unified_evidence_resolves_approved_append_artifact_relative_dataset(
+    tmp_path,
+):
+    worktree_root = tmp_path / "greyhound-autonomous-accuracy-odds-v1"
+    evidence_root = worktree_root / "artifacts/full_evidence_orchestration_20260525"
+    dataset_dir = (
+        evidence_root
+        / "unified_evidence_dataset_live_db_approved_append_20260701T0630p1000_01"
+    )
+    dataset_dir.mkdir(parents=True)
+    dataset_path = dataset_dir / "unified_evidence_dataset.jsonl"
+    dataset_path.write_text("{}\n", encoding="utf-8")
+    report_path = dataset_dir / "unified_evidence_dataset_report.json"
+    dataset_jsonl = (
+        "artifacts/full_evidence_orchestration_20260525/"
+        "unified_evidence_dataset_live_db_approved_append_20260701T0630p1000_01/"
+        "unified_evidence_dataset.jsonl"
+    )
+    autopilot.write_json(
+        report_path,
+        {
+            "final_status": "UNIFIED_EVIDENCE_DATASET_BUILT",
+            "dataset_jsonl": dataset_jsonl,
+            "unified_evidence_eligible_rows": 70,
+        },
+    )
+
+    reports = autopilot.historical_unified_evidence_report_paths(evidence_root)
+
+    assert autopilot.unified_report_dataset_path(
+        report_path,
+        autopilot.load_json(report_path),
+    ) == dataset_path
+    assert reports == [report_path]
 
 
 def test_historical_unified_evidence_default_retains_more_than_100_reports(tmp_path):


### PR DESCRIPTION
## Summary

Preserves the validated PR25 source-selection/path-resolution patch in Git.

This patch:

- raises the historical unified evidence report limit from 500 to 600
- allows `_live_db_approved_append_` unified evidence directories in automatic historical source selection
- resolves relative `dataset_jsonl` paths against ancestor roots and adjacent `unified_evidence_dataset.jsonl`
- adds focused regression coverage for approved append selection and artifact-root-relative dataset paths

## Why

The installed PR25 runtime was excluding the approved append unified evidence reports from automatic source selection. After the patch, fresh daemon evidence reached the rolling review floor with the approved append sources included.

This does not make the model production-ready. Promotion remains blocked and high accuracy remains keep-baseline because the current candidate fails policy/market-safety gates.

## Validation

- `git diff --cached --check`: passed before commit
- staged-index temporary checkout: `python3 -m py_compile scripts/shadow_autopilot_v1.py tests/test_shadow_autopilot_v1.py`: passed
- staged-index focused test calls:
  - `test_autopilot_default_min_joined_races_matches_review_target`
  - `test_historical_unified_evidence_reports_use_automatic_daemon_evidence_only`
  - `test_historical_unified_evidence_resolves_approved_append_artifact_relative_dataset`
- Code review of the staged subset: no findings

## Boundaries

No service restart, deployment, live DB write, official-result capture, training, promotion, registry/pointer mutation, dependency install, TGR enablement, EV action, betting action, or unrelated dirty-work cleanup was performed.

The source runtime checkout had unrelated pre-existing dirty files. This PR contains only the two-file approved patch commit.
