### PR TITLE
[codex] Preserve PR25 evidence root output guards

### DIFF
--- a/scripts/aggregate_forward_shadow_results.py
+++ b/scripts/aggregate_forward_shadow_results.py
@@ -26,8 +26,12 @@ ROOT = Path(__file__).resolve().parents[1]
 ROOT_STR = str(ROOT)
 sys.path = [path for path in sys.path if path != ROOT_STR]
 sys.path.insert(0, ROOT_STR)
+
+from utils.report_output_dir_guard import assert_prefixed_report_output_dir  # noqa: E402
+
 DEFAULT_EVIDENCE_ROOT = ROOT / "artifacts/full_evidence_orchestration_20260525"
 OUTPUT_PREFIX = "artifacts/full_evidence_orchestration_20260525/forward_shadow_result_aggregate_"
+OUTPUT_ARTIFACT_PREFIX = "forward_shadow_result_aggregate_"
 PROBABILITY_COLUMN = "shadow_rf_calibrated_probability"
 FINAL_AGGREGATED = "FORWARD_SHADOW_RESULTS_AGGREGATED"
 FINAL_PARTIAL = "PARTIAL_AGGREGATE_PENDING_MORE_RESULTS"
@@ -98,17 +102,19 @@ def read_jsonl(path: Path) -> list[dict[str, Any]]:
     return rows
 
 
-def assert_output_dir_safe(output_dir: Path) -> Path:
-    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
-    try:
-        relative = logical.absolute().relative_to(ROOT.absolute())
-    except ValueError as exc:
-        raise ValueError("output_dir_must_be_inside_repo") from exc
-    if ".." in relative.parts:
-        raise ValueError("output_dir_must_not_contain_parent_traversal")
-    if not relative.as_posix().startswith(OUTPUT_PREFIX):
-        raise ValueError(f"output_dir_must_be_forward_shadow_result_aggregate_artifact:{relative}")
-    return logical.absolute()
+def assert_output_dir_safe(
+    output_dir: Path,
+    *,
+    evidence_root: Path | None = None,
+) -> Path:
+    return assert_prefixed_report_output_dir(
+        output_dir,
+        repo_root=ROOT,
+        repo_prefix=OUTPUT_PREFIX,
+        artifact_prefix=OUTPUT_ARTIFACT_PREFIX,
+        prefix_error="output_dir_must_be_forward_shadow_result_aggregate_artifact",
+        evidence_root=evidence_root,
+    )
 
 
 def discovered_result_join_dirs(evidence_root: Path) -> list[Path]:
@@ -417,7 +423,7 @@ def run_aggregate(
 ) -> dict[str, Any]:
     generated_at = datetime.now().astimezone()
     output_dir = output_dir or evidence_root / f"forward_shadow_result_aggregate_{generated_at.strftime('%Y%m%dT%H%M%S%z')}"
-    output_dir = assert_output_dir_safe(output_dir)
+    output_dir = assert_output_dir_safe(output_dir, evidence_root=evidence_root)
     output_dir.mkdir(parents=True, exist_ok=False)
     protected_before = protected_hashes()
     report = build_aggregate_report(evidence_root=evidence_root, generated_at=generated_at)

--- a/scripts/autonomous_official_result_capture.py
+++ b/scripts/autonomous_official_result_capture.py
@@ -32,6 +32,7 @@ sys.path.insert(0, ROOT_STR)
 
 from scripts import ingest_results_for_date as ingest
 from scripts.refresh_prejump_upcoming import venue_exclusion_aliases
+from utils.report_output_dir_guard import assert_prefixed_report_output_dir
 from utils.runner_completeness import RunnerRow, analyze_runner_rows, normalise_runner_name
 
 try:
@@ -43,6 +44,7 @@ except Exception:
 
 DEFAULT_EVIDENCE_ROOT = ROOT / "artifacts/full_evidence_orchestration_20260525"
 OUTPUT_PREFIX = "artifacts/full_evidence_orchestration_20260525/autonomous_official_result_capture_"
+OUTPUT_ARTIFACT_PREFIX = "autonomous_official_result_capture_"
 OFFICIAL_SOURCE = "thedogs_official"
 RESULTED_STATUS = "resulted"
 OFFICIAL_RESULT_EVIDENCE_RACES_TABLE = "autonomous_official_result_evidence_races"
@@ -142,17 +144,19 @@ def parse_current_time(value: str | None) -> datetime:
     return parsed
 
 
-def assert_output_dir_safe(output_dir: Path) -> Path:
-    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
-    try:
-        relative = logical.absolute().relative_to(ROOT.absolute())
-    except ValueError as exc:
-        raise ValueError("output_dir_must_be_inside_repo") from exc
-    if ".." in relative.parts:
-        raise ValueError("output_dir_must_not_contain_parent_traversal")
-    if not relative.as_posix().startswith(OUTPUT_PREFIX):
-        raise ValueError(f"output_dir_must_be_autonomous_official_result_capture_artifact:{relative}")
-    return logical.absolute()
+def assert_output_dir_safe(
+    output_dir: Path,
+    *,
+    evidence_root: Path | None = None,
+) -> Path:
+    return assert_prefixed_report_output_dir(
+        output_dir,
+        repo_root=ROOT,
+        repo_prefix=OUTPUT_PREFIX,
+        artifact_prefix=OUTPUT_ARTIFACT_PREFIX,
+        prefix_error="output_dir_must_be_autonomous_official_result_capture_artifact",
+        evidence_root=evidence_root,
+    )
 
 
 def unique_dir(base: Path) -> Path:
@@ -3024,6 +3028,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--snapshot-dir", type=Path, default=ROOT / "artifacts/prediction_snapshots")
     parser.add_argument("--db", type=Path, default=ROOT / "greyhound_racing_data.db")
     parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--evidence-root", type=Path, default=DEFAULT_EVIDENCE_ROOT)
     parser.add_argument("--existing-race-rows-jsonl", type=Path)
     parser.add_argument("--existing-runner-rows-jsonl", type=Path)
     parser.add_argument("--existing-quarantine-jsonl", type=Path)
@@ -3076,7 +3081,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     generated_at = datetime.now().astimezone()
     output_dir = assert_output_dir_safe(
         args.output_dir
-        or DEFAULT_EVIDENCE_ROOT / f"autonomous_official_result_capture_{now_id(generated_at)}"
+        or args.evidence_root / f"autonomous_official_result_capture_{now_id(generated_at)}",
+        evidence_root=args.evidence_root,
     )
     output_dir = unique_dir(output_dir)
     output_dir.mkdir(parents=True, exist_ok=False)

--- a/scripts/build_pre_race_gated_challenger_packet.py
+++ b/scripts/build_pre_race_gated_challenger_packet.py
@@ -47,6 +47,7 @@ from scripts.build_market_residual_challenger_packet import (  # noqa: E402
     split_folds,
     stage2_uncalibrated_scores,
 )
+from utils.report_output_dir_guard import assert_prefixed_report_output_dir  # noqa: E402
 
 
 DEFAULT_EVIDENCE_ROOT = ROOT / "artifacts/full_evidence_orchestration_20260525"
@@ -54,6 +55,7 @@ OUTPUT_PREFIX = (
     "artifacts/full_evidence_orchestration_20260525/"
     "pre_race_gated_challenger_"
 )
+OUTPUT_ARTIFACT_PREFIX = "pre_race_gated_challenger_"
 REPORT_FILE = "pre_race_gated_challenger_report.json"
 FOLD_SUMMARY_CSV = "cross_validated_fold_summary.csv"
 RACE_PREDICTIONS_CSV = "cross_validated_race_predictions.csv"
@@ -111,17 +113,19 @@ def relpath(path: Path | None) -> str | None:
         return str(path)
 
 
-def assert_output_dir_safe(output_dir: Path) -> Path:
-    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
-    try:
-        relative = logical.absolute().relative_to(ROOT.absolute())
-    except ValueError as exc:
-        raise ValueError("output_dir_must_be_inside_repo") from exc
-    if ".." in relative.parts:
-        raise ValueError("output_dir_must_not_contain_parent_traversal")
-    if not relative.as_posix().startswith(OUTPUT_PREFIX):
-        raise ValueError(f"output_dir_must_be_pre_race_gated_challenger:{relative}")
-    return logical.absolute()
+def assert_output_dir_safe(
+    output_dir: Path,
+    *,
+    evidence_root: Path | None = None,
+) -> Path:
+    return assert_prefixed_report_output_dir(
+        output_dir,
+        repo_root=ROOT,
+        repo_prefix=OUTPUT_PREFIX,
+        artifact_prefix=OUTPUT_ARTIFACT_PREFIX,
+        prefix_error="output_dir_must_be_pre_race_gated_challenger",
+        evidence_root=evidence_root,
+    )
 
 
 def unique_dir(base: Path) -> Path:
@@ -1050,6 +1054,7 @@ def build_packet(
     *,
     runner_matrix_csv: Path,
     output_dir: Path,
+    evidence_root: Path | None = None,
     fold_count: int = DEFAULT_FOLDS,
     min_train_races: int = DEFAULT_MIN_TRAIN_RACES,
     min_races_for_review: int = MIN_RACES_FOR_REVIEW,
@@ -1057,7 +1062,7 @@ def build_packet(
     generated_at: datetime | None = None,
 ) -> dict[str, Any]:
     generated_at = generated_at or datetime.now().astimezone()
-    output_dir = unique_dir(assert_output_dir_safe(output_dir))
+    output_dir = unique_dir(assert_output_dir_safe(output_dir, evidence_root=evidence_root))
     output_dir.mkdir(parents=True, exist_ok=False)
 
     matrix_rows = load_matrix(runner_matrix_csv)
@@ -1157,6 +1162,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--runner-matrix-csv", type=Path, required=True)
     parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--evidence-root", type=Path, default=DEFAULT_EVIDENCE_ROOT)
     parser.add_argument("--fold-count", type=int, default=DEFAULT_FOLDS)
     parser.add_argument("--min-train-races", type=int, default=DEFAULT_MIN_TRAIN_RACES)
     parser.add_argument("--min-races-for-review", type=int, default=MIN_RACES_FOR_REVIEW)
@@ -1175,11 +1181,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     generated_at = datetime.now().astimezone()
     output_dir = (
         args.output_dir
-        or DEFAULT_EVIDENCE_ROOT / f"pre_race_gated_challenger_{now_id(generated_at)}"
+        or args.evidence_root / f"pre_race_gated_challenger_{now_id(generated_at)}"
     )
     report = build_packet(
         runner_matrix_csv=args.runner_matrix_csv,
         output_dir=output_dir,
+        evidence_root=args.evidence_root,
         fold_count=args.fold_count,
         min_train_races=args.min_train_races,
         min_races_for_review=args.min_races_for_review,

--- a/scripts/collect_shadow_odds_snapshots.py
+++ b/scripts/collect_shadow_odds_snapshots.py
@@ -33,11 +33,13 @@ sys.path.insert(0, ROOT_STR)
 from accuracy_program.odds_coverage import normalize_dog_name, normalize_venue  # noqa: E402
 from accuracy_program.snapshots import TRUSTED_ODDS_SOURCES, classify_odds_snapshot_for_ev  # noqa: E402
 from scripts.refresh_prejump_upcoming import venue_exclusion_aliases  # noqa: E402
+from utils.report_output_dir_guard import assert_prefixed_report_output_dir  # noqa: E402
 
 
 DEFAULT_DB = ROOT / "greyhound_racing_data.db"
 DEFAULT_OUTPUT_PARENT = ROOT / "artifacts/full_evidence_orchestration_20260525"
 OUTPUT_PREFIX = "artifacts/full_evidence_orchestration_20260525/shadow_odds_snapshot_"
+OUTPUT_ARTIFACT_PREFIX = "shadow_odds_snapshot_"
 EXPECTED_OFFICIAL_RACES = 214
 EXPECTED_OFFICIAL_DOG_ROWS = 1493
 DEFAULT_STALE_ODDS_AFTER_MINUTES = 30.0
@@ -338,17 +340,19 @@ def protected_hashes(paths: Sequence[Path] = PROTECTED_PATHS) -> dict[str, str |
     return {relpath(path) or str(path): sha256_file(path) for path in paths}
 
 
-def assert_output_dir_safe(output_dir: Path) -> Path:
-    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
-    try:
-        relative = logical.absolute().relative_to(ROOT.absolute())
-    except ValueError as exc:
-        raise ValueError("output_dir_must_be_inside_repo") from exc
-    if ".." in relative.parts:
-        raise ValueError("output_dir_must_not_contain_parent_traversal")
-    if not relative.as_posix().startswith(OUTPUT_PREFIX):
-        raise ValueError(f"output_dir_must_be_shadow_odds_snapshot_artifact:{relative}")
-    return logical.absolute()
+def assert_output_dir_safe(
+    output_dir: Path,
+    *,
+    evidence_root: Path | None = None,
+) -> Path:
+    return assert_prefixed_report_output_dir(
+        output_dir,
+        repo_root=ROOT,
+        repo_prefix=OUTPUT_PREFIX,
+        artifact_prefix=OUTPUT_ARTIFACT_PREFIX,
+        prefix_error="output_dir_must_be_shadow_odds_snapshot_artifact",
+        evidence_root=evidence_root,
+    )
 
 
 def parse_current_time(value: str | None) -> datetime:
@@ -2102,6 +2106,7 @@ def collect_shadow_odds_snapshot(
     shadow_run_dir: Path,
     db_path: Path,
     output_dir: Path,
+    evidence_root: Path | None = None,
     current_time: datetime | None = None,
     current_only: bool = True,
     stale_odds_after_minutes: float = DEFAULT_STALE_ODDS_AFTER_MINUTES,
@@ -2109,7 +2114,7 @@ def collect_shadow_odds_snapshot(
     if not math.isfinite(stale_odds_after_minutes) or stale_odds_after_minutes <= 0:
         raise ValueError("stale_odds_after_minutes_must_be_positive")
     generated_at = current_time or datetime.now().astimezone()
-    output_dir = assert_output_dir_safe(output_dir)
+    output_dir = assert_output_dir_safe(output_dir, evidence_root=evidence_root)
     protected_before = protected_hashes()
     db_state = verify_db_state(db_path)
     predictions = read_jsonl(shadow_predictions_path(shadow_run_dir))
@@ -2424,6 +2429,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--shadow-run-dir", required=True, type=Path)
     parser.add_argument("--db", default=DEFAULT_DB, type=Path)
     parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--evidence-root", type=Path, default=DEFAULT_OUTPUT_PARENT)
     parser.add_argument("--current-time")
     parser.add_argument("--all-odds", action="store_true")
     parser.add_argument(
@@ -2435,12 +2441,13 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     current_time = parse_current_time(args.current_time)
     output_dir = args.output_dir or (
-        DEFAULT_OUTPUT_PARENT / f"shadow_odds_snapshot_{now_id(current_time)}"
+        args.evidence_root / f"shadow_odds_snapshot_{now_id(current_time)}"
     )
     report = collect_shadow_odds_snapshot(
         shadow_run_dir=args.shadow_run_dir,
         db_path=args.db,
         output_dir=output_dir,
+        evidence_root=args.evidence_root,
         current_time=current_time,
         current_only=not args.all_odds,
         stale_odds_after_minutes=args.stale_odds_after_minutes,
@@ -2449,7 +2456,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         json.dumps(
             {
                 "final_status": report["final_status"],
-                "output_dir": relpath(assert_output_dir_safe(output_dir)),
+                "output_dir": relpath(
+                    assert_output_dir_safe(output_dir, evidence_root=args.evidence_root)
+                ),
                 "prediction_rows": report["prediction_rows"],
                 "odds_candidate_rows": report["odds_candidate_rows"],
                 "valid_pre_jump_dog_odds_rows": report["valid_pre_jump_dog_odds_rows"],

--- a/scripts/daily_race_ingest_shadow_orchestrator.py
+++ b/scripts/daily_race_ingest_shadow_orchestrator.py
@@ -78,6 +78,7 @@ UV_SCORE_LIVE_PACKAGES = (
     "requests",
 )
 DAILY_OUTPUT_PREFIX = "artifacts/full_evidence_orchestration_20260525/daily_race_ingest_shadow_"
+DAILY_OUTPUT_ARTIFACT_PREFIX = "daily_race_ingest_shadow_"
 EXPECTED_OFFICIAL_RACES = 214
 EXPECTED_OFFICIAL_DOG_ROWS = 1493
 FINAL_STATUS_FORWARD_COMPLETE = "FORWARD_SHADOW_RUN_COMPLETE"
@@ -132,18 +133,45 @@ def parse_current_time(value: str | None) -> datetime:
     return parsed
 
 
-def assert_daily_output_dir_safe(output_dir: Path) -> Path:
+def assert_daily_output_dir_safe(
+    output_dir: Path,
+    *,
+    output_parent: Path | None = None,
+) -> Path:
     logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
+    candidate = logical.absolute()
     try:
-        relative_path = logical.absolute().relative_to(ROOT.absolute())
+        relative_path = candidate.relative_to(ROOT.absolute())
     except ValueError as exc:
-        raise ValueError("output_dir_must_be_inside_repo") from exc
+        if output_parent is None:
+            raise ValueError("output_dir_must_be_inside_repo") from exc
+    else:
+        if ".." in relative_path.parts:
+            raise ValueError("output_dir_must_not_contain_parent_traversal")
+        relative = relative_path.as_posix()
+        if relative.startswith(DAILY_OUTPUT_PREFIX):
+            return candidate
+        raise ValueError(f"output_dir_must_be_daily_shadow_artifact:{relative}")
+
+    parent = output_parent if output_parent.is_absolute() else ROOT / output_parent
+    try:
+        relative_path = candidate.relative_to(parent.absolute())
+    except ValueError as exc:
+        raise ValueError("output_dir_must_be_inside_repo_or_output_parent") from exc
     if ".." in relative_path.parts:
         raise ValueError("output_dir_must_not_contain_parent_traversal")
-    relative = relative_path.as_posix()
-    if not relative.startswith(DAILY_OUTPUT_PREFIX):
-        raise ValueError(f"output_dir_must_be_daily_shadow_artifact:{relative}")
-    return logical.absolute()
+    if relative_path.parts and relative_path.parts[0].startswith(DAILY_OUTPUT_ARTIFACT_PREFIX):
+        return candidate
+    raise ValueError(f"output_dir_must_be_daily_shadow_artifact:{relative_path.as_posix()}")
+
+
+def path_is_inside_repo(path: Path) -> bool:
+    logical = path if path.is_absolute() else ROOT / path
+    try:
+        logical.absolute().relative_to(ROOT.absolute())
+    except ValueError:
+        return False
+    return True
 
 
 def verify_db_state(db_path: Path) -> dict[str, Any]:
@@ -1237,6 +1265,7 @@ def build_score_live_command(
     repaired_packet: Path,
     all_missing_train_policy: str,
     shadow_model: Path | None = None,
+    evidence_root: Path | None = None,
     score_command_mode: str = DEFAULT_SCORE_COMMAND_MODE,
 ) -> list[str]:
     command = [
@@ -1266,6 +1295,8 @@ def build_score_live_command(
             str(output_dir),
         ]
     )
+    if evidence_root is not None:
+        command.extend(["--evidence-root", str(evidence_root)])
     return command
 
 
@@ -1693,7 +1724,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.output_dir
         else (args.output_parent / f"daily_race_ingest_shadow_{now_id()}")
     )
-    output_dir = assert_daily_output_dir_safe(output_dir)
+    output_dir = assert_daily_output_dir_safe(output_dir, output_parent=args.output_parent)
     output_dir.mkdir(parents=True, exist_ok=False)
 
     protected_before = protected_path_snapshot()
@@ -1768,6 +1799,9 @@ def main(argv: list[str] | None = None) -> int:
                 repaired_packet=args.repaired_packet,
                 all_missing_train_policy=args.all_missing_train_policy,
                 shadow_model=args.shadow_model,
+                evidence_root=args.output_parent
+                if not path_is_inside_repo(score_output_dir)
+                else None,
                 score_command_mode=args.score_command_mode,
             )
             write_json(

--- a/scripts/forward_shadow_runtime_state.py
+++ b/scripts/forward_shadow_runtime_state.py
@@ -246,6 +246,9 @@ def decide_runtime_action(
         return "DAEMON_RUNNING_WAIT_FOR_CYCLE", ["shadow_autopilot_service_active"]
 
     verdict = daemon_state.get("last_verdict")
+    if verdict == "DAEMON_READY_NEEDS_DEPLOYMENT":
+        reasons.append("daemon_ready_timer_not_active")
+        return "DEPLOY_OR_RESTART_DAEMON_TIMER", reasons
     if verdict not in {"DAEMON_READY", "AUTOPILOT_READY", None}:
         reasons.append("daemon_not_ready")
         return "CHECK_DAEMON_FAILURE", reasons

--- a/scripts/forward_shadow_status_report.py
+++ b/scripts/forward_shadow_status_report.py
@@ -28,9 +28,11 @@ sys.path.insert(0, ROOT_STR)
 from accuracy_program.odds_coverage import (
     summarize_read_only_odds_coverage_report,
 )
+from utils.report_output_dir_guard import assert_prefixed_report_output_dir  # noqa: E402
 
 DEFAULT_EVIDENCE_ROOT = ROOT / "artifacts/full_evidence_orchestration_20260525"
 OUTPUT_PREFIX = "artifacts/full_evidence_orchestration_20260525/forward_shadow_status_"
+OUTPUT_ARTIFACT_PREFIX = "forward_shadow_status_"
 DEFAULT_PROTECTED_PATHS = (
     ROOT / "greyhound_racing_data.db",
     ROOT / "greyhound_racing_data_writable.db",
@@ -552,17 +554,19 @@ def build_status_report(
     }
 
 
-def assert_output_dir_safe(output_dir: Path) -> Path:
-    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
-    try:
-        relative = logical.absolute().relative_to(ROOT.absolute())
-    except ValueError as exc:
-        raise ValueError("output_dir_must_be_inside_repo") from exc
-    if ".." in relative.parts:
-        raise ValueError("output_dir_must_not_contain_parent_traversal")
-    if not relative.as_posix().startswith(OUTPUT_PREFIX):
-        raise ValueError(f"output_dir_must_be_forward_shadow_status_artifact:{relative}")
-    return logical.absolute()
+def assert_output_dir_safe(
+    output_dir: Path,
+    *,
+    evidence_root: Path | None = None,
+) -> Path:
+    return assert_prefixed_report_output_dir(
+        output_dir,
+        repo_root=ROOT,
+        repo_prefix=OUTPUT_PREFIX,
+        artifact_prefix=OUTPUT_ARTIFACT_PREFIX,
+        prefix_error="output_dir_must_be_forward_shadow_status_artifact",
+        evidence_root=evidence_root,
+    )
 
 
 def build_summary(report: Mapping[str, Any]) -> str:
@@ -617,7 +621,7 @@ def run_status_report(
 ) -> dict[str, Any]:
     generated_at = datetime.now().astimezone()
     output_dir = output_dir or evidence_root / f"forward_shadow_status_{generated_at.strftime('%Y%m%dT%H%M%S%z')}"
-    output_dir = assert_output_dir_safe(output_dir)
+    output_dir = assert_output_dir_safe(output_dir, evidence_root=evidence_root)
     output_dir.mkdir(parents=True, exist_ok=False)
     protected_before = protected_hashes()
     report = build_status_report(

--- a/scripts/join_forward_shadow_results.py
+++ b/scripts/join_forward_shadow_results.py
@@ -39,6 +39,7 @@ from scripts.ingest_results_for_date import (  # noqa: E402
     thedogs_result_urls_from_race_url,
 )
 from utils.race_lifecycle import extract_target_metadata_from_filename  # noqa: E402
+from utils.report_output_dir_guard import assert_prefixed_report_output_dir  # noqa: E402
 
 
 DEFAULT_OUTPUT_PARENT = ROOT / "artifacts/full_evidence_orchestration_20260525"
@@ -53,6 +54,7 @@ DEFAULT_PROTECTED_PATHS = (
 EXPECTED_OFFICIAL_RACES = 214
 EXPECTED_OFFICIAL_DOG_ROWS = 1493
 RESULT_JOIN_PREFIX = "artifacts/full_evidence_orchestration_20260525/forward_shadow_result_join_"
+RESULT_JOIN_ARTIFACT_PREFIX = "forward_shadow_result_join_"
 PROBABILITY_COLUMN = "shadow_rf_calibrated_probability"
 NON_NAME_RESULT_BADGES = frozenset({"NBT"})
 SCRATCH_STATUSES = frozenset({"SCR", "L/SCR", "LSCR"})
@@ -104,26 +106,36 @@ def relpath(path: Path) -> str:
         return str(path)
 
 
-def assert_result_join_output_dir_safe(output_dir: Path) -> Path:
-    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
-    try:
-        relative = logical.absolute().relative_to(ROOT.absolute())
-    except ValueError as exc:
-        raise ValueError("output_dir_must_be_inside_repo") from exc
-    if ".." in relative.parts:
-        raise ValueError("output_dir_must_not_contain_parent_traversal")
-    if not relative.as_posix().startswith(RESULT_JOIN_PREFIX):
-        raise ValueError(f"output_dir_must_be_forward_shadow_result_join_artifact:{relative}")
-    return logical.absolute()
+def assert_result_join_output_dir_safe(
+    output_dir: Path,
+    *,
+    evidence_root: Path | None = None,
+) -> Path:
+    return assert_prefixed_report_output_dir(
+        output_dir,
+        repo_root=ROOT,
+        repo_prefix=RESULT_JOIN_PREFIX,
+        artifact_prefix=RESULT_JOIN_ARTIFACT_PREFIX,
+        prefix_error="output_dir_must_be_forward_shadow_result_join_artifact",
+        evidence_root=evidence_root,
+    )
 
 
-def unique_default_output_dir(output_parent: Path, generated_at: datetime) -> Path:
+def unique_default_output_dir(
+    output_parent: Path,
+    generated_at: datetime,
+    *,
+    evidence_root: Path | None = None,
+) -> Path:
     base = output_parent / f"forward_shadow_result_join_{now_id(generated_at)}"
-    output_dir = assert_result_join_output_dir_safe(base)
+    output_dir = assert_result_join_output_dir_safe(base, evidence_root=evidence_root)
     if not output_dir.exists():
         return output_dir
     for index in range(1, 1000):
-        candidate = assert_result_join_output_dir_safe(Path(f"{base}_{index:03d}"))
+        candidate = assert_result_join_output_dir_safe(
+            Path(f"{base}_{index:03d}"),
+            evidence_root=evidence_root,
+        )
         if not candidate.exists():
             return candidate
     raise RuntimeError("forward_shadow_result_join_output_dir_collision_exhausted")
@@ -869,6 +881,7 @@ def join_forward_shadow_results(
     shadow_run_dir: Path,
     output_parent: Path = DEFAULT_OUTPUT_PARENT,
     output_dir: Path | None = None,
+    evidence_root: Path | None = None,
     refresh_metadata_path: Path | None = None,
     db_path: Path = DEFAULT_DB_PATH,
     current_time: datetime | None = None,
@@ -878,9 +891,13 @@ def join_forward_shadow_results(
     generated_at = current_time or datetime.now().astimezone()
     shadow_run_dir = shadow_run_dir.resolve()
     output_dir = (
-        assert_result_join_output_dir_safe(output_dir)
+        assert_result_join_output_dir_safe(output_dir, evidence_root=evidence_root)
         if output_dir is not None
-        else unique_default_output_dir(output_parent, generated_at)
+        else unique_default_output_dir(
+            output_parent,
+            generated_at,
+            evidence_root=evidence_root or output_parent,
+        )
     )
     output_dir.mkdir(parents=True, exist_ok=False)
 
@@ -1247,6 +1264,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--shadow-run-dir", required=True, type=Path)
     parser.add_argument("--output-parent", default=DEFAULT_OUTPUT_PARENT, type=Path)
     parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--evidence-root", default=DEFAULT_OUTPUT_PARENT, type=Path)
     parser.add_argument("--refresh-metadata", type=Path)
     parser.add_argument("--db", default=DEFAULT_DB_PATH, type=Path)
     parser.add_argument("--current-time", help="ISO timestamp used for pending race-time decisions")
@@ -1259,6 +1277,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         shadow_run_dir=args.shadow_run_dir,
         output_parent=args.output_parent,
         output_dir=args.output_dir,
+        evidence_root=args.evidence_root,
         refresh_metadata_path=args.refresh_metadata,
         db_path=args.db,
         current_time=parse_current_time(args.current_time),

--- a/scripts/refresh_prejump_upcoming.py
+++ b/scripts/refresh_prejump_upcoming.py
@@ -29,6 +29,18 @@ from utils.expert_form_metadata import safe_expert_form_metadata_from_payload  #
 from utils.race_lifecycle import melbourne_now  # noqa: E402
 
 
+def parse_current_time(value: str | None) -> datetime:
+    if not value:
+        return melbourne_now()
+    text = str(value).strip()
+    if len(text) >= 5 and text[-5] in {"+", "-"} and text[-4:].isdigit():
+        text = f"{text[:-5]}{text[-5:-2]}:{text[-2:]}"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=melbourne_now().tzinfo)
+    return parsed
+
+
 VENUE_EXCLUSION_ALIAS_GROUPS = [
     {"QOT", "LADBROKES-Q-STRAIGHT", "LADBROKES_Q_STRAIGHT", "LADBROKES Q STRAIGHT"},
     {"LCTN", "LAUNCESTON"},
@@ -584,7 +596,7 @@ def refresh_prejump_upcoming(args: argparse.Namespace) -> dict[str, Any]:
 
     from upcoming_race_browser import UpcomingRaceBrowser
 
-    now = melbourne_now()
+    now = parse_current_time(getattr(args, "current_time", None))
     browser = UpcomingRaceBrowser()
     races = browser.get_upcoming_races(days_ahead=int(args.days_ahead))
     excluded_race_ids = load_excluded_race_ids(
@@ -678,6 +690,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional newline, JSON list, or JSON object file of race IDs to skip.",
     )
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--current-time")
     parser.add_argument(
         "--require-safe-metadata",
         action="store_true",

--- a/scripts/run_shadow_non_tgr_rf_evaluation.py
+++ b/scripts/run_shadow_non_tgr_rf_evaluation.py
@@ -88,6 +88,7 @@ AUXILIARY_LIVE_INPUT_DIR_NAMES = frozenset({"raw_exports", "quarantine"})
 
 DEFAULT_FULL_EVIDENCE_PARENT = ROOT / "artifacts/full_evidence_orchestration_20260525"
 DEFAULT_LIVE_PARENT = ROOT / "artifacts/shadow_evaluation"
+DAILY_OUTPUT_ARTIFACT_PREFIX = "daily_race_ingest_shadow_"
 
 ALLOWED_OUTPUT_PREFIXES = (
     "artifacts/shadow_evaluation",
@@ -163,18 +164,41 @@ def shadow_relpath(path: Path) -> str:
         return relpath(path)
 
 
-def assert_shadow_output_dir_safe(output_dir: Path, root: Path = ROOT) -> Path:
-    relative = repo_relative_text(output_dir, root)
-    allowed = False
-    for prefix in ALLOWED_OUTPUT_PREFIXES:
-        if relative == prefix or relative.startswith(prefix + "/"):
-            allowed = True
-            break
-        if prefix.endswith("_") and relative.startswith(prefix):
-            allowed = True
-            break
-    if not allowed:
-        raise ValueError(f"output_dir_must_be_shadow_artifact:{relative}")
+def assert_shadow_output_dir_safe(
+    output_dir: Path,
+    root: Path = ROOT,
+    evidence_root: Path | None = None,
+) -> Path:
+    try:
+        relative = repo_relative_text(output_dir, root)
+    except ValueError:
+        if evidence_root is None:
+            raise
+        logical = output_dir if output_dir.is_absolute() else root / output_dir
+        parent = evidence_root if evidence_root.is_absolute() else root / evidence_root
+        try:
+            evidence_relative = logical.absolute().relative_to(parent.absolute())
+        except ValueError as exc:
+            raise ValueError("output_dir_must_be_inside_repo_or_evidence_root") from exc
+        if not (
+            evidence_relative.parts
+            and evidence_relative.parts[0].startswith(DAILY_OUTPUT_ARTIFACT_PREFIX)
+        ):
+            raise ValueError(
+                f"output_dir_must_be_shadow_artifact:{evidence_relative.as_posix()}"
+            )
+        return logical.absolute()
+    else:
+        allowed = False
+        for prefix in ALLOWED_OUTPUT_PREFIXES:
+            if relative == prefix or relative.startswith(prefix + "/"):
+                allowed = True
+                break
+            if prefix.endswith("_") and relative.startswith(prefix):
+                allowed = True
+                break
+        if not allowed:
+            raise ValueError(f"output_dir_must_be_shadow_artifact:{relative}")
 
     for prefix in PROTECTED_OUTPUT_PREFIXES:
         if relative == prefix or relative.startswith(prefix + "/"):
@@ -182,8 +206,8 @@ def assert_shadow_output_dir_safe(output_dir: Path, root: Path = ROOT) -> Path:
     return output_dir
 
 
-def prepare_output_dir(output_dir: Path) -> Path:
-    output_dir = assert_shadow_output_dir_safe(output_dir)
+def prepare_output_dir(output_dir: Path, evidence_root: Path | None = None) -> Path:
+    output_dir = assert_shadow_output_dir_safe(output_dir, evidence_root=evidence_root)
     if output_dir.exists() and any(output_dir.iterdir()):
         raise ValueError(f"output_dir_already_exists:{relpath(output_dir)}")
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -2481,7 +2505,10 @@ def build_live_feature_rows(
 def score_live(args: argparse.Namespace) -> int:
     ensure_shadow_runtime_guard()
     run_started_at = datetime.now().astimezone()
-    output_dir = prepare_output_dir(args.output_dir or default_live_output_dir())
+    output_dir = prepare_output_dir(
+        args.output_dir or default_live_output_dir(),
+        evidence_root=args.evidence_root,
+    )
     protected_before = protected_path_snapshot()
     final_status = "IMPLEMENTATION_ABORTED"
     try:
@@ -2725,6 +2752,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     live_parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
     live_parser.add_argument("--db", type=Path, default=DEFAULT_DB)
     live_parser.add_argument("--output-dir", type=Path, default=None)
+    live_parser.add_argument("--evidence-root", type=Path, default=None)
     live_parser.add_argument(
         "--all-missing-train-policy",
         choices=ALL_MISSING_TRAIN_POLICIES,

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -65,8 +65,8 @@ DEFAULT_ODDS_CAPTURE_ONLY_TIMER_ON_CALENDAR = (
 )
 DEFAULT_ODDS_CAPTURE_ONLY_TIMER_ACCURACY = "15s"
 DEFAULT_ODDS_CAPTURE_ONLY_TIMEOUT_SECONDS = 600
-DEFAULT_ODDS_CAPTURE_ONLY_REFRESH_LIMIT = 8
-DEFAULT_FULL_DAEMON_AUTONOMOUS_ODDS_CAPTURE_LIMIT = 2
+DEFAULT_ODDS_CAPTURE_ONLY_REFRESH_LIMIT = 16
+DEFAULT_FULL_DAEMON_AUTONOMOUS_ODDS_CAPTURE_LIMIT = 16
 DEFAULT_FULL_DAEMON_RESULT_BACKLOG_LIMIT = 32
 DEFAULT_FULL_DAEMON_RESULT_BACKLOG_SHADOW_RUN_LIMIT = 64
 DEFAULT_FULL_DAEMON_RESULT_BACKLOG_LOOKBACK_DAYS = 2
@@ -1620,6 +1620,7 @@ def pre_race_gated_challenger_command(
     *,
     runner_matrix_csv: Path,
     output_dir: Path,
+    evidence_root: Path,
     rank_first_hypotheses_json: Path | None = None,
 ) -> list[str]:
     command = [
@@ -1627,6 +1628,8 @@ def pre_race_gated_challenger_command(
         str(ROOT / "scripts/build_pre_race_gated_challenger_packet.py"),
         "--runner-matrix-csv",
         str(runner_matrix_csv),
+        "--evidence-root",
+        str(evidence_root),
         "--output-dir",
         str(output_dir),
     ]
@@ -1689,12 +1692,15 @@ def promotion_distance_report_command(
     pre_race_gated_report: Path,
     high_accuracy_gate: Path,
     output_dir: Path,
+    evidence_root: Path,
 ) -> list[str]:
     return [
         sys.executable,
         str(ROOT / "scripts/build_promotion_distance_report.py"),
         "--rolling-report",
         str(rolling_report),
+        "--evidence-root",
+        str(evidence_root),
         "--pre-race-gated-report",
         str(pre_race_gated_report),
         "--high-accuracy-gate",
@@ -5628,6 +5634,7 @@ def build_rejoin_unified_evidence_datasets(
         command = autopilot.unified_evidence_dataset_command(
             shadow_run_dir=shadow_run_dir,
             output_dir=dataset_dir,
+            evidence_root=evidence_root,
             db_path=db_path,
             odds_jsonl_paths=autopilot.shadow_odds_snapshot_paths_for_daily_dir(
                 evidence_root=evidence_root,
@@ -9117,6 +9124,8 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
             str(args.refresh_limit),
             "--autonomous-odds-capture-limit",
             str(args.autonomous_odds_capture_limit),
+            "--odds-capture-refresh-limit",
+            str(args.autonomous_odds_capture_limit),
             "--result-backlog-limit",
             str(args.result_backlog_limit),
             "--result-backlog-shadow-run-limit",
@@ -9511,6 +9520,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
                 command=autopilot.rolling_model_comparison_command(
                     unified_evidence_reports=rejoin_comparison_report_paths,
                     output_dir=rejoin_rolling_dir,
+                    evidence_root=evidence_root,
                 ),
                 output_dir=output_dir,
                 timeout_seconds=args.timeout_seconds,
@@ -9542,6 +9552,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
                     command=pre_race_gated_challenger_command(
                         runner_matrix_csv=rejoin_runner_matrix_csv,
                         output_dir=rejoin_pre_race_gated_dir,
+                        evidence_root=evidence_root,
                     ),
                     output_dir=output_dir,
                     timeout_seconds=args.timeout_seconds,
@@ -9666,6 +9677,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
                             command=pre_race_gated_challenger_command(
                                 runner_matrix_csv=rejoin_runner_matrix_csv,
                                 output_dir=rejoin_rank_first_hypothesis_gated_dir,
+                                evidence_root=evidence_root,
                                 rank_first_hypotheses_json=rank_first_hypotheses_json,
                             ),
                             output_dir=output_dir,
@@ -9832,6 +9844,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
                     command=autopilot.high_accuracy_refinement_packet_command(
                         unified_evidence_report=best_rejoin_unified_report,
                         output_dir=rejoin_high_accuracy_dir,
+                        evidence_root=evidence_root,
                         stage2_predictions=(
                             daily_shadow_run_dir / "stage2_shadow_predictions.jsonl"
                             if daily_shadow_run_dir
@@ -9900,6 +9913,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
                         pre_race_gated_report=rejoin_pre_race_gated_report_path,
                         high_accuracy_gate=rejoin_high_accuracy_gate_path,
                         output_dir=rejoin_promotion_distance_dir,
+                        evidence_root=evidence_root,
                     ),
                     output_dir=output_dir,
                     timeout_seconds=args.timeout_seconds,
@@ -9924,6 +9938,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
                     command=autopilot.high_accuracy_refinement_packet_command(
                         unified_evidence_report=best_rejoin_unified_report,
                         output_dir=rejoin_high_accuracy_after_promotion_dir,
+                        evidence_root=evidence_root,
                         stage2_predictions=(
                             daily_shadow_run_dir / "stage2_shadow_predictions.jsonl"
                             if daily_shadow_run_dir

--- a/scripts/shadow_autopilot_v1.py
+++ b/scripts/shadow_autopilot_v1.py
@@ -42,7 +42,7 @@ DEFAULT_TARGET_JOINED_RACES = 100
 DEFAULT_MIN_JOINED_RACES_FOR_STATUS = 100
 DEFAULT_ODDS_CAPTURE_MIN_MINUTES = 0.0
 DEFAULT_ODDS_CAPTURE_MAX_MINUTES = 60.0
-DEFAULT_ODDS_CAPTURE_REFRESH_LIMIT = 8
+DEFAULT_ODDS_CAPTURE_REFRESH_LIMIT = 16
 DEFAULT_AUTONOMOUS_ODDS_CAPTURE_LIMIT: int | None = None
 DEFAULT_HISTORICAL_UNIFIED_EVIDENCE_REPORT_LIMIT = 600
 DEFAULT_RESULT_BACKLOG_LIMIT = 128
@@ -550,12 +550,15 @@ def shadow_odds_snapshot_command(
     *,
     daily_dir: Path,
     odds_dir: Path,
+    evidence_root: Path,
     db_path: Path,
     current_time: str,
 ) -> list[str]:
     return [
         sys.executable,
         str(ROOT / "scripts/collect_shadow_odds_snapshots.py"),
+        "--evidence-root",
+        str(evidence_root),
         "--shadow-run-dir",
         str(daily_dir),
         "--output-dir",
@@ -641,6 +644,7 @@ def autonomous_official_result_capture_command(
     shadow_run_dir: Path | None = None,
     snapshot_dir: Path | None,
     output_dir: Path,
+    evidence_root: Path,
     db_path: Path,
     current_time: str | None = None,
     race_ids: Sequence[str] | None = None,
@@ -657,6 +661,8 @@ def autonomous_official_result_capture_command(
         str(ROOT / "scripts/autonomous_official_result_capture.py"),
         "--date",
         target_date,
+        "--evidence-root",
+        str(evidence_root),
         "--output-dir",
         str(output_dir),
         "--db",
@@ -697,6 +703,7 @@ def unified_evidence_dataset_command(
     *,
     shadow_run_dir: Path,
     output_dir: Path,
+    evidence_root: Path,
     db_path: Path,
     odds_jsonl_paths: Sequence[Path] | None = None,
     official_result_runner_paths: Sequence[Path] | None = None,
@@ -708,6 +715,8 @@ def unified_evidence_dataset_command(
         str(ROOT / "scripts/build_unified_evidence_dataset.py"),
         "--shadow-run-dir",
         str(shadow_run_dir),
+        "--evidence-root",
+        str(evidence_root),
         "--output-dir",
         str(output_dir),
         "--db",
@@ -2006,6 +2015,7 @@ def high_accuracy_refinement_packet_command(
     *,
     unified_evidence_report: Path,
     output_dir: Path,
+    evidence_root: Path,
     stage2_predictions: Path | None = None,
     odds_augmented_report: Path | None = None,
     odds_gate_report: Path | None = None,
@@ -2020,6 +2030,8 @@ def high_accuracy_refinement_packet_command(
         str(ROOT / "scripts/build_high_accuracy_refinement_packet.py"),
         "--unified-evidence-report",
         str(unified_evidence_report),
+        "--evidence-root",
+        str(evidence_root),
         "--output-dir",
         str(output_dir),
     ]
@@ -2081,12 +2093,15 @@ def pre_race_gated_challenger_command(
     *,
     runner_matrix_csv: Path,
     output_dir: Path,
+    evidence_root: Path,
 ) -> list[str]:
     return [
         sys.executable,
         str(ROOT / "scripts/build_pre_race_gated_challenger_packet.py"),
         "--runner-matrix-csv",
         str(runner_matrix_csv),
+        "--evidence-root",
+        str(evidence_root),
         "--output-dir",
         str(output_dir),
     ]
@@ -2098,12 +2113,15 @@ def promotion_distance_report_command(
     pre_race_gated_report: Path,
     high_accuracy_gate: Path,
     output_dir: Path,
+    evidence_root: Path,
 ) -> list[str]:
     return [
         sys.executable,
         str(ROOT / "scripts/build_promotion_distance_report.py"),
         "--rolling-report",
         str(rolling_report),
+        "--evidence-root",
+        str(evidence_root),
         "--pre-race-gated-report",
         str(pre_race_gated_report),
         "--high-accuracy-gate",
@@ -2136,10 +2154,13 @@ def rolling_model_comparison_command(
     *,
     unified_evidence_reports: Sequence[Path],
     output_dir: Path,
+    evidence_root: Path,
 ) -> list[str]:
     command = [
         sys.executable,
         str(ROOT / "scripts/build_rolling_model_comparison_packet.py"),
+        "--evidence-root",
+        str(evidence_root),
         "--output-dir",
         str(output_dir),
     ]
@@ -3127,6 +3148,8 @@ def build_timing_aligned_prediction_rerun_plan(
         "full-dry-run",
         "--output-dir",
         str(rerun_output_dir),
+        "--output-parent",
+        str(output_dir.parent),
         "--current-time",
         planned_current_time,
         "--db",
@@ -3310,6 +3333,7 @@ def execute_timing_aligned_prediction_rerun_plan(
         odds_command = shadow_odds_snapshot_command(
             daily_dir=rerun_daily_dir,
             odds_dir=rerun_odds_dir,
+            evidence_root=output_dir.parent,
             db_path=db_path,
             current_time=current_time,
         )
@@ -5084,6 +5108,41 @@ def build_daily_status(
         backlog_unified_eligible_rows,
         high_accuracy_unified_eligible_rows,
     )
+    races_scored_today = int((daily_manifest or {}).get("race_count") or 0)
+    prediction_rows_today = int((daily_manifest or {}).get("prediction_rows") or 0)
+    complete_prejump_odds_races = safe_count(
+        (odds_snapshot_status or {}).get("races_with_complete_valid_prejump_odds")
+    )
+    reported_missing_odds_races = safe_count(
+        (odds_snapshot_status or {}).get("races_with_missing_odds_rows")
+    )
+    missing_prejump_odds_races = max(
+        reported_missing_odds_races,
+        max(0, races_scored_today - complete_prejump_odds_races),
+    )
+    if races_scored_today <= 0:
+        prediction_sample_odds_coverage_status = "DATA_MISSING_NO_PREDICTION_SAMPLE"
+        prediction_sample_odds_coverage_blocker = None
+    elif missing_prejump_odds_races > 0:
+        prediction_sample_odds_coverage_status = "BLOCKED_MISSING_PREJUMP_ODDS"
+        prediction_sample_odds_coverage_blocker = (
+            "prediction_sample_missing_complete_valid_prejump_odds"
+        )
+    else:
+        prediction_sample_odds_coverage_status = "PASS_COMPLETE_PREJUMP_ODDS"
+        prediction_sample_odds_coverage_blocker = None
+    autonomous_odds_ready_count = safe_count(
+        (autonomous_live_odds_capture_status or {}).get("ready_count")
+    )
+    autonomous_odds_scope_gap = max(0, races_scored_today - autonomous_odds_ready_count)
+    if races_scored_today <= 0:
+        autonomous_odds_scope_status = "DATA_MISSING_NO_PREDICTION_SAMPLE"
+    elif autonomous_odds_ready_count >= races_scored_today:
+        autonomous_odds_scope_status = "PASS_AUTONOMOUS_ODDS_SCOPE_COVERS_SAMPLE"
+    elif autonomous_odds_ready_count > 0:
+        autonomous_odds_scope_status = "PARTIAL_AUTONOMOUS_ODDS_SCOPE"
+    else:
+        autonomous_odds_scope_status = "BLOCKED_NO_AUTONOMOUS_ODDS_SCOPE"
     comparisons = {
         key: {
             "current": current.get(key),
@@ -5097,8 +5156,8 @@ def build_daily_status(
         "schema_version": "shadow_autopilot_daily_status_v1",
         "generated_at": generated_at.isoformat(),
         "what_happened_today": "Ran shadow autopilot collection, odds diagnostics, exact result join, aggregate dashboard, drift report, and readiness tracker.",
-        "races_scored_today": int((daily_manifest or {}).get("race_count") or 0),
-        "prediction_rows_today": int((daily_manifest or {}).get("prediction_rows") or 0),
+        "races_scored_today": races_scored_today,
+        "prediction_rows_today": prediction_rows_today,
         "results_joined_this_run": (result_join_status.get("latest_join") or {}).get("joined_count", 0),
         "odds_snapshot_status": (odds_snapshot_status or {}).get("status"),
         "odds_candidate_rows": (odds_snapshot_status or {}).get("odds_candidate_rows", 0),
@@ -5114,6 +5173,24 @@ def build_daily_status(
             "races_with_missing_odds_rows",
             0,
         ),
+        "prediction_sample_odds_coverage_status": (
+            prediction_sample_odds_coverage_status
+        ),
+        "prediction_sample_odds_coverage_blocker": (
+            prediction_sample_odds_coverage_blocker
+        ),
+        "prediction_sample_odds_expected_races": races_scored_today,
+        "prediction_sample_odds_complete_prejump_races": (
+            complete_prejump_odds_races
+        ),
+        "prediction_sample_odds_missing_prejump_races": (
+            missing_prejump_odds_races
+        ),
+        "prediction_sample_odds_coverage_report": (
+            odds_snapshot_status or {}
+        ).get("race_coverage_path"),
+        "autonomous_live_odds_capture_scope_status": autonomous_odds_scope_status,
+        "autonomous_live_odds_capture_scope_gap_races": autonomous_odds_scope_gap,
         "ev_output_rows": (odds_snapshot_status or {}).get("ev_output_rows", 0),
         "live_odds_capture_approval_status": (live_odds_capture_packet or {}).get(
             "status"
@@ -6029,6 +6106,12 @@ def daily_status_markdown(daily_status: Mapping[str, Any]) -> str:
         f"Valid pre-jump dog odds rows: `{daily_status.get('valid_pre_jump_dog_odds_rows')}`",
         f"Races with complete valid pre-jump odds: `{daily_status.get('races_with_complete_valid_prejump_odds')}`",
         f"Races with missing odds rows: `{daily_status.get('races_with_missing_odds_rows')}`",
+        f"Prediction-sample odds coverage: `{daily_status.get('prediction_sample_odds_coverage_status')}`",
+        f"Prediction-sample odds coverage blocker: `{daily_status.get('prediction_sample_odds_coverage_blocker')}`",
+        f"Prediction-sample odds complete/missing races: `{daily_status.get('prediction_sample_odds_complete_prejump_races')}` / `{daily_status.get('prediction_sample_odds_missing_prejump_races')}`",
+        f"Prediction-sample odds coverage report: `{daily_status.get('prediction_sample_odds_coverage_report')}`",
+        f"Autonomous odds scope: `{daily_status.get('autonomous_live_odds_capture_scope_status')}`",
+        f"Autonomous odds scope gap races: `{daily_status.get('autonomous_live_odds_capture_scope_gap_races')}`",
         f"Odds research gate: `{daily_status.get('odds_research_gate_status')}`",
         f"Odds research gate complete valid races: `{daily_status.get('odds_research_gate_complete_valid_prejump_odds_races')}`",
         f"Odds research next action: `{daily_status.get('odds_research_next_action')}`",
@@ -6384,6 +6467,8 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
             str(args.max_minutes),
             "--limit",
             str(args.refresh_limit),
+            "--current-time",
+            current_time,
             "--output",
             str(output_dir / "refresh_prejump_report.json"),
         ]
@@ -6452,6 +6537,8 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
             str(args.odds_capture_max_minutes),
             "--limit",
             str(odds_capture_limit),
+            "--current-time",
+            current_time,
             "--output",
             str(output_dir / "odds_capture_refresh_report.json"),
         ]
@@ -6548,6 +6635,8 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
             "full-dry-run",
             "--output-dir",
             str(daily_dir),
+            "--output-parent",
+            str(evidence_root),
             "--current-time",
             current_time,
             "--db",
@@ -6637,6 +6726,7 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
             if result_capture_shadow_dir is None
             else None,
             output_dir=autonomous_result_capture_dir,
+            evidence_root=evidence_root,
             db_path=args.db,
             current_time=result_capture_command_current_time,
             require_ready_snapshot=result_capture_shadow_dir is None,
@@ -6720,6 +6810,7 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
         odds_command = shadow_odds_snapshot_command(
             daily_dir=daily_dir,
             odds_dir=odds_dir,
+            evidence_root=evidence_root,
             db_path=args.db,
             current_time=current_time,
         )
@@ -6833,6 +6924,7 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
         unified_dataset_command = unified_evidence_dataset_command(
             shadow_run_dir=daily_dir,
             output_dir=unified_dataset_dir,
+            evidence_root=evidence_root,
             db_path=args.db,
             odds_jsonl_paths=odds_jsonl_paths,
             official_result_runner_paths=official_result_runner_paths,
@@ -6901,6 +6993,7 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
             backlog_dataset_command = unified_evidence_dataset_command(
                 shadow_run_dir=backlog_shadow_dir,
                 output_dir=backlog_dataset_dir,
+                evidence_root=evidence_root,
                 db_path=args.db,
                 odds_jsonl_paths=shadow_odds_snapshot_paths_for_daily_dir(
                     evidence_root=evidence_root,
@@ -7010,6 +7103,7 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
             rolling_comparison_command = rolling_model_comparison_command(
                 unified_evidence_reports=unified_report_paths,
                 output_dir=rolling_comparison_dir,
+                evidence_root=evidence_root,
             )
             rolling_comparison_step = step_command(
                 name="rolling_model_comparison",
@@ -7061,6 +7155,7 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
             command=pre_race_gated_challenger_command(
                 runner_matrix_csv=rolling_runner_matrix_csv,
                 output_dir=pre_race_gated_dir,
+                evidence_root=evidence_root,
             ),
             output_dir=output_dir,
             timeout_seconds=args.step_timeout_seconds,
@@ -7101,6 +7196,7 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
         high_accuracy_command = high_accuracy_refinement_packet_command(
             unified_evidence_report=unified_report_path,
             output_dir=high_accuracy_dir,
+            evidence_root=evidence_root,
             stage2_predictions=stage2_predictions_path,
             odds_augmented_report=(
                 rolling_comparison_dir / "rolling_model_comparison_report.json"
@@ -7148,6 +7244,7 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
                     pre_race_gated_report=pre_race_gated_report_path,
                     high_accuracy_gate=high_accuracy_gate_path,
                     output_dir=promotion_distance_dir,
+                    evidence_root=evidence_root,
                 ),
                 output_dir=output_dir,
                 timeout_seconds=args.step_timeout_seconds,
@@ -7159,6 +7256,7 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
                     command=high_accuracy_refinement_packet_command(
                         unified_evidence_report=unified_report_path,
                         output_dir=high_accuracy_after_promotion_dir,
+                        evidence_root=evidence_root,
                         stage2_predictions=stage2_predictions_path,
                         odds_augmented_report=rolling_comparison_report_path,
                         odds_gate_report=odds_gate_report_path,
@@ -7210,6 +7308,8 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
         join_command = [
             sys.executable,
             str(ROOT / "scripts/join_forward_shadow_results.py"),
+            "--evidence-root",
+            str(evidence_root),
             "--shadow-run-dir",
             str(daily_dir),
             "--output-dir",
@@ -7330,6 +7430,8 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
         activation_command = [
             sys.executable,
             str(ROOT / "scripts/shadow_feature_activation_gate.py"),
+            "--evidence-root",
+            str(evidence_root),
             "--parity-report",
             str(activation_gate_inputs["parity_report"]),
             "--provenance-audit",
@@ -7734,6 +7836,12 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
         protected_paths_unchanged=protected_paths_unchanged_or_allowed,
         required_outputs_present=required_outputs_present,
     )
+    if (
+        final_verdict == "AUTOPILOT_READY"
+        and daily_status.get("prediction_sample_odds_coverage_status")
+        == "BLOCKED_MISSING_PREJUMP_ODDS"
+    ):
+        final_verdict = "PARTIAL_AUTOMATION_READY"
     write_text(
         output_dir / "verification_results.txt",
         "\n".join(
@@ -7750,6 +7858,14 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
                 f"tgr_enabled=False",
                 f"betting_or_ev_action=False",
                 f"shadow_odds_snapshot_status={odds_snapshot_status.get('status')}",
+                f"races_with_complete_valid_prejump_odds={odds_snapshot_status.get('races_with_complete_valid_prejump_odds')}",
+                f"races_with_missing_odds_rows={odds_snapshot_status.get('races_with_missing_odds_rows')}",
+                f"prediction_sample_odds_coverage_status={daily_status.get('prediction_sample_odds_coverage_status')}",
+                f"prediction_sample_odds_coverage_blocker={daily_status.get('prediction_sample_odds_coverage_blocker')}",
+                f"prediction_sample_odds_complete_prejump_races={daily_status.get('prediction_sample_odds_complete_prejump_races')}",
+                f"prediction_sample_odds_missing_prejump_races={daily_status.get('prediction_sample_odds_missing_prejump_races')}",
+                f"autonomous_live_odds_capture_scope_status={daily_status.get('autonomous_live_odds_capture_scope_status')}",
+                f"autonomous_live_odds_capture_scope_gap_races={daily_status.get('autonomous_live_odds_capture_scope_gap_races')}",
                 f"shadow_odds_snapshot_ev_output_rows={odds_snapshot_status.get('ev_output_rows')}",
                 f"timing_aligned_prediction_rerun_plan_status={timing_aligned_rerun_plan.get('status')}",
                 f"timing_aligned_prediction_rerun_execution_status={timing_aligned_rerun_execution_status.get('status')}",
@@ -7890,6 +8006,18 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
         ),
         "autonomous_live_odds_capture_inserted_rows": autonomous_odds_capture_status.get(
             "inserted_live_odds_rows"
+        ),
+        "prediction_sample_odds_coverage_status": daily_status.get(
+            "prediction_sample_odds_coverage_status"
+        ),
+        "prediction_sample_odds_missing_prejump_races": daily_status.get(
+            "prediction_sample_odds_missing_prejump_races"
+        ),
+        "autonomous_live_odds_capture_scope_status": daily_status.get(
+            "autonomous_live_odds_capture_scope_status"
+        ),
+        "autonomous_live_odds_capture_scope_gap_races": daily_status.get(
+            "autonomous_live_odds_capture_scope_gap_races"
         ),
         "autonomous_official_result_capture_status": autonomous_result_capture_status.get("status"),
         "autonomous_official_result_race_rows": autonomous_result_capture_status.get(

--- a/scripts/shadow_feature_activation_gate.py
+++ b/scripts/shadow_feature_activation_gate.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
@@ -19,8 +20,15 @@ from typing import Any, Mapping, Sequence
 
 
 ROOT = Path(__file__).resolve().parents[1]
+ROOT_STR = str(ROOT)
+sys.path = [path for path in sys.path if path != ROOT_STR]
+sys.path.insert(0, ROOT_STR)
+
+from utils.report_output_dir_guard import assert_prefixed_report_output_dir  # noqa: E402
+
 DEFAULT_OUTPUT_PARENT = ROOT / "artifacts/full_evidence_orchestration_20260525"
 OUTPUT_PREFIX = "artifacts/full_evidence_orchestration_20260525/shadow_feature_activation_gate_"
+OUTPUT_ARTIFACT_PREFIX = "shadow_feature_activation_gate_"
 DEFAULT_CANDIDATE_FEATURES = (
     "same_distance_same_grade_best_time",
     "same_distance_same_grade_avg_time",
@@ -82,17 +90,19 @@ def write_text(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
-def assert_output_dir_safe(output_dir: Path) -> Path:
-    logical = output_dir if output_dir.is_absolute() else ROOT / output_dir
-    try:
-        relative = logical.absolute().relative_to(ROOT.absolute())
-    except ValueError as exc:
-        raise ValueError("output_dir_must_be_inside_repo") from exc
-    if ".." in relative.parts:
-        raise ValueError("output_dir_must_not_contain_parent_traversal")
-    if not relative.as_posix().startswith(OUTPUT_PREFIX):
-        raise ValueError(f"output_dir_must_be_shadow_feature_activation_gate_artifact:{relative}")
-    return logical.absolute()
+def assert_output_dir_safe(
+    output_dir: Path,
+    *,
+    evidence_root: Path | None = None,
+) -> Path:
+    return assert_prefixed_report_output_dir(
+        output_dir,
+        repo_root=ROOT,
+        repo_prefix=OUTPUT_PREFIX,
+        artifact_prefix=OUTPUT_ARTIFACT_PREFIX,
+        prefix_error="output_dir_must_be_shadow_feature_activation_gate_artifact",
+        evidence_root=evidence_root,
+    )
 
 
 def ratio_too_unstable(train_pct: float, holdout_pct: float, max_ratio: float) -> bool:
@@ -702,13 +712,14 @@ def run_activation_gate(
     candidate_metrics_path: Path | None = None,
     output_parent: Path = DEFAULT_OUTPUT_PARENT,
     output_dir: Path | None = None,
+    evidence_root: Path | None = None,
     candidate_features: Sequence[str] = DEFAULT_CANDIDATE_FEATURES,
     thresholds: ActivationThresholds = ActivationThresholds(),
     generated_at: datetime | None = None,
 ) -> dict[str, Any]:
     generated_at = generated_at or datetime.now().astimezone()
     output_dir = output_dir or output_parent / f"shadow_feature_activation_gate_{now_id(generated_at)}"
-    output_dir = assert_output_dir_safe(output_dir)
+    output_dir = assert_output_dir_safe(output_dir, evidence_root=evidence_root)
     output_dir.mkdir(parents=True, exist_ok=False)
     report = build_activation_report(
         candidate_features=candidate_features,
@@ -750,6 +761,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--candidate-metrics", type=Path)
     parser.add_argument("--output-parent", default=DEFAULT_OUTPUT_PARENT, type=Path)
     parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--evidence-root", default=DEFAULT_OUTPUT_PARENT, type=Path)
     parser.add_argument("--feature", action="append", dest="features")
     parser.add_argument("--min-train-present-rows", type=int, default=ActivationThresholds.min_train_present_rows)
     parser.add_argument("--min-train-present-pct", type=float, default=ActivationThresholds.min_train_present_pct)
@@ -787,6 +799,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         candidate_metrics_path=args.candidate_metrics,
         output_parent=args.output_parent,
         output_dir=args.output_dir,
+        evidence_root=args.evidence_root,
         candidate_features=args.features or DEFAULT_CANDIDATE_FEATURES,
         thresholds=thresholds,
     )

--- a/tests/test_daily_race_ingest_shadow_orchestrator.py
+++ b/tests/test_daily_race_ingest_shadow_orchestrator.py
@@ -1006,6 +1006,28 @@ def test_score_live_command_reuses_shadow_model_without_training(tmp_path):
     assert "--train-if-missing" not in command
 
 
+def test_score_live_command_passes_retained_evidence_root(tmp_path):
+    evidence_root = (
+        tmp_path.parent
+        / f"{tmp_path.name}_retained"
+        / "artifacts/full_evidence_orchestration_20260525"
+    )
+
+    command = build_score_live_command(
+        input_dir=evidence_root / "daily_race_ingest_shadow_x" / "eligible_inputs",
+        output_dir=evidence_root / "daily_race_ingest_shadow_x" / "shadow_score_live",
+        db_path=Path("greyhound_racing_data.db"),
+        schema_path=Path("schema.json"),
+        clean_dataset=Path("clean.jsonl"),
+        repaired_packet=Path("packet.csv"),
+        all_missing_train_policy="quarantine_feature",
+        evidence_root=evidence_root,
+    )
+
+    assert "--evidence-root" in command
+    assert command[command.index("--evidence-root") + 1] == str(evidence_root)
+
+
 def test_score_live_command_auto_falls_back_to_uv_when_current_python_lacks_ml_deps(
     tmp_path,
     monkeypatch,
@@ -1154,6 +1176,22 @@ def test_daily_output_guard_accepts_only_shadow_artifact_prefix():
     assert assert_daily_output_dir_safe(output_dir).name == (
         "daily_race_ingest_shadow_20260607T220000+1000"
     )
+
+
+def test_daily_output_guard_accepts_configured_external_output_parent(tmp_path):
+    evidence_root = tmp_path / "runtime_artifacts" / "full_evidence_orchestration_20260525"
+    output_dir = evidence_root / "daily_race_ingest_shadow_external"
+
+    assert (
+        assert_daily_output_dir_safe(output_dir, output_parent=evidence_root)
+        == output_dir.absolute()
+    )
+
+    with pytest.raises(ValueError, match="output_dir_must_be_daily_shadow_artifact"):
+        assert_daily_output_dir_safe(
+            evidence_root / "not_a_daily_shadow_artifact",
+            output_parent=evidence_root,
+        )
 
 
 def test_daily_output_guard_rejects_production_paths():

--- a/tests/test_forward_shadow_runtime_state.py
+++ b/tests/test_forward_shadow_runtime_state.py
@@ -1290,6 +1290,21 @@ def test_runtime_action_reports_active_daemon_before_waiting_state():
     assert reasons == ["shadow_autopilot_service_active"]
 
 
+def test_runtime_action_reports_ready_needs_deployment_without_failure():
+    action, reasons = runtime.decide_runtime_action(
+        daemon_state={
+            "last_verdict": "DAEMON_READY_NEEDS_DEPLOYMENT",
+            "last_next_prejump_refresh_status": "READY_FOR_REFRESH",
+            "last_safe_joined_races": 1061,
+        },
+        timer={"service_status": "inactive", "timer_status": "inactive"},
+        target_joined_races=100,
+    )
+
+    assert action == "DEPLOY_OR_RESTART_DAEMON_TIMER"
+    assert reasons == ["daemon_ready_timer_not_active"]
+
+
 def test_runtime_action_continues_collection_when_not_waiting_and_under_target():
     action, reasons = runtime.decide_runtime_action(
         daemon_state={

--- a/tests/test_prejump_prediction_loop.py
+++ b/tests/test_prejump_prediction_loop.py
@@ -682,6 +682,58 @@ def test_refresh_prejump_upcoming_reports_top_level_artifact_counts(tmp_path, mo
     assert report["sidecar_metadata_coverage"]["safe_weather_race_count"] == 0
 
 
+def test_refresh_prejump_upcoming_honors_supplied_current_time(tmp_path, monkeypatch):
+    refresh_module = sys.modules[refresh_prejump_upcoming.__module__]
+    wall_clock = datetime(2026, 6, 24, 0, 47, tzinfo=ZoneInfo("Australia/Melbourne"))
+    monkeypatch.setattr(refresh_module, "melbourne_now", lambda: wall_clock)
+
+    class FakeUpcomingRaceBrowser:
+        def get_upcoming_races(self, days_ahead):
+            assert days_ahead == 1
+            return [
+                {
+                    "url": "https://www.thedogs.com.au/racing/murray-bridge-straight/2026-06-24/1/test?trial=false",
+                    "date": "2026-06-24",
+                    "race_time": "11:29 AM",
+                    "race_number": 1,
+                    "venue": "MURR",
+                }
+            ]
+
+        def download_race_csv(self, url):
+            csv_path = tmp_path / "upcoming" / "Race 1 - MURR - 2026-06-24.csv"
+            csv_path.write_text("box|dog_name\n1|Alpha Runner\n", encoding="utf-8")
+            csv_path.with_name(csv_path.name + ".metadata.json").write_text(
+                json.dumps({"race_url": url}),
+                encoding="utf-8",
+            )
+            return {"success": True, "path": str(csv_path)}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "upcoming_race_browser",
+        types.SimpleNamespace(UpcomingRaceBrowser=FakeUpcomingRaceBrowser),
+    )
+
+    report = refresh_prejump_upcoming(
+        Namespace(
+            upcoming_dir=str(tmp_path / "upcoming"),
+            days_ahead=1,
+            min_minutes=20,
+            max_minutes=160,
+            limit=16,
+            exclude_race_id=[],
+            exclude_race_ids_file=None,
+            dry_run=False,
+            current_time="2026-06-24T09:30:00+10:00",
+        )
+    )
+
+    assert report["generated_at"] == "2026-06-24T09:30:00+10:00"
+    assert report["selected_count"] == 1
+    assert report["bucket_counts"] == {"preferred_window": 1}
+
+
 def _write_safe_collection_sidecar(csv_path: Path, *, expert_form: bool = True):
     csv_path.write_text("box|dog_name\n1|Alpha Runner\n", encoding="utf-8")
     expert = {

--- a/tests/test_run_shadow_non_tgr_rf_evaluation.py
+++ b/tests/test_run_shadow_non_tgr_rf_evaluation.py
@@ -1066,11 +1066,28 @@ def test_shadow_output_path_rejects_production_paths(tmp_path):
         / "shadow_run",
         root=tmp_path,
     )
+    retained_root = (
+        tmp_path.parent
+        / f"{tmp_path.name}_retained"
+        / "artifacts"
+        / "full_evidence_orchestration_20260525"
+    )
+    assert_shadow_output_dir_safe(
+        retained_root / "daily_race_ingest_shadow_test" / "shadow_score_live",
+        root=tmp_path,
+        evidence_root=retained_root,
+    )
 
     with pytest.raises(ValueError, match="output_dir_must_be_shadow_artifact"):
         assert_shadow_output_dir_safe(tmp_path / "predictions" / "shadow", root=tmp_path)
     with pytest.raises(ValueError, match="output_dir_must_be_shadow_artifact"):
         assert_shadow_output_dir_safe(tmp_path / "model_registry" / "shadow", root=tmp_path)
+    with pytest.raises(ValueError, match="output_dir_must_be_shadow_artifact"):
+        assert_shadow_output_dir_safe(
+            retained_root / "not_daily_shadow" / "shadow_score_live",
+            root=tmp_path,
+            evidence_root=retained_root,
+        )
 
 
 def test_cli_stop_after_definition_writes_only_shadow_candidate(tmp_path, monkeypatch):

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -26,6 +26,7 @@ def test_daemon_default_min_joined_races_matches_review_target():
         args.autonomous_odds_capture_limit
         == daemon.DEFAULT_FULL_DAEMON_AUTONOMOUS_ODDS_CAPTURE_LIMIT
     )
+    assert daemon.DEFAULT_FULL_DAEMON_AUTONOMOUS_ODDS_CAPTURE_LIMIT == 16
     assert args.result_backlog_limit == daemon.DEFAULT_FULL_DAEMON_RESULT_BACKLOG_LIMIT
     assert (
         args.result_backlog_shadow_run_limit
@@ -456,7 +457,7 @@ def test_run_once_releases_after_primary_when_odds_refresh_due(tmp_path, monkeyp
     def fake_run_command(*, name, command, output_dir, timeout_seconds, cwd=daemon.ROOT):
         if name != "autopilot_cycle":
             raise AssertionError(f"post-primary release should not run {name}")
-        assert command[command.index("--autonomous-odds-capture-limit") + 1] == "2"
+        assert command[command.index("--autonomous-odds-capture-limit") + 1] == "16"
         assert command[command.index("--result-backlog-limit") + 1] == "32"
         assert command[command.index("--result-backlog-shadow-run-limit") + 1] == "64"
         assert command[command.index("--result-backlog-lookback-days") + 1] == "2"
@@ -1202,16 +1203,19 @@ def test_odds_capture_only_autopilot_command_is_narrow_and_append_only():
 
 
 def test_gated_challenger_commands_use_report_only_packet_builders():
+    evidence_root = Path("/evidence")
     runner_matrix_csv = Path("/evidence/rolling/market_residual_runner_matrix.csv")
     race_predictions_csv = Path("/evidence/residual/cross_validated_race_predictions.csv")
 
     pre_race_command = daemon.pre_race_gated_challenger_command(
         runner_matrix_csv=runner_matrix_csv,
         output_dir=Path("/evidence/pre_race_gated_challenger_run"),
+        evidence_root=evidence_root,
     )
     rank_first_command = daemon.pre_race_gated_challenger_command(
         runner_matrix_csv=runner_matrix_csv,
         output_dir=Path("/evidence/pre_race_rank_first_hypothesis_review_run"),
+        evidence_root=evidence_root,
         rank_first_hypotheses_json=Path(
             "/evidence/regime/next_hypotheses.json"
         ),
@@ -1236,17 +1240,24 @@ def test_gated_challenger_commands_use_report_only_packet_builders():
         ),
         high_accuracy_gate=Path("/evidence/high_accuracy/promotion_pr_gate.json"),
         output_dir=Path("/evidence/promotion_distance_report_run"),
+        evidence_root=evidence_root,
     )
     watchlist_command = daemon.rank_first_hypothesis_watchlist_command(
-        evidence_root=Path("/evidence"),
+        evidence_root=evidence_root,
         output_dir=Path("/evidence/rank_first_hypothesis_watchlist_run"),
     )
 
     assert "scripts/build_pre_race_gated_challenger_packet.py" in pre_race_command[1]
     assert "--runner-matrix-csv" in pre_race_command
     assert str(runner_matrix_csv) in pre_race_command
+    assert pre_race_command[pre_race_command.index("--evidence-root") + 1] == str(
+        evidence_root
+    )
     assert "--output-dir" in pre_race_command
     assert "scripts/build_pre_race_gated_challenger_packet.py" in rank_first_command[1]
+    assert rank_first_command[rank_first_command.index("--evidence-root") + 1] == str(
+        evidence_root
+    )
     assert "--rank-first-hypotheses-json" in rank_first_command
     assert "/evidence/regime/next_hypotheses.json" in rank_first_command
     assert "scripts/build_time_split_gated_challenger_packet.py" in time_split_command[1]
@@ -1261,6 +1272,9 @@ def test_gated_challenger_commands_use_report_only_packet_builders():
     assert str(race_predictions_csv) in regime_command
     assert "scripts/build_promotion_distance_report.py" in promotion_distance_command[1]
     assert "--rolling-report" in promotion_distance_command
+    assert promotion_distance_command[
+        promotion_distance_command.index("--evidence-root") + 1
+    ] == str(evidence_root)
     assert "--pre-race-gated-report" in promotion_distance_command
     assert "--high-accuracy-gate" in promotion_distance_command
     assert "scripts/build_rank_first_hypothesis_watchlist.py" in watchlist_command[1]

--- a/tests/test_shadow_autopilot_v1.py
+++ b/tests/test_shadow_autopilot_v1.py
@@ -439,11 +439,13 @@ def test_shadow_odds_snapshot_command_is_report_only_artifact():
     command = autopilot.shadow_odds_snapshot_command(
         daily_dir=Path("artifacts/full_evidence_orchestration_20260525/daily_race_ingest_shadow_x"),
         odds_dir=Path("artifacts/full_evidence_orchestration_20260525/shadow_odds_snapshot_x"),
+        evidence_root=Path("artifacts/full_evidence_orchestration_20260525"),
         db_path=Path("greyhound_racing_data.db"),
         current_time="2026-06-09T00:52:00+10:00",
     )
 
     assert "scripts/collect_shadow_odds_snapshots.py" in command[1]
+    assert "--evidence-root" in command
     assert "--shadow-run-dir" in command
     assert "--output-dir" in command
     assert "artifacts/full_evidence_orchestration_20260525/shadow_odds_snapshot_x" in command
@@ -621,6 +623,7 @@ def test_autonomous_official_result_capture_command_is_dry_run_artifact_lane():
             "artifacts/full_evidence_orchestration_20260525/"
             "autonomous_official_result_capture_x"
         ),
+        evidence_root=Path("artifacts/full_evidence_orchestration_20260525"),
         db_path=Path("greyhound_racing_data.db"),
         race_ids=["Race 1 - WPK - 2026-06-10"],
         require_ready_snapshot=True,
@@ -645,6 +648,7 @@ def test_autonomous_official_result_capture_command_can_use_shadow_run_candidate
             "artifacts/full_evidence_orchestration_20260525/"
             "autonomous_official_result_capture_x"
         ),
+        evidence_root=Path("artifacts/full_evidence_orchestration_20260525"),
         db_path=Path("greyhound_racing_data.db"),
         current_time="2026-06-10T15:00:00+10:00",
         require_ready_snapshot=False,
@@ -1052,6 +1056,7 @@ def test_unified_evidence_dataset_command_is_report_only_artifact_lane(tmp_path)
             "artifacts/full_evidence_orchestration_20260525/"
             "unified_evidence_dataset_x"
         ),
+        evidence_root=Path("artifacts/full_evidence_orchestration_20260525"),
         db_path=Path("greyhound_racing_data.db"),
         odds_jsonl_paths=[odds_path],
         official_result_runner_paths=[result_path],
@@ -1060,6 +1065,7 @@ def test_unified_evidence_dataset_command_is_report_only_artifact_lane(tmp_path)
     )
 
     assert "scripts/build_unified_evidence_dataset.py" in command[1]
+    assert "--evidence-root" in command
     assert "--shadow-run-dir" in command
     assert "--odds-jsonl" in command
     assert "--official-result-runners-jsonl" in command
@@ -2929,6 +2935,44 @@ def test_dashboard_and_daily_status_surface_backlog_unified_evidence(tmp_path):
     ) in summary
 
 
+def test_daily_status_blocks_missing_prediction_sample_odds():
+    daily_status = autopilot.build_daily_status(
+        generated_at=datetime.fromisoformat("2026-06-24T14:32:00+10:00"),
+        daily_manifest={"race_count": 13, "prediction_rows": 97},
+        result_join_status={"latest_join": {"joined_count": 0}},
+        dashboard={},
+        timeseries=[],
+        readiness={"decision": "READY_FOR_RELIABILITY_REVIEW"},
+        odds_snapshot_status={
+            "status": "SHADOW_ODDS_SNAPSHOT_COLLECTED",
+            "races_with_complete_valid_prejump_odds": 5,
+            "races_with_missing_odds_rows": 8,
+            "race_coverage_path": "shadow_odds_snapshot_x/race_coverage.json",
+        },
+        autonomous_live_odds_capture_status={
+            "status": "AUTONOMOUS_LIVE_ODDS_CAPTURE_APPENDED",
+            "ready_count": 2,
+        },
+    )
+
+    assert daily_status["prediction_sample_odds_coverage_status"] == (
+        "BLOCKED_MISSING_PREJUMP_ODDS"
+    )
+    assert daily_status["prediction_sample_odds_coverage_blocker"] == (
+        "prediction_sample_missing_complete_valid_prejump_odds"
+    )
+    assert daily_status["prediction_sample_odds_expected_races"] == 13
+    assert daily_status["prediction_sample_odds_complete_prejump_races"] == 5
+    assert daily_status["prediction_sample_odds_missing_prejump_races"] == 8
+    assert daily_status["prediction_sample_odds_coverage_report"] == (
+        "shadow_odds_snapshot_x/race_coverage.json"
+    )
+    assert daily_status["autonomous_live_odds_capture_scope_status"] == (
+        "PARTIAL_AUTONOMOUS_ODDS_SCOPE"
+    )
+    assert daily_status["autonomous_live_odds_capture_scope_gap_races"] == 11
+
+
 def test_high_accuracy_refinement_packet_command_and_status_are_report_only(tmp_path):
     odds_augmented_report = tmp_path / "rolling_model_comparison_report.json"
     odds_augmented_report.write_text("{}", encoding="utf-8")
@@ -2954,6 +2998,7 @@ def test_high_accuracy_refinement_packet_command_and_status_are_report_only(tmp_
             "artifacts/full_evidence_orchestration_20260525/"
             "high_accuracy_refinement_packet_x"
         ),
+        evidence_root=Path("artifacts/full_evidence_orchestration_20260525"),
         stage2_predictions=stage2_predictions,
         odds_augmented_report=odds_augmented_report,
         odds_gate_report=odds_gate_report,
@@ -3433,6 +3478,7 @@ def test_autopilot_promotion_distance_commands_are_report_only():
     pre_race_command = autopilot.pre_race_gated_challenger_command(
         runner_matrix_csv=Path("/evidence/rolling/market_residual_runner_matrix.csv"),
         output_dir=Path("/evidence/pre_race_gated_challenger_run"),
+        evidence_root=Path("/evidence"),
     )
     promotion_distance_command = autopilot.promotion_distance_report_command(
         rolling_report=Path("/evidence/rolling/rolling_model_comparison_report.json"),
@@ -3441,6 +3487,7 @@ def test_autopilot_promotion_distance_commands_are_report_only():
         ),
         high_accuracy_gate=Path("/evidence/high_accuracy/promotion_pr_gate.json"),
         output_dir=Path("/evidence/promotion_distance_report_run"),
+        evidence_root=Path("/evidence"),
     )
 
     assert "scripts/build_pre_race_gated_challenger_packet.py" in pre_race_command[1]
@@ -3463,6 +3510,7 @@ def test_high_accuracy_refinement_packet_command_omits_missing_odds_gate_report(
             "artifacts/full_evidence_orchestration_20260525/"
             "high_accuracy_refinement_packet_x"
         ),
+        evidence_root=Path("artifacts/full_evidence_orchestration_20260525"),
         odds_gate_report=tmp_path / "missing_odds_research_gate_report.json",
     )
 
@@ -3479,6 +3527,7 @@ def test_high_accuracy_refinement_packet_command_includes_backlog_unified_status
             "artifacts/full_evidence_orchestration_20260525/"
             "high_accuracy_refinement_packet_x"
         ),
+        evidence_root=Path("artifacts/full_evidence_orchestration_20260525"),
         backlog_unified_evidence_status=backlog_status,
     )
 
@@ -3532,9 +3581,11 @@ def test_rolling_model_comparison_command_and_status_are_report_only(tmp_path):
             "artifacts/full_evidence_orchestration_20260525/"
             "rolling_model_comparison_x"
         ),
+        evidence_root=Path("artifacts/full_evidence_orchestration_20260525"),
     )
 
     assert "scripts/build_rolling_model_comparison_packet.py" in command[1]
+    assert "--evidence-root" in command
     assert command.count("--unified-evidence-report") == 2
     assert "--output-dir" in command
     assert "--execute" not in command
@@ -4042,8 +4093,16 @@ def test_autonomous_live_odds_capture_runs_before_daily_shadow_run(tmp_path, mon
     assert shadow_refresh_command[
         shadow_refresh_command.index("--max-minutes") + 1
     ] == "160.0"
+    assert shadow_refresh_command[
+        shadow_refresh_command.index("--current-time") + 1
+    ] == "2026-06-11T20:20:00+10:00"
+    assert odds_refresh_command[
+        odds_refresh_command.index("--current-time") + 1
+    ] == "2026-06-11T20:20:00+10:00"
     assert "--require-safe-metadata" in shadow_refresh_command
     assert "--require-safe-metadata" in odds_refresh_command
+    daily_command = commands_by_step["daily_shadow_run"]
+    assert daily_command[daily_command.index("--output-parent") + 1] == str(evidence_root)
 
 
 def test_autonomous_official_result_capture_uses_fresh_step_time(
@@ -4990,6 +5049,10 @@ def test_timing_aligned_prediction_rerun_plan_uses_source_shadow_inputs(
         },
     )
 
+    output_dir = (
+        tmp_path
+        / "artifacts/full_evidence_orchestration_20260525/shadow_autopilot_v1_x"
+    )
     plan = autopilot.build_timing_aligned_prediction_rerun_plan(
         generated_at=datetime.fromisoformat("2026-06-13T23:40:00+10:00"),
         odds_snapshot_status={
@@ -5008,10 +5071,7 @@ def test_timing_aligned_prediction_rerun_plan_uses_source_shadow_inputs(
             "effective_prediction_timestamp": "2026-06-13T22:22:36+10:00",
             "effective_prediction_timestamp_source": "prediction_timestamp",
         },
-        output_dir=(
-            tmp_path
-            / "artifacts/full_evidence_orchestration_20260525/shadow_autopilot_v1_x"
-        ),
+        output_dir=output_dir,
         db_path=tmp_path / "greyhound_racing_data.db",
         shadow_model=model_path,
         score_command_mode="python",
@@ -5041,6 +5101,7 @@ def test_timing_aligned_prediction_rerun_plan_uses_source_shadow_inputs(
     assert "full-dry-run" in command
     assert "--shadow-model" in command
     assert str(model_path) in command
+    assert command[command.index("--output-parent") + 1] == str(output_dir.parent)
     assert str(input_a) in command
     assert str(input_b) in command
     assert plan["hard_stops"] == []

--- a/tests/test_shadow_feature_activation_gate.py
+++ b/tests/test_shadow_feature_activation_gate.py
@@ -806,3 +806,10 @@ def test_gate_writes_report_only_artifact(tmp_path, monkeypatch):
     assert (output_dir / "final_status.txt").read_text(encoding="utf-8").strip() == (
         "FEATURE_ACTIVATION_BLOCKED_KEEP_QUARANTINED"
     )
+
+
+def test_gate_accepts_configured_external_evidence_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(gate, "ROOT", tmp_path / "repo")
+    evidence_root = tmp_path / "retained_evidence"
+    output_dir = evidence_root / "shadow_feature_activation_gate_20260608T120000+1000"
+    assert gate.assert_output_dir_safe(output_dir, evidence_root=evidence_root) == output_dir.resolve()


### PR DESCRIPTION
## Summary

Preserves the approved PR25 dirty source patch family on a clean branch, excluding raw systemd path retargeting and generated runtime/report artifacts.

This threads explicit `evidence_root` / output-parent handling through report-only shadow-autopilot builders and related command wrappers so retained evidence roots can be used without violating artifact-prefix safety guards. It also surfaces sample-scoped pre-jump odds coverage and autonomous odds-scope status in daily/autopilot output, and preserves the PR25 operational default increase for autonomous odds capture limits.

## Scope Controls

- Includes source and focused test changes only.
- Excludes `ops/systemd/*` host-specific path retargeting.
- Excludes generated `artifacts/*` output.
- Excludes report bundles and task cards.
- Does not mutate runtime/data, services, registry, model pointers, or production state.

## Validation

- Tenn git guard preflight on the clean preservation worktree: warning only due to approved staged source/test dirt; registry `PASS`; ledger `DATA_MISSING`; upstream `origin/master`.
- `git diff --cached --check`
- `python3 -m py_compile` on all changed source/test files
- Focused stdlib behavioral checks for retained evidence-root guards, daemon command builders, current-time parsing, readiness action classification, and sample odds-coverage status

`pytest` was not run because `pytest` is not installed in this environment; no dependencies were installed.

## Docs Impact

`DOCS_FOLLOWUP`: this changes CLI/report-output behavior and status fields. This preservation PR intentionally keeps to source/test scope; docs should be updated or explicitly waived before treating the behavior as fully closed.