### PR TITLE
[codex] Adopt Issue 30 official-result retry retention

### DIFF
--- a/docs/agent_tasks/issue30_daemon_official_result_retry_v1_20260630.md
+++ b/docs/agent_tasks/issue30_daemon_official_result_retry_v1_20260630.md
@@ -1,0 +1,91 @@
+---
+job_id: issue30_daemon_official_result_retry_v1_20260630
+title: Issue 30 daemon official-result retry candidate retention
+lane: Evaluation
+supporting_lanes:
+  - Reporting
+owner: Codex
+approval_required: true
+approval_source: "User replied 'approve', then 'allow db too', then approved proceed for Git history/GitHub PR mutation on 2026-06-30."
+allow_unapproved_safe_extension: false
+timeout_seconds: 10800
+output_dir: reports/agent_jobs/issue30_daemon_official_result_retry_v1_20260630
+mutation_mode: safe_extension
+production_data_access: false
+github_mutation_allowed: true
+git_history_mutation_allowed: true
+owner_db_append_only_approval: true
+allowed_files:
+  - docs/agent_tasks/issue30_daemon_official_result_retry_v1_20260630.md
+  - reports/agent_jobs/issue30_daemon_official_result_retry_v1_20260630/README.md
+  - reports/agent_jobs/issue30_daemon_official_result_retry_v1_20260630/STATE.md
+  - reports/agent_jobs/issue30_daemon_official_result_retry_v1_20260630/VALIDATION.md
+  - reports/agent_jobs/issue30_daemon_official_result_retry_v1_20260630/PR_REVIEW.md
+  - reports/agent_jobs/issue30_daemon_official_result_retry_v1_20260630/backlog_ranking_proof.md
+  - reports/agent_jobs/issue30_daemon_official_result_retry_v1_20260630/NEXT_GOAL.md
+  - reports/agent_jobs/issue30_daemon_official_result_retry_v1_20260630/diff-check.json
+  - scripts/autonomous_official_result_capture.py
+  - tests/test_autonomous_official_result_capture.py
+docs_impact: DOCS_NOT_REQUIRED
+docs_checked:
+  - docs/agent_tasks/issue30_daemon_official_result_retry_v1_20260630.md
+docs_changed: []
+docs_followup: NONE
+reason: "Narrow bug fix to existing official-result capture candidate retention; no operator command or public workflow contract is changed."
+task_tier: medium
+recommended_model: "standard coding model"
+actual_model: "Codex GPT-5"
+why_this_model: "The fix is a focused daemon candidate-selection bug with DB-read proof and narrow tests."
+worker_model_allowed: false
+worker_decision_limit: "No worker delegation; orchestrator owns source, validation, and DB boundary."
+escalation_needed: false
+---
+
+# Issue 30 Daemon Official-Result Retry Candidate Retention
+
+## Objective
+
+Fix GitHub issue #30 by preserving post-jump current-source races in the
+official-result capture retry candidate set when the source-backed live-odds
+backlog is larger than the daemon candidate limit.
+
+## Scope
+
+Allowed:
+
+- Reproduce the issue #29 backlog-ranking proof with read-only DB queries.
+- Edit only `scripts/autonomous_official_result_capture.py` and
+  `tests/test_autonomous_official_result_capture.py`.
+- Add focused regression coverage showing source-backed current-source races
+  are retained for retry even when they fall after the nominal backlog limit.
+- Run read-only DB validation and focused tests.
+- If code and identity/source gates validate, run append-only official-result
+  evidence DB validation/ingest only through the existing official-result
+  evidence path and only for the issue #29 exact 15-race packet.
+- If exact append-only official-result evidence is already present, validate it
+  read-only and do not duplicate append rows.
+- Commit and open a draft PR for the narrow issue #30 code/test/task-card
+  surface after owner approval.
+
+Forbidden:
+
+- No runtime/service/config, canonical labels, model, promotion, training,
+  EV, betting, snapshot, manifest, merge, rebase, reset, stash, clean, branch
+  deletion, or worktree deletion mutation.
+- No GitHub mutation beyond opening a draft PR for this branch and no Git
+  history mutation beyond the one approved local commit/push for this task.
+- No broad DB mutation. DB approval is append-only official-result evidence
+  for validated issue #29/current-source candidates only.
+- No DB append while the shared daemon lock reports `write_allowed=false`.
+- No weakening of official source, runner identity, box-set, or result
+  completeness gates.
+- No use of raw DB totals, stale daemon activity, or old readiness packets as
+  current-source recovery proof.
+
+## Validation
+
+- `python3 /home/l4nd0/.agents/skills/tenn-git-guard/scripts/tenn_git_guard.py preflight --repo-root . --topic "GitHub issue #30 daemon official-result capture issue #29 exact 15 current-source packet" --json`
+- `python3 /home/l4nd0/tenn-control-plane-task-ledger-status-refresh-v1-20260623/scripts/agent_job_contract.py validate docs/agent_tasks/issue30_daemon_official_result_retry_v1_20260630.md`
+- Read-only issue #29 backlog-ranking proof query.
+- `python3 -m pytest tests/test_autonomous_official_result_capture.py -q`
+- `python3 /home/l4nd0/tenn-control-plane-task-ledger-status-refresh-v1-20260623/scripts/agent_job_contract.py check-diff docs/agent_tasks/issue30_daemon_official_result_retry_v1_20260630.md --repo-root .`

--- a/scripts/autonomous_official_result_capture.py
+++ b/scripts/autonomous_official_result_capture.py
@@ -625,6 +625,7 @@ def source_backed_live_odds_backlog_race_ids(
     target_date: str,
     limit: int,
     lookback_days: int = 0,
+    retain_race_ids: Sequence[str] | None = None,
 ) -> list[str]:
     """Find source-backed odds races that still need official result evidence."""
 
@@ -635,6 +636,7 @@ def source_backed_live_odds_backlog_race_ids(
             target_date=target_date,
             limit=limit,
             lookback_days=lookback_days,
+            retain_race_ids=retain_race_ids,
         )
     ]
 
@@ -657,16 +659,30 @@ def source_backed_live_odds_backlog_entries(
     target_date: str,
     limit: int,
     lookback_days: int = 0,
+    retain_race_ids: Sequence[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Find source-backed odds races that still need official result evidence."""
 
     if limit <= 0 or not db_path.exists():
         return []
+    retained_ids = sorted(
+        {
+            str(race_id).strip()
+            for race_id in retain_race_ids or []
+            if str(race_id).strip()
+        }
+    )
     target_dates = live_odds_backlog_target_dates(
         target_date,
         lookback_days=lookback_days,
     )
     placeholders = ",".join("?" for _ in target_dates)
+    retained_placeholders = ",".join("?" for _ in retained_ids)
+    retention_predicate = (
+        f"backlog_rank <= ? OR race_id IN ({retained_placeholders})"
+        if retained_ids
+        else "backlog_rank <= ?"
+    )
     try:
         with sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True) as conn:
             live_odds_columns = {
@@ -697,6 +713,7 @@ def source_backed_live_odds_backlog_entries(
                 else "''"
             )
             query = """
+        WITH backlog AS (
         SELECT
             lo.race_id,
             lo.race_date,
@@ -727,40 +744,75 @@ def source_backed_live_odds_backlog_entries(
                 AND rm.winner_source = ?
           )
         GROUP BY lo.race_id
-        ORDER BY lo.race_date DESC, latest_capture ASC, lo.race_id ASC
-        LIMIT ?
+        ),
+        ranked AS (
+            SELECT
+                ROW_NUMBER() OVER (
+                    ORDER BY race_date DESC, latest_capture ASC, race_id ASC
+                ) AS backlog_rank,
+                race_id,
+                race_date,
+                latest_capture,
+                venue,
+                race_number,
+                source_url,
+                odds_row_count,
+                box_count,
+                sportsbet_box_sources
+            FROM backlog
+        )
+        SELECT
+            backlog_rank,
+            race_id,
+            race_date,
+            latest_capture,
+            venue,
+            race_number,
+            source_url,
+            odds_row_count,
+            box_count,
+            sportsbet_box_sources
+        FROM ranked
+        WHERE {retention_predicate}
+        ORDER BY backlog_rank ASC
     """.format(
                 placeholders=placeholders,
                 venue_expr=venue_expr,
                 race_number_expr=race_number_expr,
                 box_count_expr=box_count_expr,
                 box_sources_expr=box_sources_expr,
+                retention_predicate=retention_predicate,
             )
             rows = conn.execute(
                 query,
-                [*target_dates, OFFICIAL_SOURCE, int(limit)],
+                [*target_dates, OFFICIAL_SOURCE, int(limit), *retained_ids],
             ).fetchall()
     except sqlite3.Error:
         return []
     entries: list[dict[str, Any]] = []
     for row in rows:
-        race_id = str(row[0] if row else "").strip()
+        race_id = str(row[1] if row else "").strip()
         if not race_id:
             continue
+        backlog_rank = int(row[0] or 0)
         entries.append(
             {
                 "race_id": race_id,
-                "race_date": row[1],
-                "latest_capture": row[2],
-                "venue": row[3],
-                "race_number": row[4],
-                "source_url": row[5],
-                "odds_row_count": row[6],
-                "box_count": row[7],
+                "race_date": row[2],
+                "latest_capture": row[3],
+                "venue": row[4],
+                "race_number": row[5],
+                "source_url": row[6],
+                "odds_row_count": row[7],
+                "box_count": row[8],
+                "backlog_rank": backlog_rank,
+                "retained_beyond_limit": bool(
+                    race_id in retained_ids and backlog_rank > int(limit)
+                ),
                 "sportsbet_box_sources": sorted(
                     {
                         str(value).strip()
-                        for value in str(row[8] or "").split(",")
+                        for value in str(row[9] or "").split(",")
                         if str(value).strip()
                     }
                 ),
@@ -1018,14 +1070,69 @@ def latest_shadow_run_dirs(evidence_root: Path, *, limit: int) -> list[Path]:
     candidates = [
         path
         for path in evidence_root.glob("daily_race_ingest_shadow_*")
-        if path.is_dir()
+        if is_shadow_run_candidate_dir(path)
+    ]
+    candidates.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    return candidates[:limit]
+
+
+def is_shadow_run_candidate_dir(path: Path) -> bool:
+    return (
+        path.is_dir()
         and (
             (path / "stage2_shadow_predictions.jsonl").exists()
             or (path / "shadow_predictions.jsonl").exists()
         )
+    )
+
+
+def target_date_shadow_run_dirs(
+    evidence_root: Path,
+    *,
+    target_dates: Sequence[str],
+) -> list[Path]:
+    if not evidence_root.exists():
+        return []
+    date_tokens = {
+        str(target_date).replace("-", "")
+        for target_date in target_dates
+        if str(target_date).strip()
+    }
+    candidates = [
+        path
+        for path in evidence_root.glob("daily_race_ingest_shadow_*")
+        if is_shadow_run_candidate_dir(path)
+        and any(token in path.name for token in date_tokens)
     ]
     candidates.sort(key=lambda path: path.stat().st_mtime, reverse=True)
-    return candidates[:limit]
+    return candidates
+
+
+def merge_shadow_run_dirs(*groups: Sequence[Path]) -> list[Path]:
+    merged: list[Path] = []
+    seen: set[str] = set()
+    for group in groups:
+        for path in group:
+            key = str(path.resolve())
+            if key not in seen:
+                seen.add(key)
+                merged.append(path)
+    return merged
+
+
+def shadow_run_backlog_retention_race_ids(shadow_run_dirs: Sequence[Path]) -> list[str]:
+    race_ids: set[str] = set()
+    for shadow_run_dir in shadow_run_dirs:
+        race_ids.update(feature_rows_by_race_id(shadow_run_dir))
+        for predictions_path in [
+            shadow_run_dir / "stage2_shadow_predictions.jsonl",
+            shadow_run_dir / "shadow_predictions.jsonl",
+        ]:
+            for row in load_jsonl(predictions_path):
+                race_id = str(row.get("race_id") or "").strip()
+                if race_id:
+                    race_ids.add(race_id)
+    return sorted(race_ids)
 
 
 def run_shadow_run_official_dry_run(
@@ -1069,11 +1176,30 @@ def run_shadow_run_official_dry_run(
         "discovered_races": [],
     }
     if include_live_odds_backlog:
+        target_dates = live_odds_backlog_target_dates(
+            target_date,
+            lookback_days=backlog_lookback_days,
+        )
+        resolved_backlog_evidence_root = backlog_evidence_root or DEFAULT_EVIDENCE_ROOT
+        scanned_shadow_run_dirs = merge_shadow_run_dirs(
+            latest_shadow_run_dirs(
+                resolved_backlog_evidence_root,
+                limit=backlog_shadow_run_limit,
+            ),
+            target_date_shadow_run_dirs(
+                resolved_backlog_evidence_root,
+                target_dates=target_dates,
+            ),
+        )
+        retained_shadow_race_ids = shadow_run_backlog_retention_race_ids(
+            scanned_shadow_run_dirs
+        )
         backlog_entries = source_backed_live_odds_backlog_entries(
             db_path=db_path,
             target_date=target_date,
             limit=backlog_limit,
             lookback_days=backlog_lookback_days,
+            retain_race_ids=retained_shadow_race_ids,
         )
         backlog_race_ids = [str(item.get("race_id")) for item in backlog_entries]
         backlog_race_dates = {
@@ -1082,15 +1208,18 @@ def run_shadow_run_official_dry_run(
         }
         backlog_report["discovered_race_ids"] = backlog_race_ids
         backlog_report["discovered_races"] = backlog_entries
+        backlog_report["retention_shadow_run_count"] = len(scanned_shadow_run_dirs)
+        backlog_report["retention_shadow_race_count"] = len(retained_shadow_race_ids)
+        backlog_report["retained_beyond_limit_race_ids"] = [
+            str(item.get("race_id"))
+            for item in backlog_entries
+            if item.get("retained_beyond_limit")
+        ]
         remaining = [
             race_id
             for race_id in backlog_race_ids
             if race_id not in candidate_by_race_id
         ]
-        scanned_shadow_run_dirs = latest_shadow_run_dirs(
-            backlog_evidence_root or DEFAULT_EVIDENCE_ROOT,
-            limit=backlog_shadow_run_limit,
-        )
         for backlog_dir in scanned_shadow_run_dirs:
             if not remaining:
                 break

--- a/tests/test_autonomous_official_result_capture.py
+++ b/tests/test_autonomous_official_result_capture.py
@@ -1276,7 +1276,11 @@ def test_shadow_run_official_dry_run_uses_official_fetcher_without_db_writes(
                 raw_order=[1, 2, 3, 4],
             )
 
-    monkeypatch.setattr(capture.ingest, "TheDogsResultFetcher", FakeTheDogsResultFetcher)
+    monkeypatch.setattr(
+        capture.ingest,
+        "TheDogsResultFetcher",
+        FakeTheDogsResultFetcher,
+    )
     monkeypatch.setattr(
         capture.ingest,
         "optional_browser_driver",
@@ -1332,7 +1336,11 @@ def test_shadow_run_official_dry_run_failed_validation_keeps_participant_context
                 },
             )
 
-    monkeypatch.setattr(capture.ingest, "TheDogsResultFetcher", FakeTheDogsResultFetcher)
+    monkeypatch.setattr(
+        capture.ingest,
+        "TheDogsResultFetcher",
+        FakeTheDogsResultFetcher,
+    )
     monkeypatch.setattr(
         capture.ingest,
         "optional_browser_driver",
@@ -1447,7 +1455,11 @@ def test_shadow_run_official_dry_run_retries_source_backed_live_odds_backlog(
                 raw_order=[1, 2, 3, 4],
             )
 
-    monkeypatch.setattr(capture.ingest, "TheDogsResultFetcher", FakeTheDogsResultFetcher)
+    monkeypatch.setattr(
+        capture.ingest,
+        "TheDogsResultFetcher",
+        FakeTheDogsResultFetcher,
+    )
     monkeypatch.setattr(
         capture.ingest,
         "optional_browser_driver",
@@ -1489,6 +1501,142 @@ def test_shadow_run_official_dry_run_retries_source_backed_live_odds_backlog(
         "Race 1 - WPK - 2026-06-10",
         "Race 2 - WPK - 2026-06-11",
     }
+
+
+def test_shadow_run_official_dry_run_retains_shadow_backlog_candidates_beyond_limit(
+    tmp_path,
+    monkeypatch,
+):
+    current_csv = tmp_path / "Race 99 - WPK - 2026-06-29.csv"
+    retained_csv = tmp_path / "Race 10 - WAR - 2026-06-29.csv"
+    retained_race_id = "Race 10 - WAR - 2026-06-29"
+    _write_shadow_source_csv(current_csv)
+    _write_shadow_source_csv(retained_csv)
+    current_shadow_run = _write_shadow_run(
+        tmp_path,
+        source_csv=current_csv,
+        race_id="Race 99 - WPK - 2026-06-29",
+        race_time_minutes=20 * 60,
+        dirname="shadow_current",
+    )
+    evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
+    evidence_root.mkdir(parents=True)
+    _write_shadow_run(
+        evidence_root,
+        source_csv=retained_csv,
+        race_id=retained_race_id,
+        race_time_minutes=17 * 60,
+        dirname="daily_race_ingest_shadow_20260629T170200_retained",
+    )
+    newer_unrelated_csv = tmp_path / "Race 1 - WPK - 2026-06-30.csv"
+    _write_shadow_source_csv(newer_unrelated_csv)
+    _write_shadow_run(
+        evidence_root,
+        source_csv=newer_unrelated_csv,
+        race_id="Race 1 - WPK - 2026-06-30",
+        race_time_minutes=12 * 60,
+        dirname="daily_race_ingest_shadow_20260630T120000_newer",
+    )
+    db_path = tmp_path / "labels.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE race_metadata (
+                race_id TEXT PRIMARY KEY,
+                winner_source TEXT
+            );
+            CREATE TABLE live_odds (
+                race_id TEXT,
+                race_date TEXT,
+                source_url TEXT,
+                capture_timestamp TEXT,
+                timestamp TEXT,
+                market_type TEXT,
+                odds_decimal REAL,
+                odds_level TEXT,
+                sportsbet_box_source TEXT
+            );
+            """
+        )
+        rows = [
+            (
+                f"Race {index} - FILLER{index:02d} - 2026-06-29",
+                "2026-06-29",
+                f"2026-06-29T17:{index:02d}:00+10:00",
+                f"2026-06-29T17:{index:02d}:00+10:00",
+            )
+            for index in range(1, 34)
+        ]
+        rows.append(
+            (
+                retained_race_id,
+                "2026-06-29",
+                "2026-06-29T17:34:00+10:00",
+                "2026-06-29T17:34:00+10:00",
+            )
+        )
+        conn.executemany(
+            """
+            INSERT INTO live_odds
+                (race_id, race_date, source_url, capture_timestamp, timestamp,
+                 market_type, odds_decimal, odds_level, sportsbet_box_source)
+            VALUES (?, ?, 'https://www.sportsbet.com.au/greyhound-racing/test/race',
+                    ?, ?, 'win', 2.8, 'dog', 'runner_text')
+            """,
+            rows,
+        )
+
+    class FakeTheDogsResultFetcher:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def fetch(self, candidate):
+            return capture.ingest.SourceResult(
+                source="thedogs_official",
+                status="resulted",
+                source_url=f"{candidate.canonical_thedogs_url}/results",
+                positions_by_box={1: 1, 2: 2, 3: 3, 4: 4},
+                raw_order=[1, 2, 3, 4],
+            )
+
+    monkeypatch.setattr(
+        capture.ingest,
+        "TheDogsResultFetcher",
+        FakeTheDogsResultFetcher,
+    )
+    monkeypatch.setattr(
+        capture.ingest,
+        "optional_browser_driver",
+        lambda headless=True: (None, None, "browser_unavailable"),
+    )
+
+    report, returncode = capture.run_shadow_run_official_dry_run(
+        db_path=db_path,
+        shadow_run_dir=current_shadow_run,
+        target_date="2026-06-29",
+        current_time=datetime.fromisoformat("2026-06-29T21:00:00+10:00"),
+        output_dir=tmp_path / "out",
+        race_ids=[],
+        include_live_odds_backlog=True,
+        backlog_evidence_root=evidence_root,
+        backlog_limit=32,
+        backlog_shadow_run_limit=1,
+        backlog_lookback_days=0,
+    )
+
+    assert returncode == 0
+    assert retained_race_id in report["candidate_race_ids"]
+    retained_entry = next(
+        row
+        for row in report["live_odds_backlog"]["discovered_races"]
+        if row["race_id"] == retained_race_id
+    )
+    assert retained_entry["backlog_rank"] == 34
+    assert retained_entry["retained_beyond_limit"] is True
+    assert report["live_odds_backlog"]["retained_beyond_limit_race_ids"] == [
+        retained_race_id
+    ]
+    assert retained_race_id in {row["race_id"] for row in report["ingested"]}
 
 
 def test_shadow_run_official_dry_run_reports_unresolved_live_odds_backlog_reasons(


### PR DESCRIPTION
## Summary
- ports the Issue #30 official-result retry candidate-retention fix onto feature/dog-odds-snapshot-readiness
- keeps source-backed shadow-run race IDs eligible even when they fall beyond the nominal live-odds backlog limit
- adds regression coverage for retained-beyond-limit backlog candidates

Supersedes the old master-based draft PR #31 for this slice.

## Validation
- uv run --with-requirements requirements/requirements.lock pytest tests/test_autonomous_official_result_capture.py -q
- uv run --with-requirements requirements/requirements.lock python -m compileall scripts/autonomous_official_result_capture.py tests/test_autonomous_official_result_capture.py
- python3 /home/l4nd0/tenn-control-plane-task-ledger-status-refresh-v1-20260623/scripts/agent_job_contract.py validate docs/agent_tasks/issue30_daemon_official_result_retry_v1_20260630.md
- python3 /home/l4nd0/tenn-control-plane-task-ledger-status-refresh-v1-20260623/scripts/agent_job_contract.py check-diff docs/agent_tasks/issue30_daemon_official_result_retry_v1_20260630.md --repo-root .
- git diff --cached --check && git diff --check