### PR TITLE
[codex] Centralize strict pre-jump odds provenance

### DIFF
--- a/accuracy_program/odds_coverage.py
+++ b/accuracy_program/odds_coverage.py
@@ -11,10 +11,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
-from accuracy_program.snapshots import (
-    assert_no_result_fields,
-    classify_odds_snapshot_for_ev,
-)
+from accuracy_program.odds_provenance import classify_odds_snapshot_for_ev
+from accuracy_program.snapshots import assert_no_result_fields
 
 _DOG_PREFIX_RE = re.compile(r"^\s*\d{1,2}\s*[\.\):-]\s*")
 

--- a/accuracy_program/odds_provenance.py
+++ b/accuracy_program/odds_provenance.py
@@ -1,0 +1,611 @@
+"""Strict pre-jump odds provenance and EV eligibility decisions."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any, Mapping
+from urllib.parse import urlparse
+
+try:
+    from config.venue_mapping import normalize_venue
+except Exception:
+
+    def normalize_venue(value: str) -> str:
+        return re.sub(r"[^A-Z0-9_]", "", str(value or "").upper())
+
+
+TRUSTED_ODDS_SOURCES = {"sportsbet"}
+POST_RACE_OR_RESULT_ODDS_MARKETS = {
+    "dividend",
+    "dividends",
+    "payout",
+    "result",
+    "results",
+    "sp",
+    "starting_price",
+    "startingprice",
+}
+POST_RACE_SOURCE_URL_MARKERS = ("dividend", "payout", "result")
+POST_RACE_SOURCE_TABLES = {"dog_race_data", "race_results", "results"}
+STRICT_ODDS_MATCH_METHODS = {
+    "dog_name_box",
+    "name_box",
+    "race_id_box_name",
+    "race_id_box_name_exact",
+    "strict_identity",
+}
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _safe_int(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except Exception:
+        return None
+
+
+def _normalize_identity(value: Any) -> str:
+    return re.sub(r"[^A-Z0-9]", "", str(value or "").upper())
+
+
+def normalize_odds_source(value: Any) -> str:
+    return re.sub(r"[^a-z0-9_]", "_", str(value or "").strip().lower()).strip("_")
+
+
+def _canonical_race_identity(value: Any) -> tuple[str, str, int] | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+
+    filename_match = re.match(
+        r"^\s*Race\s+(\d+)\s*-\s*(.+?)\s*-\s*(\d{4}-\d{2}-\d{2})\s*$",
+        raw,
+        re.IGNORECASE,
+    )
+    if filename_match:
+        race_number = filename_match.group(1)
+        venue = filename_match.group(2)
+        race_date = filename_match.group(3)
+    else:
+        canonical_match = re.match(
+            r"^\s*(.+?)_(\d{4}-\d{2}-\d{2})_(\d+)\s*$",
+            raw,
+            re.IGNORECASE,
+        )
+        if not canonical_match:
+            return None
+        venue = canonical_match.group(1)
+        race_date = canonical_match.group(2)
+        race_number = canonical_match.group(3)
+
+    try:
+        parsed_race_number = int(race_number)
+    except Exception:
+        return None
+
+    venue_code = normalize_venue(str(venue).replace("/", "_"))
+    if not venue_code or venue_code == "UNKNOWN":
+        return None
+    return (str(venue_code).upper(), str(race_date), parsed_race_number)
+
+
+def race_ids_match(snapshot_race_id: Any, odds_race_id: Any) -> tuple[bool, str | None]:
+    if str(snapshot_race_id) == str(odds_race_id):
+        return True, None
+
+    snapshot_identity = _canonical_race_identity(snapshot_race_id)
+    odds_identity = _canonical_race_identity(odds_race_id)
+    if snapshot_identity is not None and snapshot_identity == odds_identity:
+        return True, "canonical_race_id_box_dog"
+    return False, None
+
+
+def parse_odds_timestamp(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    for candidate in (raw, raw.replace("Z", "+00:00")):
+        try:
+            return datetime.fromisoformat(candidate)
+        except ValueError:
+            continue
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return datetime.strptime(raw[:19], fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def seconds_between(later: datetime | None, earlier: datetime | None) -> float | None:
+    if later is None or earlier is None:
+        return None
+    compare_later = later
+    compare_earlier = earlier
+    if compare_earlier.tzinfo is not None and compare_later.tzinfo is None:
+        compare_later = compare_later.replace(tzinfo=compare_earlier.tzinfo)
+    elif compare_earlier.tzinfo is None and compare_later.tzinfo is not None:
+        compare_later = compare_later.replace(tzinfo=None)
+    return (compare_later - compare_earlier).total_seconds()
+
+
+def _first_value(row: Mapping[str, Any], keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        value = row.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _normalize_market_type(value: Any, odds_snapshot: Mapping[str, Any]) -> str:
+    raw = str(value or "").strip().lower()
+    if raw:
+        return re.sub(r"[^a-z0-9_]", "_", raw)
+    return "win" if odds_snapshot.get("market_odds_win") is not None else ""
+
+
+def _source_url_is_post_race(raw_url: Any) -> bool:
+    url = str(raw_url or "").strip().lower()
+    if not url:
+        return False
+    if any(marker in url for marker in POST_RACE_SOURCE_URL_MARKERS):
+        return True
+    try:
+        parsed = urlparse(url)
+        text = " ".join(part for part in (parsed.path, parsed.query, parsed.fragment) if part)
+    except Exception:
+        text = url
+    tokens = {token for token in re.split(r"[^a-z0-9]+", text.lower()) if token}
+    return (
+        "sp" in tokens
+        or "startingprice" in tokens
+        or ("starting" in tokens and "price" in tokens)
+    )
+
+
+def _normalize_odds_level(value: Any, row: Mapping[str, Any]) -> str:
+    raw = str(value or "").strip().lower()
+    if raw:
+        return re.sub(r"[^a-z0-9_]", "_", raw)
+    if row.get("box_number") is not None and (
+        row.get("dog_clean_name") or row.get("dog_name") or row.get("name")
+    ):
+        return "dog"
+    return "unknown"
+
+
+def build_odds_snapshot(
+    row: Mapping[str, Any],
+    *,
+    prediction_timestamp: str,
+    feature_freeze_timestamp: str | None = None,
+    jump_datetime: str | None = None,
+    stale_odds_after_minutes: float = 30.0,
+) -> dict[str, Any]:
+    """Build the canonical odds snapshot shape from prediction/live odds fields."""
+
+    odds_snapshot = {
+        "market_odds_win": _safe_float(
+            row.get("market_odds_win", row.get("odds_win", row.get("live_odds")))
+        ),
+        "odds_implied_prob": _safe_float(row.get("odds_implied_prob")),
+        "odds_implied_prob_norm": _safe_float(row.get("odds_implied_prob_norm")),
+    }
+    odds_snapshot = {key: value for key, value in odds_snapshot.items() if value is not None}
+    odds_timestamp = _first_value(
+        row,
+        (
+            "odds_timestamp",
+            "market_odds_timestamp",
+            "live_odds_timestamp",
+            "odds_updated_at",
+            "odds_last_updated",
+        ),
+    )
+    if odds_timestamp:
+        odds_snapshot["odds_timestamp"] = str(odds_timestamp)
+
+    market_type = _normalize_market_type(
+        _first_value(row, ("odds_market_type", "market_type", "market_odds_type")),
+        odds_snapshot,
+    )
+    if market_type:
+        odds_snapshot["market_type"] = market_type
+    odds_level = _normalize_odds_level(
+        _first_value(row, ("odds_level", "market_odds_level", "live_odds_level")),
+        row,
+    )
+    if odds_level:
+        odds_snapshot["odds_level"] = odds_level
+
+    odds_dt = parse_odds_timestamp(odds_timestamp)
+    prediction_dt = parse_odds_timestamp(prediction_timestamp)
+    feature_freeze_dt = parse_odds_timestamp(feature_freeze_timestamp)
+    if odds_dt is not None and prediction_dt is not None:
+        age_seconds = seconds_between(prediction_dt, odds_dt)
+        odds_snapshot["odds_age_seconds_at_prediction"] = age_seconds
+        odds_snapshot["odds_age_minutes_at_prediction"] = (
+            age_seconds / 60.0 if age_seconds is not None else None
+        )
+        odds_snapshot["odds_captured_before_prediction"] = (
+            age_seconds is not None and age_seconds >= 0
+        )
+        odds_snapshot["odds_stale_at_prediction"] = (
+            age_seconds is not None and age_seconds > stale_odds_after_minutes * 60.0
+        )
+        odds_snapshot["stale_odds_after_minutes"] = stale_odds_after_minutes
+
+    if odds_dt is not None and feature_freeze_dt is not None:
+        freeze_age_seconds = seconds_between(feature_freeze_dt, odds_dt)
+        odds_snapshot["odds_age_seconds_at_feature_freeze"] = freeze_age_seconds
+        odds_snapshot["odds_age_minutes_at_feature_freeze"] = (
+            freeze_age_seconds / 60.0 if freeze_age_seconds is not None else None
+        )
+        odds_snapshot["odds_captured_before_feature_freeze"] = (
+            freeze_age_seconds is not None and freeze_age_seconds >= 0
+        )
+
+    jump_dt = parse_odds_timestamp(jump_datetime)
+    if odds_dt is not None and jump_dt is not None:
+        jump_age_seconds = seconds_between(jump_dt, odds_dt)
+        odds_snapshot["odds_age_seconds_at_jump"] = jump_age_seconds
+        odds_snapshot["odds_age_minutes_at_jump"] = (
+            jump_age_seconds / 60.0 if jump_age_seconds is not None else None
+        )
+        odds_snapshot["odds_captured_before_jump"] = (
+            jump_age_seconds is not None and jump_age_seconds >= 0
+        )
+
+    provenance = {
+        "source": _first_value(
+            row,
+            (
+                "odds_source",
+                "market_odds_source",
+                "live_odds_source",
+                "odds_provider",
+                "market_source",
+            ),
+        ),
+        "source_url": _first_value(
+            row,
+            (
+                "odds_source_url",
+                "market_odds_source_url",
+                "live_odds_source_url",
+                "source_url",
+                "sportsbet_url",
+            ),
+        ),
+        "source_table": _first_value(
+            row,
+            (
+                "odds_source_table",
+                "market_odds_source_table",
+                "live_odds_source_table",
+            ),
+        ),
+        "odds_id": _first_value(row, ("odds_id", "live_odds_id", "market_odds_id")),
+        "odds_race_id": _first_value(row, ("odds_race_id", "market_odds_race_id")),
+        "odds_dog_name": _first_value(
+            row,
+            (
+                "odds_dog_name",
+                "odds_dog_clean_name",
+                "market_odds_dog_name",
+                "market_odds_dog_clean_name",
+            ),
+        ),
+        "odds_box_number": _safe_int(
+            _first_value(row, ("odds_box_number", "market_odds_box_number"))
+        ),
+        "match_type": _first_value(row, ("odds_match_type", "market_odds_match_type")),
+        "match_method": _first_value(row, ("odds_match_method", "market_odds_match_method")),
+        "match_key": _first_value(row, ("odds_match_key", "market_odds_match_key")),
+        "match_confidence": _first_value(
+            row, ("odds_match_confidence", "market_odds_match_confidence")
+        ),
+        "candidate_count": _safe_int(
+            _first_value(
+                row,
+                (
+                    "odds_candidate_count",
+                    "market_odds_candidate_count",
+                    "odds_match_candidate_count",
+                ),
+            )
+        ),
+        "duplicate_count": _safe_int(
+            _first_value(
+                row,
+                (
+                    "odds_duplicate_count",
+                    "market_odds_duplicate_count",
+                    "duplicate_odds_count",
+                ),
+            )
+        ),
+        "sportsbet_box_source": _first_value(
+            row,
+            (
+                "odds_sportsbet_box_source",
+                "sportsbet_box_source",
+                "market_odds_sportsbet_box_source",
+            ),
+        ),
+        "sportsbet_list_position": _safe_int(
+            _first_value(
+                row,
+                (
+                    "odds_sportsbet_list_position",
+                    "sportsbet_list_position",
+                    "market_odds_sportsbet_list_position",
+                ),
+            )
+        ),
+        "sportsbet_raw_runner_text": _first_value(
+            row,
+            (
+                "odds_sportsbet_raw_runner_text",
+                "sportsbet_raw_runner_text",
+                "market_odds_sportsbet_raw_runner_text",
+            ),
+        ),
+        "capture_mode": _first_value(
+            row,
+            (
+                "odds_capture_mode",
+                "capture_mode",
+                "market_odds_capture_mode",
+            ),
+        ),
+        "fetch_timestamp": _first_value(
+            row,
+            (
+                "odds_fetch_timestamp",
+                "fetch_timestamp",
+                "fetched_at",
+                "odds_fetched_at",
+                "market_odds_fetched_at",
+            ),
+        ),
+    }
+    provenance = {key: value for key, value in provenance.items() if value not in (None, "")}
+    if provenance:
+        odds_snapshot["odds_provenance"] = provenance
+    return {key: value for key, value in odds_snapshot.items() if value is not None}
+
+
+def build_odds_snapshot_from_row(
+    row: Mapping[str, Any],
+    *,
+    prediction_time: datetime,
+    feature_freeze_time: datetime | None = None,
+    jump_time: datetime | None = None,
+    duplicate_count: int,
+    stale_odds_after_minutes: float = 30.0,
+) -> dict[str, Any]:
+    """Adapt a live-odds DB row into the canonical odds snapshot shape."""
+
+    adapted = {
+        "market_odds_win": row.get("odds_decimal"),
+        "market_type": row.get("market_type") or "win",
+        "odds_level": row.get("odds_level") or "dog",
+        "odds_timestamp": row.get("timestamp") or row.get("capture_timestamp"),
+        "odds_source": row.get("source"),
+        "odds_source_url": row.get("source_url"),
+        "odds_source_table": "live_odds",
+        "odds_id": row.get("id"),
+        "odds_race_id": row.get("race_id"),
+        "odds_dog_name": row.get("dog_clean_name") or row.get("dog_name"),
+        "odds_box_number": row.get("box_number"),
+        "odds_match_type": row.get("_match_basis") or "race_id_box_name",
+        "odds_match_method": "race_id_box_name_exact",
+        "odds_match_confidence": 1.0,
+        "odds_candidate_count": duplicate_count,
+        "odds_duplicate_count": duplicate_count,
+        "odds_sportsbet_box_source": row.get("sportsbet_box_source") or "unknown",
+        "odds_sportsbet_list_position": row.get("sportsbet_list_position"),
+        "odds_sportsbet_raw_runner_text": row.get("sportsbet_raw_runner_text"),
+        "odds_capture_mode": row.get("capture_mode"),
+    }
+    snapshot = build_odds_snapshot(
+        adapted,
+        prediction_timestamp=prediction_time.isoformat(),
+        feature_freeze_timestamp=feature_freeze_time.isoformat()
+        if feature_freeze_time is not None
+        else None,
+        jump_datetime=jump_time.isoformat() if jump_time is not None else None,
+        stale_odds_after_minutes=stale_odds_after_minutes,
+    )
+    provenance = snapshot.setdefault("odds_provenance", {})
+    provenance.setdefault("sportsbet_raw_runner_text", row.get("sportsbet_raw_runner_text"))
+    provenance.setdefault("capture_mode", row.get("capture_mode"))
+    return snapshot
+
+
+def _odds_match_method(provenance: Mapping[str, Any]) -> str | None:
+    method = provenance.get("match_method") or provenance.get("match_type")
+    return str(method).strip() if method not in (None, "") else None
+
+
+def classify_prejump_odds(
+    runner: Mapping[str, Any],
+    odds_snapshot: Mapping[str, Any] | None = None,
+    *,
+    snapshot_race_id: Any = None,
+) -> dict[str, Any]:
+    """Classify leakage-safe dog-level odds eligibility for EV calculation."""
+
+    snapshot = odds_snapshot if isinstance(odds_snapshot, Mapping) else {}
+    odds = _safe_float(
+        snapshot.get("market_odds_win")
+        or runner.get("odds")
+        or runner.get("odds_win")
+        or runner.get("market_odds_win")
+    )
+    provenance = (
+        snapshot.get("odds_provenance")
+        if isinstance(snapshot.get("odds_provenance"), Mapping)
+        else {}
+    )
+    method = _odds_match_method(provenance)
+    effective_method = method
+    canonical_match_method: str | None = None
+
+    def result(status: str) -> dict[str, Any]:
+        valid = status == "valid_pre_jump_dog_odds"
+        return {
+            "odds_match_status": status,
+            "odds_match_method": effective_method,
+            "odds_exclusion_reason": None if valid else status,
+            "odds_provenance_status": "complete" if valid else "excluded",
+            "is_ev_eligible": valid,
+            "normalized_win_odds": odds if valid else None,
+            "market_implied_raw": (1.0 / odds) if valid and odds and odds > 0 else None,
+            "reasons": [] if valid else [status],
+        }
+
+    if odds is None or odds <= 1.0:
+        return result("no_odds_row")
+
+    market_type = _normalize_market_type(snapshot.get("market_type"), snapshot)
+    if market_type in POST_RACE_OR_RESULT_ODDS_MARKETS:
+        return result("post_race_or_sp_only")
+    if market_type and market_type != "win":
+        return result("race_level_only_odds")
+
+    if str(snapshot.get("odds_level") or "").lower() in {"race", "race_level", "market"}:
+        return result("race_level_only_odds")
+
+    if not snapshot.get("odds_timestamp"):
+        return result("missing_timestamp")
+    if snapshot.get("odds_captured_before_prediction") is not True:
+        return result("timestamp_after_prediction")
+    if (
+        "odds_captured_before_feature_freeze" in snapshot
+        and snapshot.get("odds_captured_before_feature_freeze") is not True
+    ):
+        return result("timestamp_after_feature_freeze")
+    if (
+        "odds_captured_before_jump" in snapshot
+        and snapshot.get("odds_captured_before_jump") is not True
+    ):
+        return result("timestamp_after_jump")
+    if snapshot.get("odds_stale_at_prediction") is True:
+        return result("stale_beyond_ttl")
+
+    source = normalize_odds_source(provenance.get("source") or runner.get("odds_source"))
+    if source not in TRUSTED_ODDS_SOURCES:
+        return result("untrusted_source")
+    source_url = str(provenance.get("source_url") or "").strip()
+    if not source_url:
+        return result("missing_source_url")
+    if _source_url_is_post_race(source_url):
+        return result("post_race_or_sp_only")
+    source_table = str(provenance.get("source_table") or "").strip().lower()
+    if source_table in POST_RACE_SOURCE_TABLES:
+        return result("post_race_or_sp_only")
+
+    if snapshot_race_id and provenance.get("odds_race_id"):
+        race_match, canonical_method = race_ids_match(
+            snapshot_race_id,
+            provenance.get("odds_race_id"),
+        )
+        if not race_match:
+            return result("race_id_mismatch")
+        if canonical_method:
+            canonical_match_method = canonical_method
+
+    sportsbet_box_source = str(provenance.get("sportsbet_box_source") or "").strip().lower()
+    if sportsbet_box_source in {"list_position_fallback", "ambiguous_box_source"}:
+        return result("ambiguous_box_source")
+
+    runner_box = _safe_int(runner.get("box_number"))
+    odds_box = _safe_int(provenance.get("odds_box_number"))
+    if runner_box is not None and odds_box is not None and runner_box != odds_box:
+        return result("box_mismatch")
+
+    runner_name = runner.get("dog_name") or runner.get("dog_clean_name") or runner.get("name")
+    odds_name = provenance.get("odds_dog_name")
+    if odds_name and _normalize_identity(odds_name) != _normalize_identity(runner_name):
+        return result("dog_name_mismatch")
+
+    if _safe_int(provenance.get("duplicate_count")) and int(provenance["duplicate_count"]) > 1:
+        return result("duplicate_odds_rows")
+    if _safe_int(provenance.get("candidate_count")) and int(provenance["candidate_count"]) > 1:
+        return result("duplicate_odds_rows")
+
+    confidence = _safe_float(provenance.get("match_confidence"))
+    explicit_identity_match = (
+        runner_box is not None
+        and odds_box is not None
+        and runner_box == odds_box
+        and bool(odds_name)
+        and _normalize_identity(odds_name) == _normalize_identity(runner_name)
+    )
+    if canonical_match_method and explicit_identity_match:
+        effective_method = canonical_match_method
+    method_key = str(effective_method or "").strip().lower()
+    strict_method_match = method_key in STRICT_ODDS_MATCH_METHODS
+    if not explicit_identity_match and not strict_method_match:
+        return result("ambiguous_runner_identity")
+    if confidence is not None and confidence < 0.99:
+        return result("ambiguous_runner_identity")
+
+    return result("valid_pre_jump_dog_odds")
+
+
+def classify_odds_snapshot_for_ev(
+    runner: Mapping[str, Any],
+    odds_snapshot: Mapping[str, Any] | None = None,
+    *,
+    snapshot_race_id: Any = None,
+) -> dict[str, Any]:
+    return classify_prejump_odds(
+        runner,
+        odds_snapshot,
+        snapshot_race_id=snapshot_race_id,
+    )
+
+
+def is_ev_eligible(
+    runner: Mapping[str, Any],
+    odds_snapshot: Mapping[str, Any],
+    *,
+    snapshot_race_id: Any = None,
+) -> bool:
+    return classify_prejump_odds(
+        runner,
+        odds_snapshot,
+        snapshot_race_id=snapshot_race_id,
+    )["is_ev_eligible"] is True
+
+
+def ev_win_if_eligible(
+    win_prob_norm: Any,
+    runner: Mapping[str, Any],
+    odds_snapshot: Mapping[str, Any],
+    *,
+    snapshot_race_id: Any = None,
+) -> float | None:
+    if not is_ev_eligible(runner, odds_snapshot, snapshot_race_id=snapshot_race_id):
+        return None
+    probability = _safe_float(win_prob_norm)
+    odds = _safe_float(odds_snapshot.get("market_odds_win"))
+    if probability is None or odds is None:
+        return None
+    return probability * odds - 1.0

--- a/accuracy_program/snapshots.py
+++ b/accuracy_program/snapshots.py
@@ -9,9 +9,13 @@ from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Mapping
-from urllib.parse import urlparse
 
 from accuracy_program.calibration import power_normalize_prediction_group
+from accuracy_program.odds_provenance import (
+    build_odds_snapshot as _build_canonical_odds_snapshot,
+    classify_odds_snapshot_for_ev as _classify_canonical_odds_snapshot_for_ev,
+    ev_win_if_eligible as _canonical_ev_win_if_eligible,
+)
 
 try:
     from config.venue_mapping import normalize_venue
@@ -20,27 +24,6 @@ except Exception:
     def normalize_venue(value: str) -> str:
         return re.sub(r"[^A-Z0-9_]", "", str(value or "").upper())
 
-
-TRUSTED_ODDS_SOURCES = {"sportsbet"}
-POST_RACE_OR_RESULT_ODDS_MARKETS = {
-    "dividend",
-    "dividends",
-    "payout",
-    "result",
-    "results",
-    "sp",
-    "starting_price",
-    "startingprice",
-}
-POST_RACE_SOURCE_URL_MARKERS = ("dividend", "payout", "result")
-POST_RACE_SOURCE_TABLES = {"dog_race_data", "race_results", "results"}
-STRICT_ODDS_MATCH_METHODS = {
-    "dog_name_box",
-    "name_box",
-    "race_id_box_name",
-    "race_id_box_name_exact",
-    "strict_identity",
-}
 
 RESULT_FIELD_NAMES = {
     "actual_results",
@@ -123,58 +106,6 @@ def _safe_bool(value: Any) -> bool | None:
     return None
 
 
-def _normalize_identity(value: Any) -> str:
-    return re.sub(r"[^A-Z0-9]", "", str(value or "").upper())
-
-
-def _canonical_race_identity(value: Any) -> tuple[str, str, int] | None:
-    raw = str(value or "").strip()
-    if not raw:
-        return None
-
-    filename_match = re.match(
-        r"^\s*Race\s+(\d+)\s*-\s*(.+?)\s*-\s*(\d{4}-\d{2}-\d{2})\s*$",
-        raw,
-        re.IGNORECASE,
-    )
-    if filename_match:
-        race_number = filename_match.group(1)
-        venue = filename_match.group(2)
-        race_date = filename_match.group(3)
-    else:
-        canonical_match = re.match(
-            r"^\s*(.+?)_(\d{4}-\d{2}-\d{2})_(\d+)\s*$",
-            raw,
-            re.IGNORECASE,
-        )
-        if not canonical_match:
-            return None
-        venue = canonical_match.group(1)
-        race_date = canonical_match.group(2)
-        race_number = canonical_match.group(3)
-
-    try:
-        parsed_race_number = int(race_number)
-    except Exception:
-        return None
-
-    venue_code = normalize_venue(str(venue).replace("/", "_"))
-    if not venue_code or venue_code == "UNKNOWN":
-        return None
-    return (str(venue_code).upper(), str(race_date), parsed_race_number)
-
-
-def _race_ids_match(snapshot_race_id: Any, odds_race_id: Any) -> tuple[bool, str | None]:
-    if str(snapshot_race_id) == str(odds_race_id):
-        return True, None
-
-    snapshot_identity = _canonical_race_identity(snapshot_race_id)
-    odds_identity = _canonical_race_identity(odds_race_id)
-    if snapshot_identity is not None and snapshot_identity == odds_identity:
-        return True, "canonical_race_id_box_dog"
-    return False, None
-
-
 def _quality_flags(row: Mapping[str, Any]) -> list[str]:
     raw = row.get("quality_flags")
     if raw is None or (isinstance(raw, str) and not raw.strip()):
@@ -193,80 +124,6 @@ def _add_quality_flag(flags: list[str], flag: str) -> None:
         flags.append(flag)
 
 
-def _parse_timestamp(value: Any) -> datetime | None:
-    if value is None:
-        return None
-    raw = str(value).strip()
-    if not raw:
-        return None
-    for candidate in (raw, raw.replace("Z", "+00:00")):
-        try:
-            return datetime.fromisoformat(candidate)
-        except ValueError:
-            continue
-    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
-        try:
-            return datetime.strptime(raw[:19], fmt)
-        except ValueError:
-            continue
-    return None
-
-
-def _seconds_between(later: datetime, earlier: datetime) -> float:
-    compare_later = later
-    compare_earlier = earlier
-    if compare_earlier.tzinfo is not None and compare_later.tzinfo is None:
-        compare_later = compare_later.replace(tzinfo=compare_earlier.tzinfo)
-    elif compare_earlier.tzinfo is None and compare_later.tzinfo is not None:
-        compare_later = compare_later.replace(tzinfo=None)
-    return (compare_later - compare_earlier).total_seconds()
-
-
-def _first_value(row: Mapping[str, Any], keys: tuple[str, ...]) -> Any:
-    for key in keys:
-        value = row.get(key)
-        if value not in (None, ""):
-            return value
-    return None
-
-
-def _normalize_market_type(value: Any, odds_snapshot: Mapping[str, Any]) -> str:
-    raw = str(value or "").strip().lower()
-    if raw:
-        return re.sub(r"[^a-z0-9_]", "_", raw)
-    return "win" if odds_snapshot.get("market_odds_win") is not None else ""
-
-
-def _source_url_is_post_race(raw_url: Any) -> bool:
-    url = str(raw_url or "").strip().lower()
-    if not url:
-        return False
-    if any(marker in url for marker in POST_RACE_SOURCE_URL_MARKERS):
-        return True
-    try:
-        parsed = urlparse(url)
-        text = " ".join(part for part in (parsed.path, parsed.query, parsed.fragment) if part)
-    except Exception:
-        text = url
-    tokens = {token for token in re.split(r"[^a-z0-9]+", text.lower()) if token}
-    return (
-        "sp" in tokens
-        or "startingprice" in tokens
-        or ("starting" in tokens and "price" in tokens)
-    )
-
-
-def _normalize_odds_level(value: Any, row: Mapping[str, Any]) -> str:
-    raw = str(value or "").strip().lower()
-    if raw:
-        return re.sub(r"[^a-z0-9_]", "_", raw)
-    if row.get("box_number") is not None and (
-        row.get("dog_clean_name") or row.get("dog_name") or row.get("name")
-    ):
-        return "dog"
-    return "unknown"
-
-
 def _build_odds_snapshot(
     row: Mapping[str, Any],
     *,
@@ -275,173 +132,13 @@ def _build_odds_snapshot(
     jump_datetime: str | None,
     stale_odds_after_minutes: float,
 ) -> dict[str, Any]:
-    odds_snapshot = {
-        "market_odds_win": _safe_float(
-            row.get("market_odds_win", row.get("odds_win", row.get("live_odds")))
-        ),
-        "odds_implied_prob": _safe_float(row.get("odds_implied_prob")),
-        "odds_implied_prob_norm": _safe_float(row.get("odds_implied_prob_norm")),
-    }
-    odds_snapshot = {k: v for k, v in odds_snapshot.items() if v is not None}
-    odds_timestamp = _first_value(
+    return _build_canonical_odds_snapshot(
         row,
-        (
-            "odds_timestamp",
-            "market_odds_timestamp",
-            "live_odds_timestamp",
-            "odds_updated_at",
-            "odds_last_updated",
-        ),
+        prediction_timestamp=prediction_timestamp,
+        feature_freeze_timestamp=feature_freeze_timestamp,
+        jump_datetime=jump_datetime,
+        stale_odds_after_minutes=stale_odds_after_minutes,
     )
-    if odds_timestamp:
-        odds_snapshot["odds_timestamp"] = str(odds_timestamp)
-
-    market_type = _normalize_market_type(
-        _first_value(row, ("odds_market_type", "market_type", "market_odds_type")),
-        odds_snapshot,
-    )
-    if market_type:
-        odds_snapshot["market_type"] = market_type
-    odds_level = _normalize_odds_level(
-        _first_value(row, ("odds_level", "market_odds_level", "live_odds_level")),
-        row,
-    )
-    if odds_level:
-        odds_snapshot["odds_level"] = odds_level
-
-    odds_dt = _parse_timestamp(odds_timestamp)
-    prediction_dt = _parse_timestamp(prediction_timestamp)
-    feature_freeze_dt = _parse_timestamp(feature_freeze_timestamp)
-    if odds_dt is not None and prediction_dt is not None:
-        age_seconds = _seconds_between(prediction_dt, odds_dt)
-        odds_snapshot["odds_age_seconds_at_prediction"] = age_seconds
-        odds_snapshot["odds_age_minutes_at_prediction"] = age_seconds / 60.0
-        odds_snapshot["odds_captured_before_prediction"] = age_seconds >= 0
-        odds_snapshot["odds_stale_at_prediction"] = (
-            age_seconds > stale_odds_after_minutes * 60.0
-        )
-        odds_snapshot["stale_odds_after_minutes"] = stale_odds_after_minutes
-
-    if odds_dt is not None and feature_freeze_dt is not None:
-        freeze_age_seconds = _seconds_between(feature_freeze_dt, odds_dt)
-        odds_snapshot["odds_age_seconds_at_feature_freeze"] = freeze_age_seconds
-        odds_snapshot["odds_captured_before_feature_freeze"] = freeze_age_seconds >= 0
-
-    jump_dt = _parse_timestamp(jump_datetime)
-    if odds_dt is not None and jump_dt is not None:
-        odds_snapshot["odds_captured_before_jump"] = (
-            _seconds_between(jump_dt, odds_dt) >= 0
-        )
-
-    provenance = {
-        "source": _first_value(
-            row,
-            (
-                "odds_source",
-                "market_odds_source",
-                "live_odds_source",
-                "odds_provider",
-                "market_source",
-            ),
-        ),
-        "source_url": _first_value(
-            row,
-            (
-                "odds_source_url",
-                "market_odds_source_url",
-                "live_odds_source_url",
-                "source_url",
-                "sportsbet_url",
-            ),
-        ),
-        "source_table": _first_value(
-            row,
-            (
-                "odds_source_table",
-                "market_odds_source_table",
-                "live_odds_source_table",
-            ),
-        ),
-        "odds_id": _first_value(row, ("odds_id", "live_odds_id", "market_odds_id")),
-        "odds_race_id": _first_value(row, ("odds_race_id", "market_odds_race_id")),
-        "odds_dog_name": _first_value(
-            row,
-            (
-                "odds_dog_name",
-                "odds_dog_clean_name",
-                "market_odds_dog_name",
-                "market_odds_dog_clean_name",
-            ),
-        ),
-        "odds_box_number": _safe_int(
-            _first_value(row, ("odds_box_number", "market_odds_box_number"))
-        ),
-        "match_type": _first_value(row, ("odds_match_type", "market_odds_match_type")),
-        "match_method": _first_value(
-            row, ("odds_match_method", "market_odds_match_method")
-        ),
-        "match_key": _first_value(row, ("odds_match_key", "market_odds_match_key")),
-        "match_confidence": _first_value(
-            row, ("odds_match_confidence", "market_odds_match_confidence")
-        ),
-        "candidate_count": _safe_int(
-            _first_value(
-                row,
-                (
-                    "odds_candidate_count",
-                    "market_odds_candidate_count",
-                    "odds_match_candidate_count",
-                ),
-            )
-        ),
-        "duplicate_count": _safe_int(
-            _first_value(
-                row,
-                (
-                    "odds_duplicate_count",
-                    "market_odds_duplicate_count",
-                    "duplicate_odds_count",
-                ),
-            )
-        ),
-        "sportsbet_box_source": _first_value(
-            row,
-            (
-                "odds_sportsbet_box_source",
-                "sportsbet_box_source",
-                "market_odds_sportsbet_box_source",
-            ),
-        ),
-        "sportsbet_list_position": _safe_int(
-            _first_value(
-                row,
-                (
-                    "odds_sportsbet_list_position",
-                    "sportsbet_list_position",
-                    "market_odds_sportsbet_list_position",
-                ),
-            )
-        ),
-        "fetch_timestamp": _first_value(
-            row,
-            (
-                "odds_fetch_timestamp",
-                "fetch_timestamp",
-                "fetched_at",
-                "odds_fetched_at",
-                "market_odds_fetched_at",
-            ),
-        ),
-    }
-    provenance = {k: v for k, v in provenance.items() if v not in (None, "")}
-    if provenance:
-        odds_snapshot["odds_provenance"] = provenance
-    return odds_snapshot
-
-
-def _odds_match_method(provenance: Mapping[str, Any]) -> str | None:
-    method = provenance.get("match_method") or provenance.get("match_type")
-    return str(method).strip() if method not in (None, "") else None
 
 
 def classify_odds_snapshot_for_ev(
@@ -451,121 +148,11 @@ def classify_odds_snapshot_for_ev(
     snapshot_race_id: Any = None,
 ) -> dict[str, Any]:
     """Classify leakage-safe dog-level odds eligibility for EV calculation."""
-
-    snapshot = odds_snapshot if isinstance(odds_snapshot, Mapping) else {}
-    odds = _safe_float(
-        snapshot.get("market_odds_win")
-        or runner.get("odds")
-        or runner.get("odds_win")
-        or runner.get("market_odds_win")
+    return _classify_canonical_odds_snapshot_for_ev(
+        runner,
+        odds_snapshot,
+        snapshot_race_id=snapshot_race_id,
     )
-    provenance = (
-        snapshot.get("odds_provenance")
-        if isinstance(snapshot.get("odds_provenance"), Mapping)
-        else {}
-    )
-    method = _odds_match_method(provenance)
-    effective_method = method
-    canonical_match_method: str | None = None
-
-    def result(status: str) -> dict[str, Any]:
-        valid = status == "valid_pre_jump_dog_odds"
-        return {
-            "odds_match_status": status,
-            "odds_match_method": effective_method,
-            "odds_exclusion_reason": None if valid else status,
-            "odds_provenance_status": "complete" if valid else "excluded",
-            "is_ev_eligible": valid,
-        }
-
-    if odds is None or odds <= 1.0:
-        return result("no_odds_row")
-
-    market_type = _normalize_market_type(snapshot.get("market_type"), snapshot)
-    if market_type in POST_RACE_OR_RESULT_ODDS_MARKETS:
-        return result("post_race_or_sp_only")
-    if market_type and market_type != "win":
-        return result("race_level_only_odds")
-
-    if str(snapshot.get("odds_level") or "").lower() in {"race", "race_level", "market"}:
-        return result("race_level_only_odds")
-
-    if not snapshot.get("odds_timestamp"):
-        return result("missing_timestamp")
-    if snapshot.get("odds_captured_before_prediction") is not True:
-        return result("timestamp_after_prediction")
-    if (
-        "odds_captured_before_feature_freeze" in snapshot
-        and snapshot.get("odds_captured_before_feature_freeze") is not True
-    ):
-        return result("timestamp_after_feature_freeze")
-    if (
-        "odds_captured_before_jump" in snapshot
-        and snapshot.get("odds_captured_before_jump") is not True
-    ):
-        return result("timestamp_after_jump")
-    if snapshot.get("odds_stale_at_prediction") is True:
-        return result("stale_beyond_ttl")
-
-    source = str(provenance.get("source") or runner.get("odds_source") or "").strip().lower()
-    if source not in TRUSTED_ODDS_SOURCES:
-        return result("untrusted_source")
-    source_url = str(provenance.get("source_url") or "").strip()
-    if not source_url:
-        return result("missing_source_url")
-    if _source_url_is_post_race(source_url):
-        return result("post_race_or_sp_only")
-    source_table = str(provenance.get("source_table") or "").strip().lower()
-    if source_table in POST_RACE_SOURCE_TABLES:
-        return result("post_race_or_sp_only")
-
-    if snapshot_race_id and provenance.get("odds_race_id"):
-        race_ids_match, canonical_method = _race_ids_match(
-            snapshot_race_id,
-            provenance.get("odds_race_id"),
-        )
-        if not race_ids_match:
-            return result("race_id_mismatch")
-        if canonical_method:
-            canonical_match_method = canonical_method
-
-    sportsbet_box_source = str(provenance.get("sportsbet_box_source") or "").strip().lower()
-    if sportsbet_box_source in {"list_position_fallback", "ambiguous_box_source"}:
-        return result("ambiguous_box_source")
-
-    runner_box = _safe_int(runner.get("box_number"))
-    odds_box = _safe_int(provenance.get("odds_box_number"))
-    if runner_box is not None and odds_box is not None and runner_box != odds_box:
-        return result("box_mismatch")
-
-    runner_name = runner.get("dog_name") or runner.get("dog_clean_name") or runner.get("name")
-    odds_name = provenance.get("odds_dog_name")
-    if odds_name and _normalize_identity(odds_name) != _normalize_identity(runner_name):
-        return result("dog_name_mismatch")
-
-    if _safe_int(provenance.get("duplicate_count")) and int(provenance["duplicate_count"]) > 1:
-        return result("duplicate_odds_rows")
-    if _safe_int(provenance.get("candidate_count")) and int(provenance["candidate_count"]) > 1:
-        return result("duplicate_odds_rows")
-
-    confidence = _safe_float(provenance.get("match_confidence"))
-    explicit_identity_match = (
-        runner_box is not None
-        and odds_box is not None
-        and runner_box == odds_box
-        and bool(odds_name)
-        and _normalize_identity(odds_name) == _normalize_identity(runner_name)
-    )
-    if canonical_match_method and explicit_identity_match:
-        effective_method = canonical_match_method
-    method_key = str(effective_method or "").strip().lower()
-    strict_method_match = method_key in STRICT_ODDS_MATCH_METHODS
-    if not explicit_identity_match and not strict_method_match:
-        return result("ambiguous_runner_identity")
-    if confidence is not None and confidence < 0.99:
-        return result("ambiguous_runner_identity")
-
-    return result("valid_pre_jump_dog_odds")
 
 
 def _odds_valid_for_ev(
@@ -588,13 +175,12 @@ def _ev_win(
     *,
     snapshot_race_id: Any = None,
 ) -> float | None:
-    if not _odds_valid_for_ev(row, odds_snapshot, snapshot_race_id=snapshot_race_id):
-        return None
-    probability = _safe_float(win_prob_norm)
-    odds = _safe_float(odds_snapshot.get("market_odds_win"))
-    if probability is None or odds is None:
-        return None
-    return probability * odds - 1.0
+    return _canonical_ev_win_if_eligible(
+        win_prob_norm,
+        row,
+        odds_snapshot,
+        snapshot_race_id=snapshot_race_id,
+    )
 
 
 def _runner_odds_quality_flags(

--- a/prediction_pipeline_v4.py
+++ b/prediction_pipeline_v4.py
@@ -15,6 +15,10 @@ import pandas as pd
 import sqlite3
 from typing import Any, Optional
 
+from accuracy_program.odds_provenance import (
+    build_odds_snapshot as _build_canonical_odds_snapshot,
+    classify_odds_snapshot_for_ev as _classify_canonical_odds_snapshot_for_ev,
+)
 from ml_system_v4 import MLSystemV4
 from temporal_feature_builder import classify_dog_history_status
 from utils.feature_flags import load_flags
@@ -273,6 +277,12 @@ def _annotate_market_context(
     predictions: list[dict[str, Any]],
     win_odds: dict[str, float],
     win_odds_records: dict[str, dict[str, Any]] | None = None,
+    *,
+    prediction_timestamp: str | None = None,
+    feature_freeze_timestamp: str | None = None,
+    jump_datetime: str | None = None,
+    snapshot_race_id: str | None = None,
+    stale_odds_after_minutes: float = 30.0,
 ) -> dict[str, Any]:
     """Attach market-implied probabilities and disagreement flags without reranking."""
     if not predictions or not win_odds:
@@ -319,6 +329,34 @@ def _annotate_market_context(
             elif record.get("dog_clean_name"):
                 prediction["odds_match_method"] = "race_id_name"
                 prediction["odds_match_confidence"] = 0.5
+        if prediction_timestamp:
+            odds_snapshot = _build_canonical_odds_snapshot(
+                prediction,
+                prediction_timestamp=prediction_timestamp,
+                feature_freeze_timestamp=feature_freeze_timestamp or prediction_timestamp,
+                jump_datetime=jump_datetime,
+                stale_odds_after_minutes=stale_odds_after_minutes,
+            )
+            odds_decision = _classify_canonical_odds_snapshot_for_ev(
+                prediction,
+                odds_snapshot,
+                snapshot_race_id=(
+                    snapshot_race_id
+                    or (record.get("race_id") if isinstance(record, dict) else None)
+                ),
+            )
+            prediction["odds_snapshot"] = odds_snapshot
+            prediction["odds_match_status"] = odds_decision.get("odds_match_status")
+            prediction["odds_exclusion_reason"] = odds_decision.get(
+                "odds_exclusion_reason"
+            )
+            prediction["odds_provenance_status"] = odds_decision.get(
+                "odds_provenance_status"
+            )
+            if odds_decision.get("is_ev_eligible") is not True:
+                prediction["ev_win"] = None
+                prediction["ev_win_positive"] = False
+                _append_quality_flag(prediction, "invalid_pre_jump_odds")
 
     implied_total = sum(implied_by_index.values())
     threshold = _market_disagreement_threshold()
@@ -1198,10 +1236,46 @@ class PredictionPipelineV4:
                                         except Exception:
                                             p.setdefault("ev_win", None)
                                     p.setdefault("model_version", model_version)
+                            strict_odds_prediction_timestamp = str(
+                                result.get("prediction_timestamp")
+                                or result.get("generated_at")
+                                or datetime.now().astimezone().isoformat()
+                            )
+                            strict_odds_jump_datetime = (
+                                result.get("jump_datetime")
+                                or result.get("start_datetime")
+                                or result.get("race_start_time")
+                            )
+                            if not strict_odds_jump_datetime:
+                                try:
+                                    for column in (
+                                        "jump_datetime",
+                                        "start_datetime",
+                                        "race_start_time",
+                                    ):
+                                        if (
+                                            hasattr(race_data, "columns")
+                                            and column in race_data.columns
+                                            and not race_data[column].dropna().empty
+                                        ):
+                                            strict_odds_jump_datetime = str(
+                                                race_data[column].dropna().iloc[0]
+                                            )
+                                            break
+                                except Exception:
+                                    strict_odds_jump_datetime = None
                             market_summary = _annotate_market_context(
                                 preds,
                                 win_odds,
                                 win_odds_records,
+                                prediction_timestamp=strict_odds_prediction_timestamp,
+                                feature_freeze_timestamp=strict_odds_prediction_timestamp,
+                                jump_datetime=(
+                                    str(strict_odds_jump_datetime)
+                                    if strict_odds_jump_datetime
+                                    else None
+                                ),
+                                snapshot_race_id=race_id,
                             )
                             if market_summary.get("market_odds_count"):
                                 result["market_context"] = market_summary

--- a/scripts/collect_shadow_odds_snapshots.py
+++ b/scripts/collect_shadow_odds_snapshots.py
@@ -31,7 +31,11 @@ sys.path = [path for path in sys.path if path != ROOT_STR]
 sys.path.insert(0, ROOT_STR)
 
 from accuracy_program.odds_coverage import normalize_dog_name, normalize_venue  # noqa: E402
-from accuracy_program.snapshots import TRUSTED_ODDS_SOURCES, classify_odds_snapshot_for_ev  # noqa: E402
+from accuracy_program.odds_provenance import (  # noqa: E402
+    TRUSTED_ODDS_SOURCES,
+    build_odds_snapshot_from_row,
+    classify_odds_snapshot_for_ev,
+)
 from scripts.refresh_prejump_upcoming import venue_exclusion_aliases  # noqa: E402
 from utils.report_output_dir_guard import assert_prefixed_report_output_dir  # noqa: E402
 
@@ -1208,69 +1212,14 @@ def odds_snapshot_from_row(
     duplicate_count: int,
     stale_odds_after_minutes: float = DEFAULT_STALE_ODDS_AFTER_MINUTES,
 ) -> dict[str, Any]:
-    odds_timestamp = row.get("timestamp") or row.get("capture_timestamp")
-    odds_dt = parse_timestamp(odds_timestamp)
-    age_at_prediction = seconds_between(prediction_time, odds_dt)
-    status_info = runner_status_info(row)
-    provenance = {
-        "source": row.get("source"),
-        "source_url": row.get("source_url"),
-        "source_table": "live_odds",
-        "odds_id": row.get("id"),
-        "odds_race_id": row.get("race_id"),
-        "odds_dog_name": row.get("dog_clean_name") or row.get("dog_name"),
-        "odds_box_number": row.get("box_number"),
-        "match_type": row.get("_match_basis") or "race_id_box_name",
-        "match_method": "race_id_box_name_exact",
-        "match_confidence": 1.0,
-        "candidate_count": duplicate_count,
-        "duplicate_count": duplicate_count,
-        "sportsbet_box_source": row.get("sportsbet_box_source") or "unknown",
-        "sportsbet_list_position": row.get("sportsbet_list_position"),
-        "sportsbet_raw_runner_text": row.get("sportsbet_raw_runner_text"),
-        "capture_mode": row.get("capture_mode"),
-        "runner_status": status_info["runner_status"],
-        "runner_status_raw": status_info["runner_status_raw"],
-        "runner_status_source": status_info["runner_status_source"],
-        "runner_status_source_column": status_info["runner_status_source_column"],
-        "runner_status_trusted": status_info["runner_status_trusted"],
-    }
-    snapshot = {
-        "market_odds_win": row.get("odds_decimal"),
-        "market_type": row.get("market_type") or "win",
-        "odds_level": row.get("odds_level") or "dog",
-        "runner_status": status_info["runner_status"],
-        "runner_status_raw": status_info["runner_status_raw"],
-        "runner_status_source": status_info["runner_status_source"],
-        "runner_status_source_column": status_info["runner_status_source_column"],
-        "runner_status_trusted": status_info["runner_status_trusted"],
-        "runner_active_for_odds_gate": status_info["runner_active_for_odds_gate"],
-        "odds_timestamp": odds_timestamp,
-        "odds_age_seconds_at_prediction": age_at_prediction,
-        "odds_age_minutes_at_prediction": (
-            age_at_prediction / 60.0 if age_at_prediction is not None else None
-        ),
-        "odds_captured_before_prediction": (
-            age_at_prediction is not None and age_at_prediction >= 0
-        ),
-        "odds_provenance": provenance,
-    }
-    if age_at_prediction is not None:
-        snapshot["odds_stale_at_prediction"] = (
-            age_at_prediction > stale_odds_after_minutes * 60.0
-        )
-        snapshot["stale_odds_after_minutes"] = stale_odds_after_minutes
-    age_at_feature_freeze = seconds_between(feature_freeze_time, odds_dt)
-    if age_at_feature_freeze is not None:
-        snapshot["odds_age_seconds_at_feature_freeze"] = age_at_feature_freeze
-        snapshot["odds_age_minutes_at_feature_freeze"] = age_at_feature_freeze / 60.0
-        snapshot["odds_captured_before_feature_freeze"] = age_at_feature_freeze >= 0
-    age_at_jump = seconds_between(jump_time, odds_dt)
-    if age_at_jump is not None:
-        snapshot["odds_age_seconds_at_jump"] = age_at_jump
-        snapshot["odds_age_minutes_at_jump"] = age_at_jump / 60.0
-        snapshot["odds_captured_before_jump"] = age_at_jump >= 0
-    return {key: value for key, value in snapshot.items() if value is not None}
+    return build_odds_snapshot_from_row(
+        row,
+        prediction_time=prediction_time,
+        feature_freeze_time=feature_freeze_time,
+        jump_time=jump_time,
+        duplicate_count=duplicate_count,
+        stale_odds_after_minutes=stale_odds_after_minutes,
+    )
 
 
 def _race_id_from_prediction(prediction: Mapping[str, Any]) -> str:

--- a/scripts/evaluate_prediction_snapshots.py
+++ b/scripts/evaluate_prediction_snapshots.py
@@ -26,10 +26,8 @@ from accuracy_program.evaluation import (
     market_implied_probabilities,
     score_predictions,
 )
-from accuracy_program.snapshots import (
-    assert_no_result_fields,
-    classify_odds_snapshot_for_ev,
-)
+from accuracy_program.odds_provenance import classify_odds_snapshot_for_ev
+from accuracy_program.snapshots import assert_no_result_fields
 from utils.runner_completeness import (
     MIN_COMPLETE_RUNNERS,
     RunnerRow,

--- a/tests/test_collect_shadow_odds_snapshots.py
+++ b/tests/test_collect_shadow_odds_snapshots.py
@@ -391,7 +391,11 @@ def test_collect_shadow_odds_snapshot_marks_exact_dog_box_odds_eligible(tmp_path
     assert rows[0]["ev_win"] is None
     assert rows[0]["ev_calculation_status"] == "DISABLED_REPORT_ONLY_NO_EV_OUTPUT"
     assert rows[0]["odds_snapshot"]["odds_captured_before_jump"] is True
+    assert rows[0]["odds_snapshot"]["odds_age_minutes_at_jump"] == pytest.approx(694.0)
     assert rows[0]["odds_snapshot"]["odds_stale_at_prediction"] is False
+    provenance = rows[0]["odds_snapshot"]["odds_provenance"]
+    assert provenance["sportsbet_raw_runner_text"] == "1. Alpha Runner"
+    assert provenance["capture_mode"] == "autonomous_prejump_t60m"
     assert (output_dir / "shadow_odds_snapshot.csv").exists()
     assert (output_dir / "shadow_odds_race_coverage.json").exists()
     assert (output_dir / "odds_research_gate_report.json").exists()
@@ -1149,6 +1153,9 @@ def test_collect_shadow_odds_snapshot_blocks_after_feature_freeze_odds_when_avai
     )
     assert rows[0]["odds_snapshot"]["odds_captured_before_prediction"] is True
     assert rows[0]["odds_snapshot"]["odds_captured_before_feature_freeze"] is False
+    assert rows[0]["odds_snapshot"]["odds_age_minutes_at_feature_freeze"] == pytest.approx(
+        -1.0
+    )
     assert rows[0]["odds_snapshot"]["odds_captured_before_jump"] is True
     race = race_coverage["races"][0]
     assert race["post_prediction_odds_rows"] == 0

--- a/tests/test_odds_provenance_characterization.py
+++ b/tests/test_odds_provenance_characterization.py
@@ -1,0 +1,300 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from accuracy_program.odds_provenance import classify_odds_snapshot_for_ev
+from accuracy_program.snapshots import (
+    classify_odds_snapshot_for_ev as classify_snapshot_odds_for_ev,
+)
+
+
+SNAPSHOT_RACE_ID = "Race 4 - WRGL - 2026-05-21"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_real_prediction_pipeline_v4():
+    spec = importlib.util.spec_from_file_location(
+        "_real_prediction_pipeline_v4_for_odds_provenance_tests",
+        REPO_ROOT / "prediction_pipeline_v4.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _runner(**overrides):
+    runner = {
+        "dog_name": "Alpha Runner",
+        "box_number": 1,
+    }
+    runner.update(overrides)
+    return runner
+
+
+def _odds_snapshot(**overrides):
+    snapshot = {
+        "market_odds_win": 3.0,
+        "market_type": "win",
+        "odds_level": "dog",
+        "odds_timestamp": "2026-05-21T15:44:00",
+        "odds_captured_before_prediction": True,
+        "odds_captured_before_feature_freeze": True,
+        "odds_captured_before_jump": True,
+        "odds_stale_at_prediction": False,
+        "odds_provenance": {
+            "source": "SportsBet",
+            "source_url": "https://www.sportsbet.com.au/greyhound-racing/race-4",
+            "source_table": "live_odds",
+            "odds_race_id": SNAPSHOT_RACE_ID,
+            "odds_dog_name": "Alpha Runner",
+            "odds_box_number": 1,
+            "match_method": "race_id_box_name",
+            "match_confidence": 1.0,
+        },
+    }
+    provenance_overrides = overrides.pop("odds_provenance", None)
+    snapshot.update(overrides)
+    if provenance_overrides is not None:
+        snapshot["odds_provenance"] = {
+            **snapshot.get("odds_provenance", {}),
+            **provenance_overrides,
+        }
+    return snapshot
+
+
+@pytest.mark.parametrize(
+    ("expected_status", "snapshot_overrides", "runner_overrides"),
+    [
+        ("valid_pre_jump_dog_odds", {}, {}),
+        ("no_odds_row", {"market_odds_win": None}, {}),
+        ("post_race_or_sp_only", {"market_type": "sp"}, {}),
+        ("race_level_only_odds", {"market_type": "place"}, {}),
+        ("race_level_only_odds", {"odds_level": "race"}, {}),
+        ("missing_timestamp", {"odds_timestamp": None}, {}),
+        ("timestamp_after_prediction", {"odds_captured_before_prediction": False}, {}),
+        (
+            "timestamp_after_feature_freeze",
+            {"odds_captured_before_feature_freeze": False},
+            {},
+        ),
+        ("timestamp_after_jump", {"odds_captured_before_jump": False}, {}),
+        ("stale_beyond_ttl", {"odds_stale_at_prediction": True}, {}),
+        ("untrusted_source", {"odds_provenance": {"source": "unknownbook"}}, {}),
+        ("missing_source_url", {"odds_provenance": {"source_url": ""}}, {}),
+        (
+            "post_race_or_sp_only",
+            {"odds_provenance": {"source_table": "race_results"}},
+            {},
+        ),
+        (
+            "post_race_or_sp_only",
+            {
+                "odds_provenance": {
+                    "source_url": "https://sportsbet.com.au/greyhound-racing/results/race-4"
+                }
+            },
+            {},
+        ),
+        (
+            "race_id_mismatch",
+            {"odds_provenance": {"odds_race_id": "WRGL_2026-05-22_4"}},
+            {},
+        ),
+        (
+            "ambiguous_box_source",
+            {"odds_provenance": {"sportsbet_box_source": "list_position_fallback"}},
+            {},
+        ),
+        ("box_mismatch", {"odds_provenance": {"odds_box_number": 2}}, {}),
+        ("dog_name_mismatch", {"odds_provenance": {"odds_dog_name": "Beta Runner"}}, {}),
+        ("duplicate_odds_rows", {"odds_provenance": {"duplicate_count": 2}}, {}),
+        ("duplicate_odds_rows", {"odds_provenance": {"candidate_count": 2}}, {}),
+        (
+            "ambiguous_runner_identity",
+            {
+                "odds_provenance": {
+                    "odds_box_number": None,
+                    "match_method": "race_id_name",
+                }
+            },
+            {},
+        ),
+        (
+            "ambiguous_runner_identity",
+            {"odds_provenance": {"match_confidence": 0.5}},
+            {},
+        ),
+    ],
+)
+def test_odds_provenance_classifier_status_matrix(
+    expected_status,
+    snapshot_overrides,
+    runner_overrides,
+):
+    decision = classify_odds_snapshot_for_ev(
+        _runner(**runner_overrides),
+        _odds_snapshot(**snapshot_overrides),
+        snapshot_race_id=SNAPSHOT_RACE_ID,
+    )
+
+    assert decision["odds_match_status"] == expected_status
+    assert decision["is_ev_eligible"] is (expected_status == "valid_pre_jump_dog_odds")
+    if expected_status == "valid_pre_jump_dog_odds":
+        assert decision["odds_exclusion_reason"] is None
+        assert decision["odds_provenance_status"] == "complete"
+    else:
+        assert decision["odds_exclusion_reason"] == expected_status
+        assert decision["odds_provenance_status"] == "excluded"
+
+
+def test_odds_provenance_classifier_accepts_canonical_race_id_equivalence():
+    decision = classify_odds_snapshot_for_ev(
+        _runner(),
+        _odds_snapshot(odds_provenance={"odds_race_id": "WRGL_2026-05-21_4"}),
+        snapshot_race_id=SNAPSHOT_RACE_ID,
+    )
+
+    assert decision["odds_match_status"] == "valid_pre_jump_dog_odds"
+    assert decision["odds_match_method"] == "canonical_race_id_box_dog"
+    assert decision["is_ev_eligible"] is True
+
+
+def test_snapshot_compatibility_export_uses_central_odds_provenance():
+    central = classify_odds_snapshot_for_ev(
+        _runner(),
+        _odds_snapshot(odds_provenance={"source_url": ""}),
+        snapshot_race_id=SNAPSHOT_RACE_ID,
+    )
+    compatibility = classify_snapshot_odds_for_ev(
+        _runner(),
+        _odds_snapshot(odds_provenance={"source_url": ""}),
+        snapshot_race_id=SNAPSHOT_RACE_ID,
+    )
+
+    assert compatibility["odds_match_status"] == "missing_source_url"
+    assert compatibility == central
+
+
+def test_live_market_context_clears_raw_ev_when_strict_provenance_fails():
+    pipeline = _load_real_prediction_pipeline_v4()
+
+    predictions = [
+        {
+            "dog_clean_name": "Alpha Runner",
+            "box_number": 1,
+            "win_prob_norm": 0.4,
+            "ev_win": 0.2,
+            "ev_win_positive": True,
+        }
+    ]
+    market_odds = {"Alpha Runner": 3.0}
+    market_records = {
+        "Alpha Runner": {
+            "id": 10,
+            "race_id": SNAPSHOT_RACE_ID,
+            "dog_clean_name": "Alpha Runner",
+            "box_number": 1,
+            "odds_decimal": 3.0,
+            "market_type": "win",
+            "source": "sportsbet",
+            "timestamp": "2026-05-21T15:44:00",
+            "source_url": "",
+            "odds_level": "dog",
+        }
+    }
+
+    pipeline._annotate_market_context(
+        predictions,
+        market_odds,
+        market_records,
+        prediction_timestamp="2026-05-21T15:45:00",
+        feature_freeze_timestamp="2026-05-21T15:45:00",
+        jump_datetime="2026-05-21T15:58:00",
+        snapshot_race_id=SNAPSHOT_RACE_ID,
+    )
+
+    runner = predictions[0]
+    assert runner["odds_match_status"] == "missing_source_url"
+    assert runner["odds_provenance_status"] == "excluded"
+    assert runner["ev_win"] is None
+    assert runner["ev_win_positive"] is False
+    assert "invalid_pre_jump_odds" in runner["quality_flags"]
+
+
+def test_live_market_context_preserves_raw_ev_when_strict_provenance_passes():
+    pipeline = _load_real_prediction_pipeline_v4()
+
+    predictions = [
+        {
+            "dog_clean_name": "Alpha Runner",
+            "box_number": 1,
+            "win_prob_norm": 0.4,
+            "ev_win": 0.2,
+            "ev_win_positive": True,
+        }
+    ]
+    market_odds = {"Alpha Runner": 3.0}
+    market_records = {
+        "Alpha Runner": {
+            "id": 10,
+            "race_id": SNAPSHOT_RACE_ID,
+            "dog_clean_name": "Alpha Runner",
+            "box_number": 1,
+            "odds_decimal": 3.0,
+            "market_type": "win",
+            "source": "sportsbet",
+            "timestamp": "2026-05-21T15:44:00",
+            "source_url": "https://www.sportsbet.com.au/greyhound-racing/race-4",
+            "odds_level": "dog",
+        }
+    }
+
+    pipeline._annotate_market_context(
+        predictions,
+        market_odds,
+        market_records,
+        prediction_timestamp="2026-05-21T15:45:00",
+        feature_freeze_timestamp="2026-05-21T15:45:00",
+        jump_datetime="2026-05-21T15:58:00",
+        snapshot_race_id=SNAPSHOT_RACE_ID,
+    )
+
+    runner = predictions[0]
+    assert runner["odds_match_status"] == "valid_pre_jump_dog_odds"
+    assert runner["odds_provenance_status"] == "complete"
+    assert runner["ev_win"] == pytest.approx(0.2)
+    assert runner["ev_win_positive"] is True
+
+
+def test_live_market_context_fails_closed_when_price_has_no_provenance_record():
+    pipeline = _load_real_prediction_pipeline_v4()
+
+    predictions = [
+        {
+            "dog_clean_name": "Alpha Runner",
+            "box_number": 1,
+            "win_prob_norm": 0.4,
+            "ev_win": 0.2,
+            "ev_win_positive": True,
+        }
+    ]
+    market_odds = {"Alpha Runner": 3.0}
+
+    pipeline._annotate_market_context(
+        predictions,
+        market_odds,
+        None,
+        prediction_timestamp="2026-05-21T15:45:00",
+        feature_freeze_timestamp="2026-05-21T15:45:00",
+        jump_datetime="2026-05-21T15:58:00",
+        snapshot_race_id=SNAPSHOT_RACE_ID,
+    )
+
+    runner = predictions[0]
+    assert runner["odds_match_status"] == "missing_timestamp"
+    assert runner["odds_provenance_status"] == "excluded"
+    assert runner["ev_win"] is None
+    assert runner["ev_win_positive"] is False
+    assert "invalid_pre_jump_odds" in runner["quality_flags"]


### PR DESCRIPTION
## Summary
- Adopt the strict pre-jump odds provenance slice onto the current `feature/dog-odds-snapshot-readiness` base.
- Add `accuracy_program/odds_provenance.py` as the canonical odds snapshot/provenance builder and EV eligibility classifier.
- Route snapshot construction, shadow odds capture, coverage analysis, evaluator classification, and live market context through the centralized classifier.
- Preserve current branch provenance details such as `capture_mode` and `sportsbet_raw_runner_text` in shadow odds snapshots.

## Validation
- `uv run --with-requirements requirements/requirements.lock pytest tests/test_odds_provenance_characterization.py tests/test_collect_shadow_odds_snapshots.py tests/test_odds_snapshot_readiness.py tests/test_accuracy_program.py -q` -> 85 passed
- `uv run --with-requirements requirements/requirements.lock python -m compileall accuracy_program/odds_provenance.py accuracy_program/snapshots.py accuracy_program/odds_coverage.py prediction_pipeline_v4.py scripts/collect_shadow_odds_snapshots.py scripts/evaluate_prediction_snapshots.py tests/test_collect_shadow_odds_snapshots.py tests/test_odds_provenance_characterization.py` -> passed
- `git diff --check && git diff origin/feature/dog-odds-snapshot-readiness --check` -> passed

## Notes
- `tests/test_prediction_pipeline_ranking_regressions.py` was probed as an adjacent suite but is not runnable in this clean sibling worktree because the local Race 11 CSV and prediction JSON fixtures are absent/untracked.
