### PR TITLE
Preserve reviewed Greyhound evidence artifacts

### DIFF
--- a/.playwright-mcp/page-2026-07-09T09-37-09-835Z.yml
+++ b/.playwright-mcp/page-2026-07-09T09-37-09-835Z.yml
@@ -1,0 +1,1 @@
+- heading "403 Forbidden" [level=1] [ref=e3]

--- a/artifacts/full_evidence_orchestration_20260525/daemon_orchestrator_decision_packet_20260616T172233+1000/README.md
+++ b/artifacts/full_evidence_orchestration_20260525/daemon_orchestrator_decision_packet_20260616T172233+1000/README.md
@@ -1,0 +1,97 @@
+# Greyhound Daemon Orchestrator Decision Packet
+
+Generated: 2026-06-16T17:22:33+10:00
+
+## Decision
+
+`DATA_MISSING`
+
+The patched deterministic reserve-remap policy is report-only ready for a controlled backlog rejoin subset, but the full daemon readiness objective is still blocked. Current-cycle official result rows are absent, cumulative pending remains nonzero, and strict replay still leaves unresolved unsafe joins.
+
+Sub-decision: `REPORT_ONLY_BACKLOG_REJOIN_READY_FOR_RESERVE_SUBSET`
+
+## Current State
+
+- Primary checkout: `/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound_racing_collector`
+- Primary HEAD: `554bea2875ad41f55b2f100cd0f26ea358f83d0b`
+- Runtime checkout: `/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610`
+- Runtime HEAD: `2bbd35743fbb00373d132a25687c4d2f158aabe4`
+- Latest completed full packet: `/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemonization_v1_20260616T170209+1000/`
+- Newer full attempt: `/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemonization_v1_20260616T171700+1000/`
+- Newer full attempt status: incomplete, lock-held, `DAEMON_WAITING_FOR_ODDS_CAPTURE_LOCK`
+
+## Counts
+
+Latest completed join:
+
+- Safe joined races: `0`
+- Pending races: `15`
+- Unsafe races: `0`
+- Pending reason: `official_result_rows_not_present=15`
+
+Cumulative aggregate before replay:
+
+- Safe joined races: `442`
+- Safe runner rows: `3117`
+- Pending races: `82`
+- Unsafe races: `70`
+- Pending reasons: `official_result_rows_not_present=66`, `no_race_url_available_for_lookup=16`
+
+Main-agent dry replay of the 70 unsafe rows under current patched identity policy:
+
+- Safe after replay: `502`
+- Pending after replay: `82`
+- Unsafe after replay: `10`
+- Delta: `+60 safe`, `0 pending`, `-60 unsafe`
+- Accepted reserve remaps: `66`
+- Rejected reserve remaps: `0`
+- Remaining unsafe reasons: `winner_count_not_exactly_one=6`, `extra_official_non_scratch_boxes_outside_prediction_set=5`, `dog_name_mismatch_after_exact_badge_stripping=1`
+
+## Official Result Availability
+
+Cumulative pending classification from the report-only audit:
+
+- `32` races have extracted official rows but remain pending in aggregate joins.
+- `18` races now have parseable page rows but are absent from the latest official-result capture artifact.
+- `16` races have pages available but no official finish rows yet.
+- `16` races have no race URL available for lookup.
+
+The latest 15 current-cycle pending races were classified at artifact time as `race_not_jumped:upcoming_not_jumped`.
+
+## Feature Gate
+
+`same_distance_same_grade_best_time` and `same_distance_same_grade_avg_time` remain quarantined.
+
+- Train coverage for both: `0/751`
+- Holdout coverage for both: `10/192`
+- Current same-distance provenance audit: strict prior-race-only path passes.
+- Activation blockers: all-missing in train, train rows below minimum, train pct below minimum, train unique values below minimum, train/holdout ratio unstable, inactive by train-all-missing policy, missing shadow metric comparison.
+
+Minimum activation conditions remain:
+
+- Train present rows `>=30`
+- Train present pct `>=5%`
+- Train unique values `>=5`
+- Stable train/holdout ratio
+- Fresh candidate metric comparison
+- Strict history-before-race provenance with no target-race rows, no result fields, no market or odds features
+
+## No-Mutation Statement
+
+No training, promotion, model registry mutation, label write, snapshot mutation, manifest mutation, production pointer write, betting action, EV action, or daemon trigger was performed by this orchestrator closeout.
+
+The already enabled append-only live odds capture lane belongs to the running service state and was not manually triggered here.
+
+## Verification
+
+- Primary tracked status: clean before packet creation except preserved untracked artifacts.
+- Runtime tracked status: clean; large pre-existing untracked artifact surface preserved.
+- Services point at runtime checkout.
+- `uv run --with-requirements requirements/requirements.lock python -m py_compile scripts/ingest_results_for_date.py scripts/join_forward_shadow_results.py scripts/shadow_autopilot_v1.py scripts/shadow_autopilot_daemon.py`: pass.
+- `uv run --with-requirements requirements/requirements.lock pytest -q tests/test_results_ingest_official_first.py::test_result_validation_rejects_official_boxes_outside_local_participants tests/test_join_forward_shadow_results.py::test_classify_join_rejects_fuzzy_name_mismatch tests/test_shadow_autopilot_daemon.py::test_feature_activation_gate_status_from_autopilot_packet tests/test_shadow_autopilot_v1.py::test_summary_surfaces_feature_activation_gate_status`: pass, `4 passed`.
+- `git diff --check`: pass.
+- Main-agent dry replay matched subagent replay: 70 unsafe inputs, 60 safe after replay, 10 unsafe after replay, 66 reserve remaps accepted, 0 rejected.
+
+## Next Safe Action
+
+Run a controlled report-only backlog rejoin packet using the patched deterministic reserve-remap policy, and separately refresh official-result capture/report-only availability for the 18 parseable-but-not-captured pending races. Keep same-distance/same-grade timing features quarantined until train coverage and metric-comparison gates pass.

--- a/artifacts/full_evidence_orchestration_20260525/daemon_orchestrator_decision_packet_20260616T172233+1000/verification_results.txt
+++ b/artifacts/full_evidence_orchestration_20260525/daemon_orchestrator_decision_packet_20260616T172233+1000/verification_results.txt
@@ -1,0 +1,23 @@
+Generated: 2026-06-16T17:22:33+10:00
+
+Commands/results:
+
+1. git status --short --branch
+   Primary tracked source had no tracked modifications before packet creation; preserved untracked artifact dirs remained.
+
+2. systemctl --user show shadow-autopilot.service shadow-autopilot-odds-capture.service shadow-autopilot.timer shadow-autopilot-odds-capture.timer --property=Id,ActiveState,SubState,Result,ExecMainStartTimestamp,InactiveEnterTimestamp,LastTriggerUSec,NextElapseUSecRealtime,WorkingDirectory
+   PASS. Services point at /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610.
+
+3. uv run --with-requirements requirements/requirements.lock python -m py_compile scripts/ingest_results_for_date.py scripts/join_forward_shadow_results.py scripts/shadow_autopilot_v1.py scripts/shadow_autopilot_daemon.py
+   PASS.
+
+4. uv run --with-requirements requirements/requirements.lock pytest -q tests/test_results_ingest_official_first.py::test_result_validation_rejects_official_boxes_outside_local_participants tests/test_join_forward_shadow_results.py::test_classify_join_rejects_fuzzy_name_mismatch tests/test_shadow_autopilot_daemon.py::test_feature_activation_gate_status_from_autopilot_packet tests/test_shadow_autopilot_v1.py::test_summary_surfaces_feature_activation_gate_status
+   PASS: 4 passed.
+
+5. git diff --check
+   PASS.
+
+6. Main-agent dry replay using scripts.join_forward_shadow_results.classify_result_identity_join against latest aggregate unsafe_result_matches.json
+   PASS: input_unsafe_count=70, safe_after_replay=60, unsafe_after_replay=10, accepted_reserve_remaps=66, rejected_reserve_remaps=0.
+
+No training, promotion, model registry mutation, label write, snapshot mutation, manifest mutation, production pointer write, betting action, EV action, or manual daemon trigger was performed.

--- a/docs/agent_tasks/v2_merge_preserved_greyhound_evidence_pr44_v1_20260716.md
+++ b/docs/agent_tasks/v2_merge_preserved_greyhound_evidence_pr44_v1_20260716.md
@@ -1,0 +1,72 @@
+---
+job_id: v2_merge_preserved_greyhound_evidence_pr44_v1_20260716
+lane: Reporting
+supporting_lanes:
+  - Repo Hygiene
+owner: Codex
+allowed_files:
+  - docs/agent_tasks/v2_merge_preserved_greyhound_evidence_pr44_v1_20260716.md
+  - reports/agent_jobs/v2_merge_preserved_greyhound_evidence_pr44_v1_20260716/STATE.md
+  - reports/agent_jobs/v2_merge_preserved_greyhound_evidence_pr44_v1_20260716/VALIDATION.md
+  - reports/agent_jobs/v2_merge_preserved_greyhound_evidence_pr44_v1_20260716/RUN_OUTCOME.json
+  - reports/agent_jobs/v2_merge_preserved_greyhound_evidence_pr44_v1_20260716/DECISION_ENTRY.json
+  - reports/agent_jobs/v2_merge_preserved_greyhound_evidence_pr44_v1_20260716/status.json
+approval_required: true
+allow_unapproved_safe_extension: false
+timeout_seconds: 7200
+output_dir: reports/agent_jobs/v2_merge_preserved_greyhound_evidence_pr44_v1_20260716
+mutation_mode: safe_extension
+production_data_access: false
+closeout_scope: control_plane_only
+control_contract_version: 2
+project_id: greyhound_racing_collector
+claim_id: merge_preserved_greyhound_evidence_pr44_20260716
+proof_question: Can owner-approved draft PR 44 be made ready and merged by a normal merge commit after a fresh exact-head and all-checks-pass audit without changing its preserved evidence or any runtime, data, service, unit, seed, dirty, or stale surface?
+hypothesis_id: exact_green_pr44_owner_approved_merge_v1
+program_track: offline_development
+entry_state: exact_green_mergeable_draft_pr44_at_9f9b1fc3
+target_transition: preserved_greyhound_evidence_merged_to_master_with_exact_head_ancestry
+exit_predicate: The final PR 44 head consists of the previously green 9f9b1fc3f344de06e93bc1872b5ba1213f18c5a3 evidence head plus only this merge card, all required checks pass on that final head, PR 44 is marked ready and merged by a normal merge commit, and live master contains the final PR head as an ancestor.
+source_class: owner_approved_green_github_pull_request
+dataset_version: greyhound_pr44_base_d3c27ce2_head_9f9b1fc3_20260716
+evidence_hash: sha256:c6a41735dd6f278f1baba0f35e166a4840df82e9ae0df1d4fc5dbb9c73b96556
+capabilities:
+  - READ
+  - REPORT_WRITE
+  - PUBLISH
+resume_only_if: PR 44 head, base, draft state, mergeability, required checks, source blob identity, owner approval, origin/master, registry state, or worktree cleanliness changes.
+---
+
+# Merge preserved Greyhound evidence PR 44
+
+Close the already published evidence-preservation lane after the owner's
+explicit 2026-07-16 approval to mark PR #44 ready and merge it.
+
+## Authorized sequence
+
+1. Commit only this merge-authorization card and validate it.
+2. Claim the V2 task and rerun the portable guard and identity checks.
+3. Push only the task-card commit to the existing PR branch.
+4. Wait for every required check on the final PR head to pass.
+5. Reverify the live PR head, base, file scope, mergeability, and check results.
+6. Mark PR #44 ready and merge it with a normal merge commit.
+7. Verify live `master` contains the exact final PR head as an ancestor, write
+   the ignored closeout bundle, and release the claim.
+
+## Hard boundaries
+
+- Do not edit any previously published evidence or task card.
+- Do not squash, rebase, force-push, auto-merge, delete the branch, or remove a
+  worktree.
+- Do not touch databases, dependencies, installed hooks, units, services,
+  timers, live runtime, production data, models, decision-ledger seeds, dirty
+  checkouts, stale checkouts, or unrelated GitHub issues and PRs.
+- Do not restore or reactivate the abandoned Greyhound global dispatcher.
+- Stop before merge if the final head, base, scope, mergeability, checks, owner
+  approval, or exact source evidence identity changes unexpectedly.
+
+## Docs impact
+
+`DOCS_NOT_REQUIRED`: this task records approval and merges an evidence-only PR;
+it changes no product behavior, command, schema, workflow, interface, or safety
+boundary.

--- a/docs/agent_tasks/v2_preserve_greyhound_untracked_evidence_v1_20260715.md
+++ b/docs/agent_tasks/v2_preserve_greyhound_untracked_evidence_v1_20260715.md
@@ -1,0 +1,76 @@
+---
+job_id: v2_preserve_greyhound_untracked_evidence_v1_20260715
+lane: Reporting
+supporting_lanes:
+  - Repo Hygiene
+owner: Codex
+allowed_files:
+  - docs/agent_tasks/v2_preserve_greyhound_untracked_evidence_v1_20260715.md
+  - .playwright-mcp/page-2026-07-09T09-37-09-835Z.yml
+  - artifacts/full_evidence_orchestration_20260525/daemon_orchestrator_decision_packet_20260616T172233+1000/README.md
+  - artifacts/full_evidence_orchestration_20260525/daemon_orchestrator_decision_packet_20260616T172233+1000/verification_results.txt
+  - reports/agent_jobs/v2_preserve_greyhound_untracked_evidence_v1_20260715/STATE.md
+  - reports/agent_jobs/v2_preserve_greyhound_untracked_evidence_v1_20260715/VALIDATION.md
+  - reports/agent_jobs/v2_preserve_greyhound_untracked_evidence_v1_20260715/RUN_OUTCOME.json
+  - reports/agent_jobs/v2_preserve_greyhound_untracked_evidence_v1_20260715/DECISION_ENTRY.json
+  - reports/agent_jobs/v2_preserve_greyhound_untracked_evidence_v1_20260715/status.json
+approval_required: true
+allow_unapproved_safe_extension: false
+timeout_seconds: 3600
+output_dir: reports/agent_jobs/v2_preserve_greyhound_untracked_evidence_v1_20260715
+mutation_mode: safe_extension
+production_data_access: false
+closeout_scope: repo_only
+control_contract_version: 2
+project_id: greyhound_racing_collector
+claim_id: preserve_greyhound_untracked_evidence_20260715
+proof_question: Can the owner-approved three untracked Greyhound evidence files be preserved in one local commit without altering their bytes or any database, unit, runtime, seed, or unrelated checkout state?
+hypothesis_id: exact_hash_preservation_commit_v1
+program_track: offline_development
+entry_state: three_owner_approved_untracked_evidence_files
+target_transition: exact_three_file_evidence_preserved_in_local_git_history
+exit_predicate: One local commit contains this task card and the exact three reviewed evidence files at their recorded hashes, with no other path changed.
+source_class: owner_approved_existing_greyhound_evidence
+dataset_version: greyhound_head_158ea4affc31
+evidence_hash: sha256:de71e151c42eb97aed84dabd81fb2abac5fcd46c4d49f4cc13d843048fca848e
+capabilities:
+  - READ
+  - REPORT_WRITE
+  - PUBLISH
+resume_only_if: The three file hashes, Greyhound HEAD, owner authorization, or repository dirt changes before commit.
+---
+
+# Preserve existing Greyhound untracked evidence
+
+Commit the three owner-approved untracked evidence files without changing their
+contents.
+
+## Bound evidence
+
+- `.playwright-mcp/page-2026-07-09T09-37-09-835Z.yml`:
+  `sha256:6afea606eda0b554a543b503bdc88a52f64c68d084ead50233d5d9b72f8b7f56`
+- `README.md`:
+  `sha256:de71e151c42eb97aed84dabd81fb2abac5fcd46c4d49f4cc13d843048fca848e`
+- `verification_results.txt`:
+  `sha256:4d61c0f1ab6d8f4b823ae836bbdc12829804af72a473ce4df77d09be1788488b`
+
+## Hard boundaries
+
+- Do not edit the three evidence files.
+- Do not restore or reactivate the abandoned Greyhound global dispatcher.
+- Do not touch databases, units, services, timers, runtime state, seed or dirty
+  checkouts, dependencies, GitHub, or unrelated artifacts.
+- Do not push, merge, rebase, reset, stash, clean, delete, or remove worktrees.
+
+## Required checks
+
+- Validate and claim this V2 task card.
+- Run portable Git guard and identity checks.
+- Verify the three hashes before staging and after commit.
+- Stage only this task card and the three bound evidence files.
+- Review the staged diff and commit locally once.
+
+## Docs impact
+
+`DOCS_NOT_REQUIRED`: exact preservation of existing evidence does not change
+workflow, runtime, schema, commands, or safety behavior.

--- a/docs/agent_tasks/v2_publish_preserved_greyhound_evidence_v1_20260715.md
+++ b/docs/agent_tasks/v2_publish_preserved_greyhound_evidence_v1_20260715.md
@@ -1,0 +1,74 @@
+---
+job_id: v2_publish_preserved_greyhound_evidence_v1_20260715
+lane: Reporting
+supporting_lanes:
+  - Repo Hygiene
+owner: Codex
+allowed_files:
+  - docs/agent_tasks/v2_publish_preserved_greyhound_evidence_v1_20260715.md
+  - docs/agent_tasks/v2_preserve_greyhound_untracked_evidence_v1_20260715.md
+  - .playwright-mcp/page-2026-07-09T09-37-09-835Z.yml
+  - artifacts/full_evidence_orchestration_20260525/daemon_orchestrator_decision_packet_20260616T172233+1000/README.md
+  - artifacts/full_evidence_orchestration_20260525/daemon_orchestrator_decision_packet_20260616T172233+1000/verification_results.txt
+  - reports/agent_jobs/v2_publish_preserved_greyhound_evidence_v1_20260715/STATE.md
+  - reports/agent_jobs/v2_publish_preserved_greyhound_evidence_v1_20260715/VALIDATION.md
+  - reports/agent_jobs/v2_publish_preserved_greyhound_evidence_v1_20260715/RUN_OUTCOME.json
+  - reports/agent_jobs/v2_publish_preserved_greyhound_evidence_v1_20260715/DECISION_ENTRY.json
+  - reports/agent_jobs/v2_publish_preserved_greyhound_evidence_v1_20260715/status.json
+approval_required: true
+allow_unapproved_safe_extension: false
+timeout_seconds: 3600
+output_dir: reports/agent_jobs/v2_publish_preserved_greyhound_evidence_v1_20260715
+mutation_mode: safe_extension
+production_data_access: false
+closeout_scope: repo_only
+control_contract_version: 2
+project_id: greyhound_racing_collector
+claim_id: publish_preserved_greyhound_evidence_20260715
+proof_question: Can the approved preservation commit be transplanted unchanged onto current Greyhound master and published as one focused draft PR without touching stale, dirty, seed, data, unit, service, or runtime surfaces?
+hypothesis_id: current_master_evidence_publication_v1
+program_track: offline_development
+entry_state: local_evidence_commit_on_stale_diverged_branch
+target_transition: exact_preserved_evidence_available_in_current_master_draft_pr
+exit_predicate: A clean current-master branch contains this publication card and the exact four-file diff from e23951cf5ee2a61ae57034273d3464dd1e51828f, the branch is pushed, and one focused draft PR targets master.
+source_class: owner_approved_local_git_commit
+dataset_version: greyhound_master_d3c27ce21900_source_e23951cf5ee2
+evidence_hash: sha256:b0014977d71094a687df9f2e5f0703ffb7867f1b930030d1c5974ee53cce010d
+capabilities:
+  - READ
+  - REPORT_WRITE
+  - CODE_EDIT
+  - PUBLISH
+resume_only_if: Greyhound origin/master, source commit e23951cf5ee2a61ae57034273d3464dd1e51828f, remote publication branch, matching PR state, or repository cleanliness changes.
+---
+
+# Publish preserved Greyhound evidence
+
+Publish the already reviewed evidence preservation commit from a clean sibling
+worktree based on current `origin/master`.
+
+## Authorized sequence
+
+1. Validate and commit this task card as the task-card-only bootstrap commit.
+2. Claim the task and run the portable post-claim guard and identity checks.
+3. Cherry-pick only `e23951cf5ee2a61ae57034273d3464dd1e51828f`.
+4. Verify the resulting diff contains only the four source-commit files plus
+   this publication task card.
+5. Run contract, hash, diff, and closeout checks.
+6. Push `agent/preserve-greyhound-evidence` and open exactly one draft PR to
+   `master`.
+
+## Hard boundaries
+
+- Do not modify the four files supplied by the preservation commit.
+- Do not merge the PR or mark it ready for review.
+- Do not alter the stale source checkout or any dirty or seed checkout.
+- Do not touch databases, dependencies, units, services, timers, installed
+  hooks, live runtime, production data, models, or decision-ledger seeds.
+- Do not restore or reactivate the abandoned Greyhound global dispatcher.
+- Do not rebase, reset, stash, clean, force-push, delete, or remove worktrees.
+
+## Docs impact
+
+`DOCS_NOT_REQUIRED`: publication preserves existing evidence and task contracts;
+it changes no workflow, command, behavior, schema, interface, or safety rule.


### PR DESCRIPTION
## What changed

- preserves the reviewed daemon decision packet and verification results
- preserves the associated Playwright 403 snapshot
- records the V2 preservation and publication contracts

## Why

These files existed only as untracked evidence on a stale, diverged checkout.
This PR carries their exact reviewed bytes onto a clean branch based on current
`master`, so the evidence is durable and reviewable without publishing the
stale branch's unrelated history.

## Impact

Repository evidence only. No product behavior, database, dependency, service,
timer, installed unit, runtime, model, or production-data state changes.

## Validation

- task card validation passed
- post-claim V2 semantic guard admitted the new scope
- branch merge base equals `origin/master` at `d3c27ce2190021b8441c5028d8ed9f1505c25747`
- all four cherry-picked blobs match source commit `e23951cf5ee2a61ae57034273d3464dd1e51828f`
- the three evidence SHA-256 hashes match their recorded values
- `git diff --check origin/master...HEAD` passed
- local and remote branch heads match at `9f9b1fc3f344de06e93bc1872b5ba1213f18c5a3`
