### PR TITLE
Reduce Greyhound full-daemon resource impact

### DIFF
--- a/docs/agent_tasks/greyhound_resource_isolation_20260716.md
+++ b/docs/agent_tasks/greyhound_resource_isolation_20260716.md
@@ -1,0 +1,37 @@
+---
+job_id: greyhound_resource_isolation_20260716
+title: Reduce full-daemon resource impact without reducing prospective odds capture
+lane: Reporting
+owner: Codex
+approval_required: true
+approval_source: Owner authorised bounded user-service, timer, and batch-limit deployment on 2026-07-16.
+timeout_seconds: 7200
+output_dir: reports/agent_jobs/greyhound_resource_isolation_20260716
+mutation_mode: safe_extension
+production_data_access: false
+production_data_boundary: Existing append-only odds and results collection may continue; no direct DB writes or schema changes are performed by this task.
+github_mutation_allowed: true
+live_service_mutation_allowed: true
+allowed_files:
+  - docs/agent_tasks/greyhound_resource_isolation_20260716.md
+  - scripts/shadow_autopilot_daemon.py
+  - tests/test_shadow_autopilot_daemon.py
+  - ops/systemd/shadow-autopilot.service
+  - ops/systemd/shadow-autopilot.timer
+  - ops/systemd/shadow-autopilot-odds-capture.service
+  - ops/systemd/shadow-autopilot-odds-capture.timer
+  - docs/race_evidence_inventory.md
+  - reports/agent_jobs/greyhound_resource_isolation_20260716/README.md
+  - reports/agent_jobs/greyhound_resource_isolation_20260716/RUN_OUTCOME.json
+---
+
+# Greyhound resource isolation
+
+Deploy only the generated user-service/timer changes that make full daemon
+cycles completion-aware, lower their CPU/I/O priority, bound non-imminent
+refresh/result work, and retain the minutely odds-only collector.
+
+Hard boundaries: do not interrupt the running daemon, change llama-server,
+write or migrate the SQLite database directly, alter schemas, train/promote
+models, or modify historical evidence. Back up installed units before copying
+generated units, then deploy only after the current lock owner exits normally.

--- a/docs/race_evidence_inventory.md
+++ b/docs/race_evidence_inventory.md
@@ -34,6 +34,31 @@ The generated `ops/systemd/*.service` files and installed files under
 the deployed commit, unit hashes, DB/model/evidence paths and rollback evidence
 in the current runtime-reconciliation deployment manifest.
 
+## Resource-isolated scheduling
+
+The full `shadow-autopilot` timer schedules its next run **15 minutes after the
+previous service becomes inactive**, rather than from wall-clock activation.
+This prevents timer-driven full-daemon overlap when a cycle takes longer than
+15 minutes. It is intentionally constrained to a six-race refresh, eight
+result-backlog races, and sixteen backlog shadow runs. Its service has
+`Nice=10`, `CPUWeight=20`, `IOWeight=20`, and `IOSchedulingClass=idle`.
+
+The odds-only timer remains enabled on its existing near-minutely schedule with
+its 16-race capture capacity and best-effort I/O class; it is the prospective
+fixed-window collector and is not the heavy-refresh throttle.
+
+To pause only future heavy full-daemon starts while retaining odds-only
+collection, create the configured pause file and reload neither service nor
+timer:
+
+```bash
+touch /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound_racing_collector/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemon_runtime/pause-heavy-scheduling
+```
+
+Remove that file to resume the next completion-aware full-daemon activation.
+The condition is evaluated only when systemd starts the full unit, so this
+switch never interrupts a running cycle.
+
 An odds window is complete only when the same capture group contains validated
 dog-level WIN and PLACE rows for the complete active runner set. Historical
 WIN-only groups are incomplete and may be recaptured append-only; they must not

--- a/ops/systemd/shadow-autopilot-odds-capture.service
+++ b/ops/systemd/shadow-autopilot-odds-capture.service
@@ -5,11 +5,11 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-WorkingDirectory=/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-runtime-p0-20260710
+WorkingDirectory=/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-resource-isolation-20260716
 Environment=PYTHONUNBUFFERED=1
 Environment=GREYHOUND_ALLOW_TGR=0
 Environment=PATH=/home/l4nd0/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ExecStart=/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/.venv/bin/python /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-runtime-p0-20260710/scripts/shadow_autopilot_daemon.py run-odds-capture-once --evidence-root /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525 --days-ahead 1 --refresh-limit 8 --odds-capture-refresh-limit 8 --require-safe-refresh-metadata --skip-primary-refresh --db /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound_racing_collector/greyhound_racing_data.db --lock-path /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound_racing_collector/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemon_runtime/shadow_autopilot.lock --state-path /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemon_runtime/odds_capture_state.json --timeout-seconds 600
+ExecStart=/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/.venv/bin/python /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-resource-isolation-20260716/scripts/shadow_autopilot_daemon.py run-odds-capture-once --evidence-root /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525 --days-ahead 1 --refresh-limit 16 --odds-capture-refresh-limit 16 --require-safe-refresh-metadata --skip-primary-refresh --db /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound_racing_collector/greyhound_racing_data.db --lock-path /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound_racing_collector/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemon_runtime/shadow_autopilot.lock --state-path /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemon_runtime/odds_capture_state.json --timeout-seconds 600
 TimeoutStartSec=1200
 Nice=10
 IOSchedulingClass=best-effort

--- a/ops/systemd/shadow-autopilot.service
+++ b/ops/systemd/shadow-autopilot.service
@@ -2,14 +2,17 @@
 Description=Greyhound shadow autopilot evidence collection
 Wants=network-online.target
 After=network-online.target
+ConditionPathExists=!/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound_racing_collector/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemon_runtime/pause-heavy-scheduling
 
 [Service]
 Type=oneshot
-WorkingDirectory=/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-runtime-p0-20260710
+WorkingDirectory=/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-resource-isolation-20260716
 Environment=PYTHONUNBUFFERED=1
 Environment=GREYHOUND_ALLOW_TGR=0
 Environment=PATH=/home/l4nd0/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ExecStart=/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/.venv/bin/python /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-runtime-p0-20260710/scripts/shadow_autopilot_daemon.py run-once --evidence-root /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525 --days-ahead 1 --refresh-limit 16 --db /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound_racing_collector/greyhound_racing_data.db --shadow-model /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-high-accuracy-refinement-v1-20260610/artifacts/full_evidence_orchestration_20260525/shadow_evaluation_high_accuracy_stage2_20260610T_live_evidence/shadow_randomforest_model.joblib --lock-path /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound_racing_collector/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemon_runtime/shadow_autopilot.lock --state-path /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemon_runtime/state.json --odds-capture-state-path /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemon_runtime/odds_capture_state.json --enable-autonomous-odds-capture --execute-autonomous-odds-capture --allow-auto-scrape-odds --enable-autonomous-result-capture --require-safe-refresh-metadata --rejoin-pending-limit 8 --timeout-seconds 840
+ExecStart=/mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/.venv/bin/python /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-resource-isolation-20260716/scripts/shadow_autopilot_daemon.py run-once --evidence-root /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525 --days-ahead 1 --refresh-limit 6 --db /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound_racing_collector/greyhound_racing_data.db --shadow-model /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-high-accuracy-refinement-v1-20260610/artifacts/full_evidence_orchestration_20260525/shadow_evaluation_high_accuracy_stage2_20260610T_live_evidence/shadow_randomforest_model.joblib --lock-path /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound_racing_collector/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemon_runtime/shadow_autopilot.lock --state-path /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemon_runtime/state.json --odds-capture-state-path /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-autonomous-accuracy-odds-v1-20260610/artifacts/full_evidence_orchestration_20260525/shadow_autopilot_daemon_runtime/odds_capture_state.json --enable-autonomous-odds-capture --execute-autonomous-odds-capture --allow-auto-scrape-odds --enable-autonomous-result-capture --require-safe-refresh-metadata --rejoin-pending-limit 8 --autonomous-odds-capture-limit 16 --result-backlog-limit 8 --result-backlog-shadow-run-limit 16 --timeout-seconds 840
 TimeoutStartSec=3360
 Nice=10
-IOSchedulingClass=best-effort
+CPUWeight=20
+IOWeight=20
+IOSchedulingClass=idle

--- a/ops/systemd/shadow-autopilot.timer
+++ b/ops/systemd/shadow-autopilot.timer
@@ -2,7 +2,7 @@
 Description=Run greyhound shadow autopilot every 15 minutes
 
 [Timer]
-OnCalendar=*:02/15
+OnUnitInactiveSec=15min
 AccuracySec=30s
 Persistent=true
 Unit=shadow-autopilot.service

--- a/reports/agent_jobs/greyhound_resource_isolation_20260716/README.md
+++ b/reports/agent_jobs/greyhound_resource_isolation_20260716/README.md
@@ -1,0 +1,27 @@
+# Greyhound resource isolation — RUNNING
+
+Objective: lower heavy full-daemon CPU and I/O contention while retaining the
+minutely append-only odds-only collection lane.
+
+Initial evidence: full-daemon PID 1503518 held the shared lock; its HWM was
+199852 kB. Host swap was about 9.8 GiB used, with llama-server occupying about
+8.4 GiB RSS. SQLite `quick_check` and `integrity_check` both returned `ok`.
+
+The legacy feature checkout was stale relative to master, so implementation is
+in clean worktree `greyhound-resource-isolation-20260716` from `origin/master`.
+
+## Generator review
+
+```json
+{
+  "status": "SUCCESS",
+  "work_log": {
+    "assumptions": ["The full daemon is the heavy lane; odds-only capacity is time-sensitive."],
+    "sources_used": ["git diff", "installed user units", "systemd unit syntax verification"],
+    "files_read": ["scripts/shadow_autopilot_daemon.py", "ops/systemd/*.service", "ops/systemd/shadow-autopilot.timer", "tests/test_shadow_autopilot_daemon.py"],
+    "files_modified": ["scripts/shadow_autopilot_daemon.py", "ops/systemd/*.service", "ops/systemd/shadow-autopilot.timer", "tests/test_shadow_autopilot_daemon.py", "docs/race_evidence_inventory.md"],
+    "validation_checks": ["133 focused daemon tests passed", "py_compile passed", "git diff --check passed"]
+  },
+  "result": {"critical": [], "warnings": [], "suggestions": []}
+}
+```

--- a/reports/agent_jobs/greyhound_resource_isolation_20260716/README.md
+++ b/reports/agent_jobs/greyhound_resource_isolation_20260716/README.md
@@ -25,3 +25,37 @@ in clean worktree `greyhound-resource-isolation-20260716` from `origin/master`.
   "result": {"critical": [], "warnings": [], "suggestions": []}
 }
 ```
+
+## Deployment and validation
+
+- Outcome: `PARTIAL_IMPROVEMENT` — the controls are installed and effective in
+  systemd, but the next resource-capped full cycle is scheduled for 16:17:27
+  AEST and was not force-started or observed.
+- Deployed runtime code commit: `9395798f452e8c21dd28a59494e5fee11bf3f84d`.
+- Backup: `/home/l4nd0/.config/systemd/user/greyhound-resource-isolation-backup-20260716T1607+1000`.
+- Generated and installed equality: byte-for-byte `cmp` passed for both
+  services and both timers after copy and `systemctl --user daemon-reload`.
+- Full timer: `OnUnitInactiveSec=15min`; after the full daemon completed at
+  16:02:26 AEST, systemd scheduled the next start for 16:17:27 AEST.
+- Full controls: `Nice=10`, `CPUWeight=20`, `IOWeight=20`,
+  `IOSchedulingClass=idle`; `MemoryHigh` remains `infinity`.
+- Full budgets: refresh 16 -> 6; rejoin remains 8; result backlog 32 -> 8 and
+  backlog shadow runs 64 -> 16. The full lane still retains its 16-race
+  autonomous odds capacity.
+- Odds-only: timer enabled and active; its near-minutely calendar and 16-race
+  refresh/capture budget are unchanged, with best-effort I/O retained.
+- Pause switch: creating `pause-heavy-scheduling` at the documented shared
+  runtime path prevents only future full-daemon starts. It does not interrupt a
+  running cycle or disable odds-only capture.
+- Lock lifecycle: the preceding full service completed successfully and
+  released its lock. The currently active odds-only process owns the same JSON
+  lock, as designed; no second full service is active.
+- SQLite: read-only `quick_check=ok`, `integrity_check=ok`, 101 schema objects,
+  schema SHA-256 `49e3...9417de6e`. No schema-changing code or command ran.
+- Resource context: the prior full-daemon HWM was 199852 kB, so no `MemoryHigh`
+  was added. Host swap was about 9.8 GiB used and llama-server was about 8.4
+  GiB RSS; llama-server was not changed.
+- Tests: `133 passed` for `tests/test_shadow_autopilot_daemon.py` under an
+  ephemeral `uv` environment; `py_compile` and `git diff --check` passed.
+- Docs impact: `DOCS_UPDATED` in `docs/race_evidence_inventory.md` for cadence,
+  controls, odds preservation, and the operator pause switch.

--- a/reports/agent_jobs/greyhound_resource_isolation_20260716/RUN_OUTCOME.json
+++ b/reports/agent_jobs/greyhound_resource_isolation_20260716/RUN_OUTCOME.json
@@ -1,0 +1,6 @@
+{
+  "result": "PARTIAL_IMPROVEMENT",
+  "deployed_commit": "9395798f452e8c21dd28a59494e5fee11bf3f84d",
+  "reason": "Systemd controls and completion-aware cadence are installed, but no post-deployment full cycle was force-started or observed.",
+  "resume_only_if": "Observe the scheduled full cycle and compare its cgroup CPU, RSS, swap, and I/O counters without interrupting collection."
+}

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -9000,9 +9000,10 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
         evidence_root=evidence_root,
         shadow_model=args.shadow_model,
         db_path=args.db,
-        lock_path=args.lock_path,
-        state_path=args.state_path,
-        odds_capture_state_path=args.odds_capture_state_path,
+        lock_path=lock_path,
+        state_path=state_path,
+        odds_capture_state_path=odds_state_path,
+        pause_path=lock_path.parent / "pause-heavy-scheduling",
     )
     service_path = DEFAULT_SERVICE_DIR / SERVICE_NAME
     timer_path = DEFAULT_SERVICE_DIR / TIMER_NAME

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -57,7 +57,7 @@ DEFAULT_LOCK_STALE_SECONDS = 3600
 DEFAULT_REJOIN_PENDING_LIMIT = 8
 DEFAULT_REJOIN_LOOKBACK_DAYS = 7
 DEFAULT_TIMER_FREQUENCY = "15min"
-DEFAULT_TIMER_ON_CALENDAR = "*:02/15"
+DEFAULT_TIMER_ON_UNIT_INACTIVE_SEC = "15min"
 DEFAULT_TIMER_ACCURACY = "30s"
 DEFAULT_ODDS_CAPTURE_ONLY_TIMER_FREQUENCY = "1min_except_full_daemon"
 DEFAULT_ODDS_CAPTURE_ONLY_TIMER_ON_CALENDAR = (
@@ -66,10 +66,14 @@ DEFAULT_ODDS_CAPTURE_ONLY_TIMER_ON_CALENDAR = (
 DEFAULT_ODDS_CAPTURE_ONLY_TIMER_ACCURACY = "15s"
 DEFAULT_ODDS_CAPTURE_ONLY_TIMEOUT_SECONDS = 600
 DEFAULT_ODDS_CAPTURE_ONLY_REFRESH_LIMIT = 16
+# Keep the minutely odds-only lane broad: it protects fixed pre-jump windows.
+# The full daemon does the expensive refresh, scoring, result, and artifact work.
+DEFAULT_FULL_DAEMON_REFRESH_LIMIT = 6
 DEFAULT_FULL_DAEMON_AUTONOMOUS_ODDS_CAPTURE_LIMIT = 16
-DEFAULT_FULL_DAEMON_RESULT_BACKLOG_LIMIT = 32
-DEFAULT_FULL_DAEMON_RESULT_BACKLOG_SHADOW_RUN_LIMIT = 64
+DEFAULT_FULL_DAEMON_RESULT_BACKLOG_LIMIT = 8
+DEFAULT_FULL_DAEMON_RESULT_BACKLOG_SHADOW_RUN_LIMIT = 16
 DEFAULT_FULL_DAEMON_RESULT_BACKLOG_LOOKBACK_DAYS = 2
+DEFAULT_HEAVY_SCHEDULING_PAUSE_PATH = DEFAULT_RUNTIME_DIR / "pause-heavy-scheduling"
 DEFAULT_ODDS_CAPTURE_ONLY_PREFLIGHT_MAX_AGE_SECONDS = 30 * 60
 DEFAULT_ODDS_CAPTURE_ONLY_PREFLIGHT_RESUME_BUFFER_SECONDS = 5 * 60
 DEFAULT_FULL_DAEMON_ODDS_DEFER_HORIZON_SECONDS = 8 * 60
@@ -1099,6 +1103,7 @@ def service_file_text(
     lock_path: Path | None = None,
     state_path: Path | None = None,
     odds_capture_state_path: Path | None = None,
+    pause_path: Path | None = DEFAULT_HEAVY_SCHEDULING_PAUSE_PATH,
 ) -> str:
     script_path = repo_path / "scripts/shadow_autopilot_daemon.py"
     service_python = python_path or Path("/usr/bin/python3")
@@ -1120,6 +1125,7 @@ def service_file_text(
             "Description=Greyhound shadow autopilot evidence collection",
             "Wants=network-online.target",
             "After=network-online.target",
+            *( [f"ConditionPathExists=!{pause_path}"] if pause_path is not None else [] ),
             "",
             "[Service]",
             "Type=oneshot",
@@ -1130,7 +1136,7 @@ def service_file_text(
             (
                 f"ExecStart={service_python} {script_path} run-once "
                 f"{evidence_root_segment}"
-                "--days-ahead 1 --refresh-limit 16 "
+                f"--days-ahead 1 --refresh-limit {DEFAULT_FULL_DAEMON_REFRESH_LIMIT} "
                 f"{explicit_path_segment}"
                 "--enable-autonomous-odds-capture "
                 "--execute-autonomous-odds-capture "
@@ -1138,11 +1144,16 @@ def service_file_text(
                 "--enable-autonomous-result-capture "
                 "--require-safe-refresh-metadata "
                 f"--rejoin-pending-limit {DEFAULT_REJOIN_PENDING_LIMIT} "
+                f"--autonomous-odds-capture-limit {DEFAULT_FULL_DAEMON_AUTONOMOUS_ODDS_CAPTURE_LIMIT} "
+                f"--result-backlog-limit {DEFAULT_FULL_DAEMON_RESULT_BACKLOG_LIMIT} "
+                f"--result-backlog-shadow-run-limit {DEFAULT_FULL_DAEMON_RESULT_BACKLOG_SHADOW_RUN_LIMIT} "
                 f"--timeout-seconds {timeout_seconds}"
             ),
             f"TimeoutStartSec={systemd_timeout_seconds}",
             "Nice=10",
-            "IOSchedulingClass=best-effort",
+            "CPUWeight=20",
+            "IOWeight=20",
+            "IOSchedulingClass=idle",
             "",
         ]
     )
@@ -1155,7 +1166,7 @@ def timer_file_text() -> str:
             "Description=Run greyhound shadow autopilot every 15 minutes",
             "",
             "[Timer]",
-            f"OnCalendar={DEFAULT_TIMER_ON_CALENDAR}",
+            f"OnUnitInactiveSec={DEFAULT_TIMER_ON_UNIT_INACTIVE_SEC}",
             f"AccuracySec={DEFAULT_TIMER_ACCURACY}",
             "Persistent=true",
             "Unit=shadow-autopilot.service",
@@ -1253,6 +1264,7 @@ def write_service_files(
     lock_path: Path | None = None,
     state_path: Path | None = None,
     odds_capture_state_path: Path | None = None,
+    pause_path: Path | None = DEFAULT_HEAVY_SCHEDULING_PAUSE_PATH,
 ) -> dict[str, Any]:
     service_dir.mkdir(parents=True, exist_ok=True)
     service_path = service_dir / SERVICE_NAME
@@ -1269,6 +1281,7 @@ def write_service_files(
             lock_path=lock_path,
             state_path=state_path,
             odds_capture_state_path=odds_capture_state_path,
+            pause_path=pause_path,
         ),
     )
     write_text(timer_path, timer_file_text())
@@ -1276,7 +1289,7 @@ def write_service_files(
         "service_path": relpath(service_path),
         "timer_path": relpath(timer_path),
         "timer_frequency": DEFAULT_TIMER_FREQUENCY,
-        "timer_calendar": DEFAULT_TIMER_ON_CALENDAR,
+        "timer_on_unit_inactive_sec": DEFAULT_TIMER_ON_UNIT_INACTIVE_SEC,
         "repo_path": str(repo_path),
         "timeout_seconds": timeout_seconds,
         "systemd_timeout_start_seconds": max(timeout_seconds + 60, timeout_seconds * 4),
@@ -1289,6 +1302,7 @@ def write_service_files(
         "odds_capture_state_path": (
             str(odds_capture_state_path) if odds_capture_state_path is not None else None
         ),
+        "pause_path": str(pause_path) if pause_path is not None else None,
     }
 
 
@@ -3695,7 +3709,7 @@ def install_markdown(service_info: Mapping[str, Any]) -> str:
             f"journalctl -u {SERVICE_NAME} -n 200 --no-pager",
             "```",
             "",
-            f"The timer runs every {DEFAULT_TIMER_FREQUENCY} on `{DEFAULT_TIMER_ON_CALENDAR}`. Overlap is prevented by systemd oneshot semantics and the daemon lock file.",
+            f"The timer waits `{DEFAULT_TIMER_ON_UNIT_INACTIVE_SEC}` after each completed service before the next activation. Overlap is prevented by systemd oneshot semantics and the daemon lock file.",
             "",
         ]
     )
@@ -3710,7 +3724,7 @@ def daemon_design_markdown() -> str:
             "Continuously collect forward-shadow evidence without changing production state.",
             "",
             "## Architecture",
-            f"- `shadow-autopilot.timer` activates every {DEFAULT_TIMER_FREQUENCY} on `{DEFAULT_TIMER_ON_CALENDAR}`.",
+            f"- `shadow-autopilot.timer` activates {DEFAULT_TIMER_ON_UNIT_INACTIVE_SEC} after each completed full-daemon service.",
             "- `shadow-autopilot.service` runs one bounded `shadow_autopilot_daemon.py run-once` cycle.",
             "- The daemon acquires a JSON lock before any work starts.",
             "- The daemon delegates refresh, scoring, current-run join, aggregate, and status generation to `scripts/shadow_autopilot_v1.py`.",
@@ -11314,7 +11328,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
         "timer_file": relpath(timer_path),
         "service_files_present": service_files_present,
         "timer_frequency": DEFAULT_TIMER_FREQUENCY,
-        "timer_calendar": DEFAULT_TIMER_ON_CALENDAR,
+        "timer_on_unit_inactive_sec": DEFAULT_TIMER_ON_UNIT_INACTIVE_SEC,
         "systemd_timer": True,
         "cron_fallback_required": False,
         "overlap_prevention": ["systemd_oneshot_unit", "daemon_lockfile"],
@@ -12715,7 +12729,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     run_parser.add_argument("--days-ahead", type=int, default=1)
     run_parser.add_argument("--min-minutes", type=float, default=20.0)
     run_parser.add_argument("--max-minutes", type=float, default=160.0)
-    run_parser.add_argument("--refresh-limit", type=int, default=16)
+    run_parser.add_argument("--refresh-limit", type=int, default=DEFAULT_FULL_DAEMON_REFRESH_LIMIT)
     run_parser.add_argument(
         "--autonomous-odds-capture-limit",
         type=int,
@@ -12847,6 +12861,12 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     service_parser.add_argument("--lock-path", type=Path)
     service_parser.add_argument("--state-path", type=Path)
     service_parser.add_argument("--odds-capture-state-path", type=Path)
+    service_parser.add_argument(
+        "--pause-path",
+        type=Path,
+        default=DEFAULT_HEAVY_SCHEDULING_PAUSE_PATH,
+        help="Path whose presence pauses future full-daemon starts without pausing odds-only collection.",
+    )
 
     odds_service_parser = subparsers.add_parser(
         "write-odds-capture-service-files",
@@ -12890,6 +12910,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             lock_path=args.lock_path,
             state_path=args.state_path,
             odds_capture_state_path=args.odds_capture_state_path,
+            pause_path=args.pause_path,
         )
         print(json.dumps(result, indent=2, sort_keys=True))
         return 0

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -27,6 +27,7 @@ def test_daemon_default_min_joined_races_matches_review_target():
         == daemon.DEFAULT_FULL_DAEMON_AUTONOMOUS_ODDS_CAPTURE_LIMIT
     )
     assert daemon.DEFAULT_FULL_DAEMON_AUTONOMOUS_ODDS_CAPTURE_LIMIT == 16
+    assert args.refresh_limit == daemon.DEFAULT_FULL_DAEMON_REFRESH_LIMIT == 6
     assert args.result_backlog_limit == daemon.DEFAULT_FULL_DAEMON_RESULT_BACKLOG_LIMIT
     assert (
         args.result_backlog_shadow_run_limit
@@ -458,8 +459,8 @@ def test_run_once_releases_after_primary_when_odds_refresh_due(tmp_path, monkeyp
         if name != "autopilot_cycle":
             raise AssertionError(f"post-primary release should not run {name}")
         assert command[command.index("--autonomous-odds-capture-limit") + 1] == "16"
-        assert command[command.index("--result-backlog-limit") + 1] == "32"
-        assert command[command.index("--result-backlog-shadow-run-limit") + 1] == "64"
+        assert command[command.index("--result-backlog-limit") + 1] == "8"
+        assert command[command.index("--result-backlog-shadow-run-limit") + 1] == "16"
         assert command[command.index("--result-backlog-lookback-days") + 1] == "2"
         daemon.write_json(
             output_dir / "logs" / "autopilot_cycle.stdout.txt",
@@ -4263,6 +4264,10 @@ def test_service_and_timer_define_15_minute_oneshot_cycle():
     assert "--state-path /runtime/state.json" in service
     assert "--odds-capture-state-path /runtime/odds_capture_state.json" in service
     assert "--rejoin-pending-limit 8" in service
+    assert "--refresh-limit 6" in service
+    assert "--autonomous-odds-capture-limit 16" in service
+    assert "--result-backlog-limit 8" in service
+    assert "--result-backlog-shadow-run-limit 16" in service
     assert "--enable-autonomous-odds-capture" in service
     assert "--execute-autonomous-odds-capture" in service
     assert "--allow-auto-scrape-odds" in service
@@ -4271,10 +4276,15 @@ def test_service_and_timer_define_15_minute_oneshot_cycle():
     assert "TimeoutStartSec=3360" in service
     assert "GREYHOUND_ALLOW_TGR=0" in service
     assert "/home/l4nd0/.local/bin" in service
-    assert "OnCalendar=*:02/15" in timer
-    assert "OnUnitActiveSec" not in timer
+    assert "OnUnitInactiveSec=15min" in timer
+    assert "OnCalendar" not in timer
     assert "AccuracySec=30s" in timer
     assert "Persistent=true" in timer
+    assert f"ConditionPathExists=!{daemon.DEFAULT_HEAVY_SCHEDULING_PAUSE_PATH}" in service
+    assert "Nice=10" in service
+    assert "CPUWeight=20" in service
+    assert "IOWeight=20" in service
+    assert "IOSchedulingClass=idle" in service
 
 
 def test_odds_capture_service_and_timer_define_minutely_locked_lane():

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -202,14 +202,16 @@ def test_run_once_exception_writes_terminal_daemon_report(tmp_path, monkeypatch)
     monkeypatch.setattr(daemon, "ROOT", tmp_path)
     monkeypatch.setattr(daemon, "protected_hashes", lambda: {})
     monkeypatch.setattr(daemon, "copy_if_exists", lambda source, dest: None)
-    monkeypatch.setattr(
-        daemon,
-        "write_service_files",
-        lambda **kwargs: {
+    generated = {}
+
+    def capture_write_service_files(**kwargs):
+        generated.update(kwargs)
+        return {
             "status": "SERVICE_FILES_WRITTEN",
             "systemd_deployment_ready": True,
-        },
-    )
+        }
+
+    monkeypatch.setattr(daemon, "write_service_files", capture_write_service_files)
     monkeypatch.setattr(
         daemon,
         "acquire_lock_with_odds_capture_retry",
@@ -258,6 +260,8 @@ def test_run_once_exception_writes_terminal_daemon_report(tmp_path, monkeypatch)
             str(db_path),
             "--shadow-model",
             str(shadow_model),
+            "--lock-path",
+            str(tmp_path / "shared-runtime" / "shadow_autopilot.lock"),
         ]
     )
 
@@ -269,6 +273,9 @@ def test_run_once_exception_writes_terminal_daemon_report(tmp_path, monkeypatch)
     assert report["exception_type"] == "RuntimeError"
     assert report["exception_message"] == "synthetic daemon failure"
     assert written["runtime_action"] == "CHECK_DAEMON_EXCEPTION"
+    assert generated["pause_path"] == (
+        tmp_path / "shared-runtime" / "pause-heavy-scheduling"
+    )
     assert (output_dir / "final_status.txt").read_text(encoding="utf-8") == (
         "PARTIAL_DAEMONIZATION\n"
     )


### PR DESCRIPTION
## Summary
- make the full-daemon timer completion-aware
- bound heavy refresh and result work while preserving 16-race odds-only coverage
- apply CPU and I/O resource weights to the heavy service and document its pause switch

## Validation
- `133 passed` focused daemon tests
- `py_compile` and systemd unit verification passed

Deploy only commit `9395798f452e8c21dd28a59494e5fee11bf3f84d` after the active lock owner exits normally.