### PR TITLE
Add residual caller adapter

### DIFF
--- a/scripts/predict_market_form_residual.py
+++ b/scripts/predict_market_form_residual.py
@@ -1,0 +1,1616 @@
+#!/usr/bin/env python3
+"""Score one race from exact sealed system features and strict pre-jump odds.
+
+The command reads already-materialized artifacts and prints canonical JSON to
+stdout. An explicit ``--append-shadow-output`` path may also persist the same
+outcome-free frozen record to one append-only JSONL. It has no database,
+network, feature-generation, service, activation, deployment, promotion, EV,
+or betting path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import json
+import math
+import re
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlparse
+from zoneinfo import ZoneInfo
+
+
+sys.dont_write_bytecode = True
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_TEXT = str(ROOT)
+if ROOT_TEXT not in sys.path:
+    sys.path.insert(0, ROOT_TEXT)
+
+from src.predictor.market_form_residual import (  # noqa: E402
+    DEFAULT_ARTIFACT_DIR,
+    FEATURES,
+    FrozenResidualModel,
+    ResidualContractError,
+    _runner_set_sha256,
+    append_shadow_record,
+    load_frozen_model,
+    score_race,
+)
+
+
+MELBOURNE = ZoneInfo("Australia/Melbourne")
+ALLOWED_BOX_SOURCES = {"explicit_dom", "runner_text"}
+OUTCOME_KEYS = {
+    "actual_win",
+    "finish_position",
+    "official_result",
+    "outcome",
+    "placing",
+    "result",
+    "winner",
+    "winner_name",
+    "winner_odds",
+}
+POST_RACE_URL_TOKENS = {
+    "result",
+    "results",
+    "dividend",
+    "dividends",
+    "payout",
+    "payouts",
+}
+SIDECAR_SCHEMA = "form_guide_download_provenance_v1"
+FEATURE_MANIFEST_SCHEMA = "shadow_live_scoring_manifest_v1"
+IMPLEMENTATION_MANIFEST_SCHEMA = "shadow_implementation_file_manifest_v1"
+FEATURE_GENERATOR_BRANCH = "codex/greyhound-resource-isolation-20260716"
+FEATURE_GENERATOR_HEAD = "aa35fa70fc49"
+LEGACY_FEATURE_ROWS_SHA256 = (
+    "0ebecaf980665545aa8c19d1a4b1ef976bd069049d42f7f6ebde0f3b29a36b62"
+)
+LEGACY_IMPLEMENTATION_MANIFEST_SHA256 = (
+    "9822a77a4d69a72c8b7b2e7d234538b6207b99530b3b717fb9cb31f64929a651"
+)
+LEGACY_FEATURE_GENERATOR_FILES = [
+    "scripts/run_shadow_non_tgr_rf_evaluation.py",
+    "tests/test_run_shadow_non_tgr_rf_evaluation.py",
+]
+FEATURE_GENERATOR_FILES = [
+    "scripts/run_shadow_non_tgr_rf_evaluation.py",
+    "scripts/run_feature_recovery_execution_v1.py",
+    "utils/expert_form_metadata.py",
+    "utils/prejump_weather.py",
+    "utils/http_client.py",
+    "utils/csv_metadata.py",
+    "utils/runner_completeness.py",
+    "utils/race_lifecycle.py",
+    "tests/test_run_shadow_non_tgr_rf_evaluation.py",
+]
+CAPTURE_REPORT_SCHEMAS = {
+    "autonomous_live_odds_capture_report_v1",
+    # Current capture reports overlay this summary after the report header.
+    "autonomous_live_odds_capture_t2_miss_cause_summary_v1",
+}
+CAPTURE_ATTEMPT_SCHEMA = "autonomous_live_odds_capture_attempt_v1"
+CAPTURE_VALIDATION_SCHEMA = "autonomous_live_odds_capture_validation_v1"
+OUTPUT_SCHEMA = "manual_market_form_residual_prediction_v2"
+DEFAULT_EVIDENCE_ROOT = ROOT / "artifacts/full_evidence_orchestration_20260525"
+VENUE_URL_ALIASES = {
+    "MAND": {"mand", "mandurah"},
+    "SAN": {"san", "sandown", "sandown-park"},
+    "SHEP": {"shep", "shepparton"},
+    "WPK": {"wpk", "wentworth-park"},
+}
+
+
+class ManualPredictionError(RuntimeError):
+    """Raised when the exact manual scoring contract fails closed."""
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    try:
+        encoded = json.dumps(
+            value,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ManualPredictionError("input_not_canonical_json") from exc
+    return (encoded + "\n").encode("utf-8")
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _read_input(path: Path, label: str) -> tuple[bytes, str]:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise ManualPredictionError(f"{label}_unreadable") from exc
+    if not raw:
+        raise ManualPredictionError(f"{label}_empty")
+    return raw, _sha256_bytes(raw)
+
+
+def _json_value(raw: bytes, label: str) -> Any:
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ManualPredictionError(f"{label}_invalid_json") from exc
+
+
+def _json_object(raw: bytes, label: str) -> dict[str, Any]:
+    payload = _json_value(raw, label)
+    if not isinstance(payload, dict):
+        raise ManualPredictionError(f"{label}_not_object")
+    return payload
+
+
+def _runner_token(value: Any) -> str:
+    return re.sub(r"[^A-Z0-9]", "", str(value or "").upper())
+
+
+def _contains_outcome_key(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        return any(
+            str(key).strip().lower() in OUTCOME_KEYS or _contains_outcome_key(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return any(_contains_outcome_key(item) for item in value)
+    return False
+
+
+def _parse_timestamp(value: Any, label: str) -> datetime:
+    text = str(value or "").strip()
+    if not text:
+        raise ManualPredictionError(f"{label}_missing")
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ManualPredictionError(f"{label}_invalid") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ManualPredictionError(f"{label}_timezone_missing")
+    return parsed
+
+
+def _parse_date(value: Any, label: str) -> date:
+    try:
+        return date.fromisoformat(str(value or "").strip())
+    except ValueError as exc:
+        raise ManualPredictionError(f"{label}_invalid") from exc
+
+
+def _race_id_parts(race_id: str) -> tuple[int, str, date]:
+    match = re.fullmatch(
+        r"Race\s+([0-9]{1,2})\s+-\s+(.+?)\s+-\s+([0-9]{4}-[0-9]{2}-[0-9]{2})",
+        str(race_id or "").strip(),
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        raise ManualPredictionError("discovery_race_id_invalid")
+    return (
+        int(match.group(1)),
+        match.group(2).strip().upper(),
+        _parse_date(match.group(3), "discovery_race_date"),
+    )
+
+
+def _race_query_parts(query: str) -> tuple[int, str]:
+    text = str(query or "").strip()
+    match = re.search(r"\b(?:R|RACE)\s*([0-9]{1,2})\b", text, flags=re.IGNORECASE)
+    if not match:
+        raise ManualPredictionError("race_query_number_missing")
+    race_number = int(match.group(1))
+    venue = _runner_token(f"{text[: match.start()]} {text[match.end() :]}")
+    if not venue:
+        raise ManualPredictionError("race_query_venue_missing")
+    return race_number, venue
+
+
+def _venue_query_match_rank(
+    query: str,
+    *,
+    canonical_venue: str,
+    full_aliases: Sequence[str],
+) -> int | None:
+    canonical = _runner_token(canonical_venue)
+    aliases = {_runner_token(value) for value in full_aliases if _runner_token(value)}
+    if query == canonical:
+        return 0
+    if query in aliases:
+        return 1
+    if any(
+        (len(query) >= 4 and query in alias) or (len(alias) >= 4 and alias in query)
+        for alias in aliases
+    ):
+        return 2
+    if any(
+        min(len(query), len(alias)) >= 5
+        and difflib.SequenceMatcher(a=query, b=alias).ratio() >= 0.8
+        for alias in aliases
+    ):
+        return 3
+    return None
+
+
+def _path_in_roots(path: Path, roots: Sequence[Path]) -> bool:
+    resolved = path.resolve()
+    for root in roots:
+        try:
+            resolved.relative_to(root.resolve())
+        except ValueError:
+            continue
+        return True
+    return False
+
+
+def _integer(value: Any, label: str, *, minimum: int = 0) -> int:
+    if isinstance(value, bool):
+        raise ManualPredictionError(f"{label}_invalid")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ManualPredictionError(f"{label}_invalid") from exc
+    if isinstance(value, float) and not value.is_integer():
+        raise ManualPredictionError(f"{label}_invalid")
+    if parsed < minimum:
+        raise ManualPredictionError(f"{label}_invalid")
+    return parsed
+
+
+def _box(value: Any, label: str) -> int:
+    parsed = _integer(value, label, minimum=1)
+    if parsed > 8:
+        raise ManualPredictionError(f"{label}_invalid")
+    return parsed
+
+
+def _nullable_float(value: Any, label: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ManualPredictionError(f"{label}_invalid")
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ManualPredictionError(f"{label}_invalid") from exc
+    if not math.isfinite(parsed):
+        raise ManualPredictionError(f"{label}_not_finite")
+    return parsed
+
+
+def _url_tokens(value: Any) -> tuple[Any, set[str]]:
+    text = str(value or "").strip()
+    try:
+        parsed = urlparse(text)
+    except ValueError:
+        return None, set()
+    tokens = {
+        token
+        for token in re.split(r"[^a-z0-9]+", f"{parsed.path} {parsed.query}".lower())
+        if token
+    }
+    return parsed, tokens
+
+
+def _trusted_thedogs_url(value: Any) -> bool:
+    parsed, tokens = _url_tokens(value)
+    if parsed is None:
+        return False
+    hostname = (parsed.hostname or "").lower()
+    try:
+        port = parsed.port
+    except ValueError:
+        return False
+    return bool(
+        parsed.scheme == "https"
+        and hostname == "www.thedogs.com.au"
+        and parsed.username is None
+        and parsed.password is None
+        and port in (None, 443)
+        and re.fullmatch(
+            r"/racing/[a-z0-9]+(?:-[a-z0-9]+)*/\d{4}-\d{2}-\d{2}/\d{1,2}/[a-z0-9]+(?:-[a-z0-9]+)*/?",
+            parsed.path.lower(),
+        )
+        and not (tokens & POST_RACE_URL_TOKENS)
+    )
+
+
+def _venue_url_aliases(venue: str) -> set[str]:
+    normalized = str(venue or "").strip().lower().replace("_", "-")
+    aliases = {normalized}
+    aliases.update(VENUE_URL_ALIASES.get(str(venue or "").strip().upper(), set()))
+    return aliases
+
+
+def _trusted_sportsbet_url(value: Any, race_id: str, expected_venue: str) -> bool:
+    parsed, tokens = _url_tokens(value)
+    if parsed is None:
+        return False
+    hostname = (parsed.hostname or "").lower()
+    try:
+        port = parsed.port
+    except ValueError:
+        return False
+    if (
+        parsed.scheme != "https"
+        or hostname != "www.sportsbet.com.au"
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in (None, 443)
+    ):
+        return False
+    if tokens & POST_RACE_URL_TOKENS:
+        return False
+    path_match = re.fullmatch(
+        r"/(?:betting/)?greyhound-racing/australia-nz/([a-z0-9]+(?:-[a-z0-9]+)*)/race-(\d+)(?:-\d+)?/?",
+        parsed.path.lower(),
+    )
+    race_match = re.fullmatch(
+        r"Race (\d+) - [A-Z0-9_]+(?:-[A-Z0-9_]+)* - \d{4}-\d{2}-\d{2}", race_id
+    )
+    return bool(
+        path_match
+        and race_match
+        and path_match.group(1) in _venue_url_aliases(expected_venue)
+        and int(path_match.group(2)) == int(race_match.group(1))
+    )
+
+
+def _canonical_target_grade(value: Any) -> str | None:
+    text = re.sub(r"\s+", " ", str(value or "").strip())
+    grade_match = re.fullmatch(r"Grade\s+([1-7])", text, flags=re.IGNORECASE)
+    if grade_match is None:
+        grade_match = re.fullmatch(
+            r"([1-7])(?:st|nd|rd|th)(?:\s+Grade)?",
+            text,
+            flags=re.IGNORECASE,
+        )
+    if grade_match:
+        return f"GRADE{grade_match.group(1)}"
+    exact = {
+        "MAIDEN": "MAIDEN",
+        "NOVICE": "NOVICE",
+        "OPEN": "OPEN",
+        "MIXED": "MIXED",
+        "RESTRICTED": "RESTRICTED",
+        "FREE FOR ALL": "FFA",
+        "FFA": "FFA",
+        "NO GRADE": "NO_GRADE",
+        "NON GRADED": "NO_GRADE",
+    }
+    return exact.get(text.upper())
+
+
+def _distance_metres(value: Any) -> float:
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*[mM]?", str(value or "").strip())
+    if not match:
+        raise ManualPredictionError("target_distance_invalid")
+    parsed = float(match.group(1))
+    if not 1.0 < parsed < 10_000.0:
+        raise ManualPredictionError("target_distance_invalid")
+    return parsed
+
+
+def _jump_timestamp(sidecar: Mapping[str, Any]) -> datetime:
+    shadow = sidecar.get("prejump_shadow_metadata")
+    race_info = sidecar.get("race_info")
+    if not isinstance(shadow, Mapping):
+        raise ManualPredictionError("prejump_shadow_metadata_missing")
+    race_info = race_info if isinstance(race_info, Mapping) else {}
+    explicit = shadow.get("jump_datetime") or sidecar.get("jump_datetime")
+    if explicit:
+        return _parse_timestamp(explicit, "jump_timestamp")
+    race_date = _parse_date(
+        shadow.get("race_date") or race_info.get("date"), "target_race_date"
+    )
+    raw_time = str(shadow.get("jump_time") or race_info.get("race_time") or "").strip()
+    for fmt in ("%I:%M %p", "%I:%M%p", "%H:%M"):
+        try:
+            parsed_time = datetime.strptime(raw_time.upper(), fmt).time()
+            return datetime.combine(race_date, parsed_time, tzinfo=MELBOURNE)
+        except ValueError:
+            continue
+    raise ManualPredictionError("jump_time_invalid")
+
+
+def _sidecar_context(sidecar: Mapping[str, Any]) -> dict[str, Any]:
+    if sidecar.get("schema_version") != SIDECAR_SCHEMA:
+        raise ManualPredictionError("sidecar_schema_mismatch")
+    if _contains_outcome_key(sidecar):
+        raise ManualPredictionError("sidecar_contains_outcome_field")
+    shadow = sidecar.get("prejump_shadow_metadata")
+    if not isinstance(shadow, Mapping):
+        raise ManualPredictionError("prejump_shadow_metadata_missing")
+    if shadow.get("status") != "PASS":
+        raise ManualPredictionError("prejump_shadow_metadata_not_pass")
+    if (
+        sidecar.get("metadata_is_leakage_safe") is not True
+        or shadow.get("metadata_is_leakage_safe") is not True
+    ):
+        raise ManualPredictionError("sidecar_metadata_not_leakage_safe")
+    race_info = sidecar.get("race_info")
+    race_info = race_info if isinstance(race_info, Mapping) else {}
+    source_urls = [
+        str(value).strip()
+        for value in (
+            shadow.get("source_url"),
+            sidecar.get("race_url"),
+            race_info.get("url"),
+        )
+        if str(value or "").strip()
+    ]
+    if not source_urls or len(set(source_urls)) != 1:
+        raise ManualPredictionError("sidecar_source_url_alias_mismatch")
+    source_url = source_urls[0]
+    if not _trusted_thedogs_url(source_url):
+        raise ManualPredictionError("sidecar_source_url_not_trusted_thedogs")
+    alignment = shadow.get("canonical_final_runner_alignment")
+    if not isinstance(alignment, Mapping):
+        alignment = sidecar.get("canonical_runner_alignment")
+    if not isinstance(alignment, Mapping) or str(
+        alignment.get("status")
+    ).lower() not in {
+        "aligned",
+        "pass",
+    }:
+        raise ManualPredictionError("canonical_runner_alignment_not_verified")
+    participants = shadow.get("runner_box_name_list")
+    if not isinstance(participants, list) or len(participants) < 2:
+        raise ManualPredictionError("sidecar_runner_set_missing")
+    runners: dict[int, dict[str, Any]] = {}
+    identities: set[str] = set()
+    for row in participants:
+        if not isinstance(row, Mapping):
+            raise ManualPredictionError("sidecar_runner_invalid")
+        box = _box(row.get("box_number"), "sidecar_runner_box")
+        name = str(row.get("dog_name") or "").strip()
+        identity = _runner_token(name)
+        if not identity or box in runners or identity in identities:
+            raise ManualPredictionError("sidecar_runner_invalid_or_duplicate")
+        identities.add(identity)
+        runners[box] = {"box_number": box, "dog_name": name, "identity": identity}
+    completeness = sidecar.get("runner_completeness")
+    if not isinstance(completeness, Mapping):
+        raise ManualPredictionError("sidecar_runner_completeness_missing")
+    if completeness.get("status") != "COMPLETE":
+        raise ManualPredictionError("sidecar_runner_completeness_not_complete")
+    if _integer(
+        completeness.get("runner_count"), "sidecar_runner_count", minimum=2
+    ) != len(runners):
+        raise ManualPredictionError("sidecar_runner_count_mismatch")
+    complete_rows = completeness.get("participants")
+    if not isinstance(complete_rows, list):
+        raise ManualPredictionError("sidecar_runner_completeness_participants_missing")
+    complete_set = set()
+    for row in complete_rows:
+        if not isinstance(row, Mapping):
+            raise ManualPredictionError(
+                "sidecar_runner_completeness_participant_invalid"
+            )
+        complete_set.add(
+            (
+                _box(row.get("box_number"), "sidecar_complete_box"),
+                _runner_token(row.get("dog_name")),
+            )
+        )
+    runner_set = {(box, str(row["identity"])) for box, row in runners.items()}
+    if complete_set != runner_set or len(complete_rows) != len(complete_set):
+        raise ManualPredictionError("sidecar_runner_completeness_mismatch")
+    target_date = _parse_date(
+        shadow.get("race_date") or race_info.get("date"), "target_race_date"
+    )
+    race_number = _integer(
+        shadow.get("race_number") or race_info.get("race_number"),
+        "target_race_number",
+        minimum=1,
+    )
+    venue = str(shadow.get("venue") or race_info.get("venue") or "").strip().upper()
+    if not venue or not re.fullmatch(r"[A-Z0-9_]+(?:-[A-Z0-9_]+)*", venue):
+        raise ManualPredictionError("target_venue_invalid")
+    target_distance = _distance_metres(
+        shadow.get("distance") or race_info.get("distance")
+    )
+    target_grade = str(shadow.get("grade") or race_info.get("grade") or "").strip()
+    canonical_grade = _canonical_target_grade(target_grade)
+    if canonical_grade is None:
+        raise ManualPredictionError("target_grade_not_exact_supported_alias")
+    path_parts = [part for part in urlparse(source_url).path.split("/") if part]
+    if (
+        len(path_parts) != 5
+        or path_parts[0].lower() != "racing"
+        or path_parts[1].lower() not in _venue_url_aliases(venue)
+        or path_parts[2] != target_date.isoformat()
+        or not path_parts[3].isdigit()
+        or int(path_parts[3]) != race_number
+    ):
+        raise ManualPredictionError("sidecar_source_url_race_binding_mismatch")
+    jump = _jump_timestamp(sidecar)
+    if jump.astimezone(MELBOURNE).date() != target_date:
+        raise ManualPredictionError("jump_date_target_date_mismatch")
+    return {
+        "shadow": shadow,
+        "runners": runners,
+        "jump_timestamp": jump,
+        "metadata_timestamp": _parse_timestamp(
+            shadow.get("metadata_captured_at"), "metadata_capture_timestamp"
+        ),
+        "target_race_date": target_date,
+        "target_race_number": race_number,
+        "target_distance": target_distance,
+        "target_venue": venue,
+        "target_grade": canonical_grade,
+        "source_url": str(source_url),
+        "expected_race_id": f"Race {race_number} - {venue} - {target_date.isoformat()}",
+    }
+
+
+def _validate_form_binding(
+    sidecar: Mapping[str, Any],
+    *,
+    form_csv_path: Path,
+    form_raw: bytes,
+    form_sha: str,
+) -> None:
+    if (
+        sidecar.get("filename") != form_csv_path.name
+        or _integer(sidecar.get("content_length"), "sidecar_content_length", minimum=1)
+        != len(form_raw)
+        or sidecar.get("content_sha256") != form_sha
+    ):
+        raise ManualPredictionError("form_csv_sidecar_hash_mismatch")
+
+
+def _capture_attempts(raw: bytes, *, jsonl: bool) -> list[dict[str, Any]]:
+    attempts: list[dict[str, Any]] = []
+    if jsonl:
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ManualPredictionError("capture_jsonl_invalid_encoding") from exc
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ManualPredictionError(
+                    f"capture_jsonl_invalid:{line_number}"
+                ) from exc
+            if not isinstance(row, dict):
+                raise ManualPredictionError(
+                    f"capture_jsonl_row_not_object:{line_number}"
+                )
+            attempts.append(row)
+        payload_for_outcome_check: Any = attempts
+    else:
+        payload = _json_object(raw, "capture")
+        payload_for_outcome_check = payload
+        if isinstance(payload.get("attempts"), list):
+            if payload.get("schema_version") not in CAPTURE_REPORT_SCHEMAS:
+                raise ManualPredictionError("capture_report_schema_mismatch")
+            for row in payload["attempts"]:
+                if not isinstance(row, dict):
+                    raise ManualPredictionError("capture_attempt_not_object")
+                attempts.append(row)
+        elif "race_id" in payload and "validation" in payload:
+            attempts = [payload]
+        else:
+            raise ManualPredictionError("capture_attempts_missing")
+    if _contains_outcome_key(payload_for_outcome_check):
+        raise ManualPredictionError("capture_contains_outcome_field")
+    return attempts
+
+
+def _select_capture_attempt(raw: bytes, *, jsonl: bool, race_id: str) -> dict[str, Any]:
+    matches = []
+    for attempt in _capture_attempts(raw, jsonl=jsonl):
+        validation = attempt.get("validation")
+        if (
+            attempt.get("race_id") == race_id
+            and attempt.get("status") == "APPENDED"
+            and isinstance(validation, Mapping)
+            and validation.get("status") == "PASS"
+        ):
+            matches.append(attempt)
+    if not matches:
+        raise ManualPredictionError("accepted_capture_attempt_missing")
+    if len(matches) != 1:
+        raise ManualPredictionError("accepted_capture_attempt_ambiguous")
+    attempt = matches[0]
+    if attempt.get("schema_version") != CAPTURE_ATTEMPT_SCHEMA:
+        raise ManualPredictionError("capture_attempt_schema_mismatch")
+    if attempt.get("reasons") != []:
+        raise ManualPredictionError("capture_attempt_reasons_not_empty")
+    return attempt
+
+
+def _active_capture_rows(
+    attempt: Mapping[str, Any],
+    sidecar_runners: Mapping[int, Mapping[str, Any]],
+    context: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], datetime, datetime]:
+    validation = attempt.get("validation")
+    if not isinstance(validation, Mapping):
+        raise ManualPredictionError("capture_validation_missing")
+    if validation.get("schema_version") != CAPTURE_VALIDATION_SCHEMA:
+        raise ManualPredictionError("capture_validation_schema_mismatch")
+    required = {
+        "source_url",
+        "accepted_rows",
+        "accepted_row_count",
+        "rejected_rows",
+        "expected_runner_count",
+        "active_expected_runner_count",
+        "scratched_expected_runner_count",
+        "scratched_expected_runners",
+        "scratched_expected_runners_with_odds",
+        "missing_expected_runners",
+        "extra_unexpected_runners",
+        "failure_root_cause",
+        "reasons",
+    }
+    missing = required - set(validation)
+    if missing:
+        raise ManualPredictionError(
+            f"capture_validation_fields_missing:{sorted(missing)}"
+        )
+    race_id = str(attempt.get("race_id") or "")
+    if not _trusted_sportsbet_url(
+        validation.get("source_url"), race_id, str(context["target_venue"])
+    ):
+        raise ManualPredictionError("capture_source_url_not_trusted_sportsbet")
+    if (
+        validation.get("source_race_number") != context["target_race_number"]
+        or validation.get("source_race_date") != context["target_race_date"].isoformat()
+        or validation.get("source_venue") != context["target_venue"]
+    ):
+        raise ManualPredictionError("capture_source_race_binding_mismatch")
+    if validation.get("reasons") != []:
+        raise ManualPredictionError("capture_validation_reasons_not_empty")
+    if validation.get("failure_root_cause") not in (None, ""):
+        raise ManualPredictionError("capture_validation_failure_root_cause_present")
+    for key in (
+        "rejected_rows",
+        "scratched_expected_runners_with_odds",
+        "missing_expected_runners",
+        "extra_unexpected_runners",
+    ):
+        if validation.get(key) != []:
+            raise ManualPredictionError(f"capture_{key}_not_empty")
+    scratched_rows = validation.get("scratched_expected_runners")
+    if not isinstance(scratched_rows, list):
+        raise ManualPredictionError("capture_scratched_runners_invalid")
+    scratched: set[tuple[int, str]] = set()
+    for row in scratched_rows:
+        if not isinstance(row, Mapping):
+            raise ManualPredictionError("capture_scratched_runner_invalid")
+        key = (
+            _box(row.get("box_number"), "capture_scratched_box"),
+            _runner_token(row.get("dog_name") or row.get("identity")),
+        )
+        if (
+            not key[1]
+            or key in scratched
+            or key[0] not in sidecar_runners
+            or sidecar_runners[key[0]]["identity"] != key[1]
+        ):
+            raise ManualPredictionError(
+                "capture_scratched_runner_mismatch_or_duplicate"
+            )
+        scratched.add(key)
+    expected = {
+        (box, str(row["identity"])): row
+        for box, row in sidecar_runners.items()
+        if (box, str(row["identity"])) not in scratched
+    }
+    if _integer(
+        validation.get("expected_runner_count"),
+        "capture_expected_runner_count",
+        minimum=2,
+    ) != len(sidecar_runners):
+        raise ManualPredictionError("capture_expected_runner_count_mismatch")
+    if _integer(
+        validation.get("scratched_expected_runner_count"),
+        "capture_scratched_runner_count",
+    ) != len(scratched):
+        raise ManualPredictionError("capture_scratched_runner_count_mismatch")
+    if _integer(
+        validation.get("active_expected_runner_count"),
+        "capture_active_runner_count",
+        minimum=2,
+    ) != len(expected):
+        raise ManualPredictionError("capture_active_runner_count_mismatch")
+    rows = validation.get("accepted_rows")
+    if not isinstance(rows, list):
+        raise ManualPredictionError("capture_accepted_rows_invalid")
+    if _integer(
+        validation.get("accepted_row_count"),
+        "capture_accepted_row_count",
+        minimum=2,
+    ) != len(rows) or len(rows) != len(expected):
+        raise ManualPredictionError("capture_runner_count_mismatch")
+    output = []
+    seen = set()
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise ManualPredictionError("capture_runner_invalid")
+        box = _box(row.get("box_number"), "capture_runner_box")
+        name = str(row.get("dog_name") or "").strip()
+        identity = _runner_token(name)
+        declared_identity = _runner_token(row.get("identity"))
+        key = (box, identity)
+        odds = _nullable_float(row.get("odds_decimal"), "capture_runner_odds")
+        if (
+            not identity
+            or (declared_identity and declared_identity != identity)
+            or key in seen
+            or key not in expected
+        ):
+            raise ManualPredictionError("capture_runner_set_mismatch_or_duplicate")
+        if row.get("sportsbet_box_source") not in ALLOWED_BOX_SOURCES:
+            raise ManualPredictionError("capture_runner_box_source_invalid")
+        if odds is None or odds <= 1.0:
+            raise ManualPredictionError("capture_runner_odds_invalid")
+        seen.add(key)
+        output.append(
+            {"box_number": box, "dog_name": name, "identity": identity, "odds": odds}
+        )
+    if seen != set(expected):
+        raise ManualPredictionError("capture_runner_set_mismatch")
+    fetch_time = _parse_timestamp(attempt.get("fetch_time"), "capture_fetch_timestamp")
+    append_time = _parse_timestamp(
+        attempt.get("append_time"), "capture_append_timestamp"
+    )
+    if fetch_time > append_time:
+        raise ManualPredictionError("capture_append_before_fetch")
+    return output, fetch_time, append_time
+
+
+def _manifest_entry(
+    implementation: Mapping[str, Any], path: Path, label: str
+) -> Mapping[str, Any]:
+    artifact_files = implementation.get("artifact_files")
+    if not isinstance(artifact_files, Mapping):
+        raise ManualPredictionError("implementation_manifest_artifact_files_missing")
+    matches = []
+    resolved = path.resolve()
+    for raw_path, entry in artifact_files.items():
+        if Path(str(raw_path)).resolve() == resolved:
+            matches.append(entry)
+    if len(matches) != 1 or not isinstance(matches[0], Mapping):
+        raise ManualPredictionError(f"implementation_manifest_{label}_entry_mismatch")
+    return matches[0]
+
+
+def _validate_feature_generator_identity(
+    implementation_manifest: Mapping[str, Any],
+    *,
+    implementation_manifest_sha: str,
+    feature_rows_sha: str,
+) -> None:
+    legacy_branch = (
+        implementation_manifest.get("git_branch") == FEATURE_GENERATOR_BRANCH
+    )
+    legacy_head = implementation_manifest.get("git_head") == FEATURE_GENERATOR_HEAD
+    legacy_packet = (
+        implementation_manifest_sha == LEGACY_IMPLEMENTATION_MANIFEST_SHA256
+        and feature_rows_sha == LEGACY_FEATURE_ROWS_SHA256
+    )
+    if legacy_branch and legacy_head and legacy_packet:
+        if implementation_manifest.get("implementation_files") != (
+            LEGACY_FEATURE_GENERATOR_FILES
+        ):
+            raise ManualPredictionError("feature_generator_identity_missing")
+        return
+
+    declared_hashes = implementation_manifest.get("implementation_file_hashes")
+    if not isinstance(declared_hashes, Mapping):
+        if legacy_branch and legacy_head:
+            raise ManualPredictionError("feature_generator_legacy_packet_hash_mismatch")
+        if not legacy_branch:
+            raise ManualPredictionError("feature_generator_branch_mismatch")
+        raise ManualPredictionError("feature_generator_head_mismatch")
+    implementation_files = implementation_manifest.get("implementation_files")
+    if implementation_files != FEATURE_GENERATOR_FILES:
+        raise ManualPredictionError("feature_generator_identity_missing")
+    if set(declared_hashes) != set(FEATURE_GENERATOR_FILES):
+        raise ManualPredictionError(
+            "feature_generator_implementation_hash_set_mismatch"
+        )
+    for relative in FEATURE_GENERATOR_FILES:
+        declared = str(declared_hashes.get(relative) or "").strip().lower()
+        if not re.fullmatch(r"[0-9a-f]{64}", declared):
+            raise ManualPredictionError("feature_generator_implementation_hash_invalid")
+        path = (ROOT / relative).resolve()
+        try:
+            path.relative_to(ROOT.resolve())
+            actual = _sha256_bytes(path.read_bytes())
+        except (OSError, ValueError) as exc:
+            raise ManualPredictionError(
+                "feature_generator_implementation_file_unreadable"
+            ) from exc
+        if actual != declared:
+            raise ManualPredictionError(
+                "feature_generator_implementation_hash_mismatch"
+            )
+
+
+def _feature_packet(
+    *,
+    feature_rows_path: Path,
+    feature_rows_raw: bytes,
+    feature_rows_sha: str,
+    feature_manifest_path: Path,
+    feature_manifest_raw: bytes,
+    feature_manifest_sha: str,
+    implementation_manifest_path: Path,
+    implementation_manifest: Mapping[str, Any],
+    implementation_manifest_sha: str,
+    form_csv_path: Path,
+    context: Mapping[str, Any],
+    race_id: str,
+) -> tuple[dict[int, dict[str, Any]], datetime, datetime]:
+    parent = feature_rows_path.parent.resolve()
+    if feature_rows_path.name != "shadow_feature_rows.json":
+        raise ManualPredictionError("feature_rows_filename_invalid")
+    if feature_manifest_path.resolve() != (parent / "shadow_manifest.json"):
+        raise ManualPredictionError("feature_manifest_not_adjacent")
+    if implementation_manifest_path.resolve() != (
+        parent / "implementation_file_manifest.json"
+    ):
+        raise ManualPredictionError("implementation_manifest_not_adjacent")
+    if implementation_manifest.get("schema_version") != IMPLEMENTATION_MANIFEST_SCHEMA:
+        raise ManualPredictionError("implementation_manifest_schema_mismatch")
+    if _contains_outcome_key(implementation_manifest):
+        raise ManualPredictionError("implementation_manifest_contains_outcome_field")
+    if Path(str(implementation_manifest.get("output_dir") or "")).resolve() != parent:
+        raise ManualPredictionError("feature_generator_output_dir_mismatch")
+    _validate_feature_generator_identity(
+        implementation_manifest,
+        implementation_manifest_sha=implementation_manifest_sha,
+        feature_rows_sha=feature_rows_sha,
+    )
+    for path, raw, sha, label in (
+        (feature_rows_path, feature_rows_raw, feature_rows_sha, "feature_rows"),
+        (
+            feature_manifest_path,
+            feature_manifest_raw,
+            feature_manifest_sha,
+            "feature_manifest",
+        ),
+    ):
+        entry = _manifest_entry(implementation_manifest, path, label)
+        if entry.get("sha256") != sha or _integer(
+            entry.get("bytes"), f"{label}_declared_bytes", minimum=1
+        ) != len(raw):
+            raise ManualPredictionError(f"{label}_manifest_hash_mismatch")
+    feature_manifest = _json_object(feature_manifest_raw, "feature_manifest")
+    if _contains_outcome_key(feature_manifest):
+        raise ManualPredictionError("feature_manifest_contains_outcome_field")
+    if feature_manifest.get("schema_version") != FEATURE_MANIFEST_SCHEMA:
+        raise ManualPredictionError("feature_manifest_schema_mismatch")
+    exact_flags = {
+        "output_mode": "shadow_only",
+        "betting_output": False,
+        "ev_output": False,
+        "odds_used_for_shadow_scoring": False,
+        "production_prediction_write": False,
+        "registry_mutation": False,
+        "tgr_enabled": False,
+    }
+    for key, expected in exact_flags.items():
+        if feature_manifest.get(key) != expected:
+            raise ManualPredictionError(f"feature_manifest_{key}_mismatch")
+    if Path(str(feature_manifest.get("feature_rows") or "")).resolve() != (
+        feature_rows_path.resolve()
+    ):
+        raise ManualPredictionError("feature_manifest_rows_path_mismatch")
+    input_files = feature_manifest.get("input_files")
+    if (
+        not isinstance(input_files, list)
+        or sum(
+            Path(str(item)).resolve() == form_csv_path.resolve() for item in input_files
+        )
+        != 1
+    ):
+        raise ManualPredictionError("feature_manifest_source_csv_mismatch")
+    feature_time = _parse_timestamp(
+        feature_manifest.get("feature_freeze_timestamp"), "feature_freeze_timestamp"
+    )
+    generated_time = _parse_timestamp(
+        feature_manifest.get("generated_at"), "feature_manifest_generated_at"
+    )
+    if feature_time > generated_time:
+        raise ManualPredictionError("feature_manifest_generated_before_freeze")
+    rows = _json_value(feature_rows_raw, "feature_rows")
+    if not isinstance(rows, list) or _contains_outcome_key(rows):
+        raise ManualPredictionError("feature_rows_invalid_or_contains_outcome")
+    selected = [
+        row
+        for row in rows
+        if isinstance(row, Mapping) and row.get("race_id") == race_id
+    ]
+    if len(selected) < 2:
+        raise ManualPredictionError("feature_rows_for_race_missing")
+    by_box: dict[int, dict[str, Any]] = {}
+    for row in selected:
+        if "features" in row:
+            raise ManualPredictionError("feature_values_must_be_top_level_and_exact")
+        box = _box(row.get("box_number"), "feature_runner_box")
+        name = str(row.get("dog_name") or "").strip()
+        identity = _runner_token(name)
+        if (
+            box in by_box
+            or box not in context["runners"]
+            or context["runners"][box]["identity"] != identity
+        ):
+            raise ManualPredictionError("feature_runner_set_mismatch_or_duplicate")
+        if Path(str(row.get("source_csv") or "")).resolve() != form_csv_path.resolve():
+            raise ManualPredictionError("feature_row_source_csv_mismatch")
+        if row.get("metadata_is_leakage_safe") is not True:
+            raise ManualPredictionError("feature_row_metadata_not_safe")
+        if row.get("target_metadata_from_sidecar") is not True:
+            raise ManualPredictionError("feature_row_target_metadata_not_from_sidecar")
+        if row.get("target_metadata_rejected_sources") != []:
+            raise ManualPredictionError("feature_row_target_metadata_rejected_sources")
+        if row.get("target_distance_source_is_safe") != 1:
+            raise ManualPredictionError("feature_row_target_distance_not_safe")
+        if row.get("target_grade_provenance_safe") != 1:
+            raise ManualPredictionError("feature_row_target_grade_not_safe")
+        if (
+            row.get("target_distance_missing") != 0
+            or row.get("target_grade_missing") != 0
+        ):
+            raise ManualPredictionError("feature_row_target_metadata_missing")
+        if not _trusted_thedogs_url(row.get("target_metadata_source_url")):
+            raise ManualPredictionError("feature_row_target_url_not_trusted_thedogs")
+        if str(row.get("target_metadata_source_url")) != context["source_url"]:
+            raise ManualPredictionError("feature_row_target_url_sidecar_mismatch")
+        if (
+            _parse_date(row.get("race_date"), "feature_row_race_date")
+            != context["target_race_date"]
+        ):
+            raise ManualPredictionError("feature_row_race_date_mismatch")
+        if str(row.get("venue") or "").strip().upper() != context["target_venue"]:
+            raise ManualPredictionError("feature_row_venue_mismatch")
+        if (
+            _integer(row.get("race_number"), "feature_row_race_number", minimum=1)
+            != context["target_race_number"]
+        ):
+            raise ManualPredictionError("feature_row_race_number_mismatch")
+        distance = _nullable_float(
+            row.get("target_distance_safe"), "feature_target_distance"
+        )
+        if distance is None or not math.isclose(
+            distance, float(context["target_distance"]), rel_tol=0.0, abs_tol=1e-9
+        ):
+            raise ManualPredictionError("feature_row_target_distance_mismatch")
+        if (
+            _canonical_target_grade(row.get("target_grade_safe"))
+            != context["target_grade"]
+        ):
+            raise ManualPredictionError("feature_row_target_grade_mismatch")
+        if row.get("same_distance_same_grade_history_cutoff") != (
+            "strictly_before_target_race"
+        ) or row.get("same_distance_same_grade_history_cutoff_basis") != (
+            "race_date_less_than_target_race_date"
+        ):
+            raise ManualPredictionError("feature_history_cutoff_mismatch")
+        if row.get("same_distance_same_grade_target_race_rows_used") != 0:
+            raise ManualPredictionError("feature_target_race_rows_used")
+        if row.get("same_distance_same_grade_post_outcome_rows_used") != 0:
+            raise ManualPredictionError("feature_post_outcome_rows_used")
+        if row.get("same_distance_same_grade_post_outcome_fields_used") != []:
+            raise ManualPredictionError("feature_post_outcome_fields_used")
+        features: dict[str, float | None] = {}
+        for feature in FEATURES:
+            if feature not in row:
+                raise ManualPredictionError(f"feature_value_missing:{feature}")
+            features[feature] = _nullable_float(
+                row[feature], f"feature_value:{feature}"
+            )
+        by_box[box] = {
+            "box_number": box,
+            "dog_name": name,
+            "identity": identity,
+            "features": features,
+        }
+    if set(by_box) != set(context["runners"]):
+        raise ManualPredictionError("feature_race_incomplete_or_runner_set_mismatch")
+    return by_box, feature_time, generated_time
+
+
+def discover_race_artifacts(
+    *,
+    race_query: str,
+    evidence_roots: Sequence[Path],
+    score_timestamp: datetime,
+) -> dict[str, Any]:
+    """Resolve one race to one sealed feature packet and one capture report."""
+
+    if score_timestamp.tzinfo is None or score_timestamp.utcoffset() is None:
+        raise ManualPredictionError("score_timestamp_timezone_missing")
+    roots = sorted({Path(root).resolve() for root in evidence_roots})
+    if not roots or any(not root.is_dir() for root in roots):
+        raise ManualPredictionError("evidence_root_missing_or_not_directory")
+    race_number, venue_query = _race_query_parts(race_query)
+
+    feature_candidates: list[dict[str, Any]] = []
+    seen_feature_packets: set[Path] = set()
+    for root in roots:
+        for feature_rows_path in sorted(root.rglob("shadow_feature_rows.json")):
+            feature_rows_path = feature_rows_path.resolve()
+            if feature_rows_path in seen_feature_packets:
+                continue
+            seen_feature_packets.add(feature_rows_path)
+            feature_manifest_path = feature_rows_path.with_name("shadow_manifest.json")
+            implementation_manifest_path = feature_rows_path.with_name(
+                "implementation_file_manifest.json"
+            )
+            if not all(
+                _path_in_roots(path, roots)
+                for path in (
+                    feature_rows_path,
+                    feature_manifest_path,
+                    implementation_manifest_path,
+                )
+            ):
+                raise ManualPredictionError("discovery_path_outside_evidence_root")
+            if (
+                not feature_manifest_path.is_file()
+                or not implementation_manifest_path.is_file()
+            ):
+                continue
+            feature_rows_raw, _ = _read_input(
+                feature_rows_path, "discovery_feature_rows"
+            )
+            rows = _json_value(feature_rows_raw, "discovery_feature_rows")
+            if not isinstance(rows, list):
+                continue
+            if _contains_outcome_key(rows):
+                raise ManualPredictionError("discovery_feature_packet_contains_outcome")
+            race_ids = sorted(
+                {
+                    str(row.get("race_id"))
+                    for row in rows
+                    if isinstance(row, Mapping) and row.get("race_id") not in (None, "")
+                }
+            )
+            for race_id in race_ids:
+                try:
+                    candidate_number, candidate_venue, candidate_date = _race_id_parts(
+                        race_id
+                    )
+                except ManualPredictionError:
+                    continue
+                if candidate_number != race_number:
+                    continue
+                selected_rows = [
+                    row
+                    for row in rows
+                    if isinstance(row, Mapping) and row.get("race_id") == race_id
+                ]
+                aliases: list[str] = []
+                for row in selected_rows:
+                    row_venue = str(row.get("venue") or "")
+                    if _runner_token(row_venue) != _runner_token(candidate_venue):
+                        aliases.append(row_venue)
+                    source_url = str(row.get("target_metadata_source_url") or "")
+                    try:
+                        path_parts = [
+                            part
+                            for part in urlparse(source_url).path.split("/")
+                            if part
+                        ]
+                    except ValueError:
+                        path_parts = []
+                    for index, part in enumerate(path_parts[:-1]):
+                        if part.lower() == "racing":
+                            aliases.append(path_parts[index + 1])
+                            break
+                venue_match_rank = _venue_query_match_rank(
+                    venue_query,
+                    canonical_venue=candidate_venue,
+                    full_aliases=aliases,
+                )
+                if venue_match_rank is None:
+                    continue
+                source_csv_values = {
+                    str(row.get("source_csv") or "").strip() for row in selected_rows
+                }
+                source_csv_values.discard("")
+                if len(source_csv_values) != 1:
+                    continue
+                form_csv_path = Path(next(iter(source_csv_values)))
+                if not form_csv_path.is_absolute():
+                    form_csv_path = ROOT / form_csv_path
+                form_csv_path = form_csv_path.resolve()
+                sidecar_path = form_csv_path.with_name(
+                    form_csv_path.name + ".metadata.json"
+                )
+                if (
+                    not form_csv_path.is_file()
+                    or not sidecar_path.is_file()
+                    or not _path_in_roots(form_csv_path, roots)
+                    or not _path_in_roots(sidecar_path, roots)
+                ):
+                    continue
+                feature_manifest_raw, _ = _read_input(
+                    feature_manifest_path, "discovery_feature_manifest"
+                )
+                feature_manifest = _json_object(
+                    feature_manifest_raw, "discovery_feature_manifest"
+                )
+                if _contains_outcome_key(feature_manifest):
+                    raise ManualPredictionError(
+                        "discovery_feature_manifest_contains_outcome"
+                    )
+                generated_at = _parse_timestamp(
+                    feature_manifest.get("generated_at"),
+                    "discovery_feature_manifest_generated_at",
+                )
+                if generated_at > score_timestamp:
+                    continue
+                feature_candidates.append(
+                    {
+                        "race_id": race_id,
+                        "race_date": candidate_date,
+                        "venue_code": candidate_venue,
+                        "venue_match_rank": venue_match_rank,
+                        "generated_at": generated_at,
+                        "form_csv_path": form_csv_path,
+                        "sidecar_path": sidecar_path,
+                        "feature_rows_path": feature_rows_path,
+                        "feature_manifest_path": feature_manifest_path,
+                        "implementation_manifest_path": implementation_manifest_path,
+                    }
+                )
+
+    if not feature_candidates:
+        raise ManualPredictionError("race_feature_packet_not_found")
+    best_venue_rank = min(row["venue_match_rank"] for row in feature_candidates)
+    feature_candidates = [
+        row for row in feature_candidates if row["venue_match_rank"] == best_venue_rank
+    ]
+    if len({row["venue_code"] for row in feature_candidates}) != 1:
+        raise ManualPredictionError("race_query_ambiguous")
+    current_date = score_timestamp.astimezone(MELBOURNE).date()
+    available_dates = sorted(
+        {
+            row["race_date"]
+            for row in feature_candidates
+            if row["race_date"] >= current_date
+        }
+    )
+    target_date = (
+        available_dates[0]
+        if available_dates
+        else max(row["race_date"] for row in feature_candidates)
+    )
+    dated = [row for row in feature_candidates if row["race_date"] == target_date]
+    race_ids = {row["race_id"] for row in dated}
+    if len(race_ids) != 1:
+        raise ManualPredictionError("race_query_ambiguous")
+    latest_feature_time = max(row["generated_at"] for row in dated)
+    selected_features = [
+        row for row in dated if row["generated_at"] == latest_feature_time
+    ]
+    if len(selected_features) != 1:
+        raise ManualPredictionError("race_feature_packet_ambiguous")
+    selected_feature = selected_features[0]
+    race_id = str(selected_feature["race_id"])
+
+    capture_candidates: list[dict[str, Any]] = []
+    seen_capture_reports: set[Path] = set()
+    for root in roots:
+        for capture_path in sorted(
+            root.rglob("autonomous_live_odds_capture_report.json")
+        ):
+            capture_path = capture_path.resolve()
+            if capture_path in seen_capture_reports:
+                continue
+            seen_capture_reports.add(capture_path)
+            if not _path_in_roots(capture_path, roots):
+                raise ManualPredictionError("discovery_path_outside_evidence_root")
+            capture_raw, _ = _read_input(capture_path, "discovery_capture")
+            try:
+                capture_payload = _json_object(capture_raw, "discovery_capture")
+            except ManualPredictionError:
+                continue
+            if _contains_outcome_key(capture_payload):
+                raise ManualPredictionError("discovery_capture_contains_outcome")
+            raw_attempts = capture_payload.get("attempts")
+            if not isinstance(raw_attempts, list) or not any(
+                isinstance(attempt, Mapping) and attempt.get("race_id") == race_id
+                for attempt in raw_attempts
+            ):
+                continue
+            try:
+                attempts = _capture_attempts(capture_raw, jsonl=False)
+            except ManualPredictionError as exc:
+                raise ManualPredictionError("race_capture_report_invalid") from exc
+            matches = [
+                attempt
+                for attempt in attempts
+                if attempt.get("race_id") == race_id
+                and attempt.get("status") == "APPENDED"
+                and isinstance(attempt.get("validation"), Mapping)
+                and attempt["validation"].get("status") == "PASS"
+            ]
+            if not matches:
+                continue
+            if len(matches) != 1:
+                raise ManualPredictionError("accepted_capture_attempt_ambiguous")
+            append_time = _parse_timestamp(
+                matches[0].get("append_time"), "discovery_capture_append_timestamp"
+            )
+            if append_time <= score_timestamp:
+                capture_candidates.append(
+                    {"capture_path": capture_path, "append_time": append_time}
+                )
+    if not capture_candidates:
+        raise ManualPredictionError("race_capture_report_not_found")
+    latest_append = max(row["append_time"] for row in capture_candidates)
+    selected_captures = [
+        row for row in capture_candidates if row["append_time"] == latest_append
+    ]
+    if len(selected_captures) != 1:
+        raise ManualPredictionError("race_capture_report_ambiguous")
+
+    return {
+        **selected_feature,
+        "capture_path": selected_captures[0]["capture_path"],
+    }
+
+
+def score_from_artifacts(
+    *,
+    race_id: str,
+    form_csv_path: Path,
+    sidecar_path: Path,
+    feature_rows_path: Path,
+    feature_manifest_path: Path,
+    implementation_manifest_path: Path,
+    capture_path: Path,
+    model_path: Path,
+    manifest_path: Path,
+    score_timestamp: datetime | None = None,
+    shadow_output_path: Path | None = None,
+    frozen_model: FrozenResidualModel | None = None,
+) -> dict[str, Any]:
+    """Validate immutable sealed inputs and return one outcome-free ranking."""
+
+    if not race_id or any(token in race_id for token in ("/", "\\", "..")):
+        raise ManualPredictionError("race_id_invalid")
+    expected_sidecar = form_csv_path.with_name(form_csv_path.name + ".metadata.json")
+    if sidecar_path.resolve() != expected_sidecar.resolve():
+        raise ManualPredictionError("sidecar_not_adjacent_to_form_csv")
+
+    # Every mutable source artifact is read exactly once. Hashes below describe
+    # the same immutable bytes that are parsed and scored.
+    form_raw, form_sha = _read_input(form_csv_path, "form_csv")
+    sidecar_raw, sidecar_sha = _read_input(sidecar_path, "sidecar")
+    feature_rows_raw, feature_rows_sha = _read_input(feature_rows_path, "feature_rows")
+    feature_manifest_raw, feature_manifest_sha = _read_input(
+        feature_manifest_path, "feature_manifest"
+    )
+    implementation_raw, implementation_sha = _read_input(
+        implementation_manifest_path, "implementation_manifest"
+    )
+    capture_raw, capture_sha = _read_input(capture_path, "capture")
+
+    sidecar = _json_object(sidecar_raw, "sidecar")
+    _validate_form_binding(
+        sidecar,
+        form_csv_path=form_csv_path,
+        form_raw=form_raw,
+        form_sha=form_sha,
+    )
+    context = _sidecar_context(sidecar)
+    if race_id != context["expected_race_id"]:
+        raise ManualPredictionError("race_id_sidecar_mismatch")
+    implementation = _json_object(implementation_raw, "implementation_manifest")
+    feature_by_box, feature_time, feature_generated_time = _feature_packet(
+        feature_rows_path=feature_rows_path,
+        feature_rows_raw=feature_rows_raw,
+        feature_rows_sha=feature_rows_sha,
+        feature_manifest_path=feature_manifest_path,
+        feature_manifest_raw=feature_manifest_raw,
+        feature_manifest_sha=feature_manifest_sha,
+        implementation_manifest_path=implementation_manifest_path,
+        implementation_manifest=implementation,
+        implementation_manifest_sha=implementation_sha,
+        form_csv_path=form_csv_path,
+        context=context,
+        race_id=race_id,
+    )
+    attempt = _select_capture_attempt(
+        capture_raw, jsonl=capture_path.suffix.lower() == ".jsonl", race_id=race_id
+    )
+    capture_rows, fetch_time, append_time = _active_capture_rows(
+        attempt, context["runners"], context
+    )
+    jump = context["jump_timestamp"]
+    score_time = score_timestamp or datetime.now().astimezone()
+    if score_time.tzinfo is None or score_time.utcoffset() is None:
+        raise ManualPredictionError("score_timestamp_timezone_missing")
+    feature_timeline = (
+        context["metadata_timestamp"],
+        feature_time,
+        feature_generated_time,
+        score_time,
+        jump,
+    )
+    odds_timeline = (
+        context["metadata_timestamp"],
+        fetch_time,
+        append_time,
+        score_time,
+        jump,
+    )
+    if any(
+        left > right
+        for timeline in (feature_timeline, odds_timeline)
+        for left, right in zip(timeline, timeline[1:])
+    ):
+        raise ManualPredictionError("source_timestamp_order_invalid")
+    if not score_time < jump:
+        raise ManualPredictionError("manual_score_not_prejump")
+
+    selected_attempt_sha = _sha256_bytes(_canonical_bytes(attempt))
+    feature_source_sha = _sha256_bytes(
+        _canonical_bytes(
+            {
+                "feature_manifest_sha256": feature_manifest_sha,
+                "feature_rows_sha256": feature_rows_sha,
+                "form_csv_sha256": form_sha,
+                "implementation_manifest_sha256": implementation_sha,
+                "sidecar_sha256": sidecar_sha,
+            }
+        )
+    )
+    odds_source_sha = _sha256_bytes(
+        _canonical_bytes(
+            {
+                "capture_artifact_sha256": capture_sha,
+                "selected_attempt_sha256": selected_attempt_sha,
+            }
+        )
+    )
+    active_by_box = {int(row["box_number"]): row for row in capture_rows}
+    runners = []
+    runner_ids = []
+    for box in sorted(active_by_box):
+        capture_row = active_by_box[box]
+        feature_row = feature_by_box[box]
+        runner_id = f"{race_id}|box:{box}|dog:{feature_row['identity']}"
+        runner_ids.append(runner_id)
+        runners.append(
+            {
+                "race_id": race_id,
+                "runner_id": runner_id,
+                "box_number": box,
+                "dog_name": feature_row["dog_name"],
+                "strict_win_odds": float(capture_row["odds"]),
+                "features": feature_row["features"],
+                "feature_source_sha256": feature_source_sha,
+                "odds_source_sha256": odds_source_sha,
+                "feature_freeze_timestamp": feature_time.isoformat(),
+                "odds_capture_timestamp": fetch_time.isoformat(),
+            }
+        )
+    frozen = frozen_model or load_frozen_model(model_path, manifest_path)
+    expected_ids = sorted(runner_ids)
+    provenance = {
+        "race_id": race_id,
+        "expected_runner_ids": expected_ids,
+        "runner_set_sha256": _runner_set_sha256(expected_ids),
+        "jump_timestamp": jump.isoformat(),
+        "score_timestamp": score_time.isoformat(),
+    }
+    record = score_race(frozen, runners, provenance)
+    ranking = sorted(
+        record["predictions"],
+        key=lambda row: (-float(row["full_probability"]), int(row["box_number"])),
+    )
+    persistence_status = (
+        append_shadow_record(
+            shadow_output_path,
+            record,
+            frozen=frozen,
+            runners=runners,
+            provenance=provenance,
+        )
+        if shadow_output_path is not None
+        else None
+    )
+    output = {
+        "schema_version": OUTPUT_SCHEMA,
+        "status": "MANUAL_PREJUMP_FROZEN_RESIDUAL_PREDICTION",
+        "race_id": race_id,
+        "jump_timestamp": jump.isoformat(),
+        "score_timestamp": score_time.isoformat(),
+        "metadata_capture_timestamp": context["metadata_timestamp"].isoformat(),
+        "feature_freeze_timestamp": feature_time.isoformat(),
+        "feature_manifest_generated_at": feature_generated_time.isoformat(),
+        "odds_capture_timestamp": fetch_time.isoformat(),
+        "odds_append_timestamp": append_time.isoformat(),
+        "model_sha256": record["model_sha256"],
+        "manifest_sha256": record["manifest_sha256"],
+        "runner_set_sha256": record["runner_set_sha256"],
+        "record_key": record["record_key"],
+        "variants": {"full_strength": 1.0, "half_strength": 0.5},
+        "source_contract": {
+            "feature_source": "exact_hash_bound_system_shadow_feature_rows",
+            "feature_reconstruction_performed": False,
+            "database_access": False,
+            "network_access": False,
+        },
+        "input_hashes": {
+            "form_csv_sha256": form_sha,
+            "sidecar_sha256": sidecar_sha,
+            "feature_rows_sha256": feature_rows_sha,
+            "feature_manifest_sha256": feature_manifest_sha,
+            "implementation_manifest_sha256": implementation_sha,
+            "capture_artifact_sha256": capture_sha,
+            "selected_attempt_sha256": selected_attempt_sha,
+            "feature_source_sha256": feature_source_sha,
+            "odds_source_sha256": odds_source_sha,
+        },
+        "predictions": [
+            {
+                "rank": rank,
+                "box": int(row["box_number"]),
+                "dog": row["dog_name"],
+                "win_odds": float(row["strict_win_odds"]),
+                "market_probability": float(row["market_probability"]),
+                "half_probability": float(row["half_probability"]),
+                "full_probability": float(row["full_probability"]),
+                "full_minus_market": float(row["full_probability"])
+                - float(row["market_probability"]),
+            }
+            for rank, row in enumerate(ranking, start=1)
+        ],
+        "probability_sums": {
+            key: sum(float(row[f"{key}_probability"]) for row in ranking)
+            for key in ("market", "half", "full")
+        },
+        "activation": False,
+        "persisted": persistence_status is not None,
+        "persistence_status": persistence_status,
+        "shadow_output_path": (
+            str(shadow_output_path.resolve())
+            if shadow_output_path is not None
+            else None
+        ),
+        "outcomes_present": False,
+    }
+    _canonical_bytes(output)
+    return output
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--race-id")
+    parser.add_argument(
+        "--race",
+        help='Race-first query such as "sandown r6" over the evidence root.',
+    )
+    parser.add_argument(
+        "--evidence-root",
+        action="append",
+        type=Path,
+        help=(
+            "Outcome-free evidence root to search in race-first mode. May be repeated; "
+            "defaults to the repository evidence root."
+        ),
+    )
+    parser.add_argument("--form-csv", type=Path)
+    parser.add_argument("--sidecar", type=Path)
+    parser.add_argument("--feature-rows", type=Path)
+    parser.add_argument("--feature-manifest", type=Path)
+    parser.add_argument("--implementation-manifest", type=Path)
+    parser.add_argument("--capture", type=Path)
+    parser.add_argument(
+        "--append-shadow-output",
+        type=Path,
+        help=(
+            "Explicit append-only .jsonl path for the canonical outcome-free "
+            "frozen shadow record. The parent directory must already exist."
+        ),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    artifact_dir = ROOT / DEFAULT_ARTIFACT_DIR
+    try:
+        score_time = datetime.now().astimezone()
+        if args.race:
+            if any(
+                value is not None
+                for value in (
+                    args.race_id,
+                    args.form_csv,
+                    args.sidecar,
+                    args.feature_rows,
+                    args.feature_manifest,
+                    args.implementation_manifest,
+                    args.capture,
+                )
+            ):
+                raise ManualPredictionError(
+                    "race_first_mode_cannot_mix_explicit_artifact_arguments"
+                )
+            discovered = discover_race_artifacts(
+                race_query=args.race,
+                evidence_roots=args.evidence_root or [DEFAULT_EVIDENCE_ROOT],
+                score_timestamp=score_time,
+            )
+            race_id = str(discovered["race_id"])
+            form_csv = Path(discovered["form_csv_path"])
+            sidecar = Path(discovered["sidecar_path"])
+            feature_rows = Path(discovered["feature_rows_path"])
+            feature_manifest = Path(discovered["feature_manifest_path"])
+            implementation_manifest = Path(discovered["implementation_manifest_path"])
+            capture = Path(discovered["capture_path"])
+        else:
+            if args.evidence_root:
+                raise ManualPredictionError("evidence_root_requires_race_first_mode")
+            if (
+                not args.race_id
+                or args.form_csv is None
+                or args.feature_rows is None
+                or args.capture is None
+            ):
+                raise ManualPredictionError("explicit_artifact_arguments_incomplete")
+            race_id = args.race_id
+            form_csv = args.form_csv
+            sidecar = args.sidecar or form_csv.with_name(
+                form_csv.name + ".metadata.json"
+            )
+            feature_rows = args.feature_rows
+            feature_manifest = args.feature_manifest or feature_rows.with_name(
+                "shadow_manifest.json"
+            )
+            implementation_manifest = (
+                args.implementation_manifest
+                or feature_rows.with_name("implementation_file_manifest.json")
+            )
+            capture = args.capture
+        output = score_from_artifacts(
+            race_id=race_id,
+            form_csv_path=form_csv,
+            sidecar_path=sidecar,
+            feature_rows_path=feature_rows,
+            feature_manifest_path=feature_manifest,
+            implementation_manifest_path=implementation_manifest,
+            capture_path=capture,
+            model_path=artifact_dir / "model.json",
+            manifest_path=artifact_dir / "manifest.json",
+            score_timestamp=score_time if args.race else None,
+            shadow_output_path=args.append_shadow_output,
+        )
+    except (ManualPredictionError, ResidualContractError) as exc:
+        sys.stderr.buffer.write(
+            _canonical_bytes(
+                {"status": "BLOCKED_MANUAL_PREDICTION", "reason": str(exc)}
+            )
+        )
+        return 2
+    sys.stdout.buffer.write(_canonical_bytes(output))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/predict_market_form_residual.py
+++ b/scripts/predict_market_form_residual.py
@@ -33,6 +33,7 @@ if ROOT_TEXT not in sys.path:
 from src.predictor.market_form_residual import (  # noqa: E402
     DEFAULT_ARTIFACT_DIR,
     FEATURES,
+    SHADOW_RECORD_SCHEMA,
     FrozenResidualModel,
     ResidualContractError,
     _runner_set_sha256,
@@ -46,14 +47,50 @@ MELBOURNE = ZoneInfo("Australia/Melbourne")
 ALLOWED_BOX_SOURCES = {"explicit_dom", "runner_text"}
 OUTCOME_KEYS = {
     "actual_win",
+    "actual_winner",
+    "db_finish_position",
+    "db_result_position",
+    "db_scraped_finish_position",
+    "dividend",
+    "finish",
     "finish_position",
+    "finishing_position",
+    "future_position",
+    "future_result",
+    "future_time",
+    "individual_time",
+    "is_placer",
+    "is_winner",
+    "margin",
+    "mgn",
+    "official_finish_position",
+    "official_position",
     "official_result",
+    "official_result_status",
+    "official_winner",
     "outcome",
+    "payout",
+    "place",
     "placing",
+    "plc",
+    "position",
+    "race_time_result",
     "result",
+    "result_position",
+    "result_status",
+    "results",
+    "results_status",
+    "scraped_finish_position",
+    "scraped_raw_result",
+    "starting_price",
+    "target_finish_position",
+    "time",
+    "win_time",
     "winner",
+    "winner_margin",
     "winner_name",
     "winner_odds",
+    "winning_time",
 }
 POST_RACE_URL_TOKENS = {
     "result",
@@ -135,6 +172,48 @@ def _read_input(path: Path, label: str) -> tuple[bytes, str]:
     if not raw:
         raise ManualPredictionError(f"{label}_empty")
     return raw, _sha256_bytes(raw)
+
+
+def _existing_replay_score_timestamp(
+    path: Path, identity: Mapping[str, str]
+) -> datetime | None:
+    """Return one prior score time as a hint for writer-validated exact replay."""
+
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise ManualPredictionError("shadow_output_unreadable") from exc
+    if not raw:
+        return None
+    try:
+        lines = raw.decode("utf-8").splitlines()
+    except UnicodeDecodeError as exc:
+        raise ManualPredictionError("shadow_output_invalid_utf8") from exc
+    matches = []
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            raise ManualPredictionError(f"shadow_output_blank_line:{line_number}")
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ManualPredictionError(
+                f"shadow_output_invalid_json:{line_number}"
+            ) from exc
+        if not isinstance(row, Mapping):
+            raise ManualPredictionError(f"shadow_output_row_not_object:{line_number}")
+        if row.get("schema_version") == SHADOW_RECORD_SCHEMA and all(
+            row.get(key) == value for key, value in identity.items()
+        ):
+            matches.append(row)
+    if len(matches) > 1:
+        raise ManualPredictionError("shadow_output_replay_identity_ambiguous")
+    if not matches:
+        return None
+    return _parse_timestamp(
+        matches[0].get("score_timestamp"), "shadow_replay_score_timestamp"
+    )
 
 
 def _json_value(raw: bytes, label: str) -> Any:
@@ -1340,32 +1419,6 @@ def score_from_artifacts(
         attempt, context["runners"], context
     )
     jump = context["jump_timestamp"]
-    score_time = score_timestamp or datetime.now().astimezone()
-    if score_time.tzinfo is None or score_time.utcoffset() is None:
-        raise ManualPredictionError("score_timestamp_timezone_missing")
-    feature_timeline = (
-        context["metadata_timestamp"],
-        feature_time,
-        feature_generated_time,
-        score_time,
-        jump,
-    )
-    odds_timeline = (
-        context["metadata_timestamp"],
-        fetch_time,
-        append_time,
-        score_time,
-        jump,
-    )
-    if any(
-        left > right
-        for timeline in (feature_timeline, odds_timeline)
-        for left, right in zip(timeline, timeline[1:])
-    ):
-        raise ManualPredictionError("source_timestamp_order_invalid")
-    if not score_time < jump:
-        raise ManualPredictionError("manual_score_not_prejump")
-
     selected_attempt_sha = _sha256_bytes(_canonical_bytes(attempt))
     feature_source_sha = _sha256_bytes(
         _canonical_bytes(
@@ -1410,10 +1463,48 @@ def score_from_artifacts(
         )
     frozen = frozen_model or load_frozen_model(model_path, manifest_path)
     expected_ids = sorted(runner_ids)
+    runner_set_sha = _runner_set_sha256(expected_ids)
+    score_time = score_timestamp
+    if score_time is None and shadow_output_path is not None:
+        score_time = _existing_replay_score_timestamp(
+            shadow_output_path,
+            {
+                "race_id": race_id,
+                "runner_set_sha256": runner_set_sha,
+                "model_sha256": frozen.model_sha256,
+                "manifest_sha256": frozen.manifest_sha256,
+                "effective_state_sha256": frozen.effective_state_sha256,
+            },
+        )
+    score_time = score_time or datetime.now().astimezone()
+    if score_time.tzinfo is None or score_time.utcoffset() is None:
+        raise ManualPredictionError("score_timestamp_timezone_missing")
+    feature_timeline = (
+        context["metadata_timestamp"],
+        feature_time,
+        feature_generated_time,
+        score_time,
+        jump,
+    )
+    odds_timeline = (
+        context["metadata_timestamp"],
+        fetch_time,
+        append_time,
+        score_time,
+        jump,
+    )
+    if any(
+        left > right
+        for timeline in (feature_timeline, odds_timeline)
+        for left, right in zip(timeline, timeline[1:])
+    ):
+        raise ManualPredictionError("source_timestamp_order_invalid")
+    if not score_time < jump:
+        raise ManualPredictionError("manual_score_not_prejump")
     provenance = {
         "race_id": race_id,
         "expected_runner_ids": expected_ids,
-        "runner_set_sha256": _runner_set_sha256(expected_ids),
+        "runner_set_sha256": runner_set_sha,
         "jump_timestamp": jump.isoformat(),
         "score_timestamp": score_time.isoformat(),
     }
@@ -1525,7 +1616,9 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         help=(
             "Explicit append-only .jsonl path for the canonical outcome-free "
-            "frozen shadow record. The parent directory must already exist."
+            "frozen shadow record. The parent directory must already exist; "
+            "an identical prior stable identity is writer-validated and returned "
+            "as EXACT_REPLAY."
         ),
     )
     return parser
@@ -1598,7 +1691,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             capture_path=capture,
             model_path=artifact_dir / "model.json",
             manifest_path=artifact_dir / "manifest.json",
-            score_timestamp=score_time if args.race else None,
+            score_timestamp=(
+                None
+                if args.append_shadow_output is not None
+                else score_time
+                if args.race
+                else None
+            ),
             shadow_output_path=args.append_shadow_output,
         )
     except (ManualPredictionError, ResidualContractError) as exc:

--- a/tests/test_predict_market_form_residual.py
+++ b/tests/test_predict_market_form_residual.py
@@ -499,6 +499,52 @@ def test_rejects_nested_or_extra_feature_bundle(tmp_path):
         _score_paths(paths)
 
 
+@pytest.mark.parametrize(
+    "outcome_key",
+    [
+        "is_winner",
+        "is_placer",
+        "official_finish_position",
+        "db_finish_position",
+        "scraped_finish_position",
+        "target_finish_position",
+        "result_position",
+        "official_position",
+        "actual_winner",
+        "official_winner",
+        "result_status",
+        "results_status",
+        "official_result_status",
+    ],
+)
+def test_rejects_supported_outcome_fields_in_feature_rows(tmp_path, outcome_key):
+    paths = _write_fixture(tmp_path)
+    _reseal(paths, lambda rows, _: rows[0].__setitem__(outcome_key, 1))
+
+    with pytest.raises(
+        ManualPredictionError, match="feature_rows_invalid_or_contains_outcome"
+    ):
+        _score_paths(paths)
+
+
+@pytest.mark.parametrize(
+    ("artifact_key", "error"),
+    [
+        ("sidecar", "sidecar_contains_outcome_field"),
+        ("capture", "capture_contains_outcome_field"),
+    ],
+)
+def test_rejects_is_winner_across_input_artifacts(tmp_path, artifact_key, error):
+    paths = _write_fixture(tmp_path)
+    artifact = _json(paths[artifact_key])
+    assert isinstance(artifact, dict)
+    artifact["is_winner"] = 1
+    _write_json(paths[artifact_key], artifact)
+
+    with pytest.raises(ManualPredictionError, match=error):
+        _score_paths(paths)
+
+
 def test_rejects_outcome_field_in_feature_manifest(tmp_path):
     paths = _write_fixture(tmp_path)
     _reseal(paths, lambda _, manifest: manifest.__setitem__("winner", "Alpha Fast"))
@@ -917,22 +963,23 @@ def test_cli_explicit_shadow_output_persists_v3_record(tmp_path):
     paths = _write_fixture(tmp_path / "fixture")
     race_id = _retime_for_cli(paths)
     shadow_output = tmp_path / "market_form_residual_shadow_predictions_v3.jsonl"
+    command = [
+        sys.executable,
+        str(ROOT / "scripts/predict_market_form_residual.py"),
+        "--race-id",
+        race_id,
+        "--form-csv",
+        str(paths["form_csv"]),
+        "--feature-rows",
+        str(paths["feature_rows"]),
+        "--capture",
+        str(paths["capture"]),
+        "--append-shadow-output",
+        str(shadow_output),
+    ]
 
     completed = subprocess.run(
-        [
-            sys.executable,
-            str(ROOT / "scripts/predict_market_form_residual.py"),
-            "--race-id",
-            race_id,
-            "--form-csv",
-            str(paths["form_csv"]),
-            "--feature-rows",
-            str(paths["feature_rows"]),
-            "--capture",
-            str(paths["capture"]),
-            "--append-shadow-output",
-            str(shadow_output),
-        ],
+        command,
         cwd=tmp_path,
         check=False,
         capture_output=True,
@@ -946,12 +993,74 @@ def test_cli_explicit_shadow_output_persists_v3_record(tmp_path):
     assert output["persistence_status"] == "APPENDED"
     assert output["shadow_output_path"] == str(shadow_output.resolve())
 
+    replayed = subprocess.run(
+        command,
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+    )
+    assert replayed.returncode == 0, replayed.stderr.decode("utf-8")
+    assert replayed.stderr == b""
+    replayed_output = json.loads(replayed.stdout)
+    assert replayed.stdout == _canonical_bytes(replayed_output)
+    assert replayed_output["persistence_status"] == "EXACT_REPLAY"
+    assert replayed_output["record_key"] == output["record_key"]
+    assert replayed_output["score_timestamp"] == output["score_timestamp"]
+
     records = [json.loads(line) for line in shadow_output.read_bytes().splitlines()]
     assert len(records) == 1
     assert records[0]["schema_version"] == "market_form_residual_shadow_record_v3"
     assert records[0]["race_id"] == race_id
     assert records[0]["outcomes_present"] is False
     assert records[0]["activation"] is False
+
+
+def test_cli_explicit_shadow_output_rejects_changed_input_as_conflict(tmp_path):
+    paths = _write_fixture(tmp_path / "fixture")
+    race_id = _retime_for_cli(paths)
+    shadow_output = tmp_path / "market_form_residual_shadow_predictions_v3.jsonl"
+    command = [
+        sys.executable,
+        str(ROOT / "scripts/predict_market_form_residual.py"),
+        "--race-id",
+        race_id,
+        "--form-csv",
+        str(paths["form_csv"]),
+        "--feature-rows",
+        str(paths["feature_rows"]),
+        "--capture",
+        str(paths["capture"]),
+        "--append-shadow-output",
+        str(shadow_output),
+    ]
+
+    first = subprocess.run(
+        command,
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+    )
+    assert first.returncode == 0, first.stderr.decode("utf-8")
+    original = shadow_output.read_bytes()
+
+    capture = _json(paths["capture"])
+    assert isinstance(capture, dict)
+    capture["attempts"][0]["validation"]["accepted_rows"][0]["odds_decimal"] = 2.6
+    _write_json(paths["capture"], capture)
+
+    conflicting = subprocess.run(
+        command,
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+    )
+    assert conflicting.returncode == 2
+    assert conflicting.stdout == b""
+    assert json.loads(conflicting.stderr) == {
+        "status": "BLOCKED_MANUAL_PREDICTION",
+        "reason": "conflicting_shadow_duplicate",
+    }
+    assert shadow_output.read_bytes() == original
 
 
 def test_race_first_cli_discovers_exact_packet_with_one_query_and_writes_nothing(

--- a/tests/test_predict_market_form_residual.py
+++ b/tests/test_predict_market_form_residual.py
@@ -1,0 +1,1125 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+import scripts.predict_market_form_residual as manual
+from scripts.predict_market_form_residual import (
+    ManualPredictionError,
+    _canonical_target_grade,
+    _trusted_sportsbet_url,
+    _trusted_thedogs_url,
+    build_parser,
+    score_from_artifacts,
+)
+from src.predictor.market_form_residual import FEATURES
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_DIR = ROOT / "artifacts/frozen_models/market_form_residual_v1"
+RACE_ID = "Race 2 - SAN - 2026-07-16"
+MELBOURNE = ZoneInfo("Australia/Melbourne")
+SCORE_TIME = datetime(2026, 7, 16, 18, 52, tzinfo=MELBOURNE)
+SOURCE_URL = "https://www.thedogs.com.au/racing/sandown/2026-07-16/2/test"
+
+RUNNERS = (
+    (1, "Alpha Fast", "ALPHAFAST", 2.5),
+    (2, "Beta Bale", "BETABALE", 3.2),
+    (4, "Gamma Rule", "GAMMARULE", 5.0),
+)
+
+GOLDEN_FEATURES = {
+    1: dict(
+        zip(
+            FEATURES,
+            (2, 7, 2.0, 1.0, 0.5, 1.0, 1.25, 0.5, 1.0, 2.0, 2, 0.5, 2, 0.5, 2, 0.5),
+        )
+    ),
+    2: dict(
+        zip(
+            FEATURES,
+            (
+                8,
+                8,
+                3.0,
+                2.0,
+                0.125,
+                0.375,
+                2.0,
+                0.125,
+                0.375,
+                3.5,
+                4,
+                0.25,
+                6,
+                1 / 6,
+                8,
+                0.125,
+            ),
+        )
+    ),
+    4: dict(
+        zip(
+            FEATURES,
+            (
+                0,
+                None,
+                None,
+                None,
+                0.0,
+                0.0,
+                None,
+                0.0,
+                0.0,
+                None,
+                0,
+                0.0,
+                0,
+                0.0,
+                0,
+                0.0,
+            ),
+        )
+    ),
+}
+
+
+def _canonical_bytes(payload: object) -> bytes:
+    return (
+        json.dumps(payload, allow_nan=False, separators=(",", ":"), sort_keys=True)
+        + "\n"
+    ).encode("utf-8")
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(_canonical_bytes(payload))
+
+
+def _sha256(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _json(path: Path) -> object:
+    return json.loads(path.read_bytes())
+
+
+def _seal_packet(paths: dict[str, Path], rows: list[dict], manifest: dict) -> None:
+    _write_json(paths["feature_rows"], rows)
+    _write_json(paths["feature_manifest"], manifest)
+    artifacts = {}
+    for key in ("feature_rows", "feature_manifest"):
+        raw = paths[key].read_bytes()
+        artifacts[str(paths[key].resolve())] = {
+            "bytes": len(raw),
+            "sha256": _sha256(raw),
+        }
+    _write_json(
+        paths["implementation_manifest"],
+        {
+            "schema_version": "shadow_implementation_file_manifest_v1",
+            "git_branch": "codex/residual-handoff-under-test",
+            "git_head": "feedfacefeed",
+            "implementation_files": manual.FEATURE_GENERATOR_FILES,
+            "implementation_file_hashes": {
+                relative: _sha256((ROOT / relative).read_bytes())
+                for relative in manual.FEATURE_GENERATOR_FILES
+            },
+            "output_dir": str(paths["feature_rows"].parent.resolve()),
+            "artifact_files": artifacts,
+        },
+    )
+
+
+def _feature_row(box: int, name: str) -> dict:
+    return {
+        "race_id": RACE_ID,
+        "box_number": box,
+        "dog_name": name,
+        "race_date": "2026-07-16",
+        "race_number": 2,
+        "venue": "SAN",
+        "source_csv": "filled-by-fixture",
+        "metadata_is_leakage_safe": True,
+        "target_metadata_from_sidecar": True,
+        "target_metadata_rejected_sources": [],
+        "target_metadata_source_url": SOURCE_URL,
+        "target_distance_source_is_safe": 1,
+        "target_grade_provenance_safe": 1,
+        "target_distance_missing": 0,
+        "target_grade_missing": 0,
+        "target_distance_safe": 515.0,
+        "target_grade_safe": "Grade 5",
+        "same_distance_same_grade_history_cutoff": "strictly_before_target_race",
+        "same_distance_same_grade_history_cutoff_basis": (
+            "race_date_less_than_target_race_date"
+        ),
+        "same_distance_same_grade_target_race_rows_used": 0,
+        "same_distance_same_grade_post_outcome_rows_used": 0,
+        "same_distance_same_grade_post_outcome_fields_used": [],
+        **GOLDEN_FEATURES[box],
+    }
+
+
+def _write_fixture(tmp_path: Path) -> dict[str, Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    form_csv = tmp_path / f"{RACE_ID}.csv"
+    form_csv.write_text(
+        "Dog Name|PLC|DATE\n"
+        "1. Alpha Fast|1|2026-07-09\n"
+        "2. Beta Bale|2|2026-07-08\n"
+        "4. Gamma Rule|3|2026-07-07\n",
+        encoding="utf-8",
+    )
+    form_raw = form_csv.read_bytes()
+    sidecar = form_csv.with_name(form_csv.name + ".metadata.json")
+    participants = [
+        {"box_number": box, "dog_name": name} for box, name, _, _ in RUNNERS
+    ]
+    _write_json(
+        sidecar,
+        {
+            "schema_version": "form_guide_download_provenance_v1",
+            "filename": form_csv.name,
+            "content_length": len(form_raw),
+            "content_sha256": _sha256(form_raw),
+            "metadata_is_leakage_safe": True,
+            "race_url": SOURCE_URL,
+            "canonical_runner_alignment": {"status": "aligned"},
+            "runner_completeness": {
+                "status": "COMPLETE",
+                "runner_count": 3,
+                "participants": participants,
+            },
+            "prejump_shadow_metadata": {
+                "status": "PASS",
+                "metadata_is_leakage_safe": True,
+                "metadata_captured_at": "2026-07-16T18:40:00+10:00",
+                "race_date": "2026-07-16",
+                "race_number": 2,
+                "venue": "SAN",
+                "distance": "515m",
+                "grade": "Grade 5",
+                "jump_datetime": "2026-07-16T18:58:00+10:00",
+                "source_url": SOURCE_URL,
+                "canonical_final_runner_alignment": {"status": "aligned"},
+                "runner_box_name_list": participants,
+            },
+        },
+    )
+
+    packet = tmp_path / "shadow_score_live"
+    paths = {
+        "form_csv": form_csv,
+        "sidecar": sidecar,
+        "feature_rows": packet / "shadow_feature_rows.json",
+        "feature_manifest": packet / "shadow_manifest.json",
+        "implementation_manifest": packet / "implementation_file_manifest.json",
+        "capture": tmp_path / "autonomous_live_odds_capture_report.json",
+    }
+    rows = [_feature_row(box, name) for box, name, _, _ in RUNNERS]
+    for row in rows:
+        row["source_csv"] = str(form_csv.resolve())
+    feature_manifest = {
+        "schema_version": "shadow_live_scoring_manifest_v1",
+        "generated_at": "2026-07-16T18:46:00+10:00",
+        "feature_freeze_timestamp": "2026-07-16T18:45:00+10:00",
+        "output_mode": "shadow_only",
+        "betting_output": False,
+        "ev_output": False,
+        "odds_used_for_shadow_scoring": False,
+        "production_prediction_write": False,
+        "registry_mutation": False,
+        "tgr_enabled": False,
+        "feature_rows": str(paths["feature_rows"].resolve()),
+        "input_files": [str(form_csv.resolve())],
+    }
+    _seal_packet(paths, rows, feature_manifest)
+
+    accepted_rows = [
+        {
+            "box_number": box,
+            "dog_name": name,
+            "identity": identity,
+            "odds_decimal": odds,
+            "sportsbet_box_source": "runner_text",
+        }
+        for box, name, identity, odds in RUNNERS
+    ]
+    _write_json(
+        paths["capture"],
+        {
+            "schema_version": "autonomous_live_odds_capture_report_v1",
+            "attempts": [
+                {
+                    "schema_version": "autonomous_live_odds_capture_attempt_v1",
+                    "race_id": RACE_ID,
+                    "status": "APPENDED",
+                    "fetch_time": "2026-07-16T18:50:00+10:00",
+                    "append_time": "2026-07-16T18:51:00+10:00",
+                    "reasons": [],
+                    "validation": {
+                        "schema_version": (
+                            "autonomous_live_odds_capture_validation_v1"
+                        ),
+                        "status": "PASS",
+                        "source_url": (
+                            "https://www.sportsbet.com.au/greyhound-racing/"
+                            "australia-nz/sandown-park/race-2-123"
+                        ),
+                        "source_race_number": 2,
+                        "source_race_date": "2026-07-16",
+                        "source_venue": "SAN",
+                        "accepted_rows": accepted_rows,
+                        "accepted_row_count": 3,
+                        "rejected_rows": [],
+                        "expected_runner_count": 3,
+                        "active_expected_runner_count": 3,
+                        "scratched_expected_runner_count": 0,
+                        "scratched_expected_runners": [],
+                        "scratched_expected_runners_with_odds": [],
+                        "missing_expected_runners": [],
+                        "extra_unexpected_runners": [],
+                        "failure_root_cause": None,
+                        "reasons": [],
+                    },
+                }
+            ],
+        },
+    )
+    return paths
+
+
+def _reseal(paths: dict[str, Path], mutate) -> None:
+    rows = _json(paths["feature_rows"])
+    manifest = _json(paths["feature_manifest"])
+    assert isinstance(rows, list) and isinstance(manifest, dict)
+    mutate(rows, manifest)
+    _seal_packet(paths, rows, manifest)
+
+
+def _score_paths(paths: dict[str, Path], **overrides):
+    arguments = {
+        "race_id": RACE_ID,
+        "form_csv_path": paths["form_csv"],
+        "sidecar_path": paths["sidecar"],
+        "feature_rows_path": paths["feature_rows"],
+        "feature_manifest_path": paths["feature_manifest"],
+        "implementation_manifest_path": paths["implementation_manifest"],
+        "capture_path": paths["capture"],
+        "model_path": ARTIFACT_DIR / "model.json",
+        "manifest_path": ARTIFACT_DIR / "manifest.json",
+        "score_timestamp": SCORE_TIME,
+    }
+    arguments.update(overrides)
+    return score_from_artifacts(**arguments)
+
+
+def _score(tmp_path: Path):
+    return _score_paths(_write_fixture(tmp_path))
+
+
+def test_scores_exact_packet_deterministically(tmp_path):
+    paths = _write_fixture(tmp_path)
+    first = _score_paths(paths)
+    second = _score_paths(paths)
+
+    assert first == second
+    assert first["schema_version"] == "manual_market_form_residual_prediction_v2"
+    assert first["status"] == "MANUAL_PREJUMP_FROZEN_RESIDUAL_PREDICTION"
+    assert first["source_contract"] == {
+        "feature_source": "exact_hash_bound_system_shadow_feature_rows",
+        "feature_reconstruction_performed": False,
+        "database_access": False,
+        "network_access": False,
+    }
+    assert first["activation"] is False
+    assert first["persisted"] is False
+    assert first["outcomes_present"] is False
+    assert len(first["predictions"]) == 3
+    for key in ("market", "half", "full"):
+        assert first["probability_sums"][key] == pytest.approx(1.0)
+
+
+def test_explicit_shadow_output_appends_once_and_replays_idempotently(tmp_path):
+    paths = _write_fixture(tmp_path / "fixture")
+    shadow_output = tmp_path / "market_form_residual_shadow_predictions_v3.jsonl"
+
+    first = _score_paths(paths, shadow_output_path=shadow_output)
+    original = shadow_output.read_bytes()
+    second = _score_paths(paths, shadow_output_path=shadow_output)
+
+    assert first["persisted"] is True
+    assert first["persistence_status"] == "APPENDED"
+    assert second["persisted"] is True
+    assert second["persistence_status"] == "EXACT_REPLAY"
+    assert shadow_output.read_bytes() == original
+    records = [json.loads(line) for line in original.splitlines()]
+    assert len(records) == 1
+    assert records[0]["race_id"] == RACE_ID
+    assert records[0]["outcomes_present"] is False
+    assert records[0]["activation"] is False
+
+
+def test_scores_when_strict_odds_capture_precedes_feature_generation(tmp_path):
+    paths = _write_fixture(tmp_path)
+    capture = _json(paths["capture"])
+    assert isinstance(capture, dict)
+    capture["attempts"][0]["fetch_time"] = "2026-07-16T18:42:00+10:00"
+    capture["attempts"][0]["append_time"] = "2026-07-16T18:43:00+10:00"
+    _write_json(paths["capture"], capture)
+
+    output = _score_paths(paths)
+
+    assert output["odds_append_timestamp"] == "2026-07-16T18:43:00+10:00"
+    assert output["feature_manifest_generated_at"] == "2026-07-16T18:46:00+10:00"
+
+
+def test_uses_exact_top_level_golden_features(tmp_path, monkeypatch):
+    paths = _write_fixture(tmp_path)
+    real_score_race = manual.score_race
+    observed = {}
+
+    def spy(frozen, runners, provenance):
+        observed.update({int(row["box_number"]): row["features"] for row in runners})
+        return real_score_race(frozen, runners, provenance)
+
+    monkeypatch.setattr(manual, "score_race", spy)
+    _score_paths(paths)
+
+    assert observed == GOLDEN_FEATURES
+
+
+def test_reads_each_mutable_input_once_and_hashes_same_bytes(tmp_path, monkeypatch):
+    paths = _write_fixture(tmp_path)
+    watched = {path.resolve() for path in paths.values()}
+    counts = {path: 0 for path in watched}
+    original = Path.read_bytes
+
+    def counted(path):
+        resolved = path.resolve()
+        if resolved in counts:
+            counts[resolved] += 1
+        return original(path)
+
+    monkeypatch.setattr(Path, "read_bytes", counted)
+    output = _score_paths(paths)
+
+    assert counts == {path: 1 for path in watched}
+    for key, path_key in (
+        ("form_csv_sha256", "form_csv"),
+        ("sidecar_sha256", "sidecar"),
+        ("feature_rows_sha256", "feature_rows"),
+        ("feature_manifest_sha256", "feature_manifest"),
+        ("implementation_manifest_sha256", "implementation_manifest"),
+        ("capture_artifact_sha256", "capture"),
+    ):
+        assert output["input_hashes"][key] == _sha256(original(paths[path_key]))
+
+
+def test_rejects_packet_hash_mismatch(tmp_path):
+    paths = _write_fixture(tmp_path)
+    paths["feature_rows"].write_bytes(paths["feature_rows"].read_bytes() + b" ")
+
+    with pytest.raises(
+        ManualPredictionError, match="feature_rows_manifest_hash_mismatch"
+    ):
+        _score_paths(paths)
+
+
+def test_rejects_form_csv_not_bound_by_sidecar(tmp_path):
+    paths = _write_fixture(tmp_path)
+    paths["form_csv"].write_bytes(paths["form_csv"].read_bytes() + b"tampered\n")
+
+    with pytest.raises(ManualPredictionError, match="form_csv_sidecar_hash_mismatch"):
+        _score_paths(paths)
+
+
+def test_rejects_date_with_trailing_content(tmp_path):
+    paths = _write_fixture(tmp_path)
+    sidecar = _json(paths["sidecar"])
+    assert isinstance(sidecar, dict)
+    sidecar["prejump_shadow_metadata"]["race_date"] = "2026-07-16garbage"
+    _write_json(paths["sidecar"], sidecar)
+
+    with pytest.raises(ManualPredictionError, match="target_race_date_invalid"):
+        _score_paths(paths)
+
+
+def test_rejects_box_outside_greyhound_range_even_when_sources_agree(tmp_path):
+    paths = _write_fixture(tmp_path)
+    sidecar = _json(paths["sidecar"])
+    assert isinstance(sidecar, dict)
+    sidecar["prejump_shadow_metadata"]["runner_box_name_list"][0]["box_number"] = 9
+    sidecar["runner_completeness"]["participants"][0]["box_number"] = 9
+    _write_json(paths["sidecar"], sidecar)
+
+    _reseal(paths, lambda rows, _: rows[0].__setitem__("box_number", 9))
+    capture = _json(paths["capture"])
+    assert isinstance(capture, dict)
+    capture["attempts"][0]["validation"]["accepted_rows"][0]["box_number"] = 9
+    _write_json(paths["capture"], capture)
+
+    with pytest.raises(ManualPredictionError, match="sidecar_runner_box_invalid"):
+        _score_paths(paths)
+
+
+@pytest.mark.parametrize("feature", [FEATURES[0], FEATURES[-1]])
+def test_rejects_missing_feature(tmp_path, feature):
+    paths = _write_fixture(tmp_path)
+    _reseal(paths, lambda rows, _: rows[0].pop(feature))
+
+    with pytest.raises(ManualPredictionError, match=f"feature_value_missing:{feature}"):
+        _score_paths(paths)
+
+
+def test_rejects_boolean_feature_value(tmp_path):
+    paths = _write_fixture(tmp_path)
+    _reseal(paths, lambda rows, _: rows[0].__setitem__(FEATURES[0], True))
+
+    with pytest.raises(
+        ManualPredictionError, match=f"feature_value:{FEATURES[0]}_invalid"
+    ):
+        _score_paths(paths)
+
+
+def test_rejects_nested_or_extra_feature_bundle(tmp_path):
+    paths = _write_fixture(tmp_path)
+    _reseal(paths, lambda rows, _: rows[0].__setitem__("features", {"extra": 1}))
+
+    with pytest.raises(ManualPredictionError, match="feature.*top_level.*exact"):
+        _score_paths(paths)
+
+
+def test_rejects_outcome_field_in_feature_manifest(tmp_path):
+    paths = _write_fixture(tmp_path)
+    _reseal(paths, lambda _, manifest: manifest.__setitem__("winner", "Alpha Fast"))
+
+    with pytest.raises(
+        ManualPredictionError, match="feature_manifest_contains_outcome_field"
+    ):
+        _score_paths(paths)
+
+
+def test_rejects_outcome_field_in_implementation_manifest(tmp_path):
+    paths = _write_fixture(tmp_path)
+    manifest = _json(paths["implementation_manifest"])
+    manifest["result"] = "post-race"
+    _write_json(paths["implementation_manifest"], manifest)
+
+    with pytest.raises(
+        ManualPredictionError, match="implementation_manifest_contains_outcome_field"
+    ):
+        _score_paths(paths)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error"),
+    [
+        (
+            lambda rows, manifest: rows[0].__setitem__(
+                "source_csv", "/tmp/not-the-form.csv"
+            ),
+            "feature_row_source_csv_mismatch",
+        ),
+        (
+            lambda rows, manifest: rows[0].__setitem__("dog_name", "Wrong Dog"),
+            "feature_runner_set_mismatch_or_duplicate",
+        ),
+        (
+            lambda rows, manifest: rows[0].__setitem__("box_number", 8),
+            "feature_runner_set_mismatch_or_duplicate",
+        ),
+        (
+            lambda rows, manifest: rows[0].__setitem__(
+                "metadata_is_leakage_safe", False
+            ),
+            "feature_row_metadata_not_safe",
+        ),
+        (
+            lambda rows, manifest: rows[0].__setitem__(
+                "same_distance_same_grade_post_outcome_rows_used", 1
+            ),
+            "feature_post_outcome_rows_used",
+        ),
+        (
+            lambda rows, manifest: manifest.__setitem__("betting_output", True),
+            "feature_manifest_betting_output_mismatch",
+        ),
+        (
+            lambda rows, manifest: manifest.__setitem__(
+                "production_prediction_write", True
+            ),
+            "feature_manifest_production_prediction_write_mismatch",
+        ),
+    ],
+)
+def test_rejects_unsafe_or_mismatched_packet(tmp_path, mutation, error):
+    paths = _write_fixture(tmp_path)
+    _reseal(paths, mutation)
+
+    with pytest.raises(ManualPredictionError, match=error):
+        _score_paths(paths)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.thedogs.com.au/racing/sandown/2026-07-16/2/result",
+        "https://www.thedogs.com.au/racing/sandown/2026-07-16/2/results",
+        "https://www.thedogs.com.au/racing/sandown/2026-07-16/2/test?tab=dividend",
+        "https://www.thedogs.com.au/racing/sandown/2026-07-16/2/test?view=payout",
+    ],
+)
+def test_rejects_post_race_thedogs_urls(url):
+    assert _trusted_thedogs_url(url) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://thedogs.com.au/racing/sandown/2026-07-16/2/test",
+        "https://evil.thedogs.com.au/racing/sandown/2026-07-16/2/test",
+        "https://user@www.thedogs.com.au/racing/sandown/2026-07-16/2/test",
+    ],
+)
+def test_rejects_non_exact_thedogs_authority(url):
+    assert _trusted_thedogs_url(url) is False
+
+
+def test_sportsbet_binding_accepts_hyphen_venue_and_rejects_authority_tricks():
+    race_id = "Race 2 - SANDOWN-PARK - 2026-07-16"
+    valid = (
+        "https://www.sportsbet.com.au/greyhound-racing/australia-nz/"
+        "sandown-park/race-2-123"
+    )
+    assert _trusted_sportsbet_url(valid, race_id, "SANDOWN-PARK") is True
+    assert (
+        _trusted_sportsbet_url(
+            valid.replace("www.sportsbet.com.au", "evil.sportsbet.com.au"),
+            race_id,
+            "SANDOWN-PARK",
+        )
+        is False
+    )
+    assert (
+        _trusted_sportsbet_url(
+            valid.replace("www.sportsbet.com.au", "user@www.sportsbet.com.au"),
+            race_id,
+            "SANDOWN-PARK",
+        )
+        is False
+    )
+
+
+def test_grade_aliases_are_finite_and_do_not_parse_sponsor_substrings():
+    assert _canonical_target_grade("5th Grade") == "GRADE5"
+    assert _canonical_target_grade("Grade 5") == "GRADE5"
+    assert _canonical_target_grade("6th") == "GRADE6"
+    assert _canonical_target_grade("Grade 6") == "GRADE6"
+    assert _canonical_target_grade("Sponsor Grade 5 Trophy") is None
+
+
+def test_scores_strict_ordinal_grade_alias(tmp_path):
+    paths = _write_fixture(tmp_path)
+    sidecar = _json(paths["sidecar"])
+    sidecar["prejump_shadow_metadata"]["grade"] = "5th Grade"
+    _write_json(paths["sidecar"], sidecar)
+
+    assert _score_paths(paths)["race_id"] == RACE_ID
+
+
+def test_rejects_sponsor_grade_substring(tmp_path):
+    paths = _write_fixture(tmp_path)
+    sidecar = _json(paths["sidecar"])
+    sidecar["prejump_shadow_metadata"]["grade"] = "Sponsor Grade 5 Trophy"
+    _write_json(paths["sidecar"], sidecar)
+
+    with pytest.raises(
+        ManualPredictionError, match="target_grade_not_exact_supported_alias"
+    ):
+        _score_paths(paths)
+
+
+def test_rejects_result_url_in_bound_sidecar(tmp_path):
+    paths = _write_fixture(tmp_path)
+    sidecar = _json(paths["sidecar"])
+    assert isinstance(sidecar, dict)
+    sidecar["prejump_shadow_metadata"]["source_url"] = SOURCE_URL + "/result"
+    sidecar["race_url"] = SOURCE_URL + "/result"
+    _write_json(paths["sidecar"], sidecar)
+
+    with pytest.raises(ManualPredictionError, match="sidecar_source_url_not_trusted"):
+        _score_paths(paths)
+
+
+def test_rejects_contradictory_sidecar_source_url_alias(tmp_path):
+    paths = _write_fixture(tmp_path)
+    sidecar = _json(paths["sidecar"])
+    assert isinstance(sidecar, dict)
+    sidecar["race_url"] = SOURCE_URL + "/result"
+    _write_json(paths["sidecar"], sidecar)
+
+    with pytest.raises(
+        ManualPredictionError, match="sidecar_source_url_alias_mismatch"
+    ):
+        _score_paths(paths)
+
+
+def test_rejects_wrong_feature_generator_head(tmp_path):
+    paths = _write_fixture(tmp_path)
+    manifest = _json(paths["implementation_manifest"])
+    assert isinstance(manifest, dict)
+    manifest["git_branch"] = "codex/greyhound-resource-isolation-20260716"
+    manifest["git_head"] = "deadbeefdead"
+    manifest.pop("implementation_file_hashes")
+    _write_json(paths["implementation_manifest"], manifest)
+
+    with pytest.raises(ManualPredictionError, match="feature_generator_head_mismatch"):
+        _score_paths(paths)
+
+
+def test_rejects_packet_impersonating_legacy_generator_identity(tmp_path):
+    paths = _write_fixture(tmp_path)
+    manifest = _json(paths["implementation_manifest"])
+    assert isinstance(manifest, dict)
+    manifest["git_branch"] = "codex/greyhound-resource-isolation-20260716"
+    manifest["git_head"] = "aa35fa70fc49"
+    manifest.pop("implementation_file_hashes")
+    _write_json(paths["implementation_manifest"], manifest)
+
+    with pytest.raises(
+        ManualPredictionError, match="feature_generator_legacy_packet_hash_mismatch"
+    ):
+        _score_paths(paths)
+
+
+def _bind_current_generator_hashes(paths: dict[str, Path]) -> dict:
+    manifest = _json(paths["implementation_manifest"])
+    assert isinstance(manifest, dict)
+    manifest["git_branch"] = "codex/residual-handoff-under-test"
+    manifest["git_head"] = "feedfacefeed"
+    manifest["implementation_file_hashes"] = {
+        relative: _sha256((ROOT / relative).read_bytes())
+        for relative in manifest["implementation_files"]
+    }
+    _write_json(paths["implementation_manifest"], manifest)
+    return manifest
+
+
+def test_accepts_new_packet_bound_to_current_generator_hashes(tmp_path):
+    paths = _write_fixture(tmp_path)
+    _bind_current_generator_hashes(paths)
+
+    output = _score_paths(paths)
+
+    assert output["status"] == "MANUAL_PREJUMP_FROZEN_RESIDUAL_PREDICTION"
+
+
+def test_rejects_new_packet_with_generator_hash_mismatch(tmp_path):
+    paths = _write_fixture(tmp_path)
+    manifest = _bind_current_generator_hashes(paths)
+    manifest["implementation_file_hashes"][manifest["implementation_files"][0]] = (
+        "0" * 64
+    )
+    _write_json(paths["implementation_manifest"], manifest)
+
+    with pytest.raises(
+        ManualPredictionError, match="feature_generator_implementation_hash_mismatch"
+    ):
+        _score_paths(paths)
+
+
+@pytest.mark.parametrize(
+    ("append_value", "score_time", "error"),
+    [
+        (None, SCORE_TIME, "capture_append_timestamp_missing"),
+        (
+            "2026-07-16T18:49:00+10:00",
+            SCORE_TIME,
+            "capture_append_before_fetch",
+        ),
+        (
+            "2026-07-16T18:51:00+10:00",
+            datetime(2026, 7, 16, 18, 58, tzinfo=MELBOURNE),
+            "manual_score_not_prejump",
+        ),
+    ],
+)
+def test_rejects_missing_reversed_or_postjump_timestamps(
+    tmp_path, append_value, score_time, error
+):
+    paths = _write_fixture(tmp_path)
+    capture = _json(paths["capture"])
+    assert isinstance(capture, dict)
+    attempt = capture["attempts"][0]
+    if append_value is None:
+        attempt.pop("append_time")
+    else:
+        attempt["append_time"] = append_value
+    _write_json(paths["capture"], capture)
+
+    with pytest.raises(ManualPredictionError, match=error):
+        _score_paths(paths, score_timestamp=score_time)
+
+
+def test_rejects_ambiguous_accepted_attempts(tmp_path):
+    paths = _write_fixture(tmp_path)
+    capture = _json(paths["capture"])
+    assert isinstance(capture, dict)
+    capture["attempts"].append(copy.deepcopy(capture["attempts"][0]))
+    _write_json(paths["capture"], capture)
+
+    with pytest.raises(
+        ManualPredictionError, match="accepted_capture_attempt_ambiguous"
+    ):
+        _score_paths(paths)
+
+
+def test_scores_supported_scratched_runner(tmp_path):
+    paths = _write_fixture(tmp_path)
+    capture = _json(paths["capture"])
+    assert isinstance(capture, dict)
+    validation = capture["attempts"][0]["validation"]
+    validation["accepted_rows"] = [
+        row for row in validation["accepted_rows"] if row["box_number"] != 2
+    ]
+    validation["accepted_row_count"] = 2
+    validation["active_expected_runner_count"] = 2
+    validation["scratched_expected_runner_count"] = 1
+    validation["scratched_expected_runners"] = [
+        {"box_number": 2, "dog_name": "Beta Bale"}
+    ]
+    _write_json(paths["capture"], capture)
+
+    output = _score_paths(paths)
+
+    assert {row["box"] for row in output["predictions"]} == {1, 4}
+    for key in ("market", "half", "full"):
+        assert output["probability_sums"][key] == pytest.approx(1.0)
+
+
+def test_runner_reordering_is_semantically_equivalent(tmp_path):
+    paths = _write_fixture(tmp_path)
+    first = _score_paths(paths)
+    capture = _json(paths["capture"])
+    assert isinstance(capture, dict)
+    capture["attempts"][0]["validation"]["accepted_rows"].reverse()
+    _write_json(paths["capture"], capture)
+    _reseal(paths, lambda rows, _: rows.reverse())
+
+    second = _score_paths(paths)
+
+    assert first["predictions"] == second["predictions"]
+    assert first["probability_sums"] == second["probability_sums"]
+    assert first["runner_set_sha256"] == second["runner_set_sha256"]
+
+
+def test_cli_has_no_model_or_manifest_override():
+    destinations = {action.dest for action in build_parser()._actions}
+
+    assert "model" not in destinations
+    assert "model_path" not in destinations
+    assert "manifest" not in destinations
+    assert "manifest_path" not in destinations
+
+
+def _retime_for_cli(paths: dict[str, Path]) -> str:
+    now = datetime.now(MELBOURNE).replace(microsecond=0)
+    metadata = now - timedelta(minutes=6)
+    freeze = now - timedelta(minutes=5)
+    generated = now - timedelta(minutes=4)
+    fetch = now - timedelta(minutes=3)
+    append = now - timedelta(minutes=2)
+    jump = now + timedelta(hours=1)
+    race_id = f"Race 2 - SAN - {jump.date().isoformat()}"
+
+    sidecar = _json(paths["sidecar"])
+    assert isinstance(sidecar, dict)
+    shadow = sidecar["prejump_shadow_metadata"]
+    shadow["race_date"] = jump.date().isoformat()
+    shadow["jump_datetime"] = jump.isoformat()
+    shadow["metadata_captured_at"] = metadata.isoformat()
+    retimed_source_url = SOURCE_URL.replace("2026-07-16", jump.date().isoformat())
+    shadow["source_url"] = retimed_source_url
+    sidecar["race_url"] = retimed_source_url
+    _write_json(paths["sidecar"], sidecar)
+
+    capture = _json(paths["capture"])
+    assert isinstance(capture, dict)
+    attempt = capture["attempts"][0]
+    attempt["race_id"] = race_id
+    attempt["fetch_time"] = fetch.isoformat()
+    attempt["append_time"] = append.isoformat()
+    attempt["validation"]["source_race_date"] = jump.date().isoformat()
+    _write_json(paths["capture"], capture)
+
+    def retime(rows, manifest):
+        manifest["feature_freeze_timestamp"] = freeze.isoformat()
+        manifest["generated_at"] = generated.isoformat()
+        for row in rows:
+            row["race_id"] = race_id
+            row["race_date"] = jump.date().isoformat()
+            row["target_metadata_source_url"] = retimed_source_url
+
+    _reseal(paths, retime)
+    return race_id
+
+
+def test_cli_prints_canonical_json_and_writes_nothing(tmp_path):
+    paths = _write_fixture(tmp_path)
+    race_id = _retime_for_cli(paths)
+    before = {
+        path.relative_to(tmp_path): path.read_bytes()
+        for path in sorted(tmp_path.rglob("*"))
+        if path.is_file()
+    }
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/predict_market_form_residual.py"),
+            "--race-id",
+            race_id,
+            "--form-csv",
+            str(paths["form_csv"]),
+            "--feature-rows",
+            str(paths["feature_rows"]),
+            "--capture",
+            str(paths["capture"]),
+        ],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode("utf-8")
+    assert completed.stderr == b""
+    payload = json.loads(completed.stdout)
+    assert completed.stdout == _canonical_bytes(payload)
+    after = {
+        path.relative_to(tmp_path): path.read_bytes()
+        for path in sorted(tmp_path.rglob("*"))
+        if path.is_file()
+    }
+    assert after == before
+
+
+def test_cli_explicit_shadow_output_persists_v3_record(tmp_path):
+    paths = _write_fixture(tmp_path / "fixture")
+    race_id = _retime_for_cli(paths)
+    shadow_output = tmp_path / "market_form_residual_shadow_predictions_v3.jsonl"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/predict_market_form_residual.py"),
+            "--race-id",
+            race_id,
+            "--form-csv",
+            str(paths["form_csv"]),
+            "--feature-rows",
+            str(paths["feature_rows"]),
+            "--capture",
+            str(paths["capture"]),
+            "--append-shadow-output",
+            str(shadow_output),
+        ],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode("utf-8")
+    assert completed.stderr == b""
+    output = json.loads(completed.stdout)
+    assert completed.stdout == _canonical_bytes(output)
+    assert output["persisted"] is True
+    assert output["persistence_status"] == "APPENDED"
+    assert output["shadow_output_path"] == str(shadow_output.resolve())
+
+    records = [json.loads(line) for line in shadow_output.read_bytes().splitlines()]
+    assert len(records) == 1
+    assert records[0]["schema_version"] == "market_form_residual_shadow_record_v3"
+    assert records[0]["race_id"] == race_id
+    assert records[0]["outcomes_present"] is False
+    assert records[0]["activation"] is False
+
+
+def test_race_first_cli_discovers_exact_packet_with_one_query_and_writes_nothing(
+    tmp_path,
+):
+    paths = _write_fixture(tmp_path)
+    race_id = _retime_for_cli(paths)
+    before = {
+        path.relative_to(tmp_path): path.read_bytes()
+        for path in sorted(tmp_path.rglob("*"))
+        if path.is_file()
+    }
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/predict_market_form_residual.py"),
+            "--race",
+            "sundown r2",
+            "--evidence-root",
+            str(tmp_path),
+        ],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode("utf-8")
+    assert completed.stderr == b""
+    payload = json.loads(completed.stdout)
+    assert payload["race_id"] == race_id
+    assert completed.stdout == _canonical_bytes(payload)
+    after = {
+        path.relative_to(tmp_path): path.read_bytes()
+        for path in sorted(tmp_path.rglob("*"))
+        if path.is_file()
+    }
+    assert after == before
+
+
+def test_race_first_discovery_fails_closed_on_equal_latest_capture_reports(tmp_path):
+    paths = _write_fixture(tmp_path)
+    duplicate = tmp_path / "duplicate/autonomous_live_odds_capture_report.json"
+    duplicate.parent.mkdir()
+    duplicate.write_bytes(paths["capture"].read_bytes())
+
+    with pytest.raises(ManualPredictionError, match="race_capture_report_ambiguous"):
+        manual.discover_race_artifacts(
+            race_query="sandown r2",
+            evidence_roots=[tmp_path],
+            score_timestamp=SCORE_TIME,
+        )
+
+
+def test_race_first_discovery_does_not_treat_generic_url_path_as_venue(tmp_path):
+    _write_fixture(tmp_path)
+
+    with pytest.raises(ManualPredictionError, match="race_feature_packet_not_found"):
+        manual.discover_race_artifacts(
+            race_query="racing r2",
+            evidence_roots=[tmp_path],
+            score_timestamp=SCORE_TIME,
+        )
+
+
+def test_race_first_discovery_resolves_venue_before_race_date(tmp_path):
+    warrnambool = _write_fixture(tmp_path / "warrnambool")
+    warragul = _write_fixture(tmp_path / "warragul")
+
+    def retarget(paths, *, race_id, venue, url):
+        def mutate(rows, _manifest):
+            for row in rows:
+                row["race_id"] = race_id
+                row["race_date"] = race_id.rsplit(" - ", 1)[1]
+                row["venue"] = venue
+                row["target_metadata_source_url"] = url
+
+        _reseal(paths, mutate)
+
+    retarget(
+        warrnambool,
+        race_id="Race 2 - WAR - 2026-07-16",
+        venue="WAR",
+        url="https://www.thedogs.com.au/racing/warrnambool/2026-07-16/2/test",
+    )
+    retarget(
+        warragul,
+        race_id="Race 2 - WARG - 2026-07-17",
+        venue="WARG",
+        url="https://www.thedogs.com.au/racing/warragul/2026-07-17/2/test",
+    )
+
+    with pytest.raises(ManualPredictionError, match="race_query_ambiguous"):
+        manual.discover_race_artifacts(
+            race_query="warr r2",
+            evidence_roots=[tmp_path],
+            score_timestamp=SCORE_TIME,
+        )
+
+
+def test_race_first_discovery_rejects_capture_symlink_escape(tmp_path):
+    evidence_root = tmp_path / "evidence"
+    paths = _write_fixture(evidence_root)
+    outside_capture = tmp_path / "outside_capture.json"
+    outside_capture.write_bytes(paths["capture"].read_bytes())
+    paths["capture"].unlink()
+    paths["capture"].symlink_to(outside_capture)
+
+    with pytest.raises(
+        ManualPredictionError, match="discovery_path_outside_evidence_root"
+    ):
+        manual.discover_race_artifacts(
+            race_query="sandown r2",
+            evidence_roots=[evidence_root],
+            score_timestamp=SCORE_TIME,
+        )
+
+
+def test_race_first_discovery_rejects_unrelated_outcome_capture(tmp_path):
+    _write_fixture(tmp_path)
+    unrelated = tmp_path / "unrelated/autonomous_live_odds_capture_report.json"
+    _write_json(
+        unrelated,
+        {
+            "schema_version": "autonomous_live_odds_capture_report_v1",
+            "winner": "Must Not Be Read",
+            "attempts": [
+                {
+                    "race_id": "Race 9 - OTHER - 2026-07-16",
+                    "status": "APPENDED",
+                }
+            ],
+        },
+    )
+
+    with pytest.raises(
+        ManualPredictionError, match="discovery_capture_contains_outcome"
+    ):
+        manual.discover_race_artifacts(
+            race_query="sandown r2",
+            evidence_roots=[tmp_path],
+            score_timestamp=SCORE_TIME,
+        )
+
+
+def test_race_first_discovery_does_not_fallback_past_invalid_target_capture(
+    tmp_path,
+):
+    _write_fixture(tmp_path)
+    invalid = tmp_path / "later/autonomous_live_odds_capture_report.json"
+    invalid.parent.mkdir()
+    _write_json(
+        invalid,
+        {
+            "schema_version": "unexpected_capture_schema",
+            "attempts": [
+                {
+                    "race_id": RACE_ID,
+                    "status": "APPENDED",
+                    "validation": {"status": "PASS"},
+                }
+            ],
+        },
+    )
+
+    with pytest.raises(ManualPredictionError, match="race_capture_report_invalid"):
+        manual.discover_race_artifacts(
+            race_query="sandown r2",
+            evidence_roots=[tmp_path],
+            score_timestamp=SCORE_TIME,
+        )


### PR DESCRIPTION
## Summary

- Add an explicit CLI caller for the merged frozen market-form residual v3 scorer/writer contract.
- Fail closed on sealed form, feature-manifest, strict pre-jump capture, runner-set, race identity, timestamp, URL, grade, and provenance mismatches.
- Append an outcome-free v3 shadow record only when `--append-shadow-output` is explicitly supplied.
- Add subprocess coverage proving both the default no-write path and the explicit v3 JSONL persistence path.

## Why

PR #46 hardened and merged the residual scorer/writer contract. The repository still needed a compatible caller that supplies the required frozen model, runner, and provenance inputs without activating or deploying the runtime.

## Validation

- `uv run --python 3.11 --with pytest --with numpy pytest -q --noconftest tests/test_predict_market_form_residual.py tests/test_market_form_residual.py` — 153 passed
- Ruff check — passed
- Ruff format check — passed
- Python compilation — passed
- `git diff --check` — passed
- Frozen model SHA-256: `624bba020d24f93fac4d895a851195aed5d31cff2f35645d9253be1175cc694d`
- Frozen manifest SHA-256: `8537cbc3d843d106a1fe48793ef01197454ef092c0244025fd65685636a42080`

## Safety boundary

This draft does not activate or deploy anything. It does not change services, timers, installed runtime worktrees, databases, model pointers, promotion state, EV output, or betting behavior.

Docs impact: `DOCS_NOT_REQUIRED` — this is an internal explicit-artifact adapter; its command and safety contract are defined by CLI help and executable tests, and no runtime/operator activation procedure changes.