### PR TITLE
Prepare forecasting observation canary interfaces

### DIFF
--- a/bin/race-collection-operator
+++ b/bin/race-collection-operator
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Executable wrapper for the bounded Race Collection operator CLI."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from race_collection.operator import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/config/race_collection_runtime_input.schema.json
+++ b/config/race_collection_runtime_input.schema.json
@@ -246,9 +246,7 @@
         "observations",
         "odds_attempts",
         "seal",
-        "prediction",
-        "result",
-        "training_example"
+        "prediction"
       ],
       "properties": {
         "source_race_id": {"type": "string", "minLength": 1},
@@ -368,7 +366,39 @@
         "determinism_input_checksum",
         "training_request"
       ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {"mode": {"const": "result-blind-observation-v1"}},
+            "required": ["mode"]
+          },
+          "then": {
+            "properties": {
+              "races": {
+                "items": {
+                  "not": {
+                    "anyOf": [
+                      {"required": ["result"]},
+                      {"required": ["training_example"]}
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "races": {
+                "items": {"required": ["result", "training_example"]}
+              }
+            }
+          }
+        }
+      ],
       "properties": {
+        "mode": {
+          "enum": ["complete-v1", "result-blind-observation-v1"]
+        },
         "racing_day_id": {
           "type": "string",
           "pattern": "^day_[0-9a-f]{32}$"

--- a/docs/CANONICAL_RACE_FORECASTING_PHASE7.md
+++ b/docs/CANONICAL_RACE_FORECASTING_PHASE7.md
@@ -11,6 +11,11 @@ workflow-owning timers. The service orders programme discovery, card/form and
 adaptive append-only odds collection, closure and sealing, deferred prediction,
 post-prediction results, immutable joins, reconciliation, then training requests.
 It can request training but contains no training, tuning, or promotion command.
+An explicitly versioned `result-blind-observation-v1` runtime input retains the
+immutable nine-command plan but bounds execution at deferred prediction. It
+omits result and training-example inputs and produces only the contiguous
+receipt prefix 1--5; no result, join, reconciliation or training-request
+handler is executed.
 Adapters submit only closed typed commands. A `ClosedCommandDispatcher` is
 assembled once at the composition root with exactly one trusted Phase 1--6
 handler for every phase; missing, duplicate, and unknown bindings fail closed.
@@ -48,7 +53,9 @@ Release manifests are immutable content-addressed documents binding an exact
 commit, typed config checksum, exactly schema 29, artifact contract, policy, supported
 bundle versions, and a stable absolute service root. Unit generation emits one
 generic service and no independent workflow timer. Generation and validation do
-not install or enable it.
+not install or enable it. Generated user-service content requires an explicitly
+verified Python 3.11 executable and uses the valid user target
+`default.target`.
 
 That unit's `ExecStart` is backed by the checked-in
 `bin/race-collection-service` composition root. The canonical
@@ -131,6 +138,9 @@ Phase 7 never promotes.
 Backups use SQLite's transactional backup API only after complete reconciliation,
 replicate the explicit schema-versioned set of referenced immutable artifacts by
 checksum, and record an inventory. Unknown future schemas fail closed.
+An exact replay never rewrites the snapshot: it returns the recorded checksum
+only when the isolated path is still a regular non-symlink file with identical
+bytes.
 The inventory is hostile restore input: it must be canonical JSON containing a
 sorted unique list of exact checksums, and it must equal a fresh inventory
 computed from the restored read-only snapshot before any replica object is
@@ -157,3 +167,7 @@ Command success without every check records a failed drill and proves nothing.
 Tests use temporary directories and synthetic immutable fixtures only. They do
 not establish deployment, live-data collection, training, promotion, service
 installation, or runtime readiness.
+
+The bounded operator interface, separate-database preconditions, result-blind
+input contract, recovery commands and rollback boundaries are specified in
+[Forecasting observation-canary operator contract](FORECASTING_OBSERVATION_CANARY.md).

--- a/docs/FORECASTING_OBSERVATION_CANARY.md
+++ b/docs/FORECASTING_OBSERVATION_CANARY.md
@@ -1,0 +1,229 @@
+# Forecasting observation-canary operator contract
+
+This document describes repository capability only. It does not authorize or
+prove installation, live execution, prediction, database migration, model
+selection, training, promotion, betting, or deployment. Runtime status remains
+`DATA_MISSING` until a separately authorized canary produces current,
+source-bound evidence.
+
+The observation canary is result-blind. Its immutable Racing Day plan retains
+all nine command identities, but `mode: "result-blind-observation-v1"` permits
+execution only through ordinal 5, `deferred_prediction`. The runtime input must
+omit every race's `result` and `training_example` objects. The service must
+produce exactly the contiguous receipt prefix 1--5 and must not read a result
+checksum or execute result collection, joining, reconciliation, training
+requests, evaluation, or promotion.
+
+## Non-negotiable boundaries
+
+- The legacy database is never an operations-database target. Every operator
+  database command requires both absolute paths and rejects path, symlink, and
+  hard-link aliases before opening the operations store.
+- Programme migrations 0001--0029 apply only to a separately supplied
+  operations database. A fresh successful migration has the exact version set
+  1 through 29.
+- Live odds capture remains authoritative. This capability installs no unit,
+  creates no timer, owns no capture schedule, and authorizes no interruption,
+  restart, lock removal, or database mutation in the live collector.
+- Champion and challenger bundles must already be immutable canonical
+  registrations. The champion must also be the exact canonical Racing Day
+  assignment. The observation interface cannot invent, register, select,
+  promote, or switch a model.
+- Every mutating operator command requires one explicit operation ID and aware
+  timestamp. Exact replay is permitted; changed intent under an existing
+  operation ID is rejected.
+- Direct SQL, implicit paths, environment-selected inputs, interactive prompts,
+  and ad hoc persistence scripts are unsupported.
+
+## Preconditions for any future canary
+
+A fresh preflight must prove all of the following from current state:
+
+1. The reviewed change is merged into the exact clean canonical checkout. The
+   registered release manifest binds that commit, tree, service source,
+   executable bytes and executable mode.
+2. The supplied interpreter is the intended virtual-environment executable and
+   reports exact Python 3.11. Unit generation rejects any other version.
+3. The legacy database exists at its verified absolute path. The separately
+   supplied operations path is not the same file, symlink target, or hard link,
+   and its parent already exists.
+4. The operations store is either new or already contains the exact schema
+   chain 1--29. It is never inferred from filename or recency.
+5. Canonical policy, configuration, candidate release and preserved legacy
+   release documents are byte-canonical JSON and mutually consistent. The
+   configuration names the exact operations database, artifact root, runtime
+   adapter, runtime-input checksum and source allowlist.
+6. The legacy rollback pointer is initialized and still has
+   `authority=legacy` and `legacy_preserved=1`. Exactly one candidate has a
+   current observation authorization.
+7. The immutable runtime input is result-blind, contains no result or training
+   example, and binds pre-existing programme, card/form, pre-jump odds,
+   champion, challenger, day-assignment and artifact identities. Those inputs
+   must be sourced without changing the live odds-capture owner.
+8. No installed service, unit, timer, listener, lock, working directory or
+   database path would collide with the live collector. The proposed unit has
+   `WantedBy=default.target`, uses the verified Python 3.11 executable and has
+   no timer.
+9. A new isolated snapshot path and separate replica artifact root are
+   available for the operations database. Restore validation targets only that
+   snapshot and replica.
+
+Any missing or ambiguous item is `STOP / DATA_MISSING`.
+
+## Supported noninteractive interface
+
+`bin/race-collection-operator` is the only repository operator entrypoint for
+this contract. The path values below are examples of the required absolute
+shape; an operator must replace them with preflight-proven literal paths before
+separate authorization.
+
+Create or migrate only the separate operations store:
+
+```bash
+/absolute/release/bin/race-collection-operator migrate \
+  --operations-db /absolute/operations/race_collection_operations.sqlite3 \
+  --legacy-db /absolute/legacy/greyhound_racing_data.db
+```
+
+Register immutable authority documents in dependency order:
+
+```bash
+/absolute/release/bin/race-collection-operator register-policy \
+  --operations-db /absolute/operations/race_collection_operations.sqlite3 \
+  --legacy-db /absolute/legacy/greyhound_racing_data.db \
+  --artifacts-root /absolute/operations/artifacts \
+  --document /absolute/authority/policy.json \
+  --operation-id op_00000000000000000000000000000001 \
+  --at 2026-07-26T00:00:00+00:00
+
+/absolute/release/bin/race-collection-operator register-config \
+  --operations-db /absolute/operations/race_collection_operations.sqlite3 \
+  --legacy-db /absolute/legacy/greyhound_racing_data.db \
+  --artifacts-root /absolute/operations/artifacts \
+  --document /absolute/authority/configuration.json \
+  --operation-id op_00000000000000000000000000000002 \
+  --at 2026-07-26T00:00:01+00:00
+
+/absolute/release/bin/race-collection-operator register-release \
+  --operations-db /absolute/operations/race_collection_operations.sqlite3 \
+  --legacy-db /absolute/legacy/greyhound_racing_data.db \
+  --artifacts-root /absolute/operations/artifacts \
+  --document /absolute/authority/legacy-release.json \
+  --operation-id op_00000000000000000000000000000003 \
+  --at 2026-07-26T00:00:02+00:00
+
+/absolute/release/bin/race-collection-operator register-release \
+  --operations-db /absolute/operations/race_collection_operations.sqlite3 \
+  --legacy-db /absolute/legacy/greyhound_racing_data.db \
+  --artifacts-root /absolute/operations/artifacts \
+  --document /absolute/authority/candidate-release.json \
+  --operation-id op_00000000000000000000000000000004 \
+  --at 2026-07-26T00:00:03+00:00
+```
+
+Initialize the exact rollback authority and authorize observation:
+
+```bash
+/absolute/release/bin/race-collection-operator initialize-legacy \
+  --operations-db /absolute/operations/race_collection_operations.sqlite3 \
+  --legacy-db /absolute/legacy/greyhound_racing_data.db \
+  --artifacts-root /absolute/operations/artifacts \
+  --release-id legacy-release \
+  --actor authorized-operator \
+  --reason "record exact preserved legacy rollback authority" \
+  --operation-id op_00000000000000000000000000000005 \
+  --at 2026-07-26T00:00:04+00:00
+
+/absolute/release/bin/race-collection-operator authorize-observation \
+  --operations-db /absolute/operations/race_collection_operations.sqlite3 \
+  --legacy-db /absolute/legacy/greyhound_racing_data.db \
+  --artifacts-root /absolute/operations/artifacts \
+  --release-id candidate-release \
+  --actor authorized-operator \
+  --reason "separately approved result-blind observation canary" \
+  --operation-id op_00000000000000000000000000000006 \
+  --at 2026-07-26T00:00:05+00:00
+```
+
+Generate—but do not install—the user-service content:
+
+```bash
+/absolute/release/bin/race-collection-operator generate-user-service \
+  --release-document /absolute/authority/candidate-release.json \
+  --configuration-document /absolute/authority/configuration.json \
+  --config-path /absolute/authority/configuration.json \
+  --python-executable /absolute/python311-environment/bin/python
+```
+
+The command prints canonical JSON containing one `race-collection.service`
+unit. It performs no systemd write and emits no timer.
+
+Create a backup and validate only an isolated restore:
+
+```bash
+/absolute/release/bin/race-collection-operator backup \
+  --operations-db /absolute/operations/race_collection_operations.sqlite3 \
+  --legacy-db /absolute/legacy/greyhound_racing_data.db \
+  --artifacts-root /absolute/operations/artifacts \
+  --backup-id backup-20260726 \
+  --racing-day-id day_00000000000000000000000000000000 \
+  --snapshot /absolute/isolated/backup-20260726.sqlite3 \
+  --replica-root /absolute/isolated/replica \
+  --operation-id op_00000000000000000000000000000007 \
+  --at 2026-07-26T00:00:06+00:00
+
+/absolute/release/bin/race-collection-operator validate-restore \
+  --operations-db /absolute/operations/race_collection_operations.sqlite3 \
+  --legacy-db /absolute/legacy/greyhound_racing_data.db \
+  --artifacts-root /absolute/operations/artifacts \
+  --backup-id backup-20260726 \
+  --drill-id restore-20260726 \
+  --snapshot /absolute/isolated/backup-20260726.sqlite3 \
+  --replica-root /absolute/isolated/replica \
+  --operation-id op_00000000000000000000000000000008 \
+  --at 2026-07-26T00:00:07+00:00
+```
+
+An exact backup replay returns the recorded checksum only when the isolated
+snapshot bytes still match. Restore validation never copies the snapshot over
+either the operations database or the legacy database.
+
+## Rollback boundaries
+
+The result-blind observation canary does not switch the active release pointer.
+Its normal rollback is therefore:
+
+1. stop only the separately installed candidate process or unit, if a future
+   authorization installed one;
+2. revoke candidate observation authority with a new explicit operation ID;
+3. retain the separate operations database and artifacts as append-only
+   evidence; and
+4. verify that the legacy pointer, live collector, live odds rows, locks,
+   listeners and timers are unchanged.
+
+Revocation is available as:
+
+```bash
+/absolute/release/bin/race-collection-operator revoke-observation \
+  --operations-db /absolute/operations/race_collection_operations.sqlite3 \
+  --legacy-db /absolute/legacy/greyhound_racing_data.db \
+  --artifacts-root /absolute/operations/artifacts \
+  --release-id candidate-release \
+  --actor authorized-operator \
+  --reason "stop result-blind observation authority" \
+  --operation-id op_00000000000000000000000000000009 \
+  --at 2026-07-26T00:00:08+00:00
+```
+
+`activate` is not an observation-canary command. It is exposed only for a later,
+separately reviewed cutover after the existing two-complete-day and prospective
+boundary gates pass. It atomically consumes observation authority and changes
+the operations-store pointer; it does not touch the legacy database or stop the
+legacy service. `rollback` reverses only that pointer to the initialized legacy
+release. Neither command installs, starts, stops or restarts a service.
+
+Stop and retain evidence if any result-blind cycle has a non-contiguous prefix,
+an ordinal above 5, a result read, a result/join/training/evaluation/promotion
+row, a release-identity mismatch, a model-registration mismatch, or any effect
+on live odds capture. Do not repair those conditions by deleting rows,
+rewinding authority, bypassing locks, or changing the legacy database.

--- a/docs/FORECASTING_OBSERVATION_CANARY.md
+++ b/docs/FORECASTING_OBSERVATION_CANARY.md
@@ -48,7 +48,8 @@ A fresh preflight must prove all of the following from current state:
    supplied operations path is not the same file, symlink target, or hard link,
    and its parent already exists.
 4. The operations store is either new or already contains the exact schema
-   chain 1--29. It is never inferred from filename or recency.
+   chain 1--29 with the checked-in migration checksums. It is never inferred
+   from filename or recency.
 5. Canonical policy, configuration, candidate release and preserved legacy
    release documents are byte-canonical JSON and mutually consistent. The
    configuration names the exact operations database, artifact root, runtime
@@ -156,7 +157,9 @@ Generate—but do not install—the user-service content:
 ```
 
 The command prints canonical JSON containing one `race-collection.service`
-unit. It performs no systemd write and emits no timer.
+unit. The `--config-path` file must exist as a regular non-symlink file with
+bytes exactly equal to the authenticated configuration document. The command
+performs no systemd write and emits no timer.
 
 Create a backup and validate only an isolated restore:
 
@@ -187,6 +190,14 @@ Create a backup and validate only an isolated restore:
 An exact backup replay returns the recorded checksum only when the isolated
 snapshot bytes still match. Restore validation never copies the snapshot over
 either the operations database or the legacy database.
+
+The existing recovery authority permits backup only for a Racing Day with
+complete zero-mismatch reconciliation. A result-blind day stops at receipt 5
+and intentionally cannot satisfy that prerequisite. These backup and restore
+commands are therefore usable only when the separate operations store already
+contains another fully reconciled day. Otherwise recovery proof is
+`DATA_MISSING`: do not run the command against the result-blind day and do not
+weaken or bypass the reconciliation gate.
 
 ## Rollback boundaries
 
@@ -221,6 +232,33 @@ boundary gates pass. It atomically consumes observation authority and changes
 the operations-store pointer; it does not touch the legacy database or stop the
 legacy service. `rollback` reverses only that pointer to the initialized legacy
 release. Neither command installs, starts, stops or restarts a service.
+
+The exact future syntax is shown only to define the interface. It is inert in
+this repository-readiness change and requires separate cutover authorization.
+The authority uses its trusted current clock for the prospective boundary;
+caller-supplied `--at` cannot backdate that decision.
+
+```bash
+/absolute/release/bin/race-collection-operator activate \
+  --operations-db /absolute/operations/race_collection_operations.sqlite3 \
+  --legacy-db /absolute/legacy/greyhound_racing_data.db \
+  --artifacts-root /absolute/operations/artifacts \
+  --release-id candidate-release \
+  --boundary-day-id day_00000000000000000000000000000000 \
+  --actor authorized-operator \
+  --reason "separately authorized prospective cutover" \
+  --operation-id op_00000000000000000000000000000010 \
+  --at 2026-07-26T00:00:09+00:00
+
+/absolute/release/bin/race-collection-operator rollback \
+  --operations-db /absolute/operations/race_collection_operations.sqlite3 \
+  --legacy-db /absolute/legacy/greyhound_racing_data.db \
+  --artifacts-root /absolute/operations/artifacts \
+  --actor authorized-operator \
+  --reason "separately authorized exact legacy-pointer rollback" \
+  --operation-id op_00000000000000000000000000000011 \
+  --at 2026-07-26T00:00:10+00:00
+```
 
 Stop and retain evidence if any result-blind cycle has a non-contiguous prefix,
 an ordinal above 5, a result read, a result/join/training/evaluation/promotion

--- a/docs/agent_tasks/forecasting_observation_canary_readiness_v1_20260725.md
+++ b/docs/agent_tasks/forecasting_observation_canary_readiness_v1_20260725.md
@@ -1,0 +1,81 @@
+---
+job_id: FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725
+title: Forecasting observation canary repository readiness
+lane: Provenance
+supporting_lanes:
+  - Architecture
+  - Provenance
+  - Evaluation
+owner: Codex
+approval_required: true
+approval_source: "Owner /goal request on 2026-07-25 authorizes repository implementation, validation, push, and one draft PR only."
+allow_unapproved_safe_extension: false
+timeout_seconds: 21600
+mutation_mode: safe_extension
+base: origin/master
+production_data_access: false
+production_data_boundary: "No live service, installed unit, timer, runtime process, legacy database, production operations database, model pointer, prediction, training, promotion, betting, or live artifact mutation."
+github_mutation_allowed: true
+git_history_mutation_allowed: true
+live_service_mutation_allowed: false
+docs_impact: DOCS_REQUIRED
+task_tier: large
+recommended_model: high_reasoning
+actual_model: gpt-5
+worker_model_allowed: true
+worker_decision_limit: "One fresh read-only exact-diff review; no edits, GitHub writes, runtime access, or final publication decision."
+escalation_needed: false
+output_dir: reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725
+allowed_files:
+  - bin/race-collection-operator
+  - config/race_collection_runtime_input.schema.json
+  - docs/CANONICAL_RACE_FORECASTING_PHASE7.md
+  - docs/FORECASTING_OBSERVATION_CANARY.md
+  - docs/agent_tasks/forecasting_observation_canary_readiness_v1_20260725.md
+  - race_collection/operational.py
+  - race_collection/operator.py
+  - race_collection/recovery.py
+  - race_collection/runtime_adapters.py
+  - race_collection/service.py
+  - tests/race_collection/test_operator.py
+  - tests/race_collection/test_phase7_operational.py
+  - tests/race_collection/test_phase7_runtime_adapter.py
+  - reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/README.md
+  - reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/STATE.md
+  - reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/DECISIONS.md
+  - reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/VALIDATION.md
+  - reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/REVIEW.md
+---
+
+# Forecasting observation canary repository readiness
+
+## Objective
+
+Add only the repository interfaces needed for a future, separately authorized,
+result-blind observation canary while preserving the legacy database and live
+odds-capture authority.
+
+## Acceptance boundary
+
+- One explicit-path, noninteractive operator CLI delegates to existing
+  migration, immutable-registration, cutover, rollback, backup, and restore
+  authority APIs.
+- The CLI rejects the supplied legacy database as an operations database and
+  accepts only a fresh or already-valid separate schema-29 operations store.
+- A result-blind runtime input can execute the exact ordered prefix through
+  deferred prediction and then stop with receipts 1 through 5.
+- Canonical champion and challenger registrations are authenticated before any
+  cycle work.
+- Generated user service content binds an explicitly verified Python 3.11
+  executable, uses `default.target`, retains release identity checks, and emits
+  no timer.
+- Focused and current-master regression gates pass; a fresh read-only reviewer
+  accepts the exact diff before draft-PR publication.
+
+## Hard stops
+
+- No live runtime, service-manager, timer, database, model, prediction,
+  training, promotion, betting, or deployment mutation.
+- No migrations against the legacy database.
+- No ad hoc persistence outside existing authority APIs.
+- No merge.

--- a/docs/agent_tasks/forecasting_observation_canary_readiness_v1_20260725.md
+++ b/docs/agent_tasks/forecasting_observation_canary_readiness_v1_20260725.md
@@ -72,6 +72,15 @@ odds-capture authority.
 - Focused and current-master regression gates pass; a fresh read-only reviewer
   accepts the exact diff before draft-PR publication.
 
+## Owner publication exception
+
+On 2026-07-26 the owner authorized draft-only publication after one complete
+local suite had one non-reproduced final failure and a failure-free rerun was
+stopped for time at approximately 72%. This exception does not satisfy the
+current-master regression criterion, authorize merge, or establish runtime
+readiness. A complete authoritative GitHub CI pass is required before merge
+consideration.
+
 ## Hard stops
 
 - No live runtime, service-manager, timer, database, model, prediction,

--- a/race_collection/operational.py
+++ b/race_collection/operational.py
@@ -3039,9 +3039,22 @@ class OperationalAuthority:
         config_path: str,
         python_executable: str,
     ) -> Mapping[str, str]:
-        if not Path(config_path).is_absolute():
+        configuration_path = Path(config_path)
+        if not configuration_path.is_absolute():
             raise ValueError("config path must be absolute")
         _safe_operational_path(config_path)
+        if configuration_path.is_symlink() or not configuration_path.is_file():
+            raise OperationalRejected(
+                "service configuration must be an existing regular non-symlink file"
+            )
+        try:
+            configuration_bytes = configuration_path.read_bytes()
+        except OSError as error:
+            raise OperationalRejected("service configuration is unreadable") from error
+        if configuration_bytes != _canonical(configuration.document()):
+            raise OperationalRejected(
+                "service configuration bytes disagree with the authenticated configuration"
+            )
         python_path = Path(python_executable)
         if (
             not python_path.is_absolute()

--- a/race_collection/operational.py
+++ b/race_collection/operational.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import re
 import sqlite3
+import subprocess
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from pathlib import Path
@@ -3032,11 +3033,61 @@ class OperationalAuthority:
 
     @staticmethod
     def generate_units(
-        manifest: ReleaseManifest, configuration: ReleaseConfiguration, *, config_path: str
+        manifest: ReleaseManifest,
+        configuration: ReleaseConfiguration,
+        *,
+        config_path: str,
+        python_executable: str,
     ) -> Mapping[str, str]:
         if not Path(config_path).is_absolute():
             raise ValueError("config path must be absolute")
         _safe_operational_path(config_path)
+        python_path = Path(python_executable)
+        if (
+            not python_path.is_absolute()
+            or not python_path.is_file()
+            or python_path.stat().st_mode & 0o111 == 0
+        ):
+            raise OperationalRejected("Python interpreter is unavailable or not executable")
+        _safe_operational_path(python_executable)
+        if any(
+            any(
+                character.isspace() or character in {"%", "$", "\\", '"', "'"}
+                for character in value
+            )
+            for value in (manifest.service_root, config_path, python_executable)
+        ):
+            raise ValueError("systemd command paths contain unsupported syntax")
+        try:
+            probe = subprocess.run(
+                (
+                    python_executable,
+                    "-c",
+                    "import json,sys; print(json.dumps("
+                    "{'executable':sys.executable,"
+                    "'version':[sys.version_info.major,sys.version_info.minor]},"
+                    "sort_keys=True,separators=(',',':')))",
+                ),
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+            raise OperationalRejected(
+                "Python interpreter identity could not be verified"
+            ) from error
+        try:
+            python_identity = json.loads(probe.stdout)
+        except json.JSONDecodeError as error:
+            raise OperationalRejected("Python interpreter identity is malformed") from error
+        if python_identity != {
+            "executable": python_executable,
+            "version": [3, 11],
+        }:
+            raise OperationalRejected(
+                "Race Collection Service requires the exact supplied Python 3.11 environment"
+            )
         actual = _checksum(configuration.document())
         if (
             actual != manifest.config_checksum
@@ -3054,13 +3105,14 @@ class OperationalAuthority:
                 "[Service]",
                 "Type=simple",
                 f"WorkingDirectory={manifest.service_root}",
-                f"ExecStart={manifest.service_root}/bin/race-collection-service "
+                f"ExecStart={python_executable} "
+                f"{manifest.service_root}/bin/race-collection-service "
                 f"--config {config_path} --continuous",
                 "Restart=on-failure",
                 "NoNewPrivileges=true",
                 "",
                 "[Install]",
-                "WantedBy=multi-user.target",
+                "WantedBy=default.target",
                 "",
             )
         )

--- a/race_collection/operator.py
+++ b/race_collection/operator.py
@@ -1,0 +1,509 @@
+"""Fail-closed operator CLI for the Phase 7 repository authority surfaces."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from dataclasses import asdict, fields
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .artifacts import LocalArtifactStore
+from .domain import ArtifactChecksum, OperationId, require_aware
+from .evaluation import EvaluationAuthority, PromotionPolicy
+from .operational import OperationalAuthority, ReleaseConfiguration, ReleaseManifest
+from .operations import SQLiteOperationsStore
+from .recovery import RecoveryAuthority
+
+
+class OperatorRejected(RuntimeError):
+    """An operator request is unsafe, ambiguous, or outside the supported contract."""
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+
+
+def _absolute(path: Path, label: str, *, must_exist: bool = False) -> Path:
+    if not path.is_absolute():
+        raise OperatorRejected(f"{label} must be an absolute path")
+    try:
+        resolved = path.resolve(strict=must_exist)
+    except (OSError, RuntimeError) as error:
+        raise OperatorRejected(f"{label} cannot be resolved exactly") from error
+    if any(character in str(path) for character in ("\n", "\r", "\x00")):
+        raise OperatorRejected(f"{label} contains unsafe characters")
+    return resolved
+
+
+def _sqlite_tables(path: Path) -> set[str]:
+    try:
+        with sqlite3.connect(f"{path.as_uri()}?mode=ro", uri=True) as db:
+            return {
+                row[0]
+                for row in db.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+                )
+            }
+    except sqlite3.Error as error:
+        raise OperatorRejected("operations database is not readable SQLite") from error
+
+
+def _database_paths(
+    operations_path: Path,
+    legacy_path: Path,
+    *,
+    allow_new_operations: bool,
+) -> tuple[Path, Path]:
+    legacy = _absolute(legacy_path, "legacy database", must_exist=True)
+    if not legacy.is_file():
+        raise OperatorRejected("legacy database must be an existing file")
+    operations = _absolute(operations_path, "operations database")
+    if operations == legacy or (
+        operations_path.exists() and legacy_path.exists() and operations_path.samefile(legacy_path)
+    ):
+        raise OperatorRejected("legacy database cannot be used as the operations database")
+    if not operations.parent.is_dir():
+        raise OperatorRejected("operations database parent must already exist")
+    if operations_path.is_symlink():
+        raise OperatorRejected("operations database must not be a symlink")
+    if not operations_path.exists():
+        if not allow_new_operations:
+            raise OperatorRejected("operations database does not exist")
+        return operations, legacy
+    if not operations.is_file():
+        raise OperatorRejected("operations database must be a regular file")
+    tables = _sqlite_tables(operations)
+    if tables and not {"schema_migrations", "operations"} <= tables:
+        raise OperatorRejected("existing database is not a Race Collection operations database")
+    if not tables and not allow_new_operations:
+        raise OperatorRejected("operations database is empty and unmigrated")
+    return operations, legacy
+
+
+def _schema_versions(store: SQLiteOperationsStore) -> list[int]:
+    try:
+        with store._connect() as db:
+            return [
+                row[0]
+                for row in db.execute("SELECT version FROM schema_migrations ORDER BY version")
+            ]
+    except sqlite3.Error as error:
+        raise OperatorRejected("operations database schema authority is unavailable") from error
+
+
+def _store(args: argparse.Namespace, *, allow_new: bool = False) -> SQLiteOperationsStore:
+    operations, _ = _database_paths(
+        args.operations_db,
+        args.legacy_db,
+        allow_new_operations=allow_new,
+    )
+    store = SQLiteOperationsStore(operations)
+    if not allow_new and _schema_versions(store) != list(range(1, 30)):
+        raise OperatorRejected("operations database must be exactly migrated through schema 29")
+    return store
+
+
+def _artifact_root(path: Path, label: str, *, must_exist: bool = False) -> Path:
+    resolved = _absolute(path, label, must_exist=must_exist)
+    if path.is_symlink():
+        raise OperatorRejected(f"{label} must not be a symlink")
+    if path.exists() and not resolved.is_dir():
+        raise OperatorRejected(f"{label} must be a directory")
+    if not path.exists() and not resolved.parent.is_dir():
+        raise OperatorRejected(f"{label} parent must already exist")
+    return resolved
+
+
+def _artifacts(args: argparse.Namespace) -> LocalArtifactStore:
+    return LocalArtifactStore(_artifact_root(args.artifacts_root, "artifact root"))
+
+
+def _document(path: Path, label: str) -> Mapping[str, Any]:
+    resolved = _absolute(path, f"{label} document", must_exist=True)
+    if path.is_symlink() or not resolved.is_file():
+        raise OperatorRejected(f"{label} document must be a regular non-symlink file")
+    try:
+        content = resolved.read_bytes()
+        value = json.loads(content)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise OperatorRejected(f"{label} document is unreadable or malformed") from error
+    if type(value) is not dict or content != _canonical(value):
+        raise OperatorRejected(f"{label} document must be exact canonical JSON")
+    return value
+
+
+def _configuration(path: Path) -> ReleaseConfiguration:
+    value = _document(path, "configuration")
+    expected = {
+        "schema_version",
+        "service_root",
+        "artifact_root",
+        "operations_database",
+        "sources",
+        "schedule_policy",
+        "promotion_policy",
+        "bundle_versions",
+        "runtime_adapter",
+        "runtime_input_checksum",
+    }
+    if set(value) != expected:
+        raise OperatorRejected("configuration document has unknown or missing keys")
+    configuration = ReleaseConfiguration(
+        schema_version=value["schema_version"],
+        service_root=value["service_root"],
+        artifact_root=value["artifact_root"],
+        operations_database=value["operations_database"],
+        sources=tuple(value["sources"]),
+        schedule_policy=value["schedule_policy"],
+        promotion_policy=value["promotion_policy"],
+        bundle_versions=tuple(value["bundle_versions"]),
+        runtime_adapter=value["runtime_adapter"],
+        runtime_input_checksum=ArtifactChecksum(value["runtime_input_checksum"]),
+    )
+    if configuration.document() != value:
+        raise OperatorRejected("configuration document disagrees with its typed identity")
+    return configuration
+
+
+def _release(path: Path) -> ReleaseManifest:
+    value = _document(path, "release")
+    expected = {
+        "schema_version",
+        "release_id",
+        "code_commit",
+        "config_checksum",
+        "database_schema",
+        "artifact_contract",
+        "policy_version",
+        "supported_bundle_versions",
+        "service_root",
+    }
+    if set(value) != expected:
+        raise OperatorRejected("release document has unknown or missing keys")
+    manifest = ReleaseManifest(
+        schema_version=value["schema_version"],
+        release_id=value["release_id"],
+        code_commit=value["code_commit"],
+        config_checksum=ArtifactChecksum(value["config_checksum"]),
+        database_schema=value["database_schema"],
+        artifact_contract=value["artifact_contract"],
+        policy_version=value["policy_version"],
+        supported_bundle_versions=tuple(value["supported_bundle_versions"]),
+        service_root=value["service_root"],
+    )
+    if manifest.document() != value:
+        raise OperatorRejected("release document disagrees with its typed identity")
+    return manifest
+
+
+def _policy(path: Path) -> PromotionPolicy:
+    value = _document(path, "policy")
+    expected = {field.name for field in fields(PromotionPolicy)}
+    if set(value) != expected:
+        raise OperatorRejected("policy document has unknown or missing keys")
+    policy = PromotionPolicy(**value)
+    if asdict(policy) != value:
+        raise OperatorRejected("policy document disagrees with its typed identity")
+    return policy
+
+
+def _timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value)
+        require_aware(parsed, "operator timestamp")
+        return parsed
+    except (TypeError, ValueError) as error:
+        raise OperatorRejected("operator timestamp must be an aware ISO instant") from error
+
+
+def _operation(value: str) -> OperationId:
+    try:
+        return OperationId(value)
+    except ValueError as error:
+        raise OperatorRejected("operation identity is malformed") from error
+
+
+def _authority(
+    args: argparse.Namespace,
+    at: datetime,
+) -> tuple[SQLiteOperationsStore, LocalArtifactStore, OperationalAuthority]:
+    store = _store(args)
+    artifacts = _artifacts(args)
+    return store, artifacts, OperationalAuthority(store, artifacts, clock=lambda: at)
+
+
+def _add_databases(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--operations-db", required=True, type=Path)
+    parser.add_argument("--legacy-db", required=True, type=Path)
+
+
+def _add_artifacts(parser: argparse.ArgumentParser) -> None:
+    _add_databases(parser)
+    parser.add_argument("--artifacts-root", required=True, type=Path)
+
+
+def _add_operation(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--operation-id", required=True)
+    parser.add_argument("--at", required=True)
+
+
+def _add_actor(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--actor", required=True)
+    parser.add_argument("--reason", required=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="race-collection-operator",
+        description="Apply one explicit Phase 7 authority command to a separate operations DB.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    migrate = commands.add_parser("migrate")
+    _add_databases(migrate)
+
+    for name in ("register-config", "register-release", "register-policy"):
+        command = commands.add_parser(name)
+        _add_artifacts(command)
+        _add_operation(command)
+        command.add_argument("--document", required=True, type=Path)
+
+    initialize = commands.add_parser("initialize-legacy")
+    _add_artifacts(initialize)
+    _add_operation(initialize)
+    _add_actor(initialize)
+    initialize.add_argument("--release-id", required=True)
+
+    for name in ("authorize-observation", "revoke-observation"):
+        command = commands.add_parser(name)
+        _add_artifacts(command)
+        _add_operation(command)
+        _add_actor(command)
+        command.add_argument("--release-id", required=True)
+
+    activate = commands.add_parser("activate")
+    _add_artifacts(activate)
+    _add_operation(activate)
+    _add_actor(activate)
+    activate.add_argument("--release-id", required=True)
+    activate.add_argument("--boundary-day-id", required=True)
+
+    rollback = commands.add_parser("rollback")
+    _add_artifacts(rollback)
+    _add_operation(rollback)
+    _add_actor(rollback)
+
+    backup = commands.add_parser("backup")
+    _add_artifacts(backup)
+    _add_operation(backup)
+    backup.add_argument("--backup-id", required=True)
+    backup.add_argument("--racing-day-id", required=True)
+    backup.add_argument("--snapshot", required=True, type=Path)
+    backup.add_argument("--replica-root", required=True, type=Path)
+
+    restore = commands.add_parser("validate-restore")
+    _add_artifacts(restore)
+    _add_operation(restore)
+    restore.add_argument("--drill-id", required=True)
+    restore.add_argument("--backup-id", required=True)
+    restore.add_argument("--snapshot", required=True, type=Path)
+    restore.add_argument("--replica-root", required=True, type=Path)
+
+    service = commands.add_parser("generate-user-service")
+    service.add_argument("--release-document", required=True, type=Path)
+    service.add_argument("--configuration-document", required=True, type=Path)
+    service.add_argument("--config-path", required=True)
+    service.add_argument("--python-executable", required=True)
+    return parser
+
+
+def _recovery_paths(
+    args: argparse.Namespace,
+    store: SQLiteOperationsStore,
+    artifacts: LocalArtifactStore,
+    *,
+    snapshot_must_exist: bool,
+) -> tuple[Path, LocalArtifactStore]:
+    def contains(parent: Path, child: Path) -> bool:
+        try:
+            child.relative_to(parent)
+        except ValueError:
+            return False
+        return True
+
+    snapshot = _absolute(
+        args.snapshot,
+        "isolated snapshot",
+        must_exist=snapshot_must_exist,
+    )
+    if args.snapshot.is_symlink():
+        raise OperatorRejected("isolated snapshot must not be a symlink")
+    if snapshot in {store.path.resolve(), args.legacy_db.resolve()}:
+        raise OperatorRejected("isolated snapshot must not alias either database")
+    if not snapshot_must_exist and not snapshot.parent.is_dir():
+        raise OperatorRejected("isolated snapshot parent must already exist")
+    if snapshot_must_exist and not snapshot.is_file():
+        raise OperatorRejected("isolated snapshot must be an existing file")
+    replica_root = _artifact_root(
+        args.replica_root,
+        "replica artifact root",
+        must_exist=snapshot_must_exist,
+    )
+    if contains(artifacts.root, replica_root) or contains(replica_root, artifacts.root):
+        raise OperatorRejected("replica artifact root must be isolated from the primary")
+    if contains(artifacts.root, snapshot):
+        raise OperatorRejected("isolated snapshot must be outside the primary artifact root")
+    return snapshot, LocalArtifactStore(replica_root)
+
+
+def _dispatch(args: argparse.Namespace) -> tuple[Mapping[str, Any], int]:
+    if args.command == "migrate":
+        store = _store(args, allow_new=True)
+        store.migrate()
+        if _schema_versions(store) != list(range(1, 30)):
+            raise OperatorRejected("migration did not produce the exact schema 1-29 chain")
+        return {"command": "migrate", "schema_version": 29, "status": "ok"}, 0
+
+    if args.command == "generate-user-service":
+        manifest = _release(args.release_document)
+        configuration = _configuration(args.configuration_document)
+        units = OperationalAuthority.generate_units(
+            manifest,
+            configuration,
+            config_path=args.config_path,
+            python_executable=args.python_executable,
+        )
+        return {"command": args.command, "status": "ok", "units": units}, 0
+
+    at = _timestamp(args.at)
+    operation_id = _operation(args.operation_id)
+    store, artifacts, authority = _authority(args, at)
+    base = {
+        "command": args.command,
+        "operation_id": str(operation_id),
+        "status": "ok",
+    }
+
+    if args.command == "register-config":
+        configuration = _configuration(args.document)
+        if (
+            configuration.operations_database != str(store.path)
+            or Path(configuration.artifact_root).resolve() != artifacts.root
+        ):
+            raise OperatorRejected(
+                "configuration database or artifact root disagrees with explicit CLI paths"
+            )
+        checksum = authority.register_configuration(operation_id, configuration, at)
+        return {**base, "checksum": str(checksum)}, 0
+    if args.command == "register-release":
+        checksum = authority.register_release(operation_id, _release(args.document), at)
+        return {**base, "checksum": str(checksum)}, 0
+    if args.command == "register-policy":
+        checksum = EvaluationAuthority(store, artifacts).register_policy(
+            operation_id,
+            _policy(args.document),
+            at,
+        )
+        return {**base, "checksum": str(checksum)}, 0
+    if args.command == "initialize-legacy":
+        changed = authority.initialize_legacy_authority(
+            operation_id,
+            release_id=args.release_id,
+            actor=args.actor,
+            reason=args.reason,
+            at=at,
+        )
+        return {**base, "changed": changed}, 0
+    if args.command == "authorize-observation":
+        changed = authority.authorize_observation(
+            operation_id,
+            candidate_release_id=args.release_id,
+            actor=args.actor,
+            reason=args.reason,
+            at=at,
+        )
+        return {**base, "changed": changed}, 0
+    if args.command == "revoke-observation":
+        changed = authority.revoke_observation(
+            operation_id,
+            candidate_release_id=args.release_id,
+            actor=args.actor,
+            reason=args.reason,
+            at=at,
+        )
+        return {**base, "changed": changed}, 0
+    if args.command == "activate":
+        changed = authority.activate(
+            operation_id,
+            release_id=args.release_id,
+            boundary_day_id=args.boundary_day_id,
+            actor=args.actor,
+            reason=args.reason,
+            at=at,
+        )
+        return {**base, "changed": changed}, 0
+    if args.command == "rollback":
+        changed = authority.rollback(
+            operation_id,
+            actor=args.actor,
+            reason=args.reason,
+            at=at,
+        )
+        return {**base, "changed": changed}, 0
+    if args.command == "backup":
+        snapshot, replica = _recovery_paths(
+            args,
+            store,
+            artifacts,
+            snapshot_must_exist=False,
+        )
+        checksum = RecoveryAuthority(store, artifacts).backup(
+            operation_id,
+            backup_id=args.backup_id,
+            racing_day_id=args.racing_day_id,
+            snapshot_path=snapshot,
+            replica=replica,
+            at=at,
+        )
+        return {**base, "database_checksum": str(checksum)}, 0
+    if args.command == "validate-restore":
+        snapshot, replica = _recovery_paths(
+            args,
+            store,
+            artifacts,
+            snapshot_must_exist=True,
+        )
+        successful = RecoveryAuthority(store, artifacts).restore_drill(
+            operation_id,
+            drill_id=args.drill_id,
+            backup_id=args.backup_id,
+            snapshot_path=snapshot,
+            replica=replica,
+            at=at,
+        )
+        return {
+            **base,
+            "status": "ok" if successful else "rejected",
+            "successful": successful,
+        }, (0 if successful else 3)
+    raise OperatorRejected("unsupported operator command")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result, status = _dispatch(args)
+    except Exception as error:
+        print(f"race-collection-operator rejected: {error}", file=sys.stderr)
+        return 2
+    print(_canonical(result).decode())
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/race_collection/operator.py
+++ b/race_collection/operator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sqlite3
 import sys
@@ -85,15 +86,25 @@ def _database_paths(
     return operations, legacy
 
 
-def _schema_versions(store: SQLiteOperationsStore) -> list[int]:
+def _verify_schema_identity(store: SQLiteOperationsStore) -> None:
     try:
         with store._connect() as db:
-            return [
-                row[0]
-                for row in db.execute("SELECT version FROM schema_migrations ORDER BY version")
+            recorded = [
+                tuple(row)
+                for row in db.execute(
+                    "SELECT version,checksum FROM schema_migrations ORDER BY version"
+                )
             ]
-    except sqlite3.Error as error:
+        expected = [
+            (version, hashlib.sha256(content).hexdigest())
+            for version, _, content in store._migration_scripts()
+        ]
+    except (OSError, sqlite3.Error) as error:
         raise OperatorRejected("operations database schema authority is unavailable") from error
+    if recorded != expected or [version for version, _ in recorded] != list(range(1, 30)):
+        raise OperatorRejected(
+            "operations database must have the exact checked-in schema 1-29 identity"
+        )
 
 
 def _store(args: argparse.Namespace, *, allow_new: bool = False) -> SQLiteOperationsStore:
@@ -103,8 +114,8 @@ def _store(args: argparse.Namespace, *, allow_new: bool = False) -> SQLiteOperat
         allow_new_operations=allow_new,
     )
     store = SQLiteOperationsStore(operations)
-    if not allow_new and _schema_versions(store) != list(range(1, 30)):
-        raise OperatorRejected("operations database must be exactly migrated through schema 29")
+    if not allow_new:
+        _verify_schema_identity(store)
     return store
 
 
@@ -230,11 +241,10 @@ def _operation(value: str) -> OperationId:
 
 def _authority(
     args: argparse.Namespace,
-    at: datetime,
 ) -> tuple[SQLiteOperationsStore, LocalArtifactStore, OperationalAuthority]:
     store = _store(args)
     artifacts = _artifacts(args)
-    return store, artifacts, OperationalAuthority(store, artifacts, clock=lambda: at)
+    return store, artifacts, OperationalAuthority(store, artifacts)
 
 
 def _add_databases(parser: argparse.ArgumentParser) -> None:
@@ -343,7 +353,14 @@ def _recovery_paths(
     )
     if args.snapshot.is_symlink():
         raise OperatorRejected("isolated snapshot must not be a symlink")
-    if snapshot in {store.path.resolve(), args.legacy_db.resolve()}:
+    database_paths = (store.path.resolve(), args.legacy_db.resolve(strict=True))
+    try:
+        database_alias = snapshot_must_exist and any(
+            snapshot.samefile(database) for database in database_paths
+        )
+    except OSError as error:
+        raise OperatorRejected("database and snapshot identities cannot be compared") from error
+    if snapshot in set(database_paths) or database_alias:
         raise OperatorRejected("isolated snapshot must not alias either database")
     if not snapshot_must_exist and not snapshot.parent.is_dir():
         raise OperatorRejected("isolated snapshot parent must already exist")
@@ -365,8 +382,7 @@ def _dispatch(args: argparse.Namespace) -> tuple[Mapping[str, Any], int]:
     if args.command == "migrate":
         store = _store(args, allow_new=True)
         store.migrate()
-        if _schema_versions(store) != list(range(1, 30)):
-            raise OperatorRejected("migration did not produce the exact schema 1-29 chain")
+        _verify_schema_identity(store)
         return {"command": "migrate", "schema_version": 29, "status": "ok"}, 0
 
     if args.command == "generate-user-service":
@@ -382,7 +398,7 @@ def _dispatch(args: argparse.Namespace) -> tuple[Mapping[str, Any], int]:
 
     at = _timestamp(args.at)
     operation_id = _operation(args.operation_id)
-    store, artifacts, authority = _authority(args, at)
+    store, artifacts, authority = _authority(args)
     base = {
         "command": args.command,
         "operation_id": str(operation_id),

--- a/race_collection/recovery.py
+++ b/race_collection/recovery.py
@@ -137,6 +137,7 @@ class RecoveryAuthority:
             "backup": backup_id,
             "day": racing_day_id,
             "snapshot": str(snapshot_path.resolve()),
+            "replica": str(replica.root.resolve()),
             "at": iso_timestamp(at),
         }
         with self.store._connect() as existing:
@@ -273,22 +274,17 @@ class RecoveryAuthority:
             "drill": drill_id,
             "backup": backup_id,
             "snapshot": str(snapshot_path.resolve()),
+            "replica": str(replica.root.resolve()),
             "at": iso_timestamp(at),
         }
         with self.store._operation(operation_id, "phase7_restore_drill", payload) as (db, replay):
-            if replay:
-                return bool(
-                    db.execute(
-                        "SELECT successful FROM phase7_restore_drills WHERE operation_id=?",
-                        (str(operation_id),),
-                    ).fetchone()[0]
-                )
             backup = db.execute(
                 "SELECT * FROM phase7_backups WHERE backup_id=?", (backup_id,)
             ).fetchone()
             database_ok = (
                 backup is not None
-                and snapshot_path.exists()
+                and snapshot_path.is_file()
+                and not snapshot_path.is_symlink()
                 and str(_digest(snapshot_path.read_bytes())) == backup["database_checksum"]
                 and backup["artifact_reference_contract"] == ARTIFACT_REFERENCE_CONTRACT
             )
@@ -344,6 +340,25 @@ class RecoveryAuthority:
                     if recovered is not None:
                         recovered.close()
             successful = database_ok and artifacts_ok and readable
+            if replay:
+                recorded = db.execute(
+                    "SELECT database_verified,artifacts_verified,"
+                    "application_readable,successful "
+                    "FROM phase7_restore_drills WHERE operation_id=?",
+                    (str(operation_id),),
+                ).fetchone()
+                if recorded is None:
+                    raise RecoveryRejected("restore replay lacks its durable drill")
+                recorded_flags = tuple(recorded)
+                if recorded_flags[-1] and recorded_flags != (1, 1, 1, 1):
+                    raise RecoveryRejected("restore replay has inconsistent durable proof")
+                if not recorded_flags[-1]:
+                    return False
+                if not successful:
+                    raise RecoveryRejected(
+                        "restore replay no longer proves current isolated recovery"
+                    )
+                return True
             db.execute(
                 "INSERT INTO phase7_restore_drills VALUES(?,?,?,?,?,?,?,?)",
                 (

--- a/race_collection/recovery.py
+++ b/race_collection/recovery.py
@@ -4,13 +4,20 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sqlite3
 from datetime import datetime
 from pathlib import Path
 
 from .artifacts import ArtifactStore, ArtifactStoreError, LocalArtifactStore
 from .domain import ArtifactChecksum, OperationId, require_aware
-from .operations import BarrierNotSatisfied, SQLiteOperationsStore, iso_timestamp
+from .operations import (
+    BarrierNotSatisfied,
+    ConflictingOperation,
+    SQLiteOperationsStore,
+    _payload_hash,
+    iso_timestamp,
+)
 
 
 class RecoveryRejected(RuntimeError):
@@ -132,6 +139,39 @@ class RecoveryAuthority:
             "snapshot": str(snapshot_path.resolve()),
             "at": iso_timestamp(at),
         }
+        with self.store._connect() as existing:
+            operation = existing.execute(
+                "SELECT kind,payload_sha256 FROM operations WHERE operation_id=?",
+                (str(operation_id),),
+            ).fetchone()
+            if operation is not None:
+                backup = existing.execute(
+                    "SELECT backup_id,racing_day_id,database_checksum "
+                    "FROM phase7_backups WHERE operation_id=?",
+                    (str(operation_id),),
+                ).fetchone()
+                if (
+                    operation["kind"] != "phase7_backup"
+                    or operation["payload_sha256"] != _payload_hash(payload)
+                    or backup is None
+                    or backup["backup_id"] != backup_id
+                    or backup["racing_day_id"] != racing_day_id
+                ):
+                    raise ConflictingOperation(
+                        f"operation {operation_id} has different backup intent"
+                    )
+                checksum = ArtifactChecksum(backup["database_checksum"])
+                if (
+                    not snapshot_path.is_file()
+                    or snapshot_path.is_symlink()
+                    or _digest(snapshot_path.read_bytes()) != checksum
+                ):
+                    raise RecoveryRejected(
+                        "exact backup replay snapshot is missing, aliased, or changed"
+                    )
+                return checksum
+        if snapshot_path.exists() or snapshot_path.is_symlink():
+            raise RecoveryRejected("backup snapshot path must be new and non-symlinked")
         # sqlite3.Connection.backup must not run from the writer transaction it
         # is copying. A dedicated read connection produces one consistent DB
         # image; publication of its verified identity is a separate atomic op.
@@ -146,6 +186,18 @@ class RecoveryAuthority:
             ):
                 raise BarrierNotSatisfied("only a complete reconciled Racing Day may be backed up")
             snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                descriptor = os.open(
+                    snapshot_path,
+                    os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0),
+                    0o600,
+                )
+            except OSError as error:
+                raise RecoveryRejected(
+                    "backup snapshot path could not be reserved exclusively"
+                ) from error
+            else:
+                os.close(descriptor)
             target = sqlite3.connect(snapshot_path)
             try:
                 source.backup(target)
@@ -170,12 +222,19 @@ class RecoveryAuthority:
         inventory_artifact = replica.put(inventory, media_type="application/json")
         with self.store._operation(operation_id, "phase7_backup", payload) as (db, replay):
             if replay:
-                return ArtifactChecksum(
+                recorded = ArtifactChecksum(
                     db.execute(
                         "SELECT database_checksum FROM phase7_backups WHERE operation_id=?",
                         (str(operation_id),),
                     ).fetchone()[0]
                 )
+                if (
+                    not snapshot_path.is_file()
+                    or snapshot_path.is_symlink()
+                    or _digest(snapshot_path.read_bytes()) != recorded
+                ):
+                    raise RecoveryRejected("concurrent backup replay changed the reserved snapshot")
+                return recorded
             if (
                 db.execute(
                     "SELECT 1 FROM phase7_reconciliation WHERE racing_day_id=? AND mismatch_count=0",

--- a/race_collection/runtime_adapters.py
+++ b/race_collection/runtime_adapters.py
@@ -82,10 +82,11 @@ _RACE_KEYS = frozenset(
         "odds_attempts",
         "seal",
         "prediction",
-        "result",
-        "training_example",
     }
 )
+_FULL_RACE_KEYS = _RACE_KEYS | {"result", "training_example"}
+_RESULT_BLIND_MODE = "result-blind-observation-v1"
+_COMPLETE_MODE = "complete-v1"
 _IDENTITY_KEYS = frozenset(
     {
         "operation_id",
@@ -272,7 +273,7 @@ class _ExactRegisteredDeferredPredictor:
 
 
 class ImmutableInputRuntimeAdapter:
-    """Execute one closed nine-phase plan from explicit immutable source inputs."""
+    """Execute one closed plan, including a result-blind observation prefix."""
 
     def __init__(
         self,
@@ -324,6 +325,7 @@ class ImmutableInputRuntimeAdapter:
         self._cycles = tuple(cycle for cycle, _ in parsed)
         self._documents = {cycle.racing_day_id: item for cycle, item in parsed}
         self._verify_release_and_sources(configuration, document)
+        self._verify_registered_forecast_cohorts(document)
         self._verify_external_artifacts(document)
 
     def _verify_release_and_sources(
@@ -377,12 +379,19 @@ class ImmutableInputRuntimeAdapter:
                     observation["source"] for observation in race["observations"]
                 )
                 supplied_sources.update(attempt["source"] for attempt in race["odds_attempts"])
-                supplied_sources.add(race["result"]["source"])
+                if cycle.get("mode", _COMPLETE_MODE) == _COMPLETE_MODE:
+                    supplied_sources.add(race["result"]["source"])
         if not supplied_sources <= configured_sources:
             raise ServiceUnavailable("runtime input uses a source outside the configured release")
 
     def _parse_cycle(self, value: Any) -> tuple[RacingDayCycle, Mapping[str, Any]]:
-        item = _strict_object(value, _CYCLE_KEYS, "cycle")
+        if type(value) is not dict:
+            raise ServiceUnavailable("runtime cycle has unknown or missing keys")
+        mode = value.get("mode", _COMPLETE_MODE)
+        expected_cycle_keys = _CYCLE_KEYS | ({"mode"} if "mode" in value else set())
+        item = _strict_object(value, frozenset(expected_cycle_keys), "cycle")
+        if mode not in {_COMPLETE_MODE, _RESULT_BLIND_MODE}:
+            raise ServiceUnavailable("runtime cycle mode is unsupported")
         programme = _strict_object(item["programme"], _PROGRAMME_KEYS, "programme")
         champion = _strict_object(item["champion"], _CHAMPION_KEYS, "champion")
         cohort = _strict_object(item["forecast_cohort"], _COHORT_KEYS, "day forecast cohort")
@@ -392,7 +401,8 @@ class ImmutableInputRuntimeAdapter:
         source_ids: list[str] = []
         nested_operations: list[OperationId] = []
         for race_value in item["races"]:
-            race = _strict_object(race_value, _RACE_KEYS, "race")
+            race_keys = _RACE_KEYS if mode == _RESULT_BLIND_MODE else _FULL_RACE_KEYS
+            race = _strict_object(race_value, race_keys, "race")
             if type(race["source_race_id"]) is not str or not race["source_race_id"].strip():
                 raise ServiceUnavailable("runtime source race identity is malformed")
             source_ids.append(race["source_race_id"])
@@ -422,19 +432,26 @@ class ImmutableInputRuntimeAdapter:
             for attempt in race["odds_attempts"]:
                 _strict_object(attempt, _ODDS_KEYS, "odds attempt")
                 nested_operations.append(OperationId(attempt["operation_id"]))
-            for name, keys in (
+            nested_contracts = [
                 ("seal", _SEAL_KEYS),
                 ("prediction", _PREDICTION_KEYS),
-                ("result", _RESULT_KEYS),
-                ("training_example", _EXAMPLE_KEYS),
-            ):
+            ]
+            if mode == _COMPLETE_MODE:
+                nested_contracts.extend(
+                    (
+                        ("result", _RESULT_KEYS),
+                        ("training_example", _EXAMPLE_KEYS),
+                    )
+                )
+            for name, keys in nested_contracts:
                 nested = _strict_object(race[name], keys, name)
                 nested_operations.extend(
                     OperationId(value)
                     for key, value in nested.items()
                     if key.endswith("operation_id")
                 )
-            ArtifactChecksum(race["result"]["source_checksum"])
+            if mode == _COMPLETE_MODE:
+                ArtifactChecksum(race["result"]["source_checksum"])
         if len(source_ids) != len(set(source_ids)):
             raise ServiceUnavailable("runtime cycle contains duplicate source race identities")
         if type(cohort["members"]) is not list or len(cohort["members"]) < 2:
@@ -524,10 +541,76 @@ class ImmutableInputRuntimeAdapter:
             OperationId(item["plan_operation_id"]),
             advancement_ids,
             _datetime(item["at"], "cycle time"),
+            "deferred_prediction" if mode == _RESULT_BLIND_MODE else "request_training",
         )
         date.fromisoformat(item["local_date"])
         _datetime(item["opened_at"], "opened_at")
         return cycle, item
+
+    def _verify_registered_forecast_cohorts(self, document: Mapping[str, Any]) -> None:
+        """Authenticate champion and challenger registry identities before receipt one."""
+        try:
+            with self._store._connect() as db:
+                for cycle in document["cycles"]:
+                    champion = cycle["champion"]
+                    cohort = cycle["forecast_cohort"]
+                    champion_members = [
+                        member for member in cohort["members"] if member["role"] == "champion"
+                    ]
+                    assignment = db.execute(
+                        "SELECT assignment_id,bundle_id,bundle_checksum "
+                        "FROM canonical_day_assignments WHERE racing_day_id=?",
+                        (cycle["racing_day_id"],),
+                    ).fetchone()
+                    if (
+                        len(champion_members) != 1
+                        or champion_members[0]["bundle_id"] != champion["bundle_id"]
+                        or champion_members[0]["bundle_checksum"] != champion["bundle_checksum"]
+                        or assignment is None
+                        or assignment["assignment_id"] != cohort["assignment_id"]
+                        or assignment["bundle_id"] != champion["bundle_id"]
+                        or assignment["bundle_checksum"] != champion["bundle_checksum"]
+                    ):
+                        raise ServiceUnavailable(
+                            "runtime champion is not the exact registered Racing Day assignment"
+                        )
+                    for member in cohort["members"]:
+                        bundle = db.execute(
+                            "SELECT created_at FROM canonical_model_bundles "
+                            "WHERE bundle_id=? AND bundle_checksum=?",
+                            (member["bundle_id"], member["bundle_checksum"]),
+                        ).fetchone()
+                        components = db.execute(
+                            "SELECT artifact_checksum FROM canonical_bundle_components "
+                            "WHERE bundle_id=? ORDER BY component_kind",
+                            (member["bundle_id"],),
+                        ).fetchall()
+                        if (
+                            bundle is None
+                            or len(components) != 9
+                            or _datetime(bundle["created_at"], "bundle registration time")
+                            >= _datetime(cycle["at"], "cycle time")
+                        ):
+                            raise ServiceUnavailable(
+                                f"runtime {member['role']} is not exactly registered"
+                            )
+                        self._artifacts.verify(ArtifactChecksum(member["bundle_checksum"]))
+                        for component in components:
+                            self._artifacts.verify(ArtifactChecksum(component["artifact_checksum"]))
+                    bundle_identities = [
+                        (member["bundle_id"], member["bundle_checksum"])
+                        for member in cohort["members"]
+                    ]
+                    if len(bundle_identities) != len(set(bundle_identities)):
+                        raise ServiceUnavailable(
+                            "runtime champion and challenger registrations are not unique"
+                        )
+        except ServiceUnavailable:
+            raise
+        except (ArtifactStoreError, KeyError, TypeError, ValueError) as error:
+            raise ServiceUnavailable(
+                "runtime champion or challenger registration is unavailable"
+            ) from error
 
     def _verify_external_artifacts(self, document: Mapping[str, Any]) -> None:
         """Read every pre-result source object before accepting a plan."""
@@ -588,11 +671,23 @@ class ImmutableInputRuntimeAdapter:
                     or day["opened_at"] != item["opened_at"]
                 ):
                     raise ServiceUnavailable("configured Racing Day identity changed")
-                complete = db.execute(
-                    "SELECT count(*) FROM phase7_scheduler_progress WHERE racing_day_id=?",
-                    (cycle.racing_day_id,),
-                ).fetchone()[0]
-                if complete < 9 and cycle.at <= now:
+                completed = [
+                    row[0]
+                    for row in db.execute(
+                        "SELECT phase_ordinal FROM phase7_scheduler_progress "
+                        "WHERE racing_day_id=? ORDER BY phase_ordinal",
+                        (cycle.racing_day_id,),
+                    )
+                ]
+                if completed != list(range(1, len(completed) + 1)):
+                    raise ServiceUnavailable(
+                        "runtime cycle progress is not a contiguous receipt prefix"
+                    )
+                if any(ordinal > cycle.terminal_ordinal for ordinal in completed):
+                    raise ServiceUnavailable(
+                        "runtime cycle has progress beyond its authorized terminal phase"
+                    )
+                if len(completed) < cycle.terminal_ordinal and cycle.at <= now:
                     return cycle
         return None
 

--- a/race_collection/runtime_adapters.py
+++ b/race_collection/runtime_adapters.py
@@ -325,7 +325,10 @@ class ImmutableInputRuntimeAdapter:
         self._cycles = tuple(cycle for cycle, _ in parsed)
         self._documents = {cycle.racing_day_id: item for cycle, item in parsed}
         self._verify_release_and_sources(configuration, document)
-        self._verify_registered_forecast_cohorts(document)
+        self._verify_registered_forecast_cohorts(
+            document,
+            configuration.bundle_versions,
+        )
         self._verify_external_artifacts(document)
 
     def _verify_release_and_sources(
@@ -547,8 +550,13 @@ class ImmutableInputRuntimeAdapter:
         _datetime(item["opened_at"], "opened_at")
         return cycle, item
 
-    def _verify_registered_forecast_cohorts(self, document: Mapping[str, Any]) -> None:
+    def _verify_registered_forecast_cohorts(
+        self,
+        document: Mapping[str, Any],
+        release_bundle_versions: Sequence[str],
+    ) -> None:
         """Authenticate champion and challenger registry identities before receipt one."""
+        release_contracts = set(release_bundle_versions)
         try:
             with self._store._connect() as db:
                 for cycle in document["cycles"]:
@@ -576,7 +584,8 @@ class ImmutableInputRuntimeAdapter:
                         )
                     for member in cohort["members"]:
                         bundle = db.execute(
-                            "SELECT created_at FROM canonical_model_bundles "
+                            "SELECT created_at,forecast_contract_version "
+                            "FROM canonical_model_bundles "
                             "WHERE bundle_id=? AND bundle_checksum=?",
                             (member["bundle_id"], member["bundle_checksum"]),
                         ).fetchone()
@@ -588,11 +597,13 @@ class ImmutableInputRuntimeAdapter:
                         if (
                             bundle is None
                             or len(components) != 9
+                            or bundle["forecast_contract_version"] not in release_contracts
                             or _datetime(bundle["created_at"], "bundle registration time")
                             >= _datetime(cycle["at"], "cycle time")
                         ):
                             raise ServiceUnavailable(
-                                f"runtime {member['role']} is not exactly registered"
+                                f"runtime {member['role']} is not exactly registered "
+                                "for the configured release"
                             )
                         self._artifacts.verify(ArtifactChecksum(member["bundle_checksum"]))
                         for component in components:

--- a/race_collection/service.py
+++ b/race_collection/service.py
@@ -40,13 +40,14 @@ class ServiceUnavailable(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class RacingDayCycle:
-    """One immutable nine-command Racing Day plan supplied by a trusted adapter."""
+    """One immutable Racing Day plan with an explicitly bounded execution prefix."""
 
     racing_day_id: str
     commands: tuple[ApplicationCommand, ...]
     plan_operation_id: OperationId
     advancement_operation_ids: tuple[OperationId, ...]
     at: datetime
+    terminal_phase: str = "request_training"
 
     def __post_init__(self) -> None:
         phases = tuple(command.phase for command in self.commands)
@@ -54,6 +55,7 @@ class RacingDayCycle:
             not isinstance(self.racing_day_id, str)
             or not self.racing_day_id.strip()
             or phases != RaceCollectionService.ORDER
+            or self.terminal_phase not in {"deferred_prediction", "request_training"}
             or len(self.advancement_operation_ids) != len(self.commands)
             or any(command.racing_day_id != self.racing_day_id for command in self.commands)
             or len(
@@ -68,6 +70,11 @@ class RacingDayCycle:
             or self.at.utcoffset() is None
         ):
             raise ValueError("runtime cycle is not one exact ordered Racing Day plan")
+
+    @property
+    def terminal_ordinal(self) -> int:
+        """Return the last phase this immutable input is authorized to execute."""
+        return RaceCollectionService.ORDER.index(self.terminal_phase) + 1
 
 
 class RuntimeAdapter(Protocol):
@@ -402,9 +409,17 @@ class ServiceComposition:
             }
         if tuple(sorted(completed)) != tuple(range(1, len(completed) + 1)):
             raise OperationalRejected("completed scheduler progress is not a contiguous prefix")
+        if any(ordinal > cycle.terminal_ordinal for ordinal in completed):
+            raise OperationalRejected(
+                "runtime cycle has durable progress beyond its authorized terminal phase"
+            )
         results = []
         for ordinal, (command, advancement_id) in enumerate(
-            zip(cycle.commands, cycle.advancement_operation_ids, strict=True),
+            zip(
+                cycle.commands[: cycle.terminal_ordinal],
+                cycle.advancement_operation_ids[: cycle.terminal_ordinal],
+                strict=True,
+            ),
             1,
         ):
             prior = completed.get(ordinal)

--- a/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/DECISIONS.md
+++ b/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/DECISIONS.md
@@ -1,0 +1,15 @@
+# Decisions
+
+- Preserve the dirty launch checkout and implement from exact canonical in a
+  clean sibling worktree.
+- Keep migrations 0001 through 0029 unchanged; protect the legacy DB at the
+  operator boundary and prove a fresh separate DB reaches exactly schema 29.
+- Reuse existing operational, evaluation, and recovery authorities rather than
+  write persistence SQL in the operator CLI.
+- Represent result-blind observation as an immutable runtime-input mode that
+  plans the existing closed order but executes only the prefix ending at
+  deferred prediction.
+- Authenticate the complete declared champion/challenger cohort at adapter
+  construction, before receipt 1.
+- Keep runtime proof explicitly `DATA_MISSING`; repository tests do not prove a
+  live canary.

--- a/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/DECISIONS.md
+++ b/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/DECISIONS.md
@@ -13,3 +13,16 @@
   construction, before receipt 1.
 - Keep runtime proof explicitly `DATA_MISSING`; repository tests do not prove a
   live canary.
+- Apply the fresh review's fail-closed repairs before publication: bind exact
+  configuration bytes, reject hard-link aliases, authenticate release bundle
+  contracts before receipt 1, keep activation time authority internal, and bind
+  recovery replay to the current snapshot, inventory, and replica root.
+- Treat the first complete regression run as non-green because its final
+  resume-through-main test returned fail-closed code 69 once, despite that exact
+  test subsequently passing 21/21 focused repetitions and the exact
+  preceding-file sequence.
+- Stop the second complete-suite attempt at the owner's direction for time. Its
+  approximately 72% failure-free progress is partial evidence only, not a
+  complete passing-suite result.
+- Publish only a draft PR with authoritative full-suite GitHub CI confirmation
+  as a mandatory pre-merge gate. Do not claim merge or runtime readiness.

--- a/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/README.md
+++ b/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/README.md
@@ -1,0 +1,39 @@
+# Forecasting observation canary readiness
+
+## Objective
+
+Implement and validate the minimum repository-only interfaces for a future,
+separately authorized result-blind observation canary.
+
+## Current state
+
+`RUNNING`
+
+Canonical base is commit `17f7b605b9f81c5a08a88fea8835aadf291cbfe7`,
+tree `fbffb4954618dc80688c3baafa14749bf5cd14f1`. PR #64 is merged.
+Runtime functionality remains `DATA_MISSING`; no live action is authorized.
+
+## Constraints and unsafe actions
+
+The legacy DB, installed services, timers, live odds capture, production data,
+models, predictions, training, promotion, betting, and deployment are out of
+scope. Only a draft PR may be opened.
+
+## Evidence used
+
+- Owner-verified activation result: `STOP / DATA_MISSING`.
+- Fresh `origin/master` and PR #64 resolution.
+- Portable Git guard preflight.
+- Merged Phase 7 authority, runtime adapter, service, recovery, schemas, tests,
+  and deployment documentation.
+
+## Ignored and untracked artifacts
+
+The launch checkout's untracked `AGENTS.md` and two race-inventory report
+directories are unrelated and remain untouched. Work proceeds in a clean
+sibling worktree.
+
+## Unsafe actions avoided
+
+No service-manager, runtime, production database, model, data-capture,
+prediction, training, promotion, betting, or deployment command has run.

--- a/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/README.md
+++ b/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/README.md
@@ -7,11 +7,22 @@ separately authorized result-blind observation canary.
 
 ## Current state
 
-`RUNNING`
+`REPOSITORY_COMPLETE_DRAFT_PR_ONLY`
 
 Canonical base is commit `17f7b605b9f81c5a08a88fea8835aadf291cbfe7`,
 tree `fbffb4954618dc80688c3baafa14749bf5cd14f1`. PR #64 is merged.
-Runtime functionality remains `DATA_MISSING`; no live action is authorized.
+The reviewer-accepted implementation is commit
+`c56783af1a9a40bcb39a2c4a46fc07bd8fd33f50`, tree
+`9c8e1279a54c673d9704efabb71cea1d73045123`. Runtime functionality remains
+`DATA_MISSING`; no live action is authorized.
+
+Focused validation is green. One complete local regression run reached 100%
+with one non-reproduced end-of-suite failure. The exact failed test then passed
+21/21 focused repetitions and in the exact preceding-file sequence. A second
+full run was stopped by the owner for time after approximately 72% with no
+failure observed; its terminal summary recorded 353 of 478 tests completed.
+That interrupted run is not a complete passing-suite result. Authoritative
+full-suite confirmation in GitHub CI is required before merge consideration.
 
 ## Constraints and unsafe actions
 
@@ -37,3 +48,5 @@ sibling worktree.
 
 No service-manager, runtime, production database, model, data-capture,
 prediction, training, promotion, betting, or deployment command has run.
+No merge is authorized, and this repository result does not claim runtime
+functionality or merge readiness.

--- a/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/REVIEW.md
+++ b/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/REVIEW.md
@@ -1,3 +1,28 @@
 # Fresh read-only review
 
-Pending exact-diff review after implementation and focused validation.
+The fresh read-only reviewer first rejected implementation commit
+`e64cb2ca5bf7c046656ba5fed8c46634335c9d6d` for five critical gaps:
+
+1. Generated units did not authenticate the supplied configuration path's
+   exact canonical bytes.
+2. Snapshot isolation did not reject hard-link aliases.
+3. Registered champion/challenger release-bundle contracts were not checked
+   before receipt 1.
+4. The operator CLI could inject caller-supplied activation time as the trusted
+   clock.
+5. Recovery replay did not bind the replica root or revalidate current restore
+   evidence.
+
+The repair also tightened migration checksum validation and documented the
+recovery prerequisite and inert activate/rollback syntax.
+
+The same reviewer then reviewed exact commit
+`c56783af1a9a40bcb39a2c4a46fc07bd8fd33f50`, tree
+`9c8e1279a54c673d9704efabb71cea1d73045123`, and returned `ACCEPT` with no
+critical findings. Its only warning was to replace the report placeholders
+before draft publication; this closeout update resolves that warning.
+
+The review was read-only. It made no code, GitHub, runtime, service, model, or
+data mutation. Acceptance is repository-diff acceptance only and is not a
+claim of merge or runtime readiness. Full-suite GitHub CI remains a mandatory
+pre-merge gate.

--- a/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/REVIEW.md
+++ b/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/REVIEW.md
@@ -1,0 +1,3 @@
+# Fresh read-only review
+
+Pending exact-diff review after implementation and focused validation.

--- a/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/STATE.md
+++ b/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/STATE.md
@@ -1,0 +1,14 @@
+# State
+
+- state: `RUNNING`
+- task_tier: `large`
+- recommended_model: `high_reasoning`
+- actual_model: `gpt-5`
+- worker_model_allowed: `read-only reviewer only`
+- worker_decision_limit: `exact-diff findings and verdict; no mutation`
+- escalation_needed: `false`
+- task_ledger: `DATA_MISSING`; portable guard fallback found no overlapping work
+- duplicate_work_classification: `NONE_FOUND`
+- docs_impact: `DOCS_UPDATED` planned
+- runtime_functionality: `DATA_MISSING`
+- next_safe_action: add focused failing tests inside the task-card allowlist

--- a/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/STATE.md
+++ b/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/STATE.md
@@ -1,6 +1,6 @@
 # State
 
-- state: `RUNNING`
+- state: `REPOSITORY_COMPLETE_DRAFT_PR_ONLY`
 - task_tier: `large`
 - recommended_model: `high_reasoning`
 - actual_model: `gpt-5`
@@ -9,6 +9,16 @@
 - escalation_needed: `false`
 - task_ledger: `DATA_MISSING`; portable guard fallback found no overlapping work
 - duplicate_work_classification: `NONE_FOUND`
-- docs_impact: `DOCS_UPDATED` planned
+- canonical_base_commit: `17f7b605b9f81c5a08a88fea8835aadf291cbfe7`
+- canonical_base_tree: `fbffb4954618dc80688c3baafa14749bf5cd14f1`
+- reviewed_implementation_commit: `c56783af1a9a40bcb39a2c4a46fc07bd8fd33f50`
+- reviewed_implementation_tree: `9c8e1279a54c673d9704efabb71cea1d73045123`
+- docs_impact: `DOCS_UPDATED`
+- review: `ACCEPT`
+- focused_validation: `PASS`
+- complete_local_suite: `NOT_GREEN`; one non-reproduced transient failure
+- owner_stopped_rerun: `PARTIAL_ONLY`; approximately 72%, no failure observed
+- github_ci_merge_gate: `REQUIRED`
+- merge_readiness: `false`
 - runtime_functionality: `DATA_MISSING`
-- next_safe_action: add focused failing tests inside the task-card allowlist
+- next_safe_action: push the exact branch and open one draft PR; do not merge

--- a/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/VALIDATION.md
+++ b/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/VALIDATION.md
@@ -1,0 +1,4 @@
+# Validation
+
+Validation has not started. Exact commands, exits, and results will be recorded
+after implementation.

--- a/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/VALIDATION.md
+++ b/reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/VALIDATION.md
@@ -1,4 +1,82 @@
 # Validation
 
-Validation has not started. Exact commands, exits, and results will be recorded
-after implementation.
+Validated implementation commit
+`c56783af1a9a40bcb39a2c4a46fc07bd8fd33f50`, tree
+`9c8e1279a54c673d9704efabb71cea1d73045123`, from canonical commit
+`17f7b605b9f81c5a08a88fea8835aadf291cbfe7`.
+
+## Focused repaired paths
+
+Command:
+
+```text
+uv run --no-project --python 3.11 --with-requirements requirements/all.in \
+  python -m pytest -q --noconftest \
+  tests/race_collection/test_operator.py \
+  tests/race_collection/test_phase7_runtime_adapter.py \
+  tests/race_collection/test_phase7_operational.py::Phase7OperationalTests::test_release_manifest_and_generic_unit_validation \
+  tests/race_collection/test_phase7_operational.py::Phase7OperationalTests::test_backup_and_restore_require_integrity_not_command_success
+```
+
+Result: exit 0; `23 passed, 13 subtests passed in 7.02s`.
+
+Additional accepted-head results:
+
+- Runtime adapter file: exit 0; `18 passed in 5.15s`.
+- Operator and operations focus: exit 0; `27 passed in 5.62s`.
+- Full Phase 7 operational file: exit 0; `57 passed, 40 subtests passed
+  in 455.38s`.
+- The one complete-suite failure, run alone once and then in a 20-run loop:
+  21/21 passes.
+- Exact preceding Phase 7 operational file plus that test: exit 0;
+  `58 passed, 40 subtests passed in 445.58s`.
+
+## Complete-suite disclosure
+
+Command:
+
+```text
+uv run --no-project --python 3.11 --with-requirements requirements/all.in \
+  python -m pytest -q --noconftest tests/race_collection
+```
+
+First result: exit 1; `1 failed, 477 passed, 40 subtests passed in 5590.77s
+(1:33:10)`. The sole failure was
+`test_checked_in_adapter_resumes_real_prefix_through_main_once`, where the
+sanitized service boundary returned fail-closed code 69. It did not reproduce
+in the focused checks above.
+
+Second result: stopped by owner for time with SIGINT, exit 130. Approximately
+72% had completed with no failure observed when stop was requested; the
+terminal summary recorded `353 passed in 1251.80s (0:20:51)`, or 353/478
+collected tests. This is not a complete passing-suite result.
+
+Authoritative full-suite GitHub CI confirmation remains required before merge.
+
+## Static and integrity gates
+
+- Black `--check --diff` on the eight changed Python files: exit 0;
+  `8 files would be left unchanged`.
+- Flake8 on the eight changed Python files with
+  `--select=E9,F63,F7,F82`: exit 0; count `0`.
+- isort `--check-only --diff` on the eight changed Python files: exit 0.
+- `py_compile` on the eight changed Python files and executable operator
+  wrapper: exit 0.
+- Draft 2020-12 meta-schema validation of
+  `config/race_collection_runtime_input.schema.json`: exit 0;
+  `schema-valid`.
+- Operator wrapper `--help`: exit 0.
+- `git diff --check` from canonical base: exit 0.
+- Changed paths compared with the task-card allowlist: exit 0;
+  `changed-paths-valid`.
+
+A read-only repository-wide Black probe was not used as the gate because it
+reported pre-existing formatting drift outside this task (`794 files would be
+reformatted`, four could not be reformatted). It made no edits. The relevant
+changed-file formatting gate is green.
+
+## Runtime and data boundary
+
+No service, timer, database migration, production write, deployment,
+prediction, result handling, training, evaluation, promotion, model selection,
+betting, legacy shutdown, or live-odds-capture action ran.

--- a/tests/race_collection/test_operator.py
+++ b/tests/race_collection/test_operator.py
@@ -71,6 +71,29 @@ def test_migrate_rejects_legacy_and_non_operations_databases_and_ends_at_29(tmp_
         assert db.execute(
             "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
         ).fetchall() == [("race_metadata",)]
+    with sqlite3.connect(operations) as db:
+        db.execute(
+            "UPDATE schema_migrations SET checksum=? WHERE version=29",
+            ("0" * 64,),
+        )
+    assert (
+        main(
+            [
+                "register-policy",
+                *common(operations, legacy),
+                "--artifacts-root",
+                str(tmp_path / "artifacts"),
+                "--document",
+                str(tmp_path / "missing-policy.json"),
+                "--operation-id",
+                operation(99),
+                "--at",
+                NOW.isoformat(),
+            ]
+        )
+        == 2
+    )
+    assert "exact checked-in schema" in capsys.readouterr().err
 
 
 def test_registration_and_observation_commands_preserve_exact_immutable_authority(tmp_path, capsys):
@@ -278,7 +301,7 @@ def test_registration_and_observation_commands_preserve_exact_immutable_authorit
                 "--configuration-document",
                 str(configuration),
                 "--config-path",
-                "/absolute/authority/configuration.json",
+                str(configuration),
                 "--python-executable",
                 sys.executable,
             ]
@@ -292,6 +315,27 @@ def test_registration_and_observation_commands_preserve_exact_immutable_authorit
     assert f"ExecStart={sys.executable} " in unit
     assert "WantedBy=default.target" in unit
     assert "timer" not in unit
+    different_configuration = write_document(
+        tmp_path / "different-configuration.json",
+        {"not": "the authenticated configuration"},
+    )
+    assert (
+        main(
+            [
+                "generate-user-service",
+                "--release-document",
+                str(release),
+                "--configuration-document",
+                str(configuration),
+                "--config-path",
+                str(different_configuration),
+                "--python-executable",
+                sys.executable,
+            ]
+        )
+        == 2
+    )
+    assert "configuration bytes disagree" in capsys.readouterr().err
 
 
 def test_transition_and_recovery_commands_preserve_explicit_cli_identities(
@@ -309,6 +353,7 @@ def test_transition_and_recovery_commands_preserve_explicit_cli_identities(
 
     def activate(self, operation_id, **arguments):
         calls["activate"] = (self.store.path, str(operation_id), arguments)
+        calls["activate_clock"] = self._OperationalAuthority__clock()
         return True
 
     def rollback(self, operation_id, **arguments):
@@ -338,6 +383,7 @@ def test_transition_and_recovery_commands_preserve_explicit_cli_identities(
     monkeypatch.setattr("race_collection.operator.RecoveryAuthority.backup", backup)
     monkeypatch.setattr("race_collection.operator.RecoveryAuthority.restore_drill", restore)
 
+    trusted_window_start = datetime.now(timezone.utc)
     assert (
         main(
             [
@@ -359,6 +405,7 @@ def test_transition_and_recovery_commands_preserve_explicit_cli_identities(
         )
         == 0
     )
+    trusted_window_end = datetime.now(timezone.utc)
     assert (
         main(
             [
@@ -407,6 +454,26 @@ def test_transition_and_recovery_commands_preserve_explicit_cli_identities(
     )
     snapshot.write_bytes(b"isolated snapshot fixture")
     replica.mkdir()
+    for offset, database in enumerate((operations, legacy), 30):
+        alias = isolated / f"database-alias-{offset}.sqlite3"
+        alias.hardlink_to(database)
+        alias_recovery = list(recovery)
+        alias_recovery[alias_recovery.index("--snapshot") + 1] = str(alias)
+        assert (
+            main(
+                [
+                    "validate-restore",
+                    *alias_recovery,
+                    "--drill-id",
+                    f"alias-drill-{offset}",
+                    "--operation-id",
+                    operation(offset),
+                    "--at",
+                    NOW.isoformat(),
+                ]
+            )
+            == 2
+        )
     assert (
         main(
             [
@@ -434,6 +501,8 @@ def test_transition_and_recovery_commands_preserve_explicit_cli_identities(
             "at": NOW,
         },
     )
+    assert trusted_window_start <= calls["activate_clock"] <= trusted_window_end
+    assert calls["activate_clock"] != NOW
     assert calls["rollback"] == (
         operations,
         operation(21),

--- a/tests/race_collection/test_operator.py
+++ b/tests/race_collection/test_operator.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import sys
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+from race_collection.domain import ArtifactChecksum
+from race_collection.evaluation import PromotionPolicy
+from race_collection.operator import main
+
+NOW = datetime(2026, 7, 25, 1, 2, 3, tzinfo=timezone.utc)
+
+
+def canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+
+
+def operation(number: int) -> str:
+    return f"op_{number:032x}"
+
+
+def common(database: Path, legacy: Path) -> list[str]:
+    return ["--operations-db", str(database), "--legacy-db", str(legacy)]
+
+
+def write_document(path: Path, document: object) -> Path:
+    path.write_bytes(canonical(document))
+    return path
+
+
+def test_migrate_rejects_legacy_and_non_operations_databases_and_ends_at_29(tmp_path, capsys):
+    legacy = tmp_path / "greyhound_racing_data.db"
+    with sqlite3.connect(legacy) as db:
+        db.execute("CREATE TABLE race_metadata(race_id TEXT PRIMARY KEY)")
+
+    assert main(["migrate", *common(legacy, legacy)]) == 2
+    symlink_alias = tmp_path / "legacy-symlink.db"
+    symlink_alias.symlink_to(legacy)
+    assert main(["migrate", *common(symlink_alias, legacy)]) == 2
+    hardlink_alias = tmp_path / "legacy-hardlink.db"
+    hardlink_alias.hardlink_to(legacy)
+    assert main(["migrate", *common(hardlink_alias, legacy)]) == 2
+    with sqlite3.connect(legacy) as db:
+        assert db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).fetchall() == [("race_metadata",)]
+
+    mislabeled = tmp_path / "mislabeled.sqlite3"
+    with sqlite3.connect(mislabeled) as db:
+        db.execute("CREATE TABLE dogs(dog_id TEXT PRIMARY KEY)")
+    assert main(["migrate", *common(mislabeled, legacy)]) == 2
+    with sqlite3.connect(mislabeled) as db:
+        assert db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).fetchall() == [("dogs",)]
+
+    operations = tmp_path / "operations.sqlite3"
+    assert main(["migrate", *common(operations, legacy)]) == 0
+    result = json.loads(capsys.readouterr().out.splitlines()[-1])
+    assert result == {"command": "migrate", "schema_version": 29, "status": "ok"}
+    with sqlite3.connect(operations) as db:
+        assert [
+            row[0] for row in db.execute("SELECT version FROM schema_migrations ORDER BY version")
+        ] == list(range(1, 30))
+        assert db.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+    with sqlite3.connect(legacy) as db:
+        assert db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).fetchall() == [("race_metadata",)]
+
+
+def test_registration_and_observation_commands_preserve_exact_immutable_authority(tmp_path, capsys):
+    legacy = tmp_path / "legacy.db"
+    with sqlite3.connect(legacy) as db:
+        db.execute("CREATE TABLE race_metadata(race_id TEXT PRIMARY KEY)")
+    operations = tmp_path / "operations.sqlite3"
+    artifacts = tmp_path / "artifacts"
+    assert main(["migrate", *common(operations, legacy)]) == 0
+
+    policy_document = asdict(PromotionPolicy())
+    policy = write_document(tmp_path / "policy.json", policy_document)
+    configuration_document = {
+        "schema_version": "phase7-config-v1",
+        "service_root": "/opt/race-collection/current",
+        "artifact_root": str(artifacts),
+        "operations_database": str(operations),
+        "sources": ["official"],
+        "schedule_policy": "adaptive-odds-v1",
+        "promotion_policy": policy_document["policy_id"],
+        "bundle_versions": ["runner-win-probability-v1"],
+        "runtime_adapter": "race_collection.runtime_adapters:checked_in",
+        "runtime_input_checksum": "sha256:" + "9" * 64,
+    }
+    configuration = write_document(tmp_path / "configuration.json", configuration_document)
+    config_checksum = "sha256:" + hashlib.sha256(canonical(configuration_document)).hexdigest()
+    release_document = {
+        "schema_version": "phase7-release-v1",
+        "release_id": "candidate-release",
+        "code_commit": "a" * 40,
+        "config_checksum": config_checksum,
+        "database_schema": 29,
+        "artifact_contract": "canonical-artifacts-v1",
+        "policy_version": policy_document["policy_id"],
+        "supported_bundle_versions": ["runner-win-probability-v1"],
+        "service_root": "/opt/race-collection/current",
+    }
+    release = write_document(tmp_path / "release.json", release_document)
+    legacy_release = write_document(
+        tmp_path / "legacy-release.json",
+        {**release_document, "release_id": "legacy-release"},
+    )
+    authority = [*common(operations, legacy), "--artifacts-root", str(artifacts)]
+
+    assert (
+        main(
+            [
+                "register-policy",
+                *authority,
+                "--document",
+                str(policy),
+                "--operation-id",
+                operation(1),
+                "--at",
+                NOW.isoformat(),
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "register-config",
+                *authority,
+                "--document",
+                str(configuration),
+                "--operation-id",
+                operation(2),
+                "--at",
+                NOW.isoformat(),
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "register-release",
+                *authority,
+                "--document",
+                str(release),
+                "--operation-id",
+                operation(3),
+                "--at",
+                NOW.isoformat(),
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "register-release",
+                *authority,
+                "--document",
+                str(legacy_release),
+                "--operation-id",
+                operation(4),
+                "--at",
+                NOW.isoformat(),
+            ]
+        )
+        == 0
+    )
+    initialize = [
+        "initialize-legacy",
+        *authority,
+        "--release-id",
+        "legacy-release",
+        "--actor",
+        "operator",
+        "--reason",
+        "record exact rollback target",
+        "--operation-id",
+        operation(5),
+        "--at",
+        NOW.isoformat(),
+    ]
+    authorize = [
+        "authorize-observation",
+        *authority,
+        "--release-id",
+        "candidate-release",
+        "--actor",
+        "operator",
+        "--reason",
+        "future result-blind canary",
+        "--operation-id",
+        operation(6),
+        "--at",
+        NOW.isoformat(),
+    ]
+    assert main(initialize) == 0
+    assert main(authorize) == 0
+    assert main(authorize) == 0
+    conflicting = list(authorize)
+    conflicting[conflicting.index("--reason") + 1] = "different reason"
+    assert main(conflicting) == 2
+    assert (
+        main(
+            [
+                "revoke-observation",
+                *authority,
+                "--release-id",
+                "candidate-release",
+                "--actor",
+                "operator",
+                "--reason",
+                "stop before runtime",
+                "--operation-id",
+                operation(7),
+                "--at",
+                NOW.isoformat(),
+            ]
+        )
+        == 0
+    )
+
+    with sqlite3.connect(operations) as db:
+        db.row_factory = sqlite3.Row
+        config = db.execute(
+            "SELECT config_checksum,operation_id FROM phase7_release_configurations"
+        ).fetchone()
+        release_rows = db.execute(
+            "SELECT release_id,config_checksum,code_commit,operation_id "
+            "FROM phase7_release_manifests ORDER BY release_id"
+        ).fetchall()
+        pointer = db.execute(
+            "SELECT release_id,authority,legacy_preserved FROM phase7_release_pointer"
+        ).fetchone()
+        events = db.execute(
+            "SELECT candidate_release_id,action,actor,reason,operation_id "
+            "FROM phase7_observation_authority_events ORDER BY event_id"
+        ).fetchall()
+        assert tuple(config) == (config_checksum, operation(2))
+        assert [tuple(row) for row in release_rows] == [
+            ("candidate-release", config_checksum, "a" * 40, operation(3)),
+            ("legacy-release", config_checksum, "a" * 40, operation(4)),
+        ]
+        assert tuple(pointer) == ("legacy-release", "legacy", 1)
+        assert [tuple(row) for row in events] == [
+            (
+                "candidate-release",
+                "authorize",
+                "operator",
+                "future result-blind canary",
+                operation(6),
+            ),
+            (
+                "candidate-release",
+                "revoke",
+                "operator",
+                "stop before runtime",
+                operation(7),
+            ),
+        ]
+    assert "different intent" in capsys.readouterr().err
+
+    assert (
+        main(
+            [
+                "generate-user-service",
+                "--release-document",
+                str(release),
+                "--configuration-document",
+                str(configuration),
+                "--config-path",
+                "/absolute/authority/configuration.json",
+                "--python-executable",
+                sys.executable,
+            ]
+        )
+        == 0
+    )
+    generated = json.loads(capsys.readouterr().out)
+    assert generated["command"] == "generate-user-service"
+    assert set(generated["units"]) == {"race-collection.service"}
+    unit = generated["units"]["race-collection.service"]
+    assert f"ExecStart={sys.executable} " in unit
+    assert "WantedBy=default.target" in unit
+    assert "timer" not in unit
+
+
+def test_transition_and_recovery_commands_preserve_explicit_cli_identities(
+    tmp_path, capsys, monkeypatch
+):
+    legacy = tmp_path / "legacy.db"
+    with sqlite3.connect(legacy) as db:
+        db.execute("CREATE TABLE race_metadata(race_id TEXT PRIMARY KEY)")
+    operations = tmp_path / "operations.sqlite3"
+    artifacts = tmp_path / "artifacts"
+    authority = [*common(operations, legacy), "--artifacts-root", str(artifacts)]
+    assert main(["migrate", *common(operations, legacy)]) == 0
+
+    calls = {}
+
+    def activate(self, operation_id, **arguments):
+        calls["activate"] = (self.store.path, str(operation_id), arguments)
+        return True
+
+    def rollback(self, operation_id, **arguments):
+        calls["rollback"] = (self.store.path, str(operation_id), arguments)
+        return True
+
+    def backup(self, operation_id, **arguments):
+        calls["backup"] = (
+            self.store.path,
+            self.artifacts.root,
+            str(operation_id),
+            arguments,
+        )
+        return ArtifactChecksum("sha256:" + "a" * 64)
+
+    def restore(self, operation_id, **arguments):
+        calls["restore"] = (
+            self.store.path,
+            self.artifacts.root,
+            str(operation_id),
+            arguments,
+        )
+        return True
+
+    monkeypatch.setattr("race_collection.operator.OperationalAuthority.activate", activate)
+    monkeypatch.setattr("race_collection.operator.OperationalAuthority.rollback", rollback)
+    monkeypatch.setattr("race_collection.operator.RecoveryAuthority.backup", backup)
+    monkeypatch.setattr("race_collection.operator.RecoveryAuthority.restore_drill", restore)
+
+    assert (
+        main(
+            [
+                "activate",
+                *authority,
+                "--release-id",
+                "candidate-release",
+                "--boundary-day-id",
+                "day_" + "b" * 32,
+                "--actor",
+                "operator",
+                "--reason",
+                "separately authorized cutover",
+                "--operation-id",
+                operation(20),
+                "--at",
+                NOW.isoformat(),
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "rollback",
+                *authority,
+                "--actor",
+                "operator",
+                "--reason",
+                "exact legacy rollback",
+                "--operation-id",
+                operation(21),
+                "--at",
+                NOW.isoformat(),
+            ]
+        )
+        == 0
+    )
+
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    snapshot = isolated / "snapshot.sqlite3"
+    replica = tmp_path / "replica"
+    recovery = [
+        *authority,
+        "--backup-id",
+        "backup-1",
+        "--snapshot",
+        str(snapshot),
+        "--replica-root",
+        str(replica),
+    ]
+    assert (
+        main(
+            [
+                "backup",
+                *recovery,
+                "--racing-day-id",
+                "day_" + "c" * 32,
+                "--operation-id",
+                operation(22),
+                "--at",
+                NOW.isoformat(),
+            ]
+        )
+        == 0
+    )
+    snapshot.write_bytes(b"isolated snapshot fixture")
+    replica.mkdir()
+    assert (
+        main(
+            [
+                "validate-restore",
+                *recovery,
+                "--drill-id",
+                "drill-1",
+                "--operation-id",
+                operation(23),
+                "--at",
+                NOW.isoformat(),
+            ]
+        )
+        == 0
+    )
+
+    assert calls["activate"] == (
+        operations,
+        operation(20),
+        {
+            "release_id": "candidate-release",
+            "boundary_day_id": "day_" + "b" * 32,
+            "actor": "operator",
+            "reason": "separately authorized cutover",
+            "at": NOW,
+        },
+    )
+    assert calls["rollback"] == (
+        operations,
+        operation(21),
+        {
+            "actor": "operator",
+            "reason": "exact legacy rollback",
+            "at": NOW,
+        },
+    )
+    assert calls["backup"] == (
+        operations,
+        artifacts,
+        operation(22),
+        {
+            "backup_id": "backup-1",
+            "racing_day_id": "day_" + "c" * 32,
+            "snapshot_path": snapshot,
+            "replica": calls["backup"][3]["replica"],
+            "at": NOW,
+        },
+    )
+    assert calls["backup"][3]["replica"].root == replica
+    assert calls["restore"] == (
+        operations,
+        artifacts,
+        operation(23),
+        {
+            "drill_id": "drill-1",
+            "backup_id": "backup-1",
+            "snapshot_path": snapshot,
+            "replica": calls["restore"][3]["replica"],
+            "at": NOW,
+        },
+    )
+    assert calls["restore"][3]["replica"].root == replica
+    assert json.loads(capsys.readouterr().out.splitlines()[-1]) == {
+        "command": "validate-restore",
+        "operation_id": operation(23),
+        "status": "ok",
+        "successful": True,
+    }

--- a/tests/race_collection/test_operator.py
+++ b/tests/race_collection/test_operator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
+import subprocess
 import sys
 from dataclasses import asdict
 from datetime import datetime, timezone
@@ -30,6 +31,49 @@ def common(database: Path, legacy: Path) -> list[str]:
 def write_document(path: Path, document: object) -> Path:
     path.write_bytes(canonical(document))
     return path
+
+
+def python_311_executable() -> str:
+    """Resolve and authenticate a real Python 3.11 independently of the test runner."""
+    unavailable = "operator tests require a uv-resolvable exact Python 3.11 executable"
+    try:
+        probe = subprocess.run(
+            (
+                "uv",
+                "run",
+                "--no-project",
+                "--python",
+                "3.11",
+                "python",
+                "-c",
+                "import json,sys; print(json.dumps("
+                "{'executable':sys.executable,"
+                "'version':[sys.version_info.major,sys.version_info.minor]},"
+                "sort_keys=True,separators=(',',':')))",
+            ),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        identity = json.loads(probe.stdout)
+    except (
+        OSError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        json.JSONDecodeError,
+    ) as error:
+        raise AssertionError(unavailable) from error
+    if type(identity) is not dict:
+        raise AssertionError(unavailable)
+    executable = identity.get("executable")
+    if (
+        type(executable) is not str
+        or not Path(executable).is_absolute()
+        or identity != {"executable": executable, "version": [3, 11]}
+    ):
+        raise AssertionError(unavailable)
+    return executable
 
 
 def test_migrate_rejects_legacy_and_non_operations_databases_and_ends_at_29(tmp_path, capsys):
@@ -292,27 +336,25 @@ def test_registration_and_observation_commands_preserve_exact_immutable_authorit
         ]
     assert "different intent" in capsys.readouterr().err
 
-    assert (
-        main(
-            [
-                "generate-user-service",
-                "--release-document",
-                str(release),
-                "--configuration-document",
-                str(configuration),
-                "--config-path",
-                str(configuration),
-                "--python-executable",
-                sys.executable,
-            ]
-        )
-        == 0
-    )
+    python_executable = python_311_executable()
+    service_arguments = [
+        "generate-user-service",
+        "--release-document",
+        str(release),
+        "--configuration-document",
+        str(configuration),
+        "--config-path",
+        str(configuration),
+    ]
+    if sys.version_info[:2] != (3, 11):
+        assert main([*service_arguments, "--python-executable", sys.executable]) == 2
+        assert "requires the exact supplied Python 3.11" in capsys.readouterr().err
+    assert main([*service_arguments, "--python-executable", python_executable]) == 0
     generated = json.loads(capsys.readouterr().out)
     assert generated["command"] == "generate-user-service"
     assert set(generated["units"]) == {"race-collection.service"}
     unit = generated["units"]["race-collection.service"]
-    assert f"ExecStart={sys.executable} " in unit
+    assert f"ExecStart={python_executable} " in unit
     assert "WantedBy=default.target" in unit
     assert "timer" not in unit
     different_configuration = write_document(
@@ -330,7 +372,7 @@ def test_registration_and_observation_commands_preserve_exact_immutable_authorit
                 "--config-path",
                 str(different_configuration),
                 "--python-executable",
-                sys.executable,
+                python_executable,
             ]
         )
         == 2

--- a/tests/race_collection/test_phase7_operational.py
+++ b/tests/race_collection/test_phase7_operational.py
@@ -2170,6 +2170,16 @@ class Phase7OperationalTests(unittest.TestCase):
         self.register_config(19)
         checksum = self.authority.register_release(operation(20), self.manifest(), NOW)
         self.assertEqual(self.artifacts.verify(checksum).checksum, checksum)
+        service_configuration = self.configuration()
+        service_config_path = Path(self.temporary.name) / "service-config.json"
+        service_config_path.write_bytes(
+            json.dumps(
+                service_configuration.document(),
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode()
+        )
         with patch(
             "race_collection.operational.subprocess.run",
             return_value=subprocess.CompletedProcess(
@@ -2185,8 +2195,8 @@ class Phase7OperationalTests(unittest.TestCase):
         ) as python_probe:
             units = self.authority.generate_units(
                 self.manifest(),
-                self.configuration(),
-                config_path="/etc/race-collection/release.json",
+                service_configuration,
+                config_path=str(service_config_path),
                 python_executable=sys.executable,
             )
         self.assertEqual(python_probe.call_count, 1)
@@ -2201,6 +2211,15 @@ class Phase7OperationalTests(unittest.TestCase):
         self.assertIn("--continuous", units["race-collection.service"])
         self.assertIn("WantedBy=default.target", units["race-collection.service"])
         self.assertNotIn("multi-user.target", units["race-collection.service"])
+        mismatched_config_path = Path(self.temporary.name) / "mismatched-config.json"
+        mismatched_config_path.write_bytes(b"{}")
+        with self.assertRaises(OperationalRejected):
+            self.authority.generate_units(
+                self.manifest(),
+                service_configuration,
+                config_path=str(mismatched_config_path),
+                python_executable=sys.executable,
+            )
         with (
             patch(
                 "race_collection.operational.subprocess.run",
@@ -2219,8 +2238,8 @@ class Phase7OperationalTests(unittest.TestCase):
         ):
             self.authority.generate_units(
                 self.manifest(),
-                self.configuration(),
-                config_path="/etc/race-collection/release.json",
+                service_configuration,
+                config_path=str(service_config_path),
                 python_executable=sys.executable,
             )
         executable = Path(__file__).parents[2] / "bin" / "race-collection-service"
@@ -3297,6 +3316,59 @@ class Phase7OperationalTests(unittest.TestCase):
                 ).fetchone()[0],
                 1,
             )
+        changed_replica = LocalArtifactStore(root / "changed-replica")
+        with self.assertRaises(ConflictingOperation):
+            recovery.backup(
+                operation(42),
+                backup_id="backup-1",
+                racing_day_id=day_id,
+                snapshot_path=snapshot,
+                replica=changed_replica,
+                at=NOW,
+            )
+        self.assertTrue(
+            recovery.restore_drill(
+                operation(43),
+                drill_id="drill-good",
+                backup_id="backup-1",
+                snapshot_path=snapshot,
+                replica=replica,
+                at=NOW,
+            )
+        )
+        self.assertTrue(
+            recovery.restore_drill(
+                operation(43),
+                drill_id="drill-good",
+                backup_id="backup-1",
+                snapshot_path=snapshot,
+                replica=replica,
+                at=NOW,
+            )
+        )
+        with self.assertRaises(ConflictingOperation):
+            recovery.restore_drill(
+                operation(43),
+                drill_id="drill-good",
+                backup_id="backup-1",
+                snapshot_path=snapshot,
+                replica=changed_replica,
+                at=NOW,
+            )
+        snapshot_bytes = snapshot.read_bytes()
+        try:
+            snapshot.write_bytes(b"changed after successful restore validation")
+            with self.assertRaises(RecoveryRejected):
+                recovery.restore_drill(
+                    operation(43),
+                    drill_id="drill-good",
+                    backup_id="backup-1",
+                    snapshot_path=snapshot,
+                    replica=replica,
+                    at=NOW,
+                )
+        finally:
+            snapshot.write_bytes(snapshot_bytes)
         self.assertTrue(
             recovery.restore_drill(
                 operation(43),
@@ -3315,12 +3387,38 @@ class Phase7OperationalTests(unittest.TestCase):
             replica.read(ArtifactChecksum(first_backup["artifact_inventory_checksum"]))
         )
         inventory_checksum = ArtifactChecksum(first_backup["artifact_inventory_checksum"])
+        inventory_path = replica.path_for(inventory_checksum)
+        inventory_bytes = inventory_path.read_bytes()
+        try:
+            inventory_path.write_bytes(b"changed after successful restore validation")
+            with self.assertRaises(RecoveryRejected):
+                recovery.restore_drill(
+                    operation(43),
+                    drill_id="drill-good",
+                    backup_id="backup-1",
+                    snapshot_path=snapshot,
+                    replica=replica,
+                    at=NOW,
+                )
+        finally:
+            inventory_path.write_bytes(inventory_bytes)
+        self.assertTrue(
+            recovery.restore_drill(
+                operation(43),
+                drill_id="drill-good",
+                backup_id="backup-1",
+                snapshot_path=snapshot,
+                replica=replica,
+                at=NOW,
+            )
+        )
 
         class HostileInventoryReplica:
             """Serve hostile inventory bytes without weakening artifact verification."""
 
             def __init__(self, payload):
                 self.payload = payload
+                self.root = replica.root
 
             def read(self, checksum):
                 if checksum == inventory_checksum:
@@ -3494,9 +3592,7 @@ class Phase7OperationalTests(unittest.TestCase):
         test_root = str(Path(__file__).parent)
         sys.path.insert(0, test_root)
         try:
-            from test_phase6_evaluation_promotion import (
-                _build_authentic_promotion_template,
-            )
+            from test_phase6_evaluation_promotion import _build_authentic_promotion_template
         finally:
             sys.path.remove(test_root)
         root = Path(self.temporary.name) / "cross-phase"

--- a/tests/race_collection/test_phase7_operational.py
+++ b/tests/race_collection/test_phase7_operational.py
@@ -12,6 +12,7 @@ from datetime import date, datetime, timedelta, timezone
 from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from race_collection.artifacts import ArtifactStoreError, LocalArtifactStore
 from race_collection.collection import CollectionRepository
@@ -2169,16 +2170,59 @@ class Phase7OperationalTests(unittest.TestCase):
         self.register_config(19)
         checksum = self.authority.register_release(operation(20), self.manifest(), NOW)
         self.assertEqual(self.artifacts.verify(checksum).checksum, checksum)
-        units = self.authority.generate_units(
-            self.manifest(),
-            self.configuration(),
-            config_path="/etc/race-collection/release.json",
-        )
+        with patch(
+            "race_collection.operational.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                (sys.executable, "-c"),
+                0,
+                stdout=json.dumps(
+                    {"executable": sys.executable, "version": [3, 11]},
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                stderr="",
+            ),
+        ) as python_probe:
+            units = self.authority.generate_units(
+                self.manifest(),
+                self.configuration(),
+                config_path="/etc/race-collection/release.json",
+                python_executable=sys.executable,
+            )
+        self.assertEqual(python_probe.call_count, 1)
         self.assertEqual(set(units), {"race-collection.service"})
         self.assertNotIn("20260722", units["race-collection.service"])
         self.assertNotIn("timer", units["race-collection.service"])
-        self.assertIn("/bin/race-collection-service", units["race-collection.service"])
+        self.assertIn(
+            f"ExecStart={sys.executable} /opt/race-collection/current/"
+            "bin/race-collection-service",
+            units["race-collection.service"],
+        )
         self.assertIn("--continuous", units["race-collection.service"])
+        self.assertIn("WantedBy=default.target", units["race-collection.service"])
+        self.assertNotIn("multi-user.target", units["race-collection.service"])
+        with (
+            patch(
+                "race_collection.operational.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    (sys.executable, "-c"),
+                    0,
+                    stdout=json.dumps(
+                        {"executable": sys.executable, "version": [3, 10]},
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                    stderr="",
+                ),
+            ),
+            self.assertRaises(OperationalRejected),
+        ):
+            self.authority.generate_units(
+                self.manifest(),
+                self.configuration(),
+                config_path="/etc/race-collection/release.json",
+                python_executable=sys.executable,
+            )
         executable = Path(__file__).parents[2] / "bin" / "race-collection-service"
         self.assertTrue(executable.is_file())
         self.assertTrue(executable.stat().st_mode & 0o111)
@@ -3228,6 +3272,31 @@ class Phase7OperationalTests(unittest.TestCase):
                 "sha256:" + __import__("hashlib").sha256(snapshot.read_bytes()).hexdigest()
             ),
         )
+        self.assertEqual(
+            recovery.backup(
+                operation(42),
+                backup_id="backup-1",
+                racing_day_id=day_id,
+                snapshot_path=snapshot,
+                replica=replica,
+                at=NOW,
+            ),
+            checksum,
+        )
+        self.assertEqual(
+            checksum,
+            ArtifactChecksum(
+                "sha256:" + __import__("hashlib").sha256(snapshot.read_bytes()).hexdigest()
+            ),
+        )
+        with self.store._connect() as db:
+            self.assertEqual(
+                db.execute(
+                    "SELECT count(*) FROM phase7_backups WHERE operation_id=?",
+                    (str(operation(42)),),
+                ).fetchone()[0],
+                1,
+            )
         self.assertTrue(
             recovery.restore_drill(
                 operation(43),

--- a/tests/race_collection/test_phase7_runtime_adapter.py
+++ b/tests/race_collection/test_phase7_runtime_adapter.py
@@ -22,6 +22,7 @@ from race_collection.domain import (
 from race_collection.evaluation import EvaluationAuthority, PromotionPolicy
 from race_collection.forecasting import ForecastingAuthority, LegacyBundle, ModelRelease
 from race_collection.model_bundle import (
+    SUPPORTED_FORECAST_CONTRACT,
     BundleComponent,
     CanonicalBundle,
     ModelBundleAuthority,
@@ -403,7 +404,14 @@ def _register_serving_authority(store, artifacts, day_id):
     return bundle, challenger, assignment
 
 
-def _runtime_fixture(tmp_path, *, result_blind=False, unregistered_role=None):
+def _runtime_fixture(
+    tmp_path,
+    *,
+    result_blind=False,
+    unregistered_role=None,
+    release_bundle_versions=None,
+    first_cohort_role=None,
+):
     store = SQLiteOperationsStore(tmp_path / "operations.sqlite3")
     store.migrate()
     artifacts = LocalArtifactStore(tmp_path / "artifacts")
@@ -648,6 +656,10 @@ def _runtime_fixture(tmp_path, *, result_blind=False, unregistered_role=None):
         member.update(replacement)
         if unregistered_role == "champion":
             cycle["champion"].update(replacement)
+    if first_cohort_role is not None:
+        cycle["forecast_cohort"]["members"].sort(
+            key=lambda member: member["role"] != first_cohort_role
+        )
     runtime_document = {
         "schema_version": "phase7-runtime-input-v1",
         "release_id": "runtime-candidate",
@@ -658,6 +670,11 @@ def _runtime_fixture(tmp_path, *, result_blind=False, unregistered_role=None):
     source_commit = subprocess.check_output(
         ["git", "-C", str(source_root), "rev-parse", "HEAD"], text=True
     ).strip()
+    bundle_versions = (
+        (ORDERED_FINISH_CONTRACT,)
+        if release_bundle_versions is None
+        else tuple(release_bundle_versions)
+    )
     configuration = ReleaseConfiguration(
         "phase7-config-v1",
         str(source_root),
@@ -666,7 +683,7 @@ def _runtime_fixture(tmp_path, *, result_blind=False, unregistered_role=None):
         ("official", "official-card", "official-form", "market", "official-results"),
         "adaptive-odds-v1",
         "phase6-promotion-v1",
-        (ORDERED_FINISH_CONTRACT,),
+        bundle_versions,
         "race_collection.runtime_adapters:checked_in",
         runtime_artifact.checksum,
     )
@@ -688,7 +705,7 @@ def _runtime_fixture(tmp_path, *, result_blind=False, unregistered_role=None):
             29,
             "canonical-artifacts-v1",
             "phase6-promotion-v1",
-            (ORDERED_FINISH_CONTRACT,),
+            bundle_versions,
             configuration.service_root,
         )
 
@@ -805,6 +822,36 @@ def test_adapter_rejects_unregistered_forecast_cohort_before_receipt_one(
         )
     assert isinstance(rejected.value.__cause__, ServiceUnavailable)
     assert "registered" in str(rejected.value.__cause__)
+    with store._connect() as db:
+        assert (
+            db.execute("SELECT count(*) FROM phase7_application_command_receipts").fetchone()[0]
+            == 0
+        )
+
+
+@pytest.mark.parametrize("role", ["champion", "challenger"])
+def test_adapter_rejects_registered_cohort_contract_excluded_by_release_before_receipt_one(
+    tmp_path, monkeypatch, role
+):
+    store, _, config_path, _, _ = _runtime_fixture(
+        tmp_path,
+        release_bundle_versions=(SUPPORTED_FORECAST_CONTRACT,),
+        first_cohort_role=role,
+    )
+    monkeypatch.setattr(
+        "race_collection.service.verify_release_source_identity",
+        lambda *_args, **_kwargs: None,
+    )
+    with pytest.raises(ServiceUnavailable, match="composition failed") as rejected:
+        compose(
+            config_path,
+            owner="release-contract-preflight",
+            token="release-contract-preflight",
+            lease_ttl=timedelta(seconds=30),
+        )
+    assert isinstance(rejected.value.__cause__, ServiceUnavailable)
+    assert f"runtime {role}" in str(rejected.value.__cause__)
+    assert "configured release" in str(rejected.value.__cause__)
     with store._connect() as db:
         assert (
             db.execute("SELECT count(*) FROM phase7_application_command_receipts").fetchone()[0]

--- a/tests/race_collection/test_phase7_runtime_adapter.py
+++ b/tests/race_collection/test_phase7_runtime_adapter.py
@@ -403,7 +403,7 @@ def _register_serving_authority(store, artifacts, day_id):
     return bundle, challenger, assignment
 
 
-def _runtime_fixture(tmp_path):
+def _runtime_fixture(tmp_path, *, result_blind=False, unregistered_role=None):
     store = SQLiteOperationsStore(tmp_path / "operations.sqlite3")
     store.migrate()
     artifacts = LocalArtifactStore(tmp_path / "artifacts")
@@ -631,6 +631,23 @@ def _runtime_fixture(tmp_path):
             "service_run_id": str(operation(233)),
         },
     }
+    if result_blind:
+        cycle["mode"] = "result-blind-observation-v1"
+        del cycle["races"][0]["result"]
+        del cycle["races"][0]["training_example"]
+    if unregistered_role is not None:
+        replacement = {
+            "bundle_id": f"unregistered-{unregistered_role}",
+            "bundle_checksum": "sha256:" + "f" * 64,
+        }
+        member = next(
+            item
+            for item in cycle["forecast_cohort"]["members"]
+            if item["role"] == unregistered_role
+        )
+        member.update(replacement)
+        if unregistered_role == "champion":
+            cycle["champion"].update(replacement)
     runtime_document = {
         "schema_version": "phase7-runtime-input-v1",
         "release_id": "runtime-candidate",
@@ -694,6 +711,105 @@ def _runtime_fixture(tmp_path):
     config_path = tmp_path / "release.json"
     config_path.write_bytes(canonical(configuration.document()))
     return store, artifacts, config_path, cycle, result_content
+
+
+def test_result_blind_observation_stops_after_receipt_five_without_result_work(
+    tmp_path, monkeypatch
+):
+    store, _, config_path, cycle, _ = _runtime_fixture(tmp_path, result_blind=True)
+    monkeypatch.setattr(
+        "race_collection.service.verify_release_source_identity",
+        lambda *_args, **_kwargs: None,
+    )
+    trusted_now = datetime.now(timezone.utc)
+
+    def load(path, *, owner, token, lease_ttl):
+        composition = compose(
+            path,
+            owner=owner,
+            token=token,
+            lease_ttl=lease_ttl,
+        )
+        composition.clock = lambda: trusted_now
+        return composition
+
+    arguments = [
+        "--config",
+        str(config_path),
+        "--once",
+        "--owner",
+        "result-blind-observer",
+    ]
+    assert main(arguments, composition_loader=load, token_factory=lambda: "blind-token") == 0
+    assert main(arguments, composition_loader=load, token_factory=lambda: "blind-replay") == 0
+
+    with store._connect() as db:
+        progress = db.execute(
+            "SELECT phase_ordinal,phase_name FROM phase7_scheduler_progress "
+            "WHERE racing_day_id=? ORDER BY phase_ordinal",
+            (cycle["racing_day_id"],),
+        ).fetchall()
+        receipts = db.execute(
+            "SELECT phase_name FROM phase7_application_command_receipts "
+            "WHERE racing_day_id=? ORDER BY committed_at",
+            (cycle["racing_day_id"],),
+        ).fetchall()
+        assert [tuple(row) for row in progress] == [
+            (1, "discover_programme"),
+            (2, "collect_cards_and_form"),
+            (3, "collect_adaptive_odds"),
+            (4, "close_and_seal"),
+            (5, "deferred_prediction"),
+        ]
+        assert [row[0] for row in receipts] == [row[1] for row in progress]
+        assert db.execute("SELECT count(*) FROM result_attempts").fetchone()[0] == 0
+        assert db.execute("SELECT count(*) FROM training_examples").fetchone()[0] == 0
+        assert db.execute("SELECT count(*) FROM canonical_training_examples").fetchone()[0] == 0
+        assert db.execute("SELECT count(*) FROM phase7_reconciliation").fetchone()[0] == 0
+        assert db.execute("SELECT count(*) FROM phase7_day_training_requests").fetchone()[0] == 0
+        assert db.execute("SELECT count(*) FROM phase6_evaluation_evidence").fetchone()[0] == 0
+        assert db.execute("SELECT count(*) FROM phase6_trusted_evaluations").fetchone()[0] == 0
+        assert db.execute("SELECT count(*) FROM phase6_promotion_records").fetchone()[0] == 0
+        assert (
+            db.execute(
+                "SELECT count(*) FROM phase6_runs WHERE run_kind IN ('training','promotion')"
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            db.execute(
+                "SELECT count(*) FROM phase7_day_command_plan WHERE racing_day_id=?",
+                (cycle["racing_day_id"],),
+            ).fetchone()[0]
+            == 9
+        )
+    assert "result" not in cycle["races"][0]
+    assert "training_example" not in cycle["races"][0]
+
+
+@pytest.mark.parametrize("role", ["champion", "challenger"])
+def test_adapter_rejects_unregistered_forecast_cohort_before_receipt_one(
+    tmp_path, monkeypatch, role
+):
+    store, _, config_path, _, _ = _runtime_fixture(tmp_path, unregistered_role=role)
+    monkeypatch.setattr(
+        "race_collection.service.verify_release_source_identity",
+        lambda *_args, **_kwargs: None,
+    )
+    with pytest.raises(ServiceUnavailable, match="composition failed") as rejected:
+        compose(
+            config_path,
+            owner="registration-preflight",
+            token="registration-preflight",
+            lease_ttl=timedelta(seconds=30),
+        )
+    assert isinstance(rejected.value.__cause__, ServiceUnavailable)
+    assert "registered" in str(rejected.value.__cause__)
+    with store._connect() as db:
+        assert (
+            db.execute("SELECT count(*) FROM phase7_application_command_receipts").fetchone()[0]
+            == 0
+        )
 
 
 def test_checked_in_adapter_resumes_real_prefix_through_main_once(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Add only the repository interfaces needed for a future, separately authorized result-blind observation canary. This draft does not activate the forecasting programme and does not establish runtime readiness.

- add one explicit-path, noninteractive operator CLI that delegates migration, immutable registration, observation authority, activation/rollback, backup, and isolated restore validation to existing authority APIs
- reject direct, symlink, and hard-link aliases of the supplied legacy DB; require a separate operations DB with the exact checked-in schema-29 migration history
- add `result-blind-observation-v1`, which executes the closed plan only through deferred prediction and stops after receipts 1–5 without result, join, training, evaluation, or promotion work
- validate exact registered champion and challenger identities before receipt 1
- generate a user service bound to an explicitly verified Python 3.11 executable and exact canonical config, using `default.target` and no workflow-owning timer
- strengthen deterministic backup/restore replay and document exact preconditions and rollback boundaries

## Safety boundary

No live service, systemd unit, timer, database, production data, model pointer, prediction, result handling, training, evaluation, promotion, betting, legacy shutdown, or live odds-capture action was performed. The legacy DB schema is unchanged; migrations 0001–0029 remain operations-DB-only. Runtime functionality remains `DATA_MISSING`.

## Validation

Focused validation is green:

- changed authority/runtime/service/recovery tests: `23 passed, 13 subtests passed in 7.02s`
- runtime adapter file: `18 passed in 5.15s`
- operator/operations focus: `27 passed in 5.62s`
- Phase 7 operational file: `57 passed, 40 subtests passed in 455.38s`
- changed-file Black, isort, fatal Flake8, `py_compile`, schema validation, wrapper check, `git diff --check`, changed-path allowlist, and Git connectivity: pass
- fresh read-only exact-diff reviewer: `ACCEPT` for implementation commit `c56783af1a9a40bcb39a2c4a46fc07bd8fd33f50`

Complete-suite disclosure:

- one complete local suite reached 100% with `477 passed, 40 subtests passed, 1 failed in 1:33:10`; the sole end-of-suite resume-through-main failure did not reproduce
- that exact test subsequently passed 21/21 focused repetitions and passed in the exact preceding-file sequence (`58 passed, 40 subtests passed`)
- a second full-suite rerun was stopped by the owner for time after approximately 72% with no failures observed; its terminal interrupted summary recorded `353 passed` of 478 collected tests
- the interrupted rerun is not a complete passing-suite result

**Authoritative complete full-suite confirmation in GitHub CI is required before merge. This draft is not merge-ready unless that gate passes.**

## Remaining activation blockers

- this draft must be reviewed and merged separately before any activation preflight
- separately supplied operations DB, immutable artifacts, canonical configuration/release/policy, registered champion/challenger identities, and result-blind runtime input are not present or proven live
- backup eligibility still requires a fully reconciled operations day; a result-blind day alone cannot satisfy that boundary
- deployment, observation authorization, and activation require separate authority

See `docs/FORECASTING_OBSERVATION_CANARY.md` and the tracked validation/review bundle under `reports/agent_jobs/FORECASTING_OBSERVATION_CANARY_READINESS_V1_20260725/`.