### PR TITLE
Fix manual predictor exact-race receipt selection

### DIFF
--- a/scripts/predict_market_form_residual.py
+++ b/scripts/predict_market_form_residual.py
@@ -1780,6 +1780,7 @@ def _feature_packet(
 def discover_race_artifacts(
     *,
     race_query: str,
+    exact_race_id: str | None = None,
     evidence_roots: Sequence[Path],
     score_timestamp: datetime,
 ) -> dict[str, Any]:
@@ -1793,6 +1794,10 @@ def discover_race_artifacts(
     if any(_path_in_forbidden_pr51_domain(root) for root in roots):
         raise ManualPredictionError("pr51_form_only_v1_evidence_forbidden")
     race_number, venue_query = _race_query_parts(race_query)
+    exact_identity = None
+    if exact_race_id is not None:
+        exact_identity = str(exact_race_id).strip()
+        _race_id_parts(exact_identity)
 
     feature_candidates: list[dict[str, Any]] = []
     seen_feature_packets: set[Path] = set()
@@ -1838,6 +1843,8 @@ def discover_race_artifacts(
                 }
             )
             for race_id in race_ids:
+                if exact_identity is not None and race_id != exact_identity:
+                    continue
                 try:
                     candidate_number, candidate_venue, candidate_date = _race_id_parts(
                         race_id

--- a/scripts/predict_race_now.py
+++ b/scripts/predict_race_now.py
@@ -433,6 +433,7 @@ def discover_capture_handoff(
     try:
         packet = discover_race_artifacts(
             race_query=race_query,
+            exact_race_id=race_id,
             evidence_roots=available_roots,
             score_timestamp=current_time,
         )

--- a/tests/test_predict_market_form_residual.py
+++ b/tests/test_predict_market_form_residual.py
@@ -2716,6 +2716,33 @@ def test_race_first_discovery_does_not_treat_generic_url_path_as_venue(tmp_path)
         )
 
 
+def test_race_first_discovery_does_not_fallback_to_mismatched_exact_race(
+    tmp_path,
+):
+    _write_fixture(tmp_path)
+
+    with pytest.raises(ManualPredictionError, match="race_feature_packet_not_found"):
+        manual.discover_race_artifacts(
+            race_query="sandown r2",
+            exact_race_id="Race 2 - SAN - 2026-07-17",
+            evidence_roots=[tmp_path],
+            score_timestamp=SCORE_TIME + timedelta(days=1),
+        )
+
+
+def test_race_first_discovery_resolves_correctly_matched_exact_race(tmp_path):
+    _write_fixture(tmp_path)
+
+    packet = manual.discover_race_artifacts(
+        race_query="sandown r2",
+        exact_race_id=RACE_ID,
+        evidence_roots=[tmp_path],
+        score_timestamp=SCORE_TIME,
+    )
+
+    assert packet["race_id"] == RACE_ID
+
+
 def test_race_first_discovery_resolves_venue_before_race_date(tmp_path):
     warrnambool = _write_fixture(tmp_path / "warrnambool")
     warragul = _write_fixture(tmp_path / "warragul")

--- a/tests/test_predict_race_now.py
+++ b/tests/test_predict_race_now.py
@@ -635,6 +635,29 @@ def test_master_packet_adapter_rejects_pr56_jump_mismatch(
         )
 
 
+def test_master_packet_adapter_treats_mismatched_exact_race_as_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    def discover(**kwargs: Any) -> Mapping[str, Any]:
+        if kwargs.get("exact_race_id") == RACE_ID:
+            raise CaptureHandoffError("race_feature_packet_not_found")
+        return {"race_id": "Race 5 - GUNN - 2026-07-18"}
+
+    monkeypatch.setattr(predict_now, "discover_race_artifacts", discover)
+
+    assert (
+        predict_now.discover_capture_handoff(
+            evidence_roots=[tmp_path],
+            db_path=tmp_path / "unused.db",
+            race_id=RACE_ID,
+            jump_datetime=NOW + timedelta(hours=1),
+            capture_window_minutes=60,
+            current_time=NOW,
+        )
+        is None
+    )
+
+
 def test_fixture_e2e_reuses_receipt_seals_features_selects_model_and_bundles(
     tmp_path: Path,
 ):


### PR DESCRIPTION
## What changed

- add optional `exact_race_id` binding to `discover_race_artifacts`
- validate the supplied identity through the existing `_race_id_parts` contract
- filter non-identical race IDs before venue/date ranking
- pass the complete canonical race ID from `discover_capture_handoff`
- add regressions for mismatched, correctly matched, and adapter-unavailable behavior

## Root cause

Manual receipt discovery reduced the target to venue plus race number before historical ranking. It could therefore select a valid packet for the same venue/race number on a different date, after which the adapter stopped with `RECEIPT_INVALID: capture_packet_identity_mismatch` before capture or scoring.

## Impact

When no packet matches the complete canonical race ID, discovery now returns the existing unavailable result. In `auto` mode, that permits the already-supported fresh-capture path. Malformed, ambiguous, duplicate, conflicting, URL, date, venue, race-number, grade, runner-set, timestamp, source-hash, and provenance checks remain unchanged and fail closed. `_discover_for_auto` is unchanged.

## Validation

- exact source patch and committed diff are byte-identical (58 insertions across four files)
- focused predictor suites: `346 passed`
- Ruff check: passed
- Ruff format check: passed
- Python compile: passed
- `git diff --check`: passed
- fresh read-only exact-diff review: pass, no findings

No live prediction, capture, service/timer, deployment, production DB/history write, outcome inspection, training, promotion, EV/staking, betting, or merge was performed.