### PR TITLE
Bind observation authority to result-blind runtime cycles

### DIFF
--- a/docs/CANONICAL_RACE_FORECASTING_PHASE7.md
+++ b/docs/CANONICAL_RACE_FORECASTING_PHASE7.md
@@ -15,7 +15,9 @@ An explicitly versioned `result-blind-observation-v1` runtime input retains the
 immutable nine-command plan but bounds execution at deferred prediction. It
 omits result and training-example inputs and produces only the contiguous
 receipt prefix 1--5; no result, join, reconciliation or training-request
-handler is executed.
+handler is executable. Observation authority rejects an omitted or complete
+runtime mode and is bound to that explicit mode and terminal phase at
+composition and execution.
 Adapters submit only closed typed commands. A `ClosedCommandDispatcher` is
 assembled once at the composition root with exactly one trusted Phase 1--6
 handler for every phase; missing, duplicate, and unknown bindings fail closed.

--- a/docs/FORECASTING_OBSERVATION_CANARY.md
+++ b/docs/FORECASTING_OBSERVATION_CANARY.md
@@ -12,7 +12,9 @@ execution only through ordinal 5, `deferred_prediction`. The runtime input must
 omit every race's `result` and `training_example` objects. The service must
 produce exactly the contiguous receipt prefix 1--5 and must not read a result
 checksum or execute result collection, joining, reconciliation, training
-requests, evaluation, or promotion.
+requests, evaluation, or promotion. Observation release authority requires
+that explicit mode and rejects parser defaults, complete cycles, or any
+terminal phase beyond deferred prediction.
 
 ## Non-negotiable boundaries
 

--- a/docs/agent_tasks/observation_authority_mode_boundary_v1_20260726.md
+++ b/docs/agent_tasks/observation_authority_mode_boundary_v1_20260726.md
@@ -1,0 +1,71 @@
+---
+job_id: OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726
+title: Bind observation authority to the result-blind runtime cycle
+lane: Provenance
+supporting_lanes:
+  - Architecture
+  - Provenance
+owner: Codex
+approval_required: true
+approval_source: "Owner /goal request on 2026-07-26 authorizes the bounded repair, validation, commit, push, and one draft PR."
+allow_unapproved_safe_extension: false
+timeout_seconds: 21600
+mutation_mode: safe_extension
+base: origin/master
+production_data_access: false
+production_data_boundary: "No deployment, activation, service, timer, runtime input, database, model, prediction, training, promotion, betting, or live-data mutation."
+github_mutation_allowed: true
+git_history_mutation_allowed: true
+live_service_mutation_allowed: false
+docs_impact: DOCS_REQUIRED
+task_tier: large
+recommended_model: high_reasoning
+actual_model: gpt-5
+worker_model_allowed: false
+worker_decision_limit: "No delegated implementation or owner-boundary decision."
+escalation_needed: false
+output_dir: reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726
+allowed_files:
+  - config/race_collection_runtime_input.schema.json
+  - docs/CANONICAL_RACE_FORECASTING_PHASE7.md
+  - docs/FORECASTING_OBSERVATION_CANARY.md
+  - docs/agent_tasks/observation_authority_mode_boundary_v1_20260726.md
+  - race_collection/runtime_adapters.py
+  - race_collection/service.py
+  - tests/race_collection/test_phase7_runtime_adapter.py
+  - reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/README.md
+  - reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/STATE.md
+  - reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/DECISIONS.md
+  - reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/VALIDATION.md
+  - reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/REVIEW.md
+---
+
+# Observation authority mode boundary
+
+## Objective
+
+Make observation release authority mechanically compatible only with an
+explicit `result-blind-observation-v1` runtime cycle ending at deferred
+prediction, without changing separately authorised complete-cycle behavior.
+
+## Acceptance boundary
+
+- Observation authority rejects omitted, complete, unknown, conflicting, or
+  internally inconsistent runtime modes.
+- Composition binds durable release authority to the adapter's explicit mode
+  and immutable cycle terminal phase.
+- Observation cycles compose and plan only the five phases through deferred
+  prediction.
+- Full release authority preserves the valid complete nine-phase cycle.
+- Existing immutable release, bundle, operations-DB, recovery, service, and
+  Python 3.11 contracts remain unchanged.
+- Focused validation and one fresh read-only exact-diff review pass before
+  draft-PR publication.
+
+## Hard stops
+
+- No deployment, activation, service-manager, runtime input, database, model,
+  prediction, training, promotion, betting, or live-data action.
+- No weakening of full-operation release behavior beyond this authority
+  boundary.
+- No merge.

--- a/docs/agent_tasks/observation_authority_mode_boundary_v1_20260726.md
+++ b/docs/agent_tasks/observation_authority_mode_boundary_v1_20260726.md
@@ -33,6 +33,7 @@ allowed_files:
   - race_collection/runtime_adapters.py
   - race_collection/service.py
   - tests/race_collection/test_phase7_runtime_adapter.py
+  - tests/race_collection/test_phase7_operational.py
   - reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/README.md
   - reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/STATE.md
   - reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/DECISIONS.md
@@ -54,8 +55,9 @@ prediction, without changing separately authorised complete-cycle behavior.
   internally inconsistent runtime modes.
 - Composition binds durable release authority to the adapter's explicit mode
   and immutable cycle terminal phase.
-- Observation cycles compose and plan only the five phases through deferred
-  prediction.
+- Observation cycles compose only the five executable phases through deferred
+  prediction while retaining the authenticated nine-command durable plan
+  required by schema-29 recovery.
 - Full release authority preserves the valid complete nine-phase cycle.
 - Existing immutable release, bundle, operations-DB, recovery, service, and
   Python 3.11 contracts remain unchanged.

--- a/race_collection/runtime_adapters.py
+++ b/race_collection/runtime_adapters.py
@@ -43,6 +43,7 @@ from .operational import (
     OperationalAuthority,
     OperationalRejected,
     PhaseHandlerRegistration,
+    RaceCollectionService,
     ReconcileRacingDay,
     ReleaseConfiguration,
     RequestTraining,
@@ -286,6 +287,7 @@ class ImmutableInputRuntimeAdapter:
         self._repository = CollectionRepository(store)
         self._authority = OperationalAuthority(store, artifacts)
         self._closed = False
+        self._release_authority_mode: str | None = None
         try:
             content = artifacts.read(configuration.runtime_input_checksum)
             document = json.loads(content)
@@ -312,12 +314,12 @@ class ImmutableInputRuntimeAdapter:
             raise ServiceUnavailable("immutable runtime input contract is malformed") from error
         day_ids = [cycle.racing_day_id for cycle, _ in parsed]
         all_operations = [
-            str(identity)
-            for cycle, _ in parsed
+            identity
+            for _, item in parsed
             for identity in (
-                cycle.plan_operation_id,
-                *cycle.advancement_operation_ids,
-                *(command.operation_id for command in cycle.commands),
+                item["plan_operation_id"],
+                *item["advancement_operation_ids"],
+                *item["command_operation_ids"],
             )
         ]
         if len(day_ids) != len(set(day_ids)) or len(all_operations) != len(set(all_operations)):
@@ -514,18 +516,21 @@ class ImmutableInputRuntimeAdapter:
                 OperationId(training["binding_operation_id"]),
             ),
         )
-        command_ids = _identities(item["command_operation_ids"], 9, "command identities")
-        advancement_ids = _identities(
+        plan_command_ids = _identities(item["command_operation_ids"], 9, "command identities")
+        all_advancement_ids = _identities(
             item["advancement_operation_ids"], 9, "advancement identities"
         )
-        commands = tuple(
+        plan_commands = tuple(
             ApplicationCommand(identity, item["racing_day_id"], payload)
-            for identity, payload in zip(command_ids, payloads, strict=True)
+            for identity, payload in zip(plan_command_ids, payloads, strict=True)
         )
+        terminal_ordinal = 5 if mode == _RESULT_BLIND_MODE else 9
+        commands = plan_commands[:terminal_ordinal]
+        advancement_ids = all_advancement_ids[:terminal_ordinal]
         immutable_ids = (
             OperationId(item["plan_operation_id"]),
-            *command_ids,
-            *advancement_ids,
+            *plan_command_ids,
+            *all_advancement_ids,
             *nested_operations,
             OperationId(training["request_operation_id"]),
             OperationId(training["authorization_operation_id"]),
@@ -545,10 +550,50 @@ class ImmutableInputRuntimeAdapter:
             advancement_ids,
             _datetime(item["at"], "cycle time"),
             "deferred_prediction" if mode == _RESULT_BLIND_MODE else "request_training",
+            plan_commands if mode == _RESULT_BLIND_MODE else None,
         )
         date.fromisoformat(item["local_date"])
         _datetime(item["opened_at"], "opened_at")
         return cycle, item
+
+    def bind_release_authority(self, mode: str) -> None:
+        """Bind durable release authority to every explicit cycle execution boundary."""
+        if mode not in {"active", "observation"}:
+            raise ServiceUnavailable("runtime release authority mode is unsupported")
+        if self._release_authority_mode not in {None, mode}:
+            raise ServiceUnavailable("runtime release authority mode conflicts with prior binding")
+        for cycle in self._cycles:
+            item = self._documents[cycle.racing_day_id]
+            declared_mode = item.get("mode")
+            try:
+                cycle.__post_init__()
+            except ValueError as error:
+                raise ServiceUnavailable(
+                    "runtime cycle mode and terminal phase are internally inconsistent"
+                ) from error
+            expected_mode = (
+                _RESULT_BLIND_MODE
+                if cycle.terminal_phase == "deferred_prediction"
+                else _COMPLETE_MODE
+            )
+            if declared_mode is not None and declared_mode != expected_mode:
+                raise ServiceUnavailable(
+                    "runtime cycle mode and terminal phase are internally inconsistent"
+                )
+            if declared_mode is None and expected_mode != _COMPLETE_MODE:
+                raise ServiceUnavailable(
+                    "runtime cycle mode and terminal phase are internally inconsistent"
+                )
+            if mode == "observation" and (
+                declared_mode != _RESULT_BLIND_MODE
+                or cycle.terminal_phase != "deferred_prediction"
+                or tuple(command.phase for command in cycle.commands)
+                != RaceCollectionService.ORDER[:5]
+            ):
+                raise ServiceUnavailable(
+                    "observation authority requires explicit result-blind runtime mode"
+                )
+        self._release_authority_mode = mode
 
     def _verify_registered_forecast_cohorts(
         self,
@@ -667,6 +712,8 @@ class ImmutableInputRuntimeAdapter:
     def next_cycle(self, *, now: datetime) -> RacingDayCycle | None:
         if self._closed:
             raise ServiceUnavailable("runtime adapter is closed")
+        if self._release_authority_mode not in {"active", "observation"}:
+            raise ServiceUnavailable("runtime adapter release authority is unbound")
         with self._store._connect() as db:
             for cycle in self._cycles:
                 day = db.execute(

--- a/race_collection/service.py
+++ b/race_collection/service.py
@@ -48,24 +48,31 @@ class RacingDayCycle:
     advancement_operation_ids: tuple[OperationId, ...]
     at: datetime
     terminal_phase: str = "request_training"
+    plan_commands: tuple[ApplicationCommand, ...] | None = None
 
     def __post_init__(self) -> None:
-        phases = tuple(command.phase for command in self.commands)
+        planned_commands = self.planned_commands
+        planned_phases = tuple(command.phase for command in planned_commands)
+        try:
+            terminal_ordinal = RaceCollectionService.ORDER.index(self.terminal_phase) + 1
+        except ValueError:
+            terminal_ordinal = 0
         if (
             not isinstance(self.racing_day_id, str)
             or not self.racing_day_id.strip()
-            or phases != RaceCollectionService.ORDER
             or self.terminal_phase not in {"deferred_prediction", "request_training"}
+            or planned_phases != RaceCollectionService.ORDER
+            or self.commands != planned_commands[:terminal_ordinal]
             or len(self.advancement_operation_ids) != len(self.commands)
-            or any(command.racing_day_id != self.racing_day_id for command in self.commands)
+            or any(command.racing_day_id != self.racing_day_id for command in planned_commands)
             or len(
                 {
                     self.plan_operation_id,
                     *self.advancement_operation_ids,
-                    *(command.operation_id for command in self.commands),
+                    *(command.operation_id for command in planned_commands),
                 }
             )
-            != 19
+            != 1 + len(self.advancement_operation_ids) + len(planned_commands)
             or self.at.tzinfo is None
             or self.at.utcoffset() is None
         ):
@@ -76,6 +83,11 @@ class RacingDayCycle:
         """Return the last phase this immutable input is authorized to execute."""
         return RaceCollectionService.ORDER.index(self.terminal_phase) + 1
 
+    @property
+    def planned_commands(self) -> tuple[ApplicationCommand, ...]:
+        """Return the complete authenticated plan retained for recovery."""
+        return self.commands if self.plan_commands is None else self.plan_commands
+
 
 class RuntimeAdapter(Protocol):
     """Live capability plugin; it supplies bindings and plans, never a scheduler."""
@@ -85,6 +97,9 @@ class RuntimeAdapter(Protocol):
 
     def next_cycle(self, *, now: datetime) -> RacingDayCycle | None:
         """Return the next plan, rehydrating any durable command IDs for a partial day."""
+
+    def bind_release_authority(self, mode: str) -> None:
+        """Bind every immutable cycle mode and terminal phase to release authority."""
 
     def close(self) -> None:
         """Idempotently release every adapter-owned resource."""
@@ -274,8 +289,14 @@ class ServiceComposition:
         self._closed = True
 
     def _revalidate_release_mode(self) -> None:
-        if self.release_id is None or self.mode is None:
+        if self.release_id is None and self.mode is None:
             return
+        if (
+            not isinstance(self.release_id, str)
+            or not self.release_id.strip()
+            or self.mode not in {"active", "observation"}
+        ):
+            raise OperationalRejected("service release authority mode is incomplete or unsupported")
         with self.store._connect() as db:
             pointer = db.execute(
                 "SELECT release_id,authority,legacy_preserved "
@@ -302,6 +323,21 @@ class ServiceComposition:
             if not valid:
                 raise OperationalRejected("service release mode is no longer authorized")
             verify_release_authority(db, self.artifacts, self.release_id)
+
+    def _assert_cycle_authority(self, cycle: RacingDayCycle) -> None:
+        try:
+            cycle.__post_init__()
+        except ValueError as error:
+            raise OperationalRejected(
+                "runtime cycle authority contract is internally inconsistent"
+            ) from error
+        if self.mode == "observation" and (
+            cycle.terminal_phase != "deferred_prediction"
+            or tuple(command.phase for command in cycle.commands) != RaceCollectionService.ORDER[:5]
+        ):
+            raise OperationalRejected(
+                "observation authority cannot execute beyond deferred prediction"
+            )
 
     def trusted_timestamp(self) -> datetime:
         """Return the public monotonic authority time for all service work."""
@@ -337,6 +373,7 @@ class ServiceComposition:
 
     def run_cycle(self, cycle: RacingDayCycle) -> tuple[object, ...]:
         self._revalidate_release_mode()
+        self._assert_cycle_authority(cycle)
         now = self.trusted_timestamp()
         if cycle.at.astimezone(timezone.utc) > now:
             raise OperationalRejected("runtime cycle schedule time is in the future")
@@ -376,7 +413,7 @@ class ServiceComposition:
             racing_day_id=cycle.racing_day_id,
             lease_token=self.token,
             lease_generation=generation,
-            commands=cycle.commands,
+            commands=cycle.planned_commands,
             at=plan_at,
         )
         service = RaceCollectionService(
@@ -416,8 +453,8 @@ class ServiceComposition:
         results = []
         for ordinal, (command, advancement_id) in enumerate(
             zip(
-                cycle.commands[: cycle.terminal_ordinal],
-                cycle.advancement_operation_ids[: cycle.terminal_ordinal],
+                cycle.commands,
+                cycle.advancement_operation_ids,
                 strict=True,
             ),
             1,
@@ -528,6 +565,10 @@ def compose(
     adapter: RuntimeAdapter | None = None
     try:
         adapter = factory(configuration, store, artifacts)
+        binder = getattr(adapter, "bind_release_authority", None)
+        if not callable(binder):
+            raise ServiceUnavailable("runtime adapter release authority contract is unavailable")
+        binder(mode)
         return ServiceComposition(
             configuration,
             store,

--- a/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/DECISIONS.md
+++ b/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/DECISIONS.md
@@ -1,0 +1,12 @@
+# Decisions
+
+- Preserve the dirty launch checkout and repair exact remote `master` in a
+  clean sibling worktree.
+- Bind observation authority at composition and again at cycle execution; do
+  not rely on the runtime parser's complete-cycle default.
+- Compose the result-blind cycle as the exact five-command prefix rather than
+  retaining post-prediction commands in the durable day plan.
+- Preserve full-authority complete-cycle behavior and every adjacent release,
+  model, database, recovery, service-generation, and interpreter contract.
+- Keep runtime and activation `DATA_MISSING`; repository validation cannot
+  authorize or prove either.

--- a/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/DECISIONS.md
+++ b/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/DECISIONS.md
@@ -11,3 +11,6 @@
   model, database, recovery, service-generation, and interpreter contract.
 - Keep runtime and activation `DATA_MISSING`; repository validation cannot
   authorize or prove either.
+- Docs impact is `DOCS_UPDATED`: the two existing observation-contract
+  paragraphs now describe the enforced authority/mode boundary; no follow-up
+  documentation task is required.

--- a/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/DECISIONS.md
+++ b/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/DECISIONS.md
@@ -4,8 +4,9 @@
   clean sibling worktree.
 - Bind observation authority at composition and again at cycle execution; do
   not rely on the runtime parser's complete-cycle default.
-- Compose the result-blind cycle as the exact five-command prefix rather than
-  retaining post-prediction commands in the durable day plan.
+- Expose the result-blind cycle as the exact five-command executable prefix
+  while retaining the authenticated nine-command durable plan required for
+  schema-29 recovery and lease adoption.
 - Preserve full-authority complete-cycle behavior and every adjacent release,
   model, database, recovery, service-generation, and interpreter contract.
 - Keep runtime and activation `DATA_MISSING`; repository validation cannot

--- a/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/README.md
+++ b/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/README.md
@@ -7,12 +7,15 @@ and the exact cycle prefix ending at deferred prediction.
 
 ## Current state
 
-`RUNNING`
+`VALIDATING`
 
 Fresh remote `master` is
 `c989b149acc06c8de727662802c1cb58eb5f0654`, tree
 `c839ee74e82f4406e68a21e29de5e6fe7c2afcd2`. The launch checkout's unrelated
 untracked evidence remains untouched; work is isolated in this clean sibling.
+The reviewed implementation is commit
+`6aa51b97bcfb2ac257867716a9dc935e890314a0`, tree
+`1fffed933452f147c41b69147fc3e39ddd7fb59e`.
 
 ## Constraints and unsafe actions
 
@@ -29,12 +32,18 @@ authorized.
 
 ## Files touched
 
-- Task card and this report bundle only; implementation has not started.
+- `race_collection/service.py`
+- `race_collection/runtime_adapters.py`
+- `tests/race_collection/test_phase7_runtime_adapter.py`
+- `tests/race_collection/test_phase7_operational.py`
+- Two existing observation-contract documents
+- Task card and report bundle
 
 ## Files intentionally not touched
 
-- Operational, recovery, operator, migration, service-generation, deployment,
-  runtime, database, model, and live-data paths.
+- Production operational, recovery, operator, migration, schema,
+  service-generation, deployment, runtime, database, model, and live-data
+  paths.
 
 ## Approvals needed
 
@@ -44,11 +53,36 @@ None for the bounded repository repair, validation, commit, push, and draft PR.
 
 Runtime and activation remain `DATA_MISSING` and out of scope.
 
+## Validation status
+
+Focused adapter, operator, operational, recovery, service-generation, schema,
+formatting, lint, compile, allowlist, and diff checks are green. The fresh
+read-only exact-diff review returned `SUCCESS` with no findings. The local
+90-minute suite was intentionally not run; broad validation belongs to GitHub
+CI on the draft PR.
+
+## Docs impact
+
+- docs_impact: `DOCS_UPDATED`
+- docs_checked: `docs/CANONICAL_RACE_FORECASTING_PHASE7.md`,
+  `docs/FORECASTING_OBSERVATION_CANARY.md`
+- docs_changed: both checked files
+- docs_followup: none
+- reason: both documents now state the mechanically enforced authority/mode
+  boundary
+
 ## Unsafe actions avoided
 
-No live or external mutation has occurred. No merge is authorized.
+No deployment, activation, service-manager, runtime, database, model,
+prediction, training, promotion, betting, or live-data command ran. No merge
+is authorized.
 
 ## Ignored and untracked artifact note
 
 The launch checkout's untracked `AGENTS.md` and two race-evidence inventory
 directories are unrelated and remain untouched.
+
+## Remaining risk
+
+Broad CI is pending draft-PR publication. Observation-canary activation remains
+blocked until the repair is merged and a separate activation preflight passes.

--- a/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/README.md
+++ b/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/README.md
@@ -1,0 +1,54 @@
+# Observation authority mode boundary repair
+
+## Objective
+
+Bind observation release authority to the explicit result-blind runtime mode
+and the exact cycle prefix ending at deferred prediction.
+
+## Current state
+
+`RUNNING`
+
+Fresh remote `master` is
+`c989b149acc06c8de727662802c1cb58eb5f0654`, tree
+`c839ee74e82f4406e68a21e29de5e6fe7c2afcd2`. The launch checkout's unrelated
+untracked evidence remains untouched; work is isolated in this clean sibling.
+
+## Constraints and unsafe actions
+
+No deployment, activation, installed service, timer, runtime input, database,
+model, prediction, training, promotion, betting, live-data, or merge action is
+authorized.
+
+## Evidence used
+
+- Owner `/goal` request dated 2026-07-26.
+- Fresh `origin/master` and merged PR #65 identity.
+- PR #65 task, decisions, review, validation, adapter, service, schema, and
+  focused tests.
+
+## Files touched
+
+- Task card and this report bundle only; implementation has not started.
+
+## Files intentionally not touched
+
+- Operational, recovery, operator, migration, service-generation, deployment,
+  runtime, database, model, and live-data paths.
+
+## Approvals needed
+
+None for the bounded repository repair, validation, commit, push, and draft PR.
+
+## Blocked items and DATA_MISSING
+
+Runtime and activation remain `DATA_MISSING` and out of scope.
+
+## Unsafe actions avoided
+
+No live or external mutation has occurred. No merge is authorized.
+
+## Ignored and untracked artifact note
+
+The launch checkout's untracked `AGENTS.md` and two race-evidence inventory
+directories are unrelated and remain untouched.

--- a/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/README.md
+++ b/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/README.md
@@ -7,7 +7,7 @@ and the exact cycle prefix ending at deferred prediction.
 
 ## Current state
 
-`VALIDATING`
+`DONE_WITH_RISK`
 
 Fresh remote `master` is
 `c989b149acc06c8de727662802c1cb58eb5f0654`, tree
@@ -16,6 +16,8 @@ untracked evidence remains untouched; work is isolated in this clean sibling.
 The reviewed implementation is commit
 `6aa51b97bcfb2ac257867716a9dc935e890314a0`, tree
 `1fffed933452f147c41b69147fc3e39ddd7fb59e`.
+Draft PR #67 is open at
+`https://github.com/0rl4nd0l/greyhound-racing-collector/pull/67`.
 
 ## Constraints and unsafe actions
 
@@ -84,5 +86,5 @@ directories are unrelated and remain untouched.
 
 ## Remaining risk
 
-Broad CI is pending draft-PR publication. Observation-canary activation remains
+Broad CI is pending on draft PR #67. Observation-canary activation remains
 blocked until the repair is merged and a separate activation preflight passes.

--- a/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/REVIEW.md
+++ b/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/REVIEW.md
@@ -1,0 +1,3 @@
+# Review
+
+Pending exact-diff read-only review.

--- a/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/REVIEW.md
+++ b/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/REVIEW.md
@@ -1,3 +1,40 @@
-# Review
-
-Pending exact-diff read-only review.
+{
+  "status": "SUCCESS",
+  "work_log": {
+    "assumptions": [
+      "origin/master c989b149acc06c8de727662802c1cb58eb5f0654 is the exact review base",
+      "review scope is the cumulative task-card-allowed diff"
+    ],
+    "sources_used": [
+      "AGENTS.md",
+      "git diff origin/master",
+      "docs/agent_tasks/observation_authority_mode_boundary_v1_20260726.md",
+      "PR #65 merged task, decision, validation, and review evidence"
+    ],
+    "files_read": [
+      "race_collection/service.py",
+      "race_collection/runtime_adapters.py",
+      "tests/race_collection/test_phase7_runtime_adapter.py",
+      "tests/race_collection/test_phase7_operational.py",
+      "docs/CANONICAL_RACE_FORECASTING_PHASE7.md",
+      "docs/FORECASTING_OBSERVATION_CANARY.md"
+    ],
+    "files_modified": [],
+    "validation_checks": [
+      "clarity and naming",
+      "duplication and maintainability",
+      "error handling and fail-closed behavior",
+      "secret and credential exposure",
+      "authority and runtime-input validation",
+      "test coverage for all requested combinations",
+      "complete-cycle and recovery compatibility",
+      "performance and side-effect ordering",
+      "git diff --check origin/master"
+    ]
+  },
+  "result": {
+    "critical": [],
+    "warnings": [],
+    "suggestions": []
+  }
+}

--- a/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/STATE.md
+++ b/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/STATE.md
@@ -1,6 +1,6 @@
 # State
 
-- state: `RUNNING`
+- state: `VALIDATING`
 - base_commit: `c989b149acc06c8de727662802c1cb58eb5f0654`
 - base_tree: `c839ee74e82f4406e68a21e29de5e6fe7c2afcd2`
 - task_tier: `large`
@@ -12,4 +12,8 @@
 - runtime_functionality: `DATA_MISSING`
 - ledger_status: `DATA_MISSING`
 - duplicate_work_classification: `DATA_MISSING_FALLBACK_CHECKED`
-- next_safe_action: validate the task card and clean-worktree preflight
+- implementation_commit: `6aa51b97bcfb2ac257867716a9dc935e890314a0`
+- implementation_tree: `1fffed933452f147c41b69147fc3e39ddd7fb59e`
+- review_verdict: `SUCCESS`
+- docs_impact: `DOCS_UPDATED`
+- next_safe_action: push the reviewed branch and open one draft PR

--- a/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/STATE.md
+++ b/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/STATE.md
@@ -1,6 +1,6 @@
 # State
 
-- state: `VALIDATING`
+- state: `DONE_WITH_RISK`
 - base_commit: `c989b149acc06c8de727662802c1cb58eb5f0654`
 - base_tree: `c839ee74e82f4406e68a21e29de5e6fe7c2afcd2`
 - task_tier: `large`
@@ -16,4 +16,7 @@
 - implementation_tree: `1fffed933452f147c41b69147fc3e39ddd7fb59e`
 - review_verdict: `SUCCESS`
 - docs_impact: `DOCS_UPDATED`
-- next_safe_action: push the reviewed branch and open one draft PR
+- draft_pr: `https://github.com/0rl4nd0l/greyhound-racing-collector/pull/67`
+- publication_status: `draft_open_unmerged`
+- next_safe_action: allow exact-head GitHub CI to finish; do not merge without
+  separate authorization

--- a/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/STATE.md
+++ b/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/STATE.md
@@ -1,0 +1,15 @@
+# State
+
+- state: `RUNNING`
+- base_commit: `c989b149acc06c8de727662802c1cb58eb5f0654`
+- base_tree: `c839ee74e82f4406e68a21e29de5e6fe7c2afcd2`
+- task_tier: `large`
+- recommended_model: `high_reasoning`
+- actual_model: `gpt-5`
+- worker_model_allowed: `false`
+- worker_decision_limit: `none`
+- escalation_needed: `false`
+- runtime_functionality: `DATA_MISSING`
+- ledger_status: `DATA_MISSING`
+- duplicate_work_classification: `DATA_MISSING_FALLBACK_CHECKED`
+- next_safe_action: validate the task card and clean-worktree preflight

--- a/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/VALIDATION.md
+++ b/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/VALIDATION.md
@@ -1,3 +1,58 @@
 # Validation
 
-Pending implementation.
+Validated implementation commit
+`6aa51b97bcfb2ac257867716a9dc935e890314a0`, tree
+`1fffed933452f147c41b69147fc3e39ddd7fb59e`, from exact remote base
+`c989b149acc06c8de727662802c1cb58eb5f0654`, tree
+`c839ee74e82f4406e68a21e29de5e6fe7c2afcd2`.
+
+## RED and authority-boundary GREEN
+
+- Initial focused RED: exit 1; `6 failed, 2 passed, 17 deselected`. The failures
+  proved omitted and complete observation modes were accepted and authority
+  mode/terminal binding was absent.
+- Final focused authority matrix: exit 0; `8 passed, 17 deselected in 3.05s`.
+- Complete runtime-adapter file on the clean implementation commit: exit 0;
+  `25 passed in 7.12s`.
+
+The matrix covers explicit result-blind observation acceptance; omitted,
+`complete-v1`, unknown, missing, conflicting, and post-deferred terminal
+rejection; five executable observation phases; retained nine-command recovery
+plan; and unchanged explicit complete-cycle behavior under full authority.
+
+## Nearby regressions
+
+- Operator file: exit 0; `3 passed in 0.84s`.
+- Compose, service generation with exact Python 3.11, backup/restore, and
+  migrated-plan recovery focus: exit 0; `4 passed, 13 subtests passed in
+  2.78s`.
+- Ordered service advancement, nine-barrier crash recovery, real service
+  entrypoint, and lease-expiry recovery focus: exit 0; `4 passed, 3 subtests
+  passed in 2.20s`.
+
+One pre-commit run of the complete adapter file correctly failed three
+immutable-release identity checks because the source tree was intentionally
+dirty. The same file passed 25/25 after the reviewed code was committed and the
+tree was clean.
+
+## Static, schema, and contract gates
+
+- Black changed-file check: exit 0; four files unchanged.
+- isort changed-file check: exit 0.
+- flake8 changed-file fatal-error selection: exit 0.
+- `py_compile` on changed Python and test files: exit 0.
+- Draft 2020-12 meta-schema validation of the inspected unchanged runtime-input
+  schema: exit 0; `schema-valid`.
+- `git diff --check`: exit 0.
+- Task-card diff allowlist: exit 0; no disallowed files.
+- Fresh exact-diff code review: `SUCCESS`; no critical, warning, or suggestion
+  findings.
+
+The local 90-minute suite was intentionally not run. GitHub CI is the broad
+validation gate for the draft PR.
+
+## Runtime and data boundary
+
+No deployment, activation, service, timer, runtime-input, database, prediction,
+result, training, evaluation, promotion, model-replacement, betting, or
+live-data action ran.

--- a/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/VALIDATION.md
+++ b/reports/agent_jobs/OBSERVATION_AUTHORITY_MODE_BOUNDARY_V1_20260726/VALIDATION.md
@@ -1,0 +1,3 @@
+# Validation
+
+Pending implementation.

--- a/tests/race_collection/test_phase7_operational.py
+++ b/tests/race_collection/test_phase7_operational.py
@@ -4331,6 +4331,9 @@ class Phase7OperationalTests(unittest.TestCase):
         )
 
         class Adapter:
+            def bind_release_authority(self, mode):
+                self.mode = mode
+
             @staticmethod
             def registrations():
                 def noop(_command, _at):

--- a/tests/race_collection/test_phase7_runtime_adapter.py
+++ b/tests/race_collection/test_phase7_runtime_adapter.py
@@ -44,7 +44,7 @@ from race_collection.runtime_adapters import (
     ImmutableInputRuntimeAdapter,
     _official_result_timeline_valid,
 )
-from race_collection.service import ServiceUnavailable, compose, main
+from race_collection.service import RacingDayCycle, ServiceUnavailable, compose, main
 from race_collection.training import LinearStrengthModel
 
 NOW = datetime.now(timezone.utc).replace(microsecond=0)
@@ -408,6 +408,8 @@ def _runtime_fixture(
     tmp_path,
     *,
     result_blind=False,
+    runtime_mode=None,
+    release_authority=None,
     unregistered_role=None,
     release_bundle_versions=None,
     first_cohort_role=None,
@@ -640,7 +642,12 @@ def _runtime_fixture(
         },
     }
     if result_blind:
-        cycle["mode"] = "result-blind-observation-v1"
+        if runtime_mode is not None:
+            raise ValueError("result_blind and runtime_mode are mutually exclusive")
+        runtime_mode = "result-blind-observation-v1"
+    if runtime_mode is not None:
+        cycle["mode"] = runtime_mode
+    if runtime_mode == "result-blind-observation-v1":
         del cycle["races"][0]["result"]
         del cycle["races"][0]["training_example"]
     if unregistered_role is not None:
@@ -718,13 +725,31 @@ def _runtime_fixture(
         reason="synthetic baseline",
         at=NOW - timedelta(days=2),
     )
-    authority.authorize_observation(
-        operation(305),
-        candidate_release_id="runtime-candidate",
-        actor="fixture",
-        reason="exercise checked-in adapter",
-        at=NOW - timedelta(days=1),
+    release_authority = release_authority or (
+        "observation" if runtime_mode == "result-blind-observation-v1" else "active"
     )
+    if release_authority == "observation":
+        authority.authorize_observation(
+            operation(305),
+            candidate_release_id="runtime-candidate",
+            actor="fixture",
+            reason="exercise checked-in adapter",
+            at=NOW - timedelta(days=1),
+        )
+    elif release_authority == "active":
+        with store._operation(operation(306), "fixture_activate_release", {}) as (db, _):
+            db.execute(
+                "UPDATE phase7_release_pointer SET release_id=?,"
+                "authority='race_collection_service',changed_at=?,operation_id=? "
+                "WHERE singleton=1",
+                (
+                    "runtime-candidate",
+                    (NOW - timedelta(days=1)).isoformat(),
+                    str(operation(306)),
+                ),
+            )
+    else:
+        raise ValueError("unsupported fixture release authority")
     config_path = tmp_path / "release.json"
     config_path.write_bytes(canonical(configuration.document()))
     return store, artifacts, config_path, cycle, result_content
@@ -802,6 +827,152 @@ def test_result_blind_observation_stops_after_receipt_five_without_result_work(
         )
     assert "result" not in cycle["races"][0]
     assert "training_example" not in cycle["races"][0]
+
+
+@pytest.mark.parametrize("runtime_mode", [None, "complete-v1"])
+def test_observation_authority_rejects_missing_or_complete_runtime_mode(
+    tmp_path, monkeypatch, runtime_mode
+):
+    store, _, config_path, _, _ = _runtime_fixture(
+        tmp_path,
+        runtime_mode=runtime_mode,
+        release_authority="observation",
+    )
+    monkeypatch.setattr(
+        "race_collection.service.verify_release_source_identity",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with pytest.raises(ServiceUnavailable, match="composition failed") as rejected:
+        compose(
+            config_path,
+            owner="observation-mode-boundary",
+            token="observation-mode-boundary",
+            lease_ttl=timedelta(seconds=30),
+        )
+
+    assert isinstance(rejected.value.__cause__, ServiceUnavailable)
+    assert "explicit result-blind" in str(rejected.value.__cause__)
+    with store._connect() as db:
+        assert db.execute("SELECT count(*) FROM phase7_day_command_plan").fetchone()[0] == 0
+        assert db.execute("SELECT count(*) FROM phase7_scheduler_progress").fetchone()[0] == 0
+
+
+def test_observation_authority_rejects_unknown_runtime_mode(tmp_path, monkeypatch):
+    store, _, config_path, _, _ = _runtime_fixture(
+        tmp_path,
+        runtime_mode="unknown-v1",
+        release_authority="observation",
+    )
+    monkeypatch.setattr(
+        "race_collection.service.verify_release_source_identity",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with pytest.raises(ServiceUnavailable, match="composition failed") as rejected:
+        compose(
+            config_path,
+            owner="unknown-mode-boundary",
+            token="unknown-mode-boundary",
+            lease_ttl=timedelta(seconds=30),
+        )
+
+    assert isinstance(rejected.value.__cause__, ServiceUnavailable)
+    assert "unsupported" in str(rejected.value.__cause__)
+    with store._connect() as db:
+        assert db.execute("SELECT count(*) FROM phase7_day_command_plan").fetchone()[0] == 0
+
+
+def test_observation_authority_rejects_terminal_phase_after_deferred_prediction(
+    tmp_path, monkeypatch
+):
+    store, _, config_path, cycle_document, _ = _runtime_fixture(tmp_path, result_blind=True)
+    monkeypatch.setattr(
+        "race_collection.service.verify_release_source_identity",
+        lambda *_args, **_kwargs: None,
+    )
+    composition = compose(
+        config_path,
+        owner="terminal-boundary",
+        token="terminal-boundary",
+        lease_ttl=timedelta(seconds=30),
+    )
+    cycle = composition.adapter.next_cycle(now=datetime.now(timezone.utc))
+    assert cycle is not None
+    assert [command.phase for command in cycle.commands] == list(RaceCollectionService.ORDER[:5])
+    complete_cycle = RacingDayCycle(
+        cycle.racing_day_id,
+        cycle.planned_commands,
+        cycle.plan_operation_id,
+        tuple(OperationId(value) for value in cycle_document["advancement_operation_ids"]),
+        cycle.at,
+    )
+
+    with pytest.raises(OperationalRejected, match="observation authority"):
+        composition.run_cycle(complete_cycle)
+    with pytest.raises(ServiceUnavailable, match="conflicts with prior binding"):
+        composition.adapter.bind_release_authority("active")
+
+    with store._connect() as db:
+        assert db.execute("SELECT count(*) FROM phase7_day_command_plan").fetchone()[0] == 0
+        assert db.execute("SELECT count(*) FROM phase7_scheduler_progress").fetchone()[0] == 0
+    composition.close()
+
+
+def test_full_authority_preserves_explicit_complete_cycle(tmp_path, monkeypatch):
+    _, _, config_path, _, _ = _runtime_fixture(
+        tmp_path,
+        runtime_mode="complete-v1",
+        release_authority="active",
+    )
+    monkeypatch.setattr(
+        "race_collection.service.verify_release_source_identity",
+        lambda *_args, **_kwargs: None,
+    )
+    composition = compose(
+        config_path,
+        owner="complete-cycle",
+        token="complete-cycle",
+        lease_ttl=timedelta(seconds=30),
+    )
+    cycle = composition.adapter.next_cycle(now=datetime.now(timezone.utc))
+
+    assert composition.mode == "active"
+    assert cycle is not None
+    assert cycle.terminal_phase == "request_training"
+    assert [command.phase for command in cycle.commands] == list(RaceCollectionService.ORDER)
+    with pytest.raises(ValueError, match="exact ordered Racing Day plan"):
+        replace(cycle, plan_commands=())
+    composition.close()
+
+
+@pytest.mark.parametrize("conflicting_mode", [None, "unknown"])
+def test_composed_release_identity_with_missing_or_unknown_authority_mode_fails_closed(
+    tmp_path, monkeypatch, conflicting_mode
+):
+    store, _, config_path, _, _ = _runtime_fixture(
+        tmp_path,
+        runtime_mode="complete-v1",
+        release_authority="active",
+    )
+    monkeypatch.setattr(
+        "race_collection.service.verify_release_source_identity",
+        lambda *_args, **_kwargs: None,
+    )
+    composition = compose(
+        config_path,
+        owner="authority-mode-shape",
+        token="authority-mode-shape",
+        lease_ttl=timedelta(seconds=30),
+    )
+    composition.mode = conflicting_mode
+
+    with pytest.raises(OperationalRejected, match="release authority mode"):
+        composition._revalidate_release_mode()
+
+    with store._connect() as db:
+        assert db.execute("SELECT count(*) FROM phase7_day_command_plan").fetchone()[0] == 0
+    composition.close()
 
 
 @pytest.mark.parametrize("role", ["champion", "challenger"])


### PR DESCRIPTION
## Root cause

PR #65 added a result-blind cycle mode, but durable observation release authority was resolved independently from the adapter's runtime mode and terminal phase. The checked-in adapter defaulted an omitted mode to `complete-v1`, so an observation-authorized release could compose a complete cycle through result collection, joins, reconciliation, and training request.

## Repair

- Require observation authority to bind to an explicit `result-blind-observation-v1` adapter contract.
- Reject omitted, complete, unknown, conflicting, or internally inconsistent observation mode/terminal combinations before planning or lease acquisition.
- Expose only the five executable commands through deferred prediction for observation cycles while retaining the authenticated nine-command durable plan required by schema-29 recovery.
- Recheck the observation terminal boundary at cycle execution.
- Preserve explicit and default complete-cycle behavior for full release authority.
- Preserve immutable release identity, champion/challenger validation, operations-DB separation, recovery, service generation, and exact Python 3.11 requirements.

## Validation

- Runtime adapter file: `25 passed`.
- Focused authority matrix: `8 passed`.
- Operator regressions: `3 passed`.
- Focused compose/service-generation/recovery regressions: `4 passed, 13 subtests passed`.
- Focused service/lease/crash-recovery regressions: `4 passed, 3 subtests passed`.
- Black, isort, flake8 fatal checks, `py_compile`, Draft 2020-12 schema validation, task-card allowlist, and `git diff --check`: passed.
- Fresh read-only exact-diff review: `SUCCESS`, no findings.

The local 90-minute suite was intentionally not run; GitHub CI is the broad validation gate.

## Safety boundary

No deployment, activation, service, timer, runtime input, database, prediction, result, training, evaluation, promotion, model replacement, betting, or live-data action occurred. Do not merge from this draft without separate authorization and green exact-head CI.

Observation-canary activation remains blocked until this PR is merged and a separate activation preflight passes.