### PR TITLE
Add Phase 7 historical source admission

### DIFF
--- a/docs/CANONICAL_RACE_FORECASTING_PHASE5.md
+++ b/docs/CANONICAL_RACE_FORECASTING_PHASE5.md
@@ -25,6 +25,18 @@ forward-sealed promotion evidence. No production corpus was available or
 copied, so tests use small realistic synthetic records and demonstrate
 capability, not production-corpus readiness.
 
+`race_collection.source_admission` is the pure no-write gate for that later
+bootstrap decision. It accepts only an explicitly supplied, SHA-256-bound
+historical package; replays its source bytes through the production
+`sealed-race-features-v1` schema and complete optional-feature imputation
+policy; and verifies sorted source-native race/runner identities, official
+results, feature matrices, immutable example artifacts, and timezone-aware
+pre-result ordering. Its canonical admitted manifest classifies genuine input
+as `legacy-historical-bootstrap-v1`, sets `forward_sealed: false`, and keeps it
+ineligible as forward promotion evidence. Reordered race inputs produce the
+same bytes. Synthetic packages return `VALIDATION_ONLY`; they cannot establish
+production readiness or authorize training.
+
 `race_collection.ordered_finish` is the versioned
 `plackett-luce-ordered-finish-v1` contract. It converts bundle-produced finite
 latent runner strengths into one numerically stable sequential distribution.

--- a/race_collection/source_admission.py
+++ b/race_collection/source_admission.py
@@ -1,0 +1,525 @@
+"""Pure admission of immutable historical evidence for a native training decision."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from datetime import date, datetime
+from typing import Any, Mapping
+
+from .domain import ArtifactChecksum, require_aware
+from .features import FeatureQuarantine, derive_features
+from .model_bundle import SUPPORTED_FEATURE_CONTRACT
+
+SOURCE_MANIFEST_SCHEMA = "historical-source-manifest-v1"
+SOURCE_PACKAGE_SCHEMA = "historical-source-package-v1"
+ADMITTED_MANIFEST_SCHEMA = "historical-source-admission-v1"
+LEGACY_ORIGIN = "legacy-historical-bootstrap-v1"
+SYNTHETIC_ORIGIN = "synthetic-validation-fixture-v1"
+
+_MANIFEST_FIELDS = {
+    "schema_version",
+    "corpus_origin",
+    "target_bundle_id",
+    "feature_schema_checksum",
+    "missingness_policy_checksum",
+    "races",
+}
+_RACE_FIELDS = {
+    "training_example_id",
+    "race_id",
+    "racing_date",
+    "source_checksum",
+    "official_result_checksum",
+    "feature_matrix_checksum",
+    "artifact_checksum",
+    "runner_ids",
+    "feature_observed_at",
+    "scheduled_jump_at",
+    "result_published_at",
+    "result_observed_at",
+}
+_RESULT_DERIVED_KEYS = {
+    "finish_order",
+    "place",
+    "result",
+    "result_order",
+    "winner",
+}
+
+
+class SourceAdmissionRejected(ValueError):
+    """Historical source bytes cannot support a truthful training decision."""
+
+
+def _canonical(value: Any) -> bytes:
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    except (TypeError, ValueError) as error:
+        raise SourceAdmissionRejected("source package is not exact JSON") from error
+
+
+def _checksum(content: bytes) -> str:
+    return f"sha256:{hashlib.sha256(content).hexdigest()}"
+
+
+def _object(content: bytes, name: str) -> dict[str, Any]:
+    if type(content) is not bytes:
+        raise SourceAdmissionRejected(f"{name} must be exact bytes")
+    try:
+        value = json.loads(content)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SourceAdmissionRejected(f"{name} is not valid JSON") from error
+    if type(value) is not dict or content != _canonical(value):
+        raise SourceAdmissionRejected(f"{name} must be one canonical JSON object")
+    return value
+
+
+def _known_text(value: Any, name: str) -> str:
+    if (
+        type(value) is not str
+        or not value
+        or value != value.strip()
+        or value.casefold() == "unknown"
+        or any(unicodedata.category(character).startswith("C") for character in value)
+    ):
+        raise SourceAdmissionRejected(f"{name} is missing or ambiguous")
+    return value
+
+
+def _identity_key(value: Any, name: str) -> str:
+    identity = _known_text(value, name)
+    normalized = unicodedata.normalize("NFKC", " ".join(identity.split())).casefold()
+    if not normalized:
+        raise SourceAdmissionRejected(f"{name} is missing or ambiguous")
+    return normalized
+
+
+def _aware_timestamp(value: Any, name: str) -> datetime:
+    if type(value) is not str:
+        raise SourceAdmissionRejected(f"{name} timestamp is invalid")
+    try:
+        parsed = datetime.fromisoformat(value)
+        require_aware(parsed, name)
+    except (TypeError, ValueError) as error:
+        raise SourceAdmissionRejected(f"{name} timestamp is invalid") from error
+    return parsed
+
+
+def _normalized_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    races = manifest.get("races")
+    if type(races) is not list or not races or any(type(race) is not dict for race in races):
+        raise SourceAdmissionRejected("source manifest requires race objects")
+    if any(set(race) != _RACE_FIELDS for race in races):
+        raise SourceAdmissionRejected("source manifest race envelope is invalid")
+    try:
+        ordered = sorted(races, key=lambda race: _identity_key(race["race_id"], "race_id"))
+    except KeyError as error:
+        raise SourceAdmissionRejected("source manifest race identity is incomplete") from error
+    return {**manifest, "races": ordered}
+
+
+def _artifact(
+    artifacts: Mapping[str, bytes],
+    artifact_checksum: Any,
+    name: str,
+) -> bytes:
+    if type(artifact_checksum) is not str:
+        raise SourceAdmissionRejected(f"{name} checksum is invalid")
+    try:
+        ArtifactChecksum(artifact_checksum)
+    except ValueError as error:
+        raise SourceAdmissionRejected(f"{name} checksum is invalid") from error
+    try:
+        content = artifacts[artifact_checksum]
+    except KeyError as error:
+        raise SourceAdmissionRejected(f"{name} checksum is unverifiable") from error
+    if type(content) is not bytes or _checksum(content) != artifact_checksum:
+        raise SourceAdmissionRejected(f"{name} checksum is unverifiable")
+    return content
+
+
+def _reject_result_derived(value: Any) -> None:
+    if type(value) is dict:
+        for key, nested in value.items():
+            if type(key) is str and key.casefold() in _RESULT_DERIVED_KEYS:
+                raise SourceAdmissionRejected("historical source contains a post-result feature")
+            _reject_result_derived(nested)
+    elif type(value) is list:
+        for nested in value:
+            _reject_result_derived(nested)
+
+
+def _require_unique_normalized(values: list[Any], name: str) -> tuple[str, ...]:
+    identities = tuple(_known_text(value, name) for value in values)
+    normalized = tuple(_identity_key(value, name) for value in identities)
+    if len(set(normalized)) != len(normalized):
+        raise SourceAdmissionRejected(f"duplicate normalized {name}")
+    return identities
+
+
+def _validate_source(
+    source: Mapping[str, Any],
+    race: Mapping[str, Any],
+    schema: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    if set(source) != {
+        "schema_version",
+        "normalization_version",
+        "race_id",
+        "historical_capture",
+        "fields",
+    }:
+        raise SourceAdmissionRejected("historical source envelope is invalid")
+    capture = source.get("historical_capture")
+    fields = source.get("fields")
+    if (
+        type(capture) is not dict
+        or set(capture)
+        != {
+            "source",
+            "source_record_id",
+            "observed_at",
+            "scheduled_jump_at",
+            "identity_authority",
+            "reconstructed",
+        }
+        or type(fields) is not dict
+        or set(fields) != {"runner_set", "runner_identity", "runner_features"}
+    ):
+        raise SourceAdmissionRejected("historical source provenance is incomplete")
+    if (
+        source.get("schema_version") != schema["evidence_schema_version"]
+        or source.get("normalization_version") != schema["normalization_version"]
+        or source.get("race_id") != race["race_id"]
+        or capture.get("observed_at") != race["feature_observed_at"]
+        or capture.get("scheduled_jump_at") != race["scheduled_jump_at"]
+    ):
+        raise SourceAdmissionRejected("historical source identity or timestamps disagree")
+    _known_text(capture.get("source"), "historical source")
+    _known_text(capture.get("source_record_id"), "historical source record")
+    if (
+        capture.get("identity_authority") != "source-native"
+        or capture.get("reconstructed") is not False
+    ):
+        raise SourceAdmissionRejected("historical source identity is reconstructed or ambiguous")
+    runners = fields.get("runner_set")
+    identities = fields.get("runner_identity")
+    features = fields.get("runner_features")
+    if type(runners) is not list or type(identities) is not dict or type(features) is not dict:
+        raise SourceAdmissionRejected("historical source runner identities are incomplete")
+    source_runners = _require_unique_normalized(runners, "runner identity")
+    if list(source_runners) != sorted(source_runners) or list(source_runners) != race["runner_ids"]:
+        raise SourceAdmissionRejected("source and manifest runner identities disagree")
+    if (
+        set(identities) != set(source_runners)
+        or set(features) != set(source_runners)
+        or any(identities[runner] != "authoritative" for runner in source_runners)
+    ):
+        raise SourceAdmissionRejected("historical source runner identities are ambiguous")
+    _reject_result_derived(fields)
+    expected_features = {field["name"] for field in schema["fields"]}
+    if any(
+        type(features[runner]) is not dict or set(features[runner]) != expected_features
+        for runner in source_runners
+    ):
+        raise SourceAdmissionRejected("historical source feature envelope disagrees")
+    return capture
+
+
+def _validate_result(
+    result: Mapping[str, Any],
+    race: Mapping[str, Any],
+) -> tuple[str, ...]:
+    if (
+        set(result)
+        != {
+            "schema_version",
+            "race_id",
+            "official",
+            "order",
+            "published_at",
+            "exclusions",
+            "provenance",
+        }
+        or result.get("schema_version") != "official-historical-result-v1"
+    ):
+        raise SourceAdmissionRejected("official result envelope is invalid")
+    provenance = result.get("provenance")
+    if (
+        type(provenance) is not dict
+        or set(provenance)
+        != {
+            "source",
+            "source_record_id",
+            "observed_at",
+            "identity_authority",
+            "reconstructed",
+        }
+        or result.get("official") is not True
+        or result.get("exclusions") != []
+        or result.get("race_id") != race["race_id"]
+        or result.get("published_at") != race["result_published_at"]
+        or provenance.get("observed_at") != race["result_observed_at"]
+    ):
+        raise SourceAdmissionRejected("official result provenance or identity disagrees")
+    _known_text(provenance.get("source"), "official result source")
+    _known_text(provenance.get("source_record_id"), "official result source record")
+    if (
+        provenance.get("identity_authority") != "source-native"
+        or provenance.get("reconstructed") is not False
+    ):
+        raise SourceAdmissionRejected("official result identity is reconstructed or ambiguous")
+    order = result.get("order")
+    if type(order) is not list:
+        raise SourceAdmissionRejected("official result order is incomplete")
+    official_order = _require_unique_normalized(order, "official runner identity")
+    if len(official_order) < 2 or set(official_order) != set(race["runner_ids"]):
+        raise SourceAdmissionRejected("official result and source runner identities disagree")
+    return official_order
+
+
+def _training_example_document(
+    race: Mapping[str, Any],
+    *,
+    origin: str,
+    official_order: tuple[str, ...],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "historical-training-example-v1",
+        "origin": origin,
+        "forward_sealed": False,
+        "promotion_evidence_eligible": False,
+        "training_example_id": race["training_example_id"],
+        "race_id": race["race_id"],
+        "racing_date": race["racing_date"],
+        "source_checksum": race["source_checksum"],
+        "official_result_checksum": race["official_result_checksum"],
+        "feature_matrix_checksum": race["feature_matrix_checksum"],
+        "runner_ids": race["runner_ids"],
+        "official_order": list(official_order),
+        "feature_observed_at": race["feature_observed_at"],
+        "scheduled_jump_at": race["scheduled_jump_at"],
+        "result_published_at": race["result_published_at"],
+        "result_observed_at": race["result_observed_at"],
+    }
+
+
+def admit_historical_source(
+    package_bytes: bytes,
+    *,
+    artifacts: Mapping[str, bytes],
+) -> bytes:
+    """Validate supplied bytes and return one deterministic admitted manifest.
+
+    This function performs no IO or writes. A synthetic package can exercise the
+    validator but is always returned as validation-only evidence.
+    """
+
+    package = _object(package_bytes, "historical source package")
+    if set(package) != {"schema_version", "manifest_checksum", "manifest"}:
+        raise SourceAdmissionRejected("historical source package envelope is invalid")
+    if package.get("schema_version") != SOURCE_PACKAGE_SCHEMA:
+        raise SourceAdmissionRejected("historical source package schema is unsupported")
+    manifest = package.get("manifest")
+    if type(manifest) is not dict or set(manifest) != _MANIFEST_FIELDS:
+        raise SourceAdmissionRejected("historical source manifest envelope is invalid")
+    if manifest.get("schema_version") != SOURCE_MANIFEST_SCHEMA:
+        raise SourceAdmissionRejected("historical source manifest schema is unsupported")
+    normalized_manifest = _normalized_manifest(manifest)
+    manifest_checksum = package.get("manifest_checksum")
+    if type(manifest_checksum) is not str:
+        raise SourceAdmissionRejected("source manifest checksum is invalid")
+    try:
+        ArtifactChecksum(manifest_checksum)
+    except ValueError as error:
+        raise SourceAdmissionRejected("source manifest checksum is invalid") from error
+    if _checksum(_canonical(normalized_manifest)) != manifest_checksum:
+        raise SourceAdmissionRejected("source manifest checksum is unverifiable")
+
+    origin = manifest.get("corpus_origin")
+    if origin not in {LEGACY_ORIGIN, SYNTHETIC_ORIGIN}:
+        raise SourceAdmissionRejected("historical corpus origin is unsupported or untruthful")
+    target_bundle_id = _known_text(manifest.get("target_bundle_id"), "target bundle identity")
+    races = normalized_manifest["races"]
+    race_ids = [_known_text(race["race_id"], "race_id") for race in races]
+    race_keys = [_identity_key(race_id, "race_id") for race_id in race_ids]
+    if len(set(race_keys)) != len(race_keys):
+        raise SourceAdmissionRejected("duplicate normalized race identity")
+    example_ids = [
+        _identity_key(race["training_example_id"], "training example identity") for race in races
+    ]
+    if len(set(example_ids)) != len(example_ids):
+        raise SourceAdmissionRejected("duplicate normalized training example identity")
+
+    declared_checksums = [
+        manifest["feature_schema_checksum"],
+        manifest["missingness_policy_checksum"],
+        *[
+            race[field]
+            for race in races
+            for field in (
+                "source_checksum",
+                "official_result_checksum",
+                "feature_matrix_checksum",
+                "artifact_checksum",
+            )
+        ],
+    ]
+    if any(type(value) is not str for value in declared_checksums):
+        raise SourceAdmissionRejected("declared artifact checksum is invalid")
+    if len(set(declared_checksums)) != len(declared_checksums):
+        raise SourceAdmissionRejected("declared artifact identities are duplicated")
+    if set(artifacts) != set(declared_checksums):
+        raise SourceAdmissionRejected("artifact inventory is missing, duplicate, or ambiguous")
+
+    schema_bytes = _artifact(artifacts, manifest["feature_schema_checksum"], "feature schema")
+    missingness_bytes = _artifact(
+        artifacts, manifest["missingness_policy_checksum"], "missingness policy"
+    )
+    schema = _object(schema_bytes, "feature schema")
+    missingness = _object(missingness_bytes, "missingness policy")
+    if (
+        set(schema)
+        != {
+            "bundle_id",
+            "contract_version",
+            "evidence_schema_version",
+            "normalization_version",
+            "fields",
+        }
+        or schema.get("bundle_id") != target_bundle_id
+        or schema.get("contract_version") != SUPPORTED_FEATURE_CONTRACT
+        or set(missingness) != {"bundle_id", "feature_contract_version", "imputation"}
+        or missingness.get("bundle_id") != target_bundle_id
+        or missingness.get("feature_contract_version") != SUPPORTED_FEATURE_CONTRACT
+    ):
+        raise SourceAdmissionRejected("feature schema or missingness contract is unsupported")
+    fields = schema.get("fields")
+    if type(fields) is not list or not fields:
+        raise SourceAdmissionRejected("unsupported feature width")
+    for field in fields:
+        if type(field) is not dict or set(field) != (
+            {"name", "source_field", "semantics", "encoded_value"}
+            if field.get("semantics") == "inapplicable"
+            else {"name", "source_field", "semantics"}
+        ):
+            raise SourceAdmissionRejected("feature schema field envelope is unsupported")
+
+    admitted_races = []
+    source_records: set[tuple[str, str]] = set()
+    result_records: set[tuple[str, str]] = set()
+    for race in races:
+        runner_values = race.get("runner_ids")
+        if type(runner_values) is not list:
+            raise SourceAdmissionRejected("manifest runner identities are incomplete")
+        manifest_runners = _require_unique_normalized(runner_values, "runner identity")
+        if list(manifest_runners) != sorted(manifest_runners):
+            raise SourceAdmissionRejected("manifest runner identities must be sorted")
+        try:
+            racing_date = date.fromisoformat(race["racing_date"])
+        except (TypeError, ValueError) as error:
+            raise SourceAdmissionRejected("racing date is invalid") from error
+        feature_at = _aware_timestamp(race["feature_observed_at"], "feature observed_at")
+        jump_at = _aware_timestamp(race["scheduled_jump_at"], "scheduled jump")
+        published_at = _aware_timestamp(race["result_published_at"], "result published_at")
+        result_at = _aware_timestamp(race["result_observed_at"], "result observed_at")
+        if not feature_at < jump_at < published_at <= result_at:
+            raise SourceAdmissionRejected("historical feature/result temporal order is invalid")
+        if racing_date != jump_at.date():
+            raise SourceAdmissionRejected("racing date and scheduled jump disagree")
+
+        source_bytes = _artifact(artifacts, race["source_checksum"], "historical source")
+        result_bytes = _artifact(artifacts, race["official_result_checksum"], "official result")
+        feature_bytes = _artifact(artifacts, race["feature_matrix_checksum"], "feature matrix")
+        artifact_bytes = _artifact(
+            artifacts, race["artifact_checksum"], "training example artifact"
+        )
+        source = _object(source_bytes, "historical source")
+        result = _object(result_bytes, "official result")
+        capture = _validate_source(source, race, schema)
+        official_order = _validate_result(result, race)
+        source_record = (
+            _identity_key(capture["source"], "historical source"),
+            _identity_key(capture["source_record_id"], "historical source record"),
+        )
+        result_provenance = result["provenance"]
+        result_record = (
+            _identity_key(result_provenance["source"], "official result source"),
+            _identity_key(result_provenance["source_record_id"], "official result source record"),
+        )
+        if source_record in source_records or result_record in result_records:
+            raise SourceAdmissionRejected("source or result record identity is duplicated")
+        source_records.add(source_record)
+        result_records.add(result_record)
+
+        try:
+            derived = derive_features(
+                source_bytes,
+                expected_evidence_checksum=ArtifactChecksum(race["source_checksum"]),
+                schema_bytes=schema_bytes,
+                expected_schema_checksum=ArtifactChecksum(manifest["feature_schema_checksum"]),
+                missingness_policy_bytes=missingness_bytes,
+                expected_missingness_checksum=ArtifactChecksum(
+                    manifest["missingness_policy_checksum"]
+                ),
+            )
+        except (FeatureQuarantine, ValueError) as error:
+            raise SourceAdmissionRejected(str(error)) from error
+        expected_matrix = _canonical(
+            {
+                "runner_ids": list(derived.matrix.runner_ids),
+                "columns": list(derived.matrix.columns),
+                "rows": [list(row) for row in derived.matrix.rows],
+            }
+        )
+        if (
+            feature_bytes != expected_matrix
+            or _checksum(feature_bytes) != race["feature_matrix_checksum"]
+            or any(len(row) != len(derived.matrix.columns) for row in derived.matrix.rows)
+        ):
+            raise SourceAdmissionRejected("feature matrix width, order, or derived values disagree")
+        expected_artifact = _canonical(
+            _training_example_document(race, origin=origin, official_order=official_order)
+        )
+        if artifact_bytes != expected_artifact:
+            raise SourceAdmissionRejected("immutable training example artifact disagrees")
+        admitted_races.append(
+            {
+                "training_example_id": race["training_example_id"],
+                "race_id": race["race_id"],
+                "racing_date": race["racing_date"],
+                "runner_ids": list(manifest_runners),
+                "official_order": list(official_order),
+                "source_checksum": race["source_checksum"],
+                "official_result_checksum": race["official_result_checksum"],
+                "feature_matrix_checksum": race["feature_matrix_checksum"],
+                "artifact_checksum": race["artifact_checksum"],
+                "feature_observed_at": race["feature_observed_at"],
+                "scheduled_jump_at": race["scheduled_jump_at"],
+                "result_published_at": race["result_published_at"],
+                "result_observed_at": race["result_observed_at"],
+            }
+        )
+
+    admitted = {
+        "schema_version": ADMITTED_MANIFEST_SCHEMA,
+        "admission_decision": (
+            "TRAINING_ADMISSIBLE" if origin == LEGACY_ORIGIN else "VALIDATION_ONLY"
+        ),
+        "corpus_origin": origin,
+        "forward_sealed": False,
+        "promotion_evidence_eligible": False,
+        "production_readiness": False,
+        "target_bundle_id": target_bundle_id,
+        "source_manifest_checksum": manifest_checksum,
+        "feature_contract_version": SUPPORTED_FEATURE_CONTRACT,
+        "feature_schema_checksum": manifest["feature_schema_checksum"],
+        "missingness_policy_checksum": manifest["missingness_policy_checksum"],
+        "feature_width": len(fields),
+        "missingness_imputation": missingness["imputation"],
+        "race_ids": race_ids,
+        "races": admitted_races,
+    }
+    return _canonical(admitted)

--- a/tests/race_collection/test_phase7_source_admission.py
+++ b/tests/race_collection/test_phase7_source_admission.py
@@ -1,0 +1,318 @@
+import copy
+import hashlib
+import json
+
+import pytest
+
+from race_collection.source_admission import (
+    SourceAdmissionRejected,
+    admit_historical_source,
+)
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+
+
+def checksum(content):
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+def normalized_manifest_checksum(manifest):
+    normalized = {**manifest, "races": sorted(manifest["races"], key=lambda race: race["race_id"])}
+    return checksum(canonical(normalized))
+
+
+def source_package(*, origin="synthetic-validation-fixture-v1", race_ids=("race-a", "race-b")):
+    schema = canonical(
+        {
+            "bundle_id": "bundle-native-phase7-1",
+            "contract_version": "sealed-race-features-v1",
+            "evidence_schema_version": "race-evidence-v1",
+            "normalization_version": "normalizer-v1",
+            "fields": [
+                {
+                    "name": "speed",
+                    "source_field": "runner_features",
+                    "semantics": "forecast-required",
+                },
+                {
+                    "name": "days_since_run",
+                    "source_field": "runner_features",
+                    "semantics": "optional",
+                },
+            ],
+        }
+    )
+    missingness = canonical(
+        {
+            "bundle_id": "bundle-native-phase7-1",
+            "feature_contract_version": "sealed-race-features-v1",
+            "imputation": {"days_since_run": 7.0},
+        }
+    )
+    artifacts = {checksum(schema): schema, checksum(missingness): missingness}
+    races = []
+    for index, race_id in enumerate(race_ids):
+        runners = [f"dog-{index}-a", f"dog-{index}-b"]
+        feature_observed_at = f"2026-07-{index + 1:02d}T09:00:00+10:00"
+        scheduled_jump_at = f"2026-07-{index + 1:02d}T10:00:00+10:00"
+        result_published_at = f"2026-07-{index + 1:02d}T10:31:00+10:00"
+        result_observed_at = f"2026-07-{index + 1:02d}T10:32:00+10:00"
+        source = canonical(
+            {
+                "schema_version": "race-evidence-v1",
+                "normalization_version": "normalizer-v1",
+                "race_id": race_id,
+                "historical_capture": {
+                    "source": "immutable-form-archive",
+                    "source_record_id": f"form-{race_id}",
+                    "observed_at": feature_observed_at,
+                    "scheduled_jump_at": scheduled_jump_at,
+                    "identity_authority": "source-native",
+                    "reconstructed": False,
+                },
+                "fields": {
+                    "runner_set": runners,
+                    "runner_identity": {runner: "authoritative" for runner in runners},
+                    "runner_features": {
+                        runners[0]: {"speed": 8 + index, "days_since_run": {"missing": True}},
+                        runners[1]: {"speed": 5 + index, "days_since_run": 3},
+                    },
+                },
+            }
+        )
+        result = canonical(
+            {
+                "schema_version": "official-historical-result-v1",
+                "race_id": race_id,
+                "official": True,
+                "order": list(reversed(runners)),
+                "published_at": result_published_at,
+                "exclusions": [],
+                "provenance": {
+                    "source": "official-results-archive",
+                    "source_record_id": f"result-{race_id}",
+                    "observed_at": result_observed_at,
+                    "identity_authority": "source-native",
+                    "reconstructed": False,
+                },
+            }
+        )
+        matrix = canonical(
+            {
+                "runner_ids": runners,
+                "columns": ["speed", "days_since_run"],
+                "rows": [[8.0 + index, 7.0], [5.0 + index, 3.0]],
+            }
+        )
+        training_example_id = f"historical-{race_id}"
+        artifact = canonical(
+            {
+                "schema_version": "historical-training-example-v1",
+                "origin": origin,
+                "forward_sealed": False,
+                "promotion_evidence_eligible": False,
+                "training_example_id": training_example_id,
+                "race_id": race_id,
+                "racing_date": f"2026-07-{index + 1:02d}",
+                "source_checksum": checksum(source),
+                "official_result_checksum": checksum(result),
+                "feature_matrix_checksum": checksum(matrix),
+                "runner_ids": runners,
+                "official_order": list(reversed(runners)),
+                "feature_observed_at": feature_observed_at,
+                "scheduled_jump_at": scheduled_jump_at,
+                "result_published_at": result_published_at,
+                "result_observed_at": result_observed_at,
+            }
+        )
+        for content in (source, result, matrix, artifact):
+            artifacts[checksum(content)] = content
+        races.append(
+            {
+                "training_example_id": training_example_id,
+                "race_id": race_id,
+                "racing_date": f"2026-07-{index + 1:02d}",
+                "source_checksum": checksum(source),
+                "official_result_checksum": checksum(result),
+                "feature_matrix_checksum": checksum(matrix),
+                "artifact_checksum": checksum(artifact),
+                "runner_ids": runners,
+                "feature_observed_at": feature_observed_at,
+                "scheduled_jump_at": scheduled_jump_at,
+                "result_published_at": result_published_at,
+                "result_observed_at": result_observed_at,
+            }
+        )
+    manifest = {
+        "schema_version": "historical-source-manifest-v1",
+        "corpus_origin": origin,
+        "target_bundle_id": "bundle-native-phase7-1",
+        "feature_schema_checksum": checksum(schema),
+        "missingness_policy_checksum": checksum(missingness),
+        "races": races,
+    }
+    envelope = {
+        "schema_version": "historical-source-package-v1",
+        "manifest_checksum": normalized_manifest_checksum(manifest),
+        "manifest": manifest,
+    }
+    return envelope, artifacts
+
+
+def replace_artifact(envelope, artifacts, race_index, field, mutate):
+    old_checksum = envelope["manifest"]["races"][race_index][field]
+    document = json.loads(artifacts.pop(old_checksum))
+    mutate(document)
+    content = canonical(document)
+    new_checksum = checksum(content)
+    artifacts[new_checksum] = content
+    envelope["manifest"]["races"][race_index][field] = new_checksum
+    envelope["manifest_checksum"] = normalized_manifest_checksum(envelope["manifest"])
+
+
+def test_synthetic_package_validates_only_and_reordering_is_byte_identical():
+    envelope, artifacts = source_package()
+    first = admit_historical_source(canonical(envelope), artifacts=artifacts)
+    reordered = copy.deepcopy(envelope)
+    reordered["manifest"]["races"].reverse()
+    second = admit_historical_source(
+        canonical(reordered), artifacts=dict(reversed(artifacts.items()))
+    )
+    assert first == second
+    admitted = json.loads(first)
+    assert admitted["admission_decision"] == "VALIDATION_ONLY"
+    assert admitted["production_readiness"] is False
+    assert admitted["forward_sealed"] is False
+    assert admitted["race_ids"] == ["race-a", "race-b"]
+    assert admitted["races"][0]["runner_ids"] == ["dog-0-a", "dog-0-b"]
+
+
+def test_legacy_origin_is_truthful_and_never_forward_sealed():
+    envelope, artifacts = source_package(
+        origin="legacy-historical-bootstrap-v1", race_ids=("race-a",)
+    )
+    admitted = json.loads(admit_historical_source(canonical(envelope), artifacts=artifacts))
+    assert admitted["corpus_origin"] == "legacy-historical-bootstrap-v1"
+    assert admitted["admission_decision"] == "TRAINING_ADMISSIBLE"
+    assert admitted["forward_sealed"] is False
+    assert admitted["promotion_evidence_eligible"] is False
+    assert admitted["production_readiness"] is False
+    envelope["manifest"]["corpus_origin"] = "forward-sealed"
+    envelope["manifest_checksum"] = normalized_manifest_checksum(envelope["manifest"])
+    with pytest.raises(SourceAdmissionRejected, match="corpus origin"):
+        admit_historical_source(canonical(envelope), artifacts=artifacts)
+
+
+def test_identity_mismatch_and_duplicate_normalized_runner_fail_closed():
+    envelope, artifacts = source_package(race_ids=("race-a",))
+    mismatch = copy.deepcopy(envelope)
+    mismatch["manifest"]["races"][0]["runner_ids"][0] = "dog-0-0"
+    mismatch["manifest_checksum"] = normalized_manifest_checksum(mismatch["manifest"])
+    with pytest.raises(SourceAdmissionRejected, match="runner identities disagree"):
+        admit_historical_source(canonical(mismatch), artifacts=artifacts)
+
+    duplicate, duplicate_artifacts = source_package(race_ids=("race-a",))
+    replace_artifact(
+        duplicate,
+        duplicate_artifacts,
+        0,
+        "source_checksum",
+        lambda value: (
+            value["fields"].__setitem__("runner_set", ["Dog A", "dog a"]),
+            value["fields"].__setitem__(
+                "runner_identity", {"Dog A": "authoritative", "dog a": "authoritative"}
+            ),
+            value["fields"].__setitem__(
+                "runner_features",
+                {
+                    "Dog A": {"speed": 8, "days_since_run": {"missing": True}},
+                    "dog a": {"speed": 5, "days_since_run": 3},
+                },
+            ),
+        ),
+    )
+    duplicate["manifest"]["races"][0]["runner_ids"] = ["Dog A", "dog a"]
+    duplicate["manifest_checksum"] = normalized_manifest_checksum(duplicate["manifest"])
+    with pytest.raises(SourceAdmissionRejected, match="normalized runner identity"):
+        admit_historical_source(canonical(duplicate), artifacts=duplicate_artifacts)
+
+
+def test_result_leakage_and_post_result_feature_timestamp_fail_closed():
+    envelope, artifacts = source_package(race_ids=("race-a",))
+    replace_artifact(
+        envelope,
+        artifacts,
+        0,
+        "source_checksum",
+        lambda value: value["fields"]["runner_features"]["dog-0-a"].__setitem__("result_order", 1),
+    )
+    with pytest.raises(SourceAdmissionRejected, match="post-result feature"):
+        admit_historical_source(canonical(envelope), artifacts=artifacts)
+
+    late, late_artifacts = source_package(race_ids=("race-a",))
+    late["manifest"]["races"][0]["feature_observed_at"] = "2026-07-01T10:32:00+10:00"
+    late["manifest_checksum"] = normalized_manifest_checksum(late["manifest"])
+    with pytest.raises(SourceAdmissionRejected, match="temporal order"):
+        admit_historical_source(canonical(late), artifacts=late_artifacts)
+
+
+def test_missingness_policy_must_exactly_cover_optional_features():
+    envelope, artifacts = source_package(race_ids=("race-a",))
+    old_checksum = envelope["manifest"]["missingness_policy_checksum"]
+    policy = json.loads(artifacts.pop(old_checksum))
+    policy["imputation"] = {}
+    content = canonical(policy)
+    new_checksum = checksum(content)
+    artifacts[new_checksum] = content
+    envelope["manifest"]["missingness_policy_checksum"] = new_checksum
+    envelope["manifest_checksum"] = normalized_manifest_checksum(envelope["manifest"])
+    with pytest.raises(SourceAdmissionRejected, match="imputation"):
+        admit_historical_source(canonical(envelope), artifacts=artifacts)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("feature_observed_at", "2026-07-01T09:00:00"),
+        ("scheduled_jump_at", "not-a-timestamp"),
+        ("result_published_at", 7),
+    ],
+)
+def test_malformed_or_naive_timestamps_fail_closed(field, value):
+    envelope, artifacts = source_package(race_ids=("race-a",))
+    envelope["manifest"]["races"][0][field] = value
+    envelope["manifest_checksum"] = normalized_manifest_checksum(envelope["manifest"])
+    with pytest.raises(SourceAdmissionRejected, match="timestamp"):
+        admit_historical_source(canonical(envelope), artifacts=artifacts)
+
+
+def test_unsupported_feature_width_and_unverifiable_hash_fail_closed():
+    envelope, artifacts = source_package(race_ids=("race-a",))
+    replace_artifact(
+        envelope,
+        artifacts,
+        0,
+        "feature_matrix_checksum",
+        lambda value: value["rows"][0].pop(),
+    )
+    with pytest.raises(SourceAdmissionRejected, match="feature matrix"):
+        admit_historical_source(canonical(envelope), artifacts=artifacts)
+
+    bad_hash, bad_hash_artifacts = source_package(race_ids=("race-a",))
+    bad_hash_artifacts[bad_hash["manifest"]["races"][0]["source_checksum"]] += b" "
+    with pytest.raises(SourceAdmissionRejected, match="checksum"):
+        admit_historical_source(canonical(bad_hash), artifacts=bad_hash_artifacts)
+
+
+def test_manifest_hash_and_closed_artifact_inventory_are_required():
+    envelope, artifacts = source_package(race_ids=("race-a",))
+    envelope["manifest_checksum"] = "sha256:" + "0" * 64
+    with pytest.raises(SourceAdmissionRejected, match="manifest checksum"):
+        admit_historical_source(canonical(envelope), artifacts=artifacts)
+
+    envelope, artifacts = source_package(race_ids=("race-a",))
+    artifacts["sha256:" + "f" * 64] = b"undeclared"
+    with pytest.raises(SourceAdmissionRejected, match="artifact inventory"):
+        admit_historical_source(canonical(envelope), artifacts=artifacts)


### PR DESCRIPTION
## What changed

- add a pure, no-write `race_collection.source_admission` validator for explicitly supplied immutable historical packages
- require the production `sealed-race-features-v1` schema, complete optional-feature imputation, sorted source-native identities, official-result and pre-result timestamp ordering, and exact SHA-256 bindings for source/result/feature/example/manifest bytes
- emit deterministic canonical admission manifests that classify legacy bootstrap evidence truthfully, never as forward-sealed, while synthetic fixtures remain validation-only
- document the boundary in the Phase 5 handoff

## Why

Phase 7 has no compatible source-proven native `LinearStrengthModel` bundle, and training is not authorized. This is the smallest repository-only gate needed to decide whether a future immutable historical bootstrap corpus is admissible without reconstructing identities, widening schemas, or touching runtime/data.

## Validation

- focused source-admission suite: `10 passed`
- Phase 4/5/6 focused regression suites: `171 passed in 3631.91s (1:00:31)`
- changed-file Black, fatal Flake8, isort, `py_compile`, and `git diff --check`: pass
- release/runtime/service JSON Schema meta-validation: pass
- fresh read-only exact staged-diff review: `SUCCESS`, no findings

Repository-wide Black and isort were also run and report extensive pre-existing formatting/import drift on current `master` outside this three-file diff. No unrelated file was modified; all exact changed-file gates pass.

## Evidence boundary

No production historical package was supplied or accessed, so the current evidence result remains `DATA_MISSING`, not `TRAINING_ADMISSIBLE`. No training, calibration, evaluation, model export, artifact publication, bundle registration, operations database, runtime/service action, prediction, results access, promotion, betting, deployment, or merge was performed.