### PR TITLE
Bound manual predictor collector-lock wait

### DIFF
--- a/configs/prediction/manual-default.json
+++ b/configs/prediction/manual-default.json
@@ -1,1 +1,1 @@
-{"bundle":{"lock_wait_seconds":10,"poll_seconds":1,"receipt_max_age_seconds":900},"model":"market_form_residual_v1","schema_version":"on_demand_prediction_config_v1","variant":"full_strength"}
+{"bundle":{"lock_wait_seconds":30,"poll_seconds":1,"receipt_max_age_seconds":900},"model":"market_form_residual_v1","schema_version":"on_demand_prediction_config_v1","variant":"full_strength"}

--- a/configs/prediction/market-only.json
+++ b/configs/prediction/market-only.json
@@ -1,1 +1,1 @@
-{"bundle":{"lock_wait_seconds":10,"poll_seconds":1,"receipt_max_age_seconds":900},"model":"market_only_v1","schema_version":"on_demand_prediction_config_v1","variant":"market_only_implied"}
+{"bundle":{"lock_wait_seconds":30,"poll_seconds":1,"receipt_max_age_seconds":900},"model":"market_only_v1","schema_version":"on_demand_prediction_config_v1","variant":"market_only_implied"}

--- a/docs/on_demand_race_prediction.md
+++ b/docs/on_demand_race_prediction.md
@@ -36,16 +36,22 @@ always reuse-only and never falls back to collection.
 
 If no reusable receipt exists, the command tries the existing collector lock.
 It never deletes, steals, cancels, or treats a stale lock as permission to
-bypass its owner. While the lock is busy, the bounded config wait can notice a
-receipt completed by the collector. If the wait expires, the command returns
-`BUSY`. With the lock legitimately acquired, it refreshes only the exact race,
-requires master's fixed-window plan to be eligible, fetches and validates
-current Sportsbet WIN and PLACE markets, and writes the accepted capture only
-into the private run bundle. It returns `CAPTURE_WINDOW_UNAVAILABLE` instead of
-waiting when no fixed window is due. The production database is never passed to
-an append path. Before direct capture, the command also requires the lock path
-to be the canonical daemon-lock location under the selected database's
-repository root; a database/lock-root mismatch fails closed.
+bypass its owner. While the lock is busy, the bounded config wait polls the
+same no-steal acquisition path and can also notice a receipt completed by the
+collector. Checked-in configs wait at most 30 seconds by default, poll once per
+second, and enforce a 60-second schema maximum; an explicit
+`lock_wait_seconds: 0` returns immediate `BUSY`. The monotonic wait stops before
+another acquisition at its deadline and stops immediately if the race reaches
+its pre-jump boundary. If the wait expires, `BUSY` includes the elapsed and
+configured limit. With the lock legitimately acquired, the command refreshes
+only the exact race, requires master's fixed-window plan to be eligible,
+fetches and validates current Sportsbet WIN and PLACE markets, and writes the
+accepted capture only into the private run bundle. It returns
+`CAPTURE_WINDOW_UNAVAILABLE` instead of waiting when no fixed window is due.
+The production database is never passed to an append path. Before direct
+capture, the command also requires the lock path to be the canonical
+daemon-lock location under the selected database's repository root; a
+database/lock-root mismatch fails closed.
 
 The exact TheDogs meeting slug remains authoritative during named-race
 selection. Murray Bridge and Murray Bridge Straight therefore remain distinct

--- a/scripts/predict_race_now.py
+++ b/scripts/predict_race_now.py
@@ -868,29 +868,67 @@ def _acquire_or_reuse(
         if receipt is not None:
             return None, receipt, rejected_receipts
     started = dependencies.monotonic()
+    deadline = started + wait_seconds
+    last_busy: BaseException | None = None
     while True:
+        observed = dependencies.monotonic()
+        elapsed = max(0.0, observed - started)
+        observed_time = current_time + timedelta(seconds=elapsed)
+        if observed_time >= jump:
+            raise PredictionBlocked(
+                "POST_JUMP",
+                race_id=race_id,
+                jump_timestamp=jump.isoformat(),
+                lock_wait_elapsed_seconds=elapsed,
+                lock_wait_limit_seconds=wait_seconds,
+                lock_details=getattr(last_busy, "payload", None),
+            )
+        if last_busy is not None and observed >= deadline:
+            raise PredictionBlocked(
+                "BUSY",
+                lock_details=getattr(last_busy, "payload", None),
+                lock_wait_elapsed_seconds=elapsed,
+                lock_wait_limit_seconds=wait_seconds,
+            ) from last_busy
         try:
             return dependencies.acquire_lock(), None, rejected_receipts
         except dependencies.lock_busy_type as exc:
-            elapsed = dependencies.monotonic() - started
+            last_busy = exc
+            observed = dependencies.monotonic()
+            elapsed = max(0.0, observed - started)
+            observed_time = current_time + timedelta(seconds=elapsed)
+            if observed_time >= jump:
+                raise PredictionBlocked(
+                    "POST_JUMP",
+                    race_id=race_id,
+                    jump_timestamp=jump.isoformat(),
+                    lock_wait_elapsed_seconds=elapsed,
+                    lock_wait_limit_seconds=wait_seconds,
+                    lock_details=getattr(exc, "payload", None),
+                ) from exc
+            remaining = deadline - observed
+            if remaining <= 0:
+                details = getattr(exc, "payload", None)
+                raise PredictionBlocked(
+                    "BUSY",
+                    lock_details=details,
+                    lock_wait_elapsed_seconds=elapsed,
+                    lock_wait_limit_seconds=wait_seconds,
+                ) from exc
             if odds_source == "auto":
-                check_time = current_time + timedelta(seconds=max(0.0, elapsed))
                 receipt = _discover_for_auto(
                     dependencies,
                     evidence_roots=evidence_roots,
                     db_path=db_path,
                     race_id=race_id,
                     jump=jump,
-                    current_time=check_time,
+                    current_time=observed_time,
                     rejected_receipts=rejected_receipts,
                 )
                 if receipt is not None:
                     return None, receipt, rejected_receipts
-            remaining = wait_seconds - elapsed
-            if remaining <= 0:
-                details = getattr(exc, "payload", None)
-                raise PredictionBlocked("BUSY", lock_details=details) from exc
-            dependencies.sleep(min(max(poll_seconds, 0.01), remaining))
+            until_jump = (jump - observed_time).total_seconds()
+            dependencies.sleep(min(max(poll_seconds, 0.01), remaining, until_jump))
 
 
 def _run_prediction(

--- a/tests/test_predict_race_now.py
+++ b/tests/test_predict_race_now.py
@@ -305,6 +305,14 @@ def args(tmp_path: Path, **overrides: Any) -> argparse.Namespace:
     return argparse.Namespace(**values)
 
 
+def config_with_lock_wait(tmp_path: Path, value: Any) -> Path:
+    config = json.loads(Path("configs/prediction/manual-default.json").read_bytes())
+    config["bundle"]["lock_wait_seconds"] = value
+    path = tmp_path / "prediction-config.json"
+    path.write_bytes(canonical_bytes(config))
+    return path
+
+
 def test_master_packet_adapter_reuses_pr56_validated_handoff(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -833,23 +841,186 @@ def test_busy_collector_may_complete_receipt_during_bounded_wait(tmp_path: Path)
     assert calls["discover"] == 3
 
 
-def test_busy_without_receipt_returns_smallest_blocker(tmp_path: Path):
-    clock = {"value": 0.0}
+def test_zero_lock_wait_returns_immediate_busy_with_wait_evidence(tmp_path: Path):
+    sleeps: list[float] = []
+    calls = {"discover": 0}
+
+    def discover(**kwargs: Any) -> Mapping[str, Any] | None:
+        calls["discover"] += 1
+        return handoff() if calls["discover"] > 1 else None
+
+    with pytest.raises(PredictionBlocked, match="BUSY") as captured:
+        run_prediction(
+            args(
+                tmp_path,
+                config=config_with_lock_wait(tmp_path, 0),
+            ),
+            dependencies(
+                discover=discover,
+                acquire=lambda: (_ for _ in ()).throw(Busy()),
+                monotonic=lambda: 50.0,
+                sleep=sleeps.append,
+            ),
+        )
+
+    assert captured.value.code == "BUSY"
+    assert captured.value.details["lock_details"] == {"owner": "collector"}
+    assert captured.value.details["lock_wait_elapsed_seconds"] == 0.0
+    assert captured.value.details["lock_wait_limit_seconds"] == 0.0
+    assert calls["discover"] == 1
+    assert sleeps == []
+
+
+def test_lock_released_within_deadline_proceeds_once(tmp_path: Path):
+    clock = {"value": 20.0}
+    calls = {"acquire": 0, "release": 0, "fetch": 0, "score": 0}
+
+    def acquire() -> str:
+        calls["acquire"] += 1
+        if calls["acquire"] == 1:
+            raise Busy()
+        return "lock"
 
     def sleep(seconds: float) -> None:
         clock["value"] += seconds
 
+    deps = dependencies(
+        discover=lambda **kwargs: None,
+        acquire=acquire,
+        release=lambda handle: calls.__setitem__("release", calls["release"] + 1),
+        monotonic=lambda: clock["value"],
+        sleep=sleep,
+    )
+    original_fetch = deps.fetch_odds
+    original_score = deps.score_residual
+
+    def fetch(*call_args: Any, **call_kwargs: Any) -> Mapping[str, Any]:
+        calls["fetch"] += 1
+        return original_fetch(*call_args, **call_kwargs)
+
+    def score(**call_kwargs: Any) -> Mapping[str, Any]:
+        calls["score"] += 1
+        return original_score(**call_kwargs)
+
+    deps.fetch_odds = fetch
+    deps.score_residual = score
+
+    result = run_prediction(
+        args(
+            tmp_path,
+            odds_source="capture",
+            config=config_with_lock_wait(tmp_path, 5),
+        ),
+        deps,
+    )
+
+    assert result["status"] == "PREDICTION_READY"
+    assert calls == {"acquire": 2, "release": 1, "fetch": 1, "score": 1}
+
+
+def test_busy_lock_held_to_deadline_returns_wait_evidence(tmp_path: Path):
+    clock = {"value": 0.0}
+    calls = {"acquire": 0}
+
+    def sleep(seconds: float) -> None:
+        clock["value"] += seconds
+
+    def acquire() -> None:
+        calls["acquire"] += 1
+        raise Busy()
+
     with pytest.raises(PredictionBlocked, match="BUSY") as captured:
         run_prediction(
-            args(tmp_path),
+            args(
+                tmp_path,
+                odds_source="capture",
+                config=config_with_lock_wait(tmp_path, 2),
+            ),
             dependencies(
                 discover=lambda **kwargs: None,
-                acquire=lambda: (_ for _ in ()).throw(Busy()),
+                acquire=acquire,
                 monotonic=lambda: clock["value"],
                 sleep=sleep,
             ),
         )
     assert captured.value.code == "BUSY"
+    assert captured.value.details["lock_wait_elapsed_seconds"] == 2.0
+    assert captured.value.details["lock_wait_limit_seconds"] == 2.0
+    assert calls["acquire"] == 2
+
+
+def test_monotonic_deadline_prevents_acquire_at_deadline(tmp_path: Path):
+    clock = {"value": 100.0}
+    calls = {"acquire": 0, "now": 0}
+
+    def acquire() -> str:
+        calls["acquire"] += 1
+        if calls["acquire"] <= 2:
+            raise Busy()
+        return "lock"
+
+    def sleep(seconds: float) -> None:
+        clock["value"] += seconds
+
+    def wall_now() -> datetime:
+        calls["now"] += 1
+        return NOW
+
+    with pytest.raises(PredictionBlocked, match="BUSY") as captured:
+        run_prediction(
+            args(
+                tmp_path,
+                odds_source="capture",
+                config=config_with_lock_wait(tmp_path, 2),
+            ),
+            dependencies(
+                discover=lambda **kwargs: None,
+                acquire=acquire,
+                now=wall_now,
+                monotonic=lambda: clock["value"],
+                sleep=sleep,
+            ),
+        )
+
+    assert captured.value.details["lock_wait_elapsed_seconds"] == 2.0
+    assert calls == {"acquire": 2, "now": 0}
+
+
+def test_race_becoming_post_jump_while_waiting_stops_before_reacquire(
+    tmp_path: Path,
+):
+    clock = {"value": 0.0}
+    calls = {"acquire": 0}
+
+    def acquire() -> None:
+        calls["acquire"] += 1
+        raise Busy()
+
+    def sleep(seconds: float) -> None:
+        clock["value"] += seconds
+
+    deps = dependencies(
+        discover=lambda **kwargs: None,
+        acquire=acquire,
+        monotonic=lambda: clock["value"],
+        sleep=sleep,
+    )
+    deps.schedule = lambda days: [race("12:01")]
+
+    with pytest.raises(PredictionBlocked, match="POST_JUMP") as captured:
+        run_prediction(
+            args(
+                tmp_path,
+                odds_source="capture",
+                config=config_with_lock_wait(tmp_path, 10),
+                current_time=(NOW + timedelta(seconds=58)).isoformat(),
+            ),
+            deps,
+        )
+
+    assert captured.value.code == "POST_JUMP"
+    assert captured.value.details["lock_wait_elapsed_seconds"] == 2.0
+    assert calls["acquire"] == 2
 
 
 def test_default_lock_path_never_reclaims_existing_unreadable_lock(tmp_path: Path):
@@ -863,6 +1034,54 @@ def test_default_lock_path_never_reclaims_existing_unreadable_lock(tmp_path: Pat
         )
     assert captured.value.payload["reason"] == "existing_lock_present_no_steal"
     assert lock_path.read_bytes() == original
+
+
+def test_bounded_wait_does_not_mutate_or_interfere_with_lock_owner(tmp_path: Path):
+    lock_path = tmp_path / "collector.lock"
+    original = canonical_bytes({"pid": 1234, "run_id": "scheduled_collector"})
+    lock_path.write_bytes(original)
+    lock_path.chmod(0o640)
+    before = lock_path.stat(follow_symlinks=False)
+    clock = {"value": 0.0}
+
+    def acquire() -> Any:
+        return _acquire_collector_lock_no_steal(
+            lock_path,
+            run_id="on_demand_test",
+            output_dir=tmp_path / "bundle",
+        )
+
+    def sleep(seconds: float) -> None:
+        clock["value"] += seconds
+
+    deps = dependencies(
+        discover=lambda **kwargs: None,
+        acquire=acquire,
+        monotonic=lambda: clock["value"],
+        sleep=sleep,
+    )
+    deps.lock_busy_type = CollectorLockBusy
+
+    with pytest.raises(PredictionBlocked, match="BUSY"):
+        predict_now._acquire_or_reuse(
+            deps,
+            odds_source="capture",
+            evidence_roots=(tmp_path / "evidence",),
+            db_path=tmp_path / "source.db",
+            race_id=RACE_ID,
+            jump=NOW + timedelta(hours=1),
+            current_time=NOW,
+            wait_seconds=2,
+            poll_seconds=1,
+        )
+
+    after = lock_path.stat(follow_symlinks=False)
+    assert lock_path.read_bytes() == original
+    assert (after.st_dev, after.st_ino, after.st_mode) == (
+        before.st_dev,
+        before.st_ino,
+        before.st_mode,
+    )
 
 
 def test_default_dependencies_reject_db_lock_root_mismatch(tmp_path: Path):
@@ -1330,6 +1549,44 @@ def test_nonfinite_config_is_rejected_before_any_prediction_side_effect(
         sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
         == files_before
     )
+
+
+@pytest.mark.parametrize(
+    ("value", "code"),
+    [
+        (-1, "CONFIG_SCHEMA_MISMATCH"),
+        (61, "CONFIG_SCHEMA_MISMATCH"),
+        (True, "CONFIG_SCHEMA_MISMATCH"),
+        ("1", "CONFIG_SCHEMA_MISMATCH"),
+        (float("nan"), "CONFIG_INVALID_JSON"),
+        (float("inf"), "CONFIG_INVALID_JSON"),
+        (float("-inf"), "CONFIG_INVALID_JSON"),
+    ],
+)
+def test_invalid_lock_wait_values_are_rejected(tmp_path: Path, value: Any, code: str):
+    calls = {"schedule": 0}
+    deps = dependencies()
+    deps.schedule = lambda days: calls.__setitem__("schedule", calls["schedule"] + 1)
+
+    with pytest.raises(PredictionBlocked) as captured:
+        run_prediction(
+            args(tmp_path, config=config_with_lock_wait(tmp_path, value)),
+            deps,
+        )
+
+    assert captured.value.code == code
+    assert calls["schedule"] == 0
+
+
+def test_checked_in_lock_wait_default_and_max_are_bounded():
+    for name in ("manual-default.json", "market-only.json"):
+        config = json.loads((Path("configs/prediction") / name).read_bytes())
+        assert config["bundle"]["lock_wait_seconds"] == 30
+
+    for name in ("market_form_residual_v1.schema.json", "market_only_v1.schema.json"):
+        schema = json.loads((Path("configs/prediction/schemas") / name).read_bytes())
+        wait_schema = schema["properties"]["bundle"]["properties"]["lock_wait_seconds"]
+        assert wait_schema == {"maximum": 60, "minimum": 0, "type": "number"}
 
 
 def test_list_configs_is_finite_validated_and_deterministic(


### PR DESCRIPTION
## Summary

- raise the checked-in manual predictor lock-wait default from 10 seconds to a conservative 30 seconds while retaining the existing 60-second schema maximum and 1-second poll
- enforce the wait with a monotonic deadline, stop before another acquisition at the deadline, and stop at the race's pre-jump boundary
- preserve explicit zero as immediate `BUSY` and add elapsed/wait-limit evidence to terminal `BUSY`
- keep all polling on the existing no-steal `O_EXCL` lock path; no lock deletion, replacement, permission change, stale-owner recovery, queue, retry, service, timer, DB/history, or runtime mutation is added

## Root cause

Canonical `master` already had a configurable bounded wait, but the 10-second default was too short for recurring scheduled-collector overlap. The loop could also make another acquisition attempt at the nominal deadline, did not terminate the wait at the race's pre-jump boundary, and returned `BUSY` without wait timing evidence.

## Safety and compatibility

Receipt reuse remains first in `auto` mode, PR #66 exact-race filtering and provenance validation are unchanged, and a released lock continues exactly once through the existing isolated capture/prediction path. Explicit zero performs the initial safe acquisition attempt and returns immediate `BUSY` without sleeping or rechecking for a later receipt. Existing lock bytes, inode, and mode are asserted unchanged while polling.

No live prediction or capture was run. No service/timer, canonical DB/history, model, deployment, promotion, EV/staking, or betting action was performed.

## Validation

- `359 passed` — full `test_predict_race_now.py` plus `test_predict_market_form_residual.py` on-demand, exact-receipt, bundle, replay, config, and nearby regressions
- `15 passed` — final focused lock-wait/default/input-validation slice
- Ruff CI-policy check passed (`E9,F63,F7,F82`)
- Ruff format check passed
- `py_compile` passed
- `git diff --check` passed
- fresh exact-diff review: accepted, no findings
