### PR TITLE
Add forward-sealed corpus capture

### DIFF
--- a/docs/CANONICAL_RACE_FORECASTING_PHASE5.md
+++ b/docs/CANONICAL_RACE_FORECASTING_PHASE5.md
@@ -37,6 +37,21 @@ ineligible as forward promotion evidence. Reordered race inputs produce the
 same bytes. Synthetic packages return `VALIDATION_ONLY`; they cannot establish
 production readiness or authorize training.
 
+## Prospective forward-sealed collection
+
+`race_collection.forward_sealed_corpus` provides the prospective path for
+creating new authentic evidence instead of reconstructing historical inputs.
+It consumes the existing collector and `EvidenceSealer` artifacts, derives the
+production `sealed-race-features-v1` matrix before jump, and later joins only an
+official result with a source-declared publication timestamp. Raw source and
+result bytes remain separate from normalized records.
+
+A complete `forward-sealed-corpus-v1` package is training-admissible through
+`race_collection.source_admission`, while promotion and production readiness
+remain false. TheDogs observations without an authentic publication timestamp
+are retained in an explicit blocked state and cannot create a training example
+or closed package. See `docs/FORWARD_SEALED_CORPUS_CAPTURE.md`.
+
 `race_collection.ordered_finish` is the versioned
 `plackett-luce-ordered-finish-v1` contract. It converts bundle-produced finite
 latent runner strengths into one numerically stable sequential distribution.

--- a/docs/FORWARD_SEALED_CORPUS_CAPTURE.md
+++ b/docs/FORWARD_SEALED_CORPUS_CAPTURE.md
@@ -1,0 +1,133 @@
+# Forward-sealed corpus capture
+
+`race_collection.forward_sealed_corpus` is the prospective collection boundary
+for authentic Phase 7 training evidence. It does not fetch a race, schedule a
+job, write a database, train a model, register a bundle, predict, promote, or
+activate anything.
+
+The current programme, pre-jump refresh, `EvidenceSealer`, odds capture, and
+official-result collectors remain the source adapters and scheduling
+authority. The forward collector consumes one immutable adapter output at a
+time. The bounded CLI reuses the shadow-autopilot exclusive lock shape at a
+corpus-local path; it does not install or start a service or timer.
+
+## Evidence pillars
+
+### A. Pre-jump source
+
+`forward-source-capture-v1` binds:
+
+- the canonical source URL and source-native race and runner identities;
+- non-empty meeting and race metadata, racing date, and scheduled jump;
+- immutable raw source bytes and `raw_source_checksum`;
+- the existing canonical `race-evidence-v1` bytes produced by
+  `EvidenceSealer`;
+- source observation and feature-freeze timestamps before jump;
+- `identity_authority: source-native` and `reconstructed: false`.
+
+The sealed evidence must contain runner-set, identity, and runner-feature
+provenance bound to the preserved raw source checksum. Raw bytes and normalized
+evidence remain separate content-addressed objects. On first publication, the
+collector also checks its own timezone-aware clock is at or after feature
+freeze and still before jump. Exact receipt replay remains valid after jump,
+but no new receipt can first appear late.
+
+### B. Pre-jump features
+
+The collector calls the production `derive_features` function with immutable
+schema, missingness-policy, and sealed-evidence bytes. The feature schema must
+declare `sealed-race-features-v1`; the missingness policy must exactly cover
+every optional feature with finite values. The resulting canonical matrix
+contains source-native runner IDs, ordered columns, and deterministic rows.
+
+No result argument exists on the pre-jump API. Result-derived keys anywhere in
+the source metadata or sealed evidence are rejected before feature derivation.
+
+### C. Official result
+
+`official-forward-result-v1` preserves:
+
+- immutable raw official-result bytes and checksum;
+- the canonical result URL, source-native race identity, aligned runner IDs and
+  names, and complete official order;
+- a source-declared publication timestamp and collector observation timestamp,
+  both after jump;
+- `identity_authority: source-native` and `reconstructed: false`.
+
+The current TheDogs `SourceResult` contract exposes neither the exact response
+bytes nor an authentic source publication timestamp. It therefore cannot be
+wired to this closure path as-is. A later, separately authorized adapter change
+must preserve those response bytes before normalization; this pipeline will not
+reconstruct them from parsed records.
+
+When an adapter does preserve exact result bytes but its source still does not
+expose a publication timestamp, the iteration must use
+`publication_timestamp_status: not-exposed-by-source` with
+`result_published_at: null`. The collector preserves the raw bytes and
+`result_observed_at`, returns `BLOCKED_RESULT_PUBLICATION_TIMESTAMP`, and does
+not create normalized result, training-example, closure, or package evidence.
+No timestamp is inferred from HTTP, page text, jump time, or collector time.
+
+## Append-only state machine
+
+```text
+EMPTY
+  -> PREJUMP_CAPTURED
+      -> BLOCKED_RESULT_PUBLICATION_TIMESTAMP
+      -> RESULT_CAPTURED
+          -> CLOSED
+```
+
+An exact retry is an idempotent no-op. A different retry at a published stage,
+runner drift, source-native identity mismatch, late capture, missing bytes,
+unknown or naive timestamp, result-byte hash drift, or conflicting duplicate
+closure fails closed. A blocked timestamp observation may close later only
+when the same immutable result bytes receive an authentic source-declared
+publication timestamp.
+
+Objects use the repository `LocalArtifactStore`. Per-race stage receipts use
+same-filesystem temporary files, `fsync`, and an exclusive hard-link publish;
+they are never overwritten. A crash after object publication but before a
+receipt leaves only harmless content-addressed objects, and an exact retry
+completes the missing receipt.
+
+## Closed package
+
+Only a closed race has immutable `historical-training-example-v1` bytes with:
+
+- `origin: forward-sealed-corpus-v1`;
+- `forward_sealed: true`;
+- raw source/result, normalized source/result, feature matrix, and source
+  capture checksums;
+- the complete prospective and post-jump timestamp chain.
+
+`build_package()` sorts races by normalized race identity and emits the existing
+canonical `historical-source-package-v1` /
+`historical-source-manifest-v1` envelope. Input and artifact-map reordering
+therefore produces byte-identical manifests. `race_collection.source_admission`
+independently re-hashes every declared object, re-derives every feature matrix,
+re-validates identities and temporal ordering, and admits a complete forward
+package as `TRAINING_ADMISSIBLE`. Admission keeps
+`promotion_evidence_eligible` and `production_readiness` false.
+
+## One-iteration CLI
+
+```bash
+python3 scripts/collect_forward_sealed_corpus.py \
+  --root /safe/append-only/corpus \
+  --iteration /safe/adapter-iteration.json
+
+python3 scripts/collect_forward_sealed_corpus.py \
+  --root /safe/append-only/corpus \
+  --status
+```
+
+The iteration object has exactly one `action`: `prejump` or `result`. Raw and
+normalized bytes are passed as file paths generated by the existing adapters.
+A successful result iteration closes the race and rebuilds the deterministic
+package. The missing-publication decision exits non-zero after safely retaining
+the observation.
+
+This repository change is collection support only. Live invocation, service or
+timer wiring, database writes, training, model lifecycle actions, deployment,
+and activation each require separate post-merge authorization.

--- a/docs/agent_tasks/p7_model_02_forward_sealed_corpus_capture_clean_20260728.md
+++ b/docs/agent_tasks/p7_model_02_forward_sealed_corpus_capture_clean_20260728.md
@@ -1,0 +1,98 @@
+---
+job_id: P7_MODEL_02_FORWARD_SEALED_CORPUS_CAPTURE_CLEAN_20260728
+title: Prospectively capture and close authentic Phase 7 training evidence
+lane: Provenance
+supporting_lanes:
+  - Architecture
+  - Evaluation
+  - Repo Hygiene
+owner: Codex
+approval_required: true
+approval_source: "Owner /goal request on 2026-07-28 authorizes bounded repository implementation, validation, commit, push, and one draft PR; the owner then authorized a clean sibling."
+allow_unapproved_safe_extension: false
+timeout_seconds: 28800
+mutation_mode: safe_extension
+base: origin/master
+production_data_access: false
+production_data_boundary: "No live capture, historical reconstruction, database mutation, service/timer action, training, calibration, model export, bundle registration, prediction, promotion, betting, deployment, activation, merge, or other runtime action."
+github_mutation_allowed: true
+git_history_mutation_allowed: true
+live_service_mutation_allowed: false
+closeout_scope: repo_only
+docs_impact: DOCS_REQUIRED
+task_tier: large
+recommended_model: high_reasoning
+actual_model: gpt-5
+worker_model_allowed: false
+worker_decision_limit: "No subagents or delegated implementation; final provenance and publication decisions remain with the primary agent."
+escalation_needed: false
+output_dir: reports/agent_jobs/P7_MODEL_02_FORWARD_SEALED_CORPUS_CAPTURE_CLEAN_20260728
+allowed_files:
+  - docs/FORWARD_SEALED_CORPUS_CAPTURE.md
+  - docs/CANONICAL_RACE_FORECASTING_PHASE5.md
+  - docs/agent_tasks/p7_model_02_forward_sealed_corpus_capture_clean_20260728.md
+  - race_collection/forward_sealed_corpus.py
+  - race_collection/source_admission.py
+  - scripts/collect_forward_sealed_corpus.py
+  - tests/race_collection/test_forward_sealed_corpus.py
+  - tests/race_collection/test_phase7_source_admission.py
+  - reports/agent_jobs/P7_MODEL_02_FORWARD_SEALED_CORPUS_CAPTURE_CLEAN_20260728/README.md
+  - reports/agent_jobs/P7_MODEL_02_FORWARD_SEALED_CORPUS_CAPTURE_CLEAN_20260728/STATE.md
+  - reports/agent_jobs/P7_MODEL_02_FORWARD_SEALED_CORPUS_CAPTURE_CLEAN_20260728/VALIDATION.md
+  - reports/agent_jobs/P7_MODEL_02_FORWARD_SEALED_CORPUS_CAPTURE_CLEAN_20260728/REVIEW.md
+  - reports/agent_jobs/P7_MODEL_02_FORWARD_SEALED_CORPUS_CAPTURE_CLEAN_20260728/CODE_REVIEW.json
+  - reports/agent_jobs/P7_MODEL_02_FORWARD_SEALED_CORPUS_CAPTURE_CLEAN_20260728/guard-preflight.json
+  - reports/agent_jobs/P7_MODEL_02_FORWARD_SEALED_CORPUS_CAPTURE_CLEAN_20260728/status.json
+  - reports/agent_jobs/P7_MODEL_02_FORWARD_SEALED_CORPUS_CAPTURE_CLEAN_20260728/RUN_OUTCOME.json
+  - reports/agent_jobs/P7_MODEL_02_FORWARD_SEALED_CORPUS_CAPTURE_CLEAN_20260728/DECISION_ENTRY.json
+  - reports/agent_jobs/P7_MODEL_02_FORWARD_SEALED_CORPUS_CAPTURE_CLEAN_20260728/pr-body.md
+control_contract_version: 2
+project_id: greyhound_racing_collector
+claim_id: P7_MODEL_02_FORWARD_SEALED_CORPUS_CAPTURE_CLEAN_20260728
+proof_question: Can the repository prospectively bind immutable pre-jump raw source bytes, production sealed features, and later official-result bytes into deterministic forward-sealed training packages accepted by source admission, without exposing outcomes to feature derivation or performing live/runtime/model actions?
+hypothesis_id: phase7_forward_sealed_corpus_capture_clean_exact_base
+program_track: offline_development
+entry_state: owner_authorized_clean_exact_origin_master_9544d5ce_after_pr68_source_admission_merge
+target_transition: one_clean_draft_pr_adds_a_repository_only_forward_sealed_capture_and_closure_pipeline_with_synthetic_admission_proof_and_fail_closed_real_source_timestamp_boundary
+exit_predicate: The exact origin/master base and tree are verified; the diff remains inside allowed_files; synthetic end-to-end closure passes source admission; ordering, leakage, identity, runner, hash, crash recovery, idempotence, duplicate closure, deterministic reorder, focused Phase 4/5/6, source-admission, format, compile, schema, and diff checks pass; a fresh read-only review has no critical or warning findings; one exact commit is pushed and one draft PR is opened; no live capture, runtime/data/model/training/deployment/activation/merge action occurs.
+source_class: exact_origin_master_9544d5ce_tree_46d6a4e8_plus_owner_contract_and_merged_pr68_source_admission
+dataset_version: p7_model_02_repository_synthetic_validation_clean_20260728
+evidence_hash: sha256:4d7c5be001bb75c7dbe226e1562c3c196a81379911327ff58d20c86350bf75c8
+capabilities:
+  - READ
+  - REPORT_WRITE
+  - CODE_EDIT
+  - PUBLISH
+resume_only_if: Resume only while origin/master remains 9544d5ce383df0c5bedb7180d890d64fa55ad661 or any movement is disjoint from the allowed product files; the clean worktree remains task-owned; and no active claim, branch, worktree, issue, or PR overlaps this target transition.
+---
+
+# P7 Model 02 forward-sealed corpus capture
+
+Implement the smallest repository-supported, append-only prospective recorder
+over the existing Race Collection Service ordering, source adapters,
+content-addressed artifact store, collector schedules and locks, and atomic
+publication patterns.
+
+Pre-jump capture must bind canonical source URLs, source-native race and runner
+identities, immutable raw bytes, normalized sealed evidence, production feature
+schema and missingness policy, deterministic feature bytes, and prospective
+timestamps. Official result capture occurs only after jump and must preserve
+raw bytes, aligned source-native identities, collector observation time, and a
+source-declared publication timestamp when available. TheDogs' absent
+publication timestamp must remain an explicit non-closure state, never an
+inferred value.
+
+Only a complete, hash-consistent A+B+C record may publish immutable
+`historical-training-example-v1` bytes and a deterministic package accepted by
+`race_collection.source_admission`. The bounded CLI executes at most one
+supplied canonical collection iteration or reports status. It must not install
+or start a service or timer.
+
+## Hard stops
+
+- No live capture or external source access in this run.
+- No database, service, timer, label, model, training, prediction, calibration,
+  registration, promotion, betting, deployment, activation, merge, or runtime
+  action.
+- No historical reconstruction or timestamp inference.
+- No parallel scraper or widening beyond the declared files.

--- a/race_collection/forward_sealed_corpus.py
+++ b/race_collection/forward_sealed_corpus.py
@@ -1,0 +1,861 @@
+"""Append-only prospective capture for authentic Phase 7 training evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import unicodedata
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from .artifacts import ArtifactStoreError, LocalArtifactStore
+from .domain import ArtifactChecksum, require_aware
+from .features import FeatureQuarantine, derive_features
+from .model_bundle import SUPPORTED_FEATURE_CONTRACT
+
+FORWARD_CORPUS_ORIGIN = "forward-sealed-corpus-v1"
+SOURCE_CAPTURE_SCHEMA = "forward-source-capture-v1"
+RESULT_SCHEMA = "official-forward-result-v1"
+PREJUMP_RECEIPT_SCHEMA = "forward-prejump-receipt-v1"
+RESULT_RECEIPT_SCHEMA = "forward-result-receipt-v1"
+CLOSURE_RECEIPT_SCHEMA = "forward-race-closure-v1"
+STATUS_SCHEMA = "forward-sealed-corpus-status-v1"
+
+_RESULT_DERIVED_KEYS = {
+    "finish_order",
+    "finish_position",
+    "place",
+    "position",
+    "result",
+    "result_order",
+    "winner",
+}
+
+
+class ForwardCorpusRejected(ValueError):
+    """Prospective evidence cannot be truthfully captured or closed."""
+
+
+@dataclass(frozen=True, slots=True)
+class ClosedPackage:
+    package_bytes: bytes
+    package_checksum: ArtifactChecksum
+    manifest_checksum: ArtifactChecksum
+    artifacts: Mapping[str, bytes]
+
+
+def canonical_json(value: Any) -> bytes:
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    except (TypeError, ValueError) as error:
+        raise ForwardCorpusRejected("value is not exact JSON") from error
+
+
+def _checksum(content: bytes) -> ArtifactChecksum:
+    return LocalArtifactStore.checksum(content)
+
+
+def _canonical_object(content: bytes, name: str) -> dict[str, Any]:
+    if type(content) is not bytes:
+        raise ForwardCorpusRejected(f"{name} must be exact bytes")
+    try:
+        value = json.loads(content)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ForwardCorpusRejected(f"{name} is not valid JSON") from error
+    if type(value) is not dict or canonical_json(value) != content:
+        raise ForwardCorpusRejected(f"{name} must be one canonical JSON object")
+    return value
+
+
+def _known_text(value: Any, name: str) -> str:
+    if (
+        type(value) is not str
+        or not value
+        or value != value.strip()
+        or value.casefold() == "unknown"
+        or any(unicodedata.category(character).startswith("C") for character in value)
+    ):
+        raise ForwardCorpusRejected(f"{name} is missing or ambiguous")
+    return value
+
+
+def _identity_key(value: Any, name: str) -> str:
+    identity = _known_text(value, name)
+    normalized = unicodedata.normalize("NFKC", " ".join(identity.split())).casefold()
+    if not normalized:
+        raise ForwardCorpusRejected(f"{name} is missing or ambiguous")
+    return normalized
+
+
+def _timestamp(value: Any, name: str) -> tuple[datetime, str]:
+    if type(value) is not str:
+        raise ForwardCorpusRejected(f"{name} timestamp is invalid")
+    try:
+        parsed = datetime.fromisoformat(value)
+        require_aware(parsed, name)
+    except (TypeError, ValueError) as error:
+        raise ForwardCorpusRejected(f"{name} timestamp is invalid") from error
+    return parsed, parsed.isoformat(timespec="microseconds")
+
+
+def _source_url(value: Any, name: str) -> str:
+    url = _known_text(value, name)
+    parsed = urlsplit(url)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+    ):
+        raise ForwardCorpusRejected(f"{name} is not a canonical source URL")
+    return url
+
+
+def _reject_result_derived(value: Any) -> None:
+    if type(value) is dict:
+        for key, nested in value.items():
+            if type(key) is str and key.casefold() in _RESULT_DERIVED_KEYS:
+                raise ForwardCorpusRejected("pre-jump evidence contains a result-derived field")
+            _reject_result_derived(nested)
+    elif type(value) is list:
+        for nested in value:
+            _reject_result_derived(nested)
+
+
+def _metadata(value: Any, name: str) -> dict[str, Any]:
+    if type(value) is not dict or not value:
+        raise ForwardCorpusRejected(f"{name} must be a non-empty object")
+    canonical_json(value)
+    _reject_result_derived(value)
+    return dict(value)
+
+
+def _runner_rows(values: Any) -> tuple[dict[str, str], ...]:
+    if type(values) not in {list, tuple} or len(values) < 2:
+        raise ForwardCorpusRejected("source-native runner identities are incomplete")
+    rows: list[dict[str, str]] = []
+    keys: set[str] = set()
+    for value in values:
+        if type(value) is not dict or set(value) != {"source_native_runner_id", "name"}:
+            raise ForwardCorpusRejected("source-native runner identity envelope is invalid")
+        runner_id = _known_text(value["source_native_runner_id"], "source-native runner id")
+        name = _known_text(value["name"], "runner name")
+        key = _identity_key(runner_id, "source-native runner id")
+        if key in keys:
+            raise ForwardCorpusRejected("duplicate normalized source-native runner identity")
+        keys.add(key)
+        rows.append({"source_native_runner_id": runner_id, "name": name})
+    return tuple(
+        sorted(
+            rows,
+            key=lambda row: _identity_key(
+                row["source_native_runner_id"], "source-native runner id"
+            ),
+        )
+    )
+
+
+class ForwardSealedCorpus:
+    """Immutable object store plus append-only per-race stage receipts."""
+
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ):
+        self.root = Path(root).resolve()
+        self.artifacts = LocalArtifactStore(self.root / "artifacts")
+        self._clock = clock or (lambda: datetime.now().astimezone())
+
+    def _race_directory(self, race_id: str) -> Path:
+        identity = _identity_key(race_id, "race_id").encode()
+        return self.root / "races" / hashlib.sha256(identity).hexdigest()
+
+    def _receipt_path(self, race_id: str, stage: str) -> Path:
+        return self._race_directory(race_id) / f"{stage}.json"
+
+    @staticmethod
+    def _publish_once(path: Path, content: bytes) -> bool:
+        """Publish once without an overwrite window; exact retries are no-ops."""
+        try:
+            anchor = next(parent for parent in path.parents if parent.name in {"races", "packages"})
+        except StopIteration as error:
+            raise ForwardCorpusRejected("receipt path escapes the corpus root") from error
+        root = anchor.parent
+        root.mkdir(parents=True, exist_ok=True)
+        current = root
+        for part in path.parent.relative_to(root).parts:
+            current /= part
+            if current.is_symlink():
+                raise ForwardCorpusRejected("receipt directories must not be symlinks")
+            current.mkdir(exist_ok=True)
+        if path.exists():
+            if path.is_symlink() or path.read_bytes() != content:
+                raise ForwardCorpusRejected(f"append-only receipt conflict: {path.name}")
+            return False
+        descriptor, temporary_name = tempfile.mkstemp(prefix=".incoming-", dir=path.parent)
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(descriptor, "wb") as output:
+                output.write(content)
+                output.flush()
+                os.fsync(output.fileno())
+            try:
+                os.link(temporary, path)
+            except FileExistsError:
+                if path.is_symlink() or path.read_bytes() != content:
+                    raise ForwardCorpusRejected(f"append-only receipt conflict: {path.name}")
+                return False
+            directory_fd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+            return True
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    def _load_receipt(self, race_id: str, stage: str) -> dict[str, Any] | None:
+        path = self._receipt_path(race_id, stage)
+        try:
+            content = path.read_bytes()
+        except FileNotFoundError:
+            return None
+        if path.is_symlink():
+            raise ForwardCorpusRejected(f"{stage} receipt must not be a symlink")
+        return _canonical_object(content, f"{stage} receipt")
+
+    def _read_artifact(self, value: Any, name: str) -> bytes:
+        if type(value) is not str:
+            raise ForwardCorpusRejected(f"{name} checksum is invalid")
+        try:
+            return self.artifacts.read(ArtifactChecksum(value))
+        except (ArtifactStoreError, ValueError) as error:
+            raise ForwardCorpusRejected(f"{name} bytes are missing or have hash drift") from error
+
+    def capture_prejump(
+        self,
+        *,
+        race_id: str,
+        racing_date: str,
+        raw_source_bytes: bytes,
+        sealed_evidence_bytes: bytes,
+        feature_schema_bytes: bytes,
+        missingness_policy_bytes: bytes,
+        source_name: str,
+        canonical_source_url: str,
+        source_native_race_id: str,
+        runners: Sequence[Mapping[str, str]],
+        meeting_metadata: Mapping[str, Any],
+        race_metadata: Mapping[str, Any],
+        source_observed_at: str,
+        feature_frozen_at: str,
+        scheduled_jump_at: str,
+    ) -> dict[str, Any]:
+        """Capture source and production feature evidence without an outcome input."""
+        race_id = _known_text(race_id, "race_id")
+        source_name = _known_text(source_name, "source name")
+        canonical_source_url = _source_url(canonical_source_url, "canonical source URL")
+        source_native_race_id = _known_text(source_native_race_id, "source-native race identity")
+        runner_rows = _runner_rows(runners)
+        meeting = _metadata(meeting_metadata, "meeting metadata")
+        race = _metadata(race_metadata, "race metadata")
+        if type(raw_source_bytes) is not bytes or not raw_source_bytes:
+            raise ForwardCorpusRejected("immutable raw source bytes are required")
+
+        observed_at, observed_text = _timestamp(source_observed_at, "source observed_at")
+        frozen_at, frozen_text = _timestamp(feature_frozen_at, "feature frozen_at")
+        jump_at, jump_text = _timestamp(scheduled_jump_at, "scheduled jump")
+        if not observed_at <= frozen_at < jump_at:
+            raise ForwardCorpusRejected("pre-jump source/feature temporal order is invalid")
+        try:
+            race_day = date.fromisoformat(racing_date)
+        except (TypeError, ValueError) as error:
+            raise ForwardCorpusRejected("racing date is invalid") from error
+        if race_day != jump_at.date():
+            raise ForwardCorpusRejected("racing date and scheduled jump disagree")
+
+        evidence = _canonical_object(sealed_evidence_bytes, "sealed race evidence")
+        schema = _canonical_object(feature_schema_bytes, "feature schema")
+        policy = _canonical_object(missingness_policy_bytes, "missingness policy")
+        _reject_result_derived(evidence)
+        bundle_id = _known_text(schema.get("bundle_id"), "target bundle identity")
+        if (
+            set(evidence)
+            != {
+                "schema_version",
+                "normalization_version",
+                "race_id",
+                "fields",
+                "field_provenance",
+                "freeze",
+            }
+            or set(schema)
+            != {
+                "bundle_id",
+                "contract_version",
+                "evidence_schema_version",
+                "normalization_version",
+                "fields",
+            }
+            or set(policy) != {"bundle_id", "feature_contract_version", "imputation"}
+            or schema.get("contract_version") != SUPPORTED_FEATURE_CONTRACT
+            or policy.get("feature_contract_version") != SUPPORTED_FEATURE_CONTRACT
+            or policy.get("bundle_id") != bundle_id
+            or evidence.get("race_id") != race_id
+            or evidence.get("schema_version") != schema.get("evidence_schema_version")
+            or evidence.get("normalization_version") != schema.get("normalization_version")
+        ):
+            raise ForwardCorpusRejected("sealed evidence identity or feature schema disagrees")
+        contract_fields = schema.get("fields")
+        if type(contract_fields) is not list or not contract_fields:
+            raise ForwardCorpusRejected("feature schema fields are invalid")
+        for field in contract_fields:
+            if type(field) is not dict or set(field) != (
+                {"name", "source_field", "semantics", "encoded_value"}
+                if field.get("semantics") == "inapplicable"
+                else {"name", "source_field", "semantics"}
+            ):
+                raise ForwardCorpusRejected("feature schema field envelope is unsupported")
+        freeze = evidence.get("freeze")
+        try:
+            if set(freeze) != {"at", "authority", "odds_checksum"}:
+                raise ForwardCorpusRejected("sealed evidence freeze provenance is incomplete")
+            evidence_freeze, _ = _timestamp(freeze["at"], "sealed evidence freeze")
+            _known_text(freeze["authority"], "sealed evidence freeze authority")
+            ArtifactChecksum(freeze["odds_checksum"])
+        except (KeyError, TypeError, ValueError) as error:
+            raise ForwardCorpusRejected(
+                "sealed evidence freeze provenance is incomplete"
+            ) from error
+        if evidence_freeze != frozen_at:
+            raise ForwardCorpusRejected("sealed evidence and feature freeze timestamps disagree")
+        fields = evidence.get("fields")
+        if type(fields) is not dict:
+            raise ForwardCorpusRejected("sealed evidence fields are incomplete")
+        runner_ids = [row["source_native_runner_id"] for row in runner_rows]
+        if fields.get("runner_set") != runner_ids:
+            raise ForwardCorpusRejected(
+                "sealed evidence and source-native runner identities disagree"
+            )
+        identities = fields.get("runner_identity")
+        if (
+            type(identities) is not dict
+            or set(identities) != set(runner_ids)
+            or any(identities[runner_id] != "authoritative" for runner_id in runner_ids)
+        ):
+            raise ForwardCorpusRejected("sealed evidence runner identity is ambiguous")
+
+        raw_source = self.artifacts.put(
+            raw_source_bytes, media_type="application/octet-stream"
+        ).checksum
+        provenance = evidence.get("field_provenance")
+        required_bindings = {"runner_set", "runner_identity", "runner_features"}
+        if type(provenance) is not list or not provenance:
+            raise ForwardCorpusRejected("sealed feature source bindings are incomplete")
+        bound_fields = set()
+        for item in provenance:
+            if type(item) is not dict or set(item) != {
+                "field",
+                "authority",
+                "critical",
+                "value",
+                "source",
+                "artifact_checksum",
+            }:
+                raise ForwardCorpusRejected("sealed feature source binding is invalid")
+            try:
+                ArtifactChecksum(item["artifact_checksum"])
+            except (KeyError, ValueError) as error:
+                raise ForwardCorpusRejected(
+                    "sealed feature source binding checksum is invalid"
+                ) from error
+            _known_text(item.get("field"), "sealed feature source binding field")
+            _known_text(item.get("authority"), "sealed feature source binding authority")
+            _known_text(item.get("source"), "sealed feature source binding source")
+            if type(item.get("critical")) is not bool:
+                raise ForwardCorpusRejected("sealed feature source binding criticality is invalid")
+            if (
+                item.get("field") in required_bindings
+                and item.get("artifact_checksum") == str(raw_source)
+                and item.get("source") == source_name
+                and item.get("value") == fields.get(item["field"])
+            ):
+                bound_fields.add(item["field"])
+        if bound_fields != required_bindings:
+            raise ForwardCorpusRejected(
+                "runner feature evidence is not bound to the preserved raw source bytes"
+            )
+        sealed_evidence = self.artifacts.put(
+            sealed_evidence_bytes, media_type="application/json"
+        ).checksum
+        feature_schema = self.artifacts.put(
+            feature_schema_bytes, media_type="application/json"
+        ).checksum
+        missingness_policy = self.artifacts.put(
+            missingness_policy_bytes, media_type="application/json"
+        ).checksum
+        try:
+            derived = derive_features(
+                sealed_evidence_bytes,
+                expected_evidence_checksum=sealed_evidence,
+                schema_bytes=feature_schema_bytes,
+                expected_schema_checksum=feature_schema,
+                missingness_policy_bytes=missingness_policy_bytes,
+                expected_missingness_checksum=missingness_policy,
+            )
+        except (FeatureQuarantine, ValueError) as error:
+            raise ForwardCorpusRejected(str(error)) from error
+        if list(derived.matrix.runner_ids) != runner_ids:
+            raise ForwardCorpusRejected(
+                "feature matrix and source-native runner identities disagree"
+            )
+        matrix_bytes = canonical_json(
+            {
+                "runner_ids": list(derived.matrix.runner_ids),
+                "columns": list(derived.matrix.columns),
+                "rows": [list(row) for row in derived.matrix.rows],
+            }
+        )
+        feature_matrix = self.artifacts.put(
+            matrix_bytes,
+            media_type="application/json",
+            expected_checksum=derived.matrix.checksum,
+        ).checksum
+
+        source_capture_bytes = canonical_json(
+            {
+                "schema_version": SOURCE_CAPTURE_SCHEMA,
+                "race_id": race_id,
+                "racing_date": racing_date,
+                "source_name": source_name,
+                "canonical_source_url": canonical_source_url,
+                "source_native_race_id": source_native_race_id,
+                "meeting_metadata": meeting,
+                "race_metadata": race,
+                "scheduled_jump_at": jump_text,
+                "source_observed_at": observed_text,
+                "feature_frozen_at": frozen_text,
+                "raw_source_checksum": str(raw_source),
+                "sealed_evidence_checksum": str(sealed_evidence),
+                "runners": list(runner_rows),
+                "identity_authority": "source-native",
+                "reconstructed": False,
+            }
+        )
+        source_capture = self.artifacts.put(
+            source_capture_bytes, media_type="application/json"
+        ).checksum
+        receipt = {
+            "schema_version": PREJUMP_RECEIPT_SCHEMA,
+            "race_id": race_id,
+            "racing_date": racing_date,
+            "target_bundle_id": bundle_id,
+            "source_native_race_id": source_native_race_id,
+            "runner_ids": runner_ids,
+            "source_observed_at": observed_text,
+            "feature_frozen_at": frozen_text,
+            "scheduled_jump_at": jump_text,
+            "raw_source_checksum": str(raw_source),
+            "source_checksum": str(sealed_evidence),
+            "source_capture_checksum": str(source_capture),
+            "feature_schema_checksum": str(feature_schema),
+            "missingness_policy_checksum": str(missingness_policy),
+            "feature_matrix_checksum": str(feature_matrix),
+        }
+        existing_receipt = self._load_receipt(race_id, "prejump")
+        if existing_receipt is None:
+            captured_at = self._clock()
+            try:
+                if type(captured_at) is not datetime:
+                    raise TypeError
+                require_aware(captured_at, "collector pre-jump capture")
+            except (TypeError, ValueError) as error:
+                raise ForwardCorpusRejected(
+                    "collector pre-jump capture timestamp is invalid"
+                ) from error
+            if not frozen_at <= captured_at < jump_at:
+                raise ForwardCorpusRejected(
+                    "collector did not publish the pre-jump receipt prospectively"
+                )
+        self._publish_once(self._receipt_path(race_id, "prejump"), canonical_json(receipt))
+        return receipt
+
+    def _result_observations(self, race_id: str) -> list[dict[str, Any]]:
+        directory = self._race_directory(race_id) / "result-observations"
+        if not directory.exists():
+            return []
+        observations = []
+        for path in sorted(directory.glob("*.json")):
+            if path.is_symlink():
+                raise ForwardCorpusRejected("result observation receipt must not be a symlink")
+            observation = _canonical_object(path.read_bytes(), "result observation receipt")
+            self._read_artifact(
+                observation.get("raw_result_checksum"),
+                "observed raw official result",
+            )
+            observations.append(observation)
+        return observations
+
+    def capture_result(
+        self,
+        *,
+        race_id: str,
+        raw_result_bytes: bytes,
+        source_name: str,
+        canonical_source_url: str,
+        source_native_race_id: str,
+        runners: Sequence[Mapping[str, str]],
+        official_order: Sequence[str],
+        result_observed_at: str,
+        result_published_at: str | None,
+        publication_timestamp_status: str,
+    ) -> dict[str, Any]:
+        """Capture an official result and close only with a source-declared timestamp."""
+        race_id = _known_text(race_id, "race_id")
+        pre = self._load_receipt(race_id, "prejump")
+        if pre is None:
+            raise ForwardCorpusRejected("pre-jump evidence must exist before result capture")
+        existing_result = self._load_receipt(race_id, "result")
+        if existing_result is not None and publication_timestamp_status != "source-declared":
+            raise ForwardCorpusRejected("closed result cannot accept another observation")
+        if existing_result is not None:
+            for field in ("raw_result_checksum", "official_result_checksum"):
+                self._read_artifact(existing_result.get(field), field)
+        for field in (
+            "raw_source_checksum",
+            "source_checksum",
+            "source_capture_checksum",
+            "feature_schema_checksum",
+            "missingness_policy_checksum",
+            "feature_matrix_checksum",
+        ):
+            self._read_artifact(pre[field], field)
+        if type(raw_result_bytes) is not bytes or not raw_result_bytes:
+            raise ForwardCorpusRejected("immutable official-result source bytes are required")
+        source_name = _known_text(source_name, "official result source")
+        canonical_source_url = _source_url(
+            canonical_source_url, "official result canonical source URL"
+        )
+        source_native_race_id = _known_text(
+            source_native_race_id, "official result source-native race identity"
+        )
+        if source_native_race_id != pre["source_native_race_id"]:
+            raise ForwardCorpusRejected("source-native race identity mismatch")
+        runner_rows = _runner_rows(runners)
+        runner_ids = [row["source_native_runner_id"] for row in runner_rows]
+        if runner_ids != pre["runner_ids"]:
+            raise ForwardCorpusRejected("official result runner drift")
+        source_capture = _canonical_object(
+            self._read_artifact(pre["source_capture_checksum"], "source capture"),
+            "source capture",
+        )
+        if list(runner_rows) != source_capture.get("runners"):
+            raise ForwardCorpusRejected("official result runner identity or name drift")
+        if type(official_order) not in {list, tuple}:
+            raise ForwardCorpusRejected("official result order is incomplete")
+        ordered = [_known_text(value, "official runner identity") for value in official_order]
+        if len(ordered) != len(set(ordered)) or set(ordered) != set(runner_ids):
+            raise ForwardCorpusRejected("official result and pre-jump runner sets disagree")
+
+        jump_at, _ = _timestamp(pre["scheduled_jump_at"], "scheduled jump")
+        observed_at, observed_text = _timestamp(result_observed_at, "result observed_at")
+        if not jump_at < observed_at:
+            raise ForwardCorpusRejected("official result observation must be after jump")
+        raw_checksum = _checksum(raw_result_bytes)
+        if existing_result is not None and existing_result.get("raw_result_checksum") != str(
+            raw_checksum
+        ):
+            raise ForwardCorpusRejected("official result raw-byte hash drift")
+        prior_observations = self._result_observations(race_id)
+        if prior_observations and any(
+            item["raw_result_checksum"] != str(raw_checksum) for item in prior_observations
+        ):
+            raise ForwardCorpusRejected("official result raw-byte hash drift")
+        if prior_observations and any(
+            item[field] != expected
+            for item in prior_observations
+            for field, expected in (
+                ("source_name", source_name),
+                ("canonical_source_url", canonical_source_url),
+                ("source_native_race_id", source_native_race_id),
+                ("runner_ids", runner_ids),
+                ("official_order", ordered),
+            )
+        ):
+            raise ForwardCorpusRejected("official result observation provenance drift")
+
+        if publication_timestamp_status == "not-exposed-by-source":
+            if result_published_at is not None:
+                raise ForwardCorpusRejected(
+                    "unavailable result publication timestamp cannot have a value"
+                )
+            raw_result = self.artifacts.put(
+                raw_result_bytes, media_type="application/octet-stream"
+            ).checksum
+            observation = {
+                "schema_version": "forward-result-observation-v1",
+                "race_id": race_id,
+                "source_name": source_name,
+                "canonical_source_url": canonical_source_url,
+                "source_native_race_id": source_native_race_id,
+                "runner_ids": runner_ids,
+                "official_order": ordered,
+                "result_observed_at": observed_text,
+                "result_published_at": None,
+                "publication_timestamp_status": publication_timestamp_status,
+                "raw_result_checksum": str(raw_result),
+                "identity_authority": "source-native",
+                "reconstructed": False,
+                "closure_decision": "BLOCKED_RESULT_PUBLICATION_TIMESTAMP",
+            }
+            content = canonical_json(observation)
+            path = (
+                self._race_directory(race_id)
+                / "result-observations"
+                / f"{_checksum(content).hex_digest}.json"
+            )
+            self._publish_once(path, content)
+            return observation
+        if publication_timestamp_status != "source-declared":
+            raise ForwardCorpusRejected("result publication timestamp status is unsupported")
+        published_at, published_text = _timestamp(result_published_at, "result published_at")
+        if not jump_at < published_at <= observed_at:
+            raise ForwardCorpusRejected("official result temporal order is invalid")
+
+        raw_result = self.artifacts.put(
+            raw_result_bytes, media_type="application/octet-stream"
+        ).checksum
+        result_bytes = canonical_json(
+            {
+                "schema_version": RESULT_SCHEMA,
+                "race_id": race_id,
+                "official": True,
+                "order": ordered,
+                "published_at": published_text,
+                "exclusions": [],
+                "runner_names": {
+                    row["source_native_runner_id"]: row["name"] for row in runner_rows
+                },
+                "provenance": {
+                    "source": source_name,
+                    "canonical_source_url": canonical_source_url,
+                    "source_native_race_id": source_native_race_id,
+                    "observed_at": observed_text,
+                    "publication_timestamp_status": "source-declared",
+                    "raw_result_checksum": str(raw_result),
+                    "identity_authority": "source-native",
+                    "reconstructed": False,
+                },
+            }
+        )
+        official_result = self.artifacts.put(result_bytes, media_type="application/json").checksum
+        result_receipt = {
+            "schema_version": RESULT_RECEIPT_SCHEMA,
+            "race_id": race_id,
+            "runner_ids": runner_ids,
+            "official_order": ordered,
+            "result_published_at": published_text,
+            "result_observed_at": observed_text,
+            "raw_result_checksum": str(raw_result),
+            "official_result_checksum": str(official_result),
+        }
+        self._publish_once(self._receipt_path(race_id, "result"), canonical_json(result_receipt))
+        return self._close(pre, result_receipt)
+
+    def _close(
+        self,
+        pre: Mapping[str, Any],
+        result: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        race_id = pre["race_id"]
+        if result["race_id"] != race_id or result["runner_ids"] != pre["runner_ids"]:
+            raise ForwardCorpusRejected("race closure identity mismatch")
+        for field in (
+            "raw_result_checksum",
+            "official_result_checksum",
+        ):
+            self._read_artifact(result[field], field)
+        training_example_id = (
+            "forward-sealed-"
+            + hashlib.sha256(f"{race_id}\0{pre['source_native_race_id']}".encode()).hexdigest()
+        )
+        race_entry = {
+            "training_example_id": training_example_id,
+            "race_id": race_id,
+            "racing_date": pre["racing_date"],
+            "source_checksum": pre["source_checksum"],
+            "source_capture_checksum": pre["source_capture_checksum"],
+            "raw_source_checksum": pre["raw_source_checksum"],
+            "official_result_checksum": result["official_result_checksum"],
+            "raw_result_checksum": result["raw_result_checksum"],
+            "feature_matrix_checksum": pre["feature_matrix_checksum"],
+            "runner_ids": pre["runner_ids"],
+            "source_observed_at": pre["source_observed_at"],
+            "feature_observed_at": pre["feature_frozen_at"],
+            "scheduled_jump_at": pre["scheduled_jump_at"],
+            "result_published_at": result["result_published_at"],
+            "result_observed_at": result["result_observed_at"],
+        }
+        artifact_bytes = canonical_json(
+            {
+                "schema_version": "historical-training-example-v1",
+                "origin": FORWARD_CORPUS_ORIGIN,
+                "forward_sealed": True,
+                "promotion_evidence_eligible": False,
+                **race_entry,
+                "official_order": result["official_order"],
+            }
+        )
+        artifact_checksum = self.artifacts.put(
+            artifact_bytes, media_type="application/json"
+        ).checksum
+        race_entry["artifact_checksum"] = str(artifact_checksum)
+        closure = {
+            "schema_version": CLOSURE_RECEIPT_SCHEMA,
+            "race_id": race_id,
+            "target_bundle_id": pre["target_bundle_id"],
+            "feature_schema_checksum": pre["feature_schema_checksum"],
+            "missingness_policy_checksum": pre["missingness_policy_checksum"],
+            "race": race_entry,
+        }
+        self._publish_once(self._receipt_path(race_id, "closure"), canonical_json(closure))
+        return closure
+
+    def _closures(self) -> list[dict[str, Any]]:
+        directory = self.root / "races"
+        if not directory.exists():
+            return []
+        closures = []
+        for path in sorted(directory.glob("*/closure.json")):
+            if path.is_symlink():
+                raise ForwardCorpusRejected("closure receipt must not be a symlink")
+            closures.append(_canonical_object(path.read_bytes(), "closure receipt"))
+        return sorted(
+            closures,
+            key=lambda item: _identity_key(item["race_id"], "race_id"),
+        )
+
+    def build_package(self) -> ClosedPackage:
+        """Build and persist one deterministic package from every closed race."""
+        closures = self._closures()
+        if not closures:
+            raise ForwardCorpusRejected("no closed races are available")
+        bundle_ids = {item["target_bundle_id"] for item in closures}
+        schema_checksums = {item["feature_schema_checksum"] for item in closures}
+        policy_checksums = {item["missingness_policy_checksum"] for item in closures}
+        if len(bundle_ids) != 1 or len(schema_checksums) != 1 or len(policy_checksums) != 1:
+            raise ForwardCorpusRejected("closed races use different feature contracts")
+        races = [item["race"] for item in closures]
+        manifest = {
+            "schema_version": "historical-source-manifest-v1",
+            "corpus_origin": FORWARD_CORPUS_ORIGIN,
+            "target_bundle_id": next(iter(bundle_ids)),
+            "feature_schema_checksum": next(iter(schema_checksums)),
+            "missingness_policy_checksum": next(iter(policy_checksums)),
+            "races": races,
+        }
+        manifest_bytes = canonical_json(manifest)
+        manifest_checksum = _checksum(manifest_bytes)
+        package_bytes = canonical_json(
+            {
+                "schema_version": "historical-source-package-v1",
+                "manifest_checksum": str(manifest_checksum),
+                "manifest": manifest,
+            }
+        )
+        package_checksum = _checksum(package_bytes)
+        declared = {
+            str(manifest["feature_schema_checksum"]),
+            str(manifest["missingness_policy_checksum"]),
+            *{
+                race[field]
+                for race in races
+                for field in (
+                    "source_checksum",
+                    "source_capture_checksum",
+                    "raw_source_checksum",
+                    "official_result_checksum",
+                    "raw_result_checksum",
+                    "feature_matrix_checksum",
+                    "artifact_checksum",
+                )
+            },
+        }
+        artifacts = {
+            checksum: self._read_artifact(checksum, "package artifact")
+            for checksum in sorted(declared)
+        }
+        from .source_admission import admit_historical_source
+
+        admit_historical_source(package_bytes, artifacts=artifacts)
+        self.artifacts.put(
+            package_bytes,
+            media_type="application/json",
+            expected_checksum=package_checksum,
+        )
+        package_path = self.root / "packages" / f"{manifest_checksum.hex_digest}.json"
+        self._publish_once(package_path, package_bytes)
+        return ClosedPackage(
+            package_bytes,
+            package_checksum,
+            manifest_checksum,
+            artifacts,
+        )
+
+    def status(self) -> dict[str, Any]:
+        """Return deterministic state while verifying all referenced immutable bytes."""
+        directory = self.root / "races"
+        rows = []
+        if directory.exists():
+            for race_directory in sorted(path for path in directory.iterdir() if path.is_dir()):
+                pre_path = race_directory / "prejump.json"
+                if not pre_path.exists():
+                    continue
+                if pre_path.is_symlink():
+                    raise ForwardCorpusRejected("prejump receipt must not be a symlink")
+                pre = _canonical_object(pre_path.read_bytes(), "prejump receipt")
+                state = "PREJUMP_CAPTURED"
+                for field in (
+                    "raw_source_checksum",
+                    "source_checksum",
+                    "source_capture_checksum",
+                    "feature_schema_checksum",
+                    "missingness_policy_checksum",
+                    "feature_matrix_checksum",
+                ):
+                    self._read_artifact(pre[field], field)
+                result = self._load_receipt(pre["race_id"], "result")
+                closure = self._load_receipt(pre["race_id"], "closure")
+                blocked = self._result_observations(pre["race_id"])
+                if result is not None:
+                    for field in ("raw_result_checksum", "official_result_checksum"):
+                        self._read_artifact(result[field], field)
+                    state = "RESULT_CAPTURED"
+                if blocked and result is None:
+                    state = "BLOCKED_RESULT_PUBLICATION_TIMESTAMP"
+                if closure is not None:
+                    self._read_artifact(closure["race"]["artifact_checksum"], "training example")
+                    state = "CLOSED"
+                rows.append(
+                    {
+                        "race_id": pre["race_id"],
+                        "state": state,
+                        "result_observation_count": len(blocked),
+                    }
+                )
+        rows.sort(key=lambda row: _identity_key(row["race_id"], "race_id"))
+        return {
+            "schema_version": STATUS_SCHEMA,
+            "race_count": len(rows),
+            "closed_race_count": sum(row["state"] == "CLOSED" for row in rows),
+            "races": rows,
+        }

--- a/race_collection/source_admission.py
+++ b/race_collection/source_admission.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import hashlib
 import json
 import unicodedata
+from collections.abc import Mapping
 from datetime import date, datetime
-from typing import Any, Mapping
+from typing import Any
+from urllib.parse import urlsplit
 
 from .domain import ArtifactChecksum, require_aware
 from .features import FeatureQuarantine, derive_features
@@ -17,6 +19,7 @@ SOURCE_PACKAGE_SCHEMA = "historical-source-package-v1"
 ADMITTED_MANIFEST_SCHEMA = "historical-source-admission-v1"
 LEGACY_ORIGIN = "legacy-historical-bootstrap-v1"
 SYNTHETIC_ORIGIN = "synthetic-validation-fixture-v1"
+FORWARD_SEALED_ORIGIN = "forward-sealed-corpus-v1"
 
 _MANIFEST_FIELDS = {
     "schema_version",
@@ -39,6 +42,12 @@ _RACE_FIELDS = {
     "scheduled_jump_at",
     "result_published_at",
     "result_observed_at",
+}
+_FORWARD_RACE_FIELDS = _RACE_FIELDS | {
+    "source_capture_checksum",
+    "raw_source_checksum",
+    "raw_result_checksum",
+    "source_observed_at",
 }
 _RESULT_DERIVED_KEYS = {
     "finish_order",
@@ -96,6 +105,20 @@ def _identity_key(value: Any, name: str) -> str:
     return normalized
 
 
+def _canonical_source_url(value: Any, name: str) -> str:
+    url = _known_text(value, name)
+    parsed = urlsplit(url)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+    ):
+        raise SourceAdmissionRejected(f"{name} is not a canonical source URL")
+    return url
+
+
 def _aware_timestamp(value: Any, name: str) -> datetime:
     if type(value) is not str:
         raise SourceAdmissionRejected(f"{name} timestamp is invalid")
@@ -111,7 +134,12 @@ def _normalized_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
     races = manifest.get("races")
     if type(races) is not list or not races or any(type(race) is not dict for race in races):
         raise SourceAdmissionRejected("source manifest requires race objects")
-    if any(set(race) != _RACE_FIELDS for race in races):
+    expected_fields = (
+        _FORWARD_RACE_FIELDS
+        if manifest.get("corpus_origin") == FORWARD_SEALED_ORIGIN
+        else _RACE_FIELDS
+    )
+    if any(set(race) != expected_fields for race in races):
         raise SourceAdmissionRejected("source manifest race envelope is invalid")
     try:
         ordered = sorted(races, key=lambda race: _identity_key(race["race_id"], "race_id"))
@@ -280,16 +308,250 @@ def _validate_result(
     return official_order
 
 
+def _validate_forward_source(
+    source: Mapping[str, Any],
+    capture: Mapping[str, Any],
+    race: Mapping[str, Any],
+    schema: Mapping[str, Any],
+) -> tuple[str, str, dict[str, str]]:
+    if set(source) != {
+        "schema_version",
+        "normalization_version",
+        "race_id",
+        "fields",
+        "field_provenance",
+        "freeze",
+    }:
+        raise SourceAdmissionRejected("forward sealed evidence envelope is invalid")
+    if (
+        set(capture)
+        != {
+            "schema_version",
+            "race_id",
+            "racing_date",
+            "source_name",
+            "canonical_source_url",
+            "source_native_race_id",
+            "meeting_metadata",
+            "race_metadata",
+            "scheduled_jump_at",
+            "source_observed_at",
+            "feature_frozen_at",
+            "raw_source_checksum",
+            "sealed_evidence_checksum",
+            "runners",
+            "identity_authority",
+            "reconstructed",
+        }
+        or capture.get("schema_version") != "forward-source-capture-v1"
+    ):
+        raise SourceAdmissionRejected("forward source capture provenance is incomplete")
+    if (
+        source.get("schema_version") != schema["evidence_schema_version"]
+        or source.get("normalization_version") != schema["normalization_version"]
+        or source.get("race_id") != race["race_id"]
+        or capture.get("race_id") != race["race_id"]
+        or capture.get("racing_date") != race["racing_date"]
+        or capture.get("scheduled_jump_at") != race["scheduled_jump_at"]
+        or capture.get("source_observed_at") != race["source_observed_at"]
+        or capture.get("feature_frozen_at") != race["feature_observed_at"]
+        or capture.get("raw_source_checksum") != race["raw_source_checksum"]
+        or capture.get("sealed_evidence_checksum") != race["source_checksum"]
+    ):
+        raise SourceAdmissionRejected("forward source identity, hashes, or timestamps disagree")
+    _known_text(capture.get("source_name"), "forward source")
+    source_url = _canonical_source_url(capture.get("canonical_source_url"), "forward source URL")
+    source_native_race_id = _known_text(
+        capture.get("source_native_race_id"), "source-native race identity"
+    )
+    if (
+        type(capture.get("meeting_metadata")) is not dict
+        or not capture["meeting_metadata"]
+        or type(capture.get("race_metadata")) is not dict
+        or not capture["race_metadata"]
+        or capture.get("identity_authority") != "source-native"
+        or capture.get("reconstructed") is not False
+    ):
+        raise SourceAdmissionRejected("forward source metadata or identity is ambiguous")
+    _reject_result_derived(capture["meeting_metadata"])
+    _reject_result_derived(capture["race_metadata"])
+
+    runners = capture.get("runners")
+    if type(runners) is not list or len(runners) < 2:
+        raise SourceAdmissionRejected("source-native runner identities are incomplete")
+    if any(
+        type(item) is not dict or set(item) != {"source_native_runner_id", "name"}
+        for item in runners
+    ):
+        raise SourceAdmissionRejected("source-native runner identity envelope is invalid")
+    runner_ids = _require_unique_normalized(
+        [item["source_native_runner_id"] for item in runners],
+        "source-native runner identity",
+    )
+    if list(runner_ids) != sorted(runner_ids) or list(runner_ids) != race["runner_ids"]:
+        raise SourceAdmissionRejected("source and manifest runner identities disagree")
+    runner_names = {}
+    for item in runners:
+        _known_text(item["name"], "runner name")
+        runner_names[item["source_native_runner_id"]] = item["name"]
+
+    fields = source.get("fields")
+    provenance = source.get("field_provenance")
+    freeze = source.get("freeze")
+    if (
+        type(fields) is not dict
+        or type(provenance) is not list
+        or not provenance
+        or type(freeze) is not dict
+        or set(freeze) != {"at", "authority", "odds_checksum"}
+    ):
+        raise SourceAdmissionRejected("forward feature-freeze provenance is incomplete")
+    try:
+        _known_text(freeze["authority"], "sealed evidence freeze authority")
+        ArtifactChecksum(freeze["odds_checksum"])
+    except (KeyError, ValueError) as error:
+        raise SourceAdmissionRejected("forward feature-freeze provenance is incomplete") from error
+    if _aware_timestamp(freeze.get("at"), "sealed evidence freeze") != _aware_timestamp(
+        race["feature_observed_at"], "feature observed_at"
+    ):
+        raise SourceAdmissionRejected("forward feature-freeze provenance is incomplete")
+    required_bindings = {"runner_set", "runner_identity", "runner_features"}
+    bound_fields = set()
+    for item in provenance:
+        if type(item) is not dict or set(item) != {
+            "field",
+            "authority",
+            "critical",
+            "value",
+            "source",
+            "artifact_checksum",
+        }:
+            raise SourceAdmissionRejected("forward feature source binding is invalid")
+        try:
+            ArtifactChecksum(item["artifact_checksum"])
+        except ValueError as error:
+            raise SourceAdmissionRejected(
+                "forward feature source binding checksum is invalid"
+            ) from error
+        _known_text(item.get("field"), "forward feature source binding field")
+        _known_text(item.get("authority"), "forward feature source binding authority")
+        _known_text(item.get("source"), "forward feature source binding source")
+        if type(item.get("critical")) is not bool:
+            raise SourceAdmissionRejected("forward feature source binding criticality is invalid")
+        if (
+            item.get("field") in required_bindings
+            and item.get("artifact_checksum") == race["raw_source_checksum"]
+            and item.get("source") == capture["source_name"]
+            and item.get("value") == fields.get(item["field"])
+        ):
+            bound_fields.add(item["field"])
+    if bound_fields != required_bindings:
+        raise SourceAdmissionRejected(
+            "forward features are not bound to preserved raw source bytes"
+        )
+    source_runners = fields.get("runner_set")
+    identities = fields.get("runner_identity")
+    features = fields.get("runner_features")
+    if (
+        source_runners != list(runner_ids)
+        or type(identities) is not dict
+        or set(identities) != set(runner_ids)
+        or any(identities[runner] != "authoritative" for runner in runner_ids)
+        or type(features) is not dict
+        or set(features) != set(runner_ids)
+    ):
+        raise SourceAdmissionRejected("forward sealed runner identities disagree")
+    expected_features = {field["name"] for field in schema["fields"]}
+    if any(
+        type(features[runner]) is not dict or set(features[runner]) != expected_features
+        for runner in runner_ids
+    ):
+        raise SourceAdmissionRejected("forward sealed feature envelope disagrees")
+    _reject_result_derived(source)
+    return source_url, source_native_race_id, runner_names
+
+
+def _validate_forward_result(
+    result: Mapping[str, Any],
+    race: Mapping[str, Any],
+    *,
+    expected_source_native_race_id: str,
+    expected_runner_names: Mapping[str, str],
+) -> tuple[tuple[str, ...], tuple[str, str]]:
+    if (
+        set(result)
+        != {
+            "schema_version",
+            "race_id",
+            "official",
+            "order",
+            "published_at",
+            "exclusions",
+            "runner_names",
+            "provenance",
+        }
+        or result.get("schema_version") != "official-forward-result-v1"
+    ):
+        raise SourceAdmissionRejected("forward official result envelope is invalid")
+    provenance = result.get("provenance")
+    if (
+        type(provenance) is not dict
+        or set(provenance)
+        != {
+            "source",
+            "canonical_source_url",
+            "source_native_race_id",
+            "observed_at",
+            "publication_timestamp_status",
+            "raw_result_checksum",
+            "identity_authority",
+            "reconstructed",
+        }
+        or result.get("official") is not True
+        or result.get("exclusions") != []
+        or result.get("race_id") != race["race_id"]
+        or result.get("published_at") != race["result_published_at"]
+        or provenance.get("observed_at") != race["result_observed_at"]
+        or provenance.get("raw_result_checksum") != race["raw_result_checksum"]
+        or provenance.get("source_native_race_id") != expected_source_native_race_id
+        or provenance.get("publication_timestamp_status") != "source-declared"
+        or provenance.get("identity_authority") != "source-native"
+        or provenance.get("reconstructed") is not False
+    ):
+        raise SourceAdmissionRejected("forward official result provenance disagrees")
+    _known_text(provenance.get("source"), "forward official result source")
+    source_url = _canonical_source_url(
+        provenance.get("canonical_source_url"), "forward official result source URL"
+    )
+    order = result.get("order")
+    names = result.get("runner_names")
+    if type(order) is not list or type(names) is not dict:
+        raise SourceAdmissionRejected("forward official result identities are incomplete")
+    official_order = _require_unique_normalized(order, "official runner identity")
+    if (
+        len(official_order) < 2
+        or set(official_order) != set(race["runner_ids"])
+        or set(names) != set(race["runner_ids"])
+        or names != expected_runner_names
+    ):
+        raise SourceAdmissionRejected(
+            "forward official result and source runner identities disagree"
+        )
+    for name in names.values():
+        _known_text(name, "official runner name")
+    return official_order, (source_url, expected_source_native_race_id)
+
+
 def _training_example_document(
     race: Mapping[str, Any],
     *,
     origin: str,
     official_order: tuple[str, ...],
 ) -> dict[str, Any]:
-    return {
+    document = {
         "schema_version": "historical-training-example-v1",
         "origin": origin,
-        "forward_sealed": False,
+        "forward_sealed": origin == FORWARD_SEALED_ORIGIN,
         "promotion_evidence_eligible": False,
         "training_example_id": race["training_example_id"],
         "race_id": race["race_id"],
@@ -304,6 +566,16 @@ def _training_example_document(
         "result_published_at": race["result_published_at"],
         "result_observed_at": race["result_observed_at"],
     }
+    if origin == FORWARD_SEALED_ORIGIN:
+        document.update(
+            {
+                "source_capture_checksum": race["source_capture_checksum"],
+                "raw_source_checksum": race["raw_source_checksum"],
+                "raw_result_checksum": race["raw_result_checksum"],
+                "source_observed_at": race["source_observed_at"],
+            }
+        )
+    return document
 
 
 def admit_historical_source(
@@ -339,7 +611,7 @@ def admit_historical_source(
         raise SourceAdmissionRejected("source manifest checksum is unverifiable")
 
     origin = manifest.get("corpus_origin")
-    if origin not in {LEGACY_ORIGIN, SYNTHETIC_ORIGIN}:
+    if origin not in {LEGACY_ORIGIN, SYNTHETIC_ORIGIN, FORWARD_SEALED_ORIGIN}:
         raise SourceAdmissionRejected("historical corpus origin is unsupported or untruthful")
     target_bundle_id = _known_text(manifest.get("target_bundle_id"), "target bundle identity")
     races = normalized_manifest["races"]
@@ -364,12 +636,36 @@ def admit_historical_source(
                 "official_result_checksum",
                 "feature_matrix_checksum",
                 "artifact_checksum",
+                *(
+                    (
+                        "source_capture_checksum",
+                        "raw_source_checksum",
+                        "raw_result_checksum",
+                    )
+                    if origin == FORWARD_SEALED_ORIGIN
+                    else ()
+                ),
             )
         ],
     ]
     if any(type(value) is not str for value in declared_checksums):
         raise SourceAdmissionRejected("declared artifact checksum is invalid")
-    if len(set(declared_checksums)) != len(declared_checksums):
+    unique_identity_checksums = [
+        manifest["feature_schema_checksum"],
+        manifest["missingness_policy_checksum"],
+        *[
+            race[field]
+            for race in races
+            for field in (
+                "source_checksum",
+                "official_result_checksum",
+                "feature_matrix_checksum",
+                "artifact_checksum",
+                *(("source_capture_checksum",) if origin == FORWARD_SEALED_ORIGIN else ()),
+            )
+        ],
+    ]
+    if len(set(unique_identity_checksums)) != len(unique_identity_checksums):
         raise SourceAdmissionRejected("declared artifact identities are duplicated")
     if set(artifacts) != set(declared_checksums):
         raise SourceAdmissionRejected("artifact inventory is missing, duplicate, or ambiguous")
@@ -425,7 +721,12 @@ def admit_historical_source(
         jump_at = _aware_timestamp(race["scheduled_jump_at"], "scheduled jump")
         published_at = _aware_timestamp(race["result_published_at"], "result published_at")
         result_at = _aware_timestamp(race["result_observed_at"], "result observed_at")
-        if not feature_at < jump_at < published_at <= result_at:
+        source_at = (
+            _aware_timestamp(race["source_observed_at"], "source observed_at")
+            if origin == FORWARD_SEALED_ORIGIN
+            else feature_at
+        )
+        if not source_at <= feature_at < jump_at < published_at <= result_at:
             raise SourceAdmissionRejected("historical feature/result temporal order is invalid")
         if racing_date != jump_at.date():
             raise SourceAdmissionRejected("racing date and scheduled jump disagree")
@@ -438,17 +739,50 @@ def admit_historical_source(
         )
         source = _object(source_bytes, "historical source")
         result = _object(result_bytes, "official result")
-        capture = _validate_source(source, race, schema)
-        official_order = _validate_result(result, race)
-        source_record = (
-            _identity_key(capture["source"], "historical source"),
-            _identity_key(capture["source_record_id"], "historical source record"),
-        )
-        result_provenance = result["provenance"]
-        result_record = (
-            _identity_key(result_provenance["source"], "official result source"),
-            _identity_key(result_provenance["source_record_id"], "official result source record"),
-        )
+        if origin == FORWARD_SEALED_ORIGIN:
+            source_capture_bytes = _artifact(
+                artifacts, race["source_capture_checksum"], "forward source capture"
+            )
+            _artifact(artifacts, race["raw_source_checksum"], "raw forward source")
+            _artifact(artifacts, race["raw_result_checksum"], "raw official result")
+            source_capture = _object(source_capture_bytes, "forward source capture")
+            (
+                source_url,
+                source_native_race_id,
+                source_runner_names,
+            ) = _validate_forward_source(source, source_capture, race, schema)
+            official_order, result_identity = _validate_forward_result(
+                result,
+                race,
+                expected_source_native_race_id=source_native_race_id,
+                expected_runner_names=source_runner_names,
+            )
+            source_record = (
+                _identity_key(source_url, "forward source URL"),
+                _identity_key(source_native_race_id, "source-native race identity"),
+            )
+            result_record = (
+                _identity_key(result_identity[0], "forward official result source URL"),
+                _identity_key(
+                    result_identity[1],
+                    "forward official result source-native race identity",
+                ),
+            )
+        else:
+            capture = _validate_source(source, race, schema)
+            official_order = _validate_result(result, race)
+            source_record = (
+                _identity_key(capture["source"], "historical source"),
+                _identity_key(capture["source_record_id"], "historical source record"),
+            )
+            result_provenance = result["provenance"]
+            result_record = (
+                _identity_key(result_provenance["source"], "official result source"),
+                _identity_key(
+                    result_provenance["source_record_id"],
+                    "official result source record",
+                ),
+            )
         if source_record in source_records or result_record in result_records:
             raise SourceAdmissionRejected("source or result record identity is duplicated")
         source_records.add(source_record)
@@ -485,31 +819,39 @@ def admit_historical_source(
         )
         if artifact_bytes != expected_artifact:
             raise SourceAdmissionRejected("immutable training example artifact disagrees")
-        admitted_races.append(
-            {
-                "training_example_id": race["training_example_id"],
-                "race_id": race["race_id"],
-                "racing_date": race["racing_date"],
-                "runner_ids": list(manifest_runners),
-                "official_order": list(official_order),
-                "source_checksum": race["source_checksum"],
-                "official_result_checksum": race["official_result_checksum"],
-                "feature_matrix_checksum": race["feature_matrix_checksum"],
-                "artifact_checksum": race["artifact_checksum"],
-                "feature_observed_at": race["feature_observed_at"],
-                "scheduled_jump_at": race["scheduled_jump_at"],
-                "result_published_at": race["result_published_at"],
-                "result_observed_at": race["result_observed_at"],
-            }
-        )
+        admitted_race = {
+            "training_example_id": race["training_example_id"],
+            "race_id": race["race_id"],
+            "racing_date": race["racing_date"],
+            "runner_ids": list(manifest_runners),
+            "official_order": list(official_order),
+            "source_checksum": race["source_checksum"],
+            "official_result_checksum": race["official_result_checksum"],
+            "feature_matrix_checksum": race["feature_matrix_checksum"],
+            "artifact_checksum": race["artifact_checksum"],
+            "feature_observed_at": race["feature_observed_at"],
+            "scheduled_jump_at": race["scheduled_jump_at"],
+            "result_published_at": race["result_published_at"],
+            "result_observed_at": race["result_observed_at"],
+        }
+        if origin == FORWARD_SEALED_ORIGIN:
+            admitted_race.update(
+                {
+                    "source_capture_checksum": race["source_capture_checksum"],
+                    "raw_source_checksum": race["raw_source_checksum"],
+                    "raw_result_checksum": race["raw_result_checksum"],
+                    "source_observed_at": race["source_observed_at"],
+                }
+            )
+        admitted_races.append(admitted_race)
 
     admitted = {
         "schema_version": ADMITTED_MANIFEST_SCHEMA,
         "admission_decision": (
-            "TRAINING_ADMISSIBLE" if origin == LEGACY_ORIGIN else "VALIDATION_ONLY"
+            "VALIDATION_ONLY" if origin == SYNTHETIC_ORIGIN else "TRAINING_ADMISSIBLE"
         ),
         "corpus_origin": origin,
-        "forward_sealed": False,
+        "forward_sealed": origin == FORWARD_SEALED_ORIGIN,
         "promotion_evidence_eligible": False,
         "production_readiness": False,
         "target_bundle_id": target_bundle_id,

--- a/scripts/collect_forward_sealed_corpus.py
+++ b/scripts/collect_forward_sealed_corpus.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Run one adapter-fed forward-sealed corpus iteration or report status."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from race_collection.forward_sealed_corpus import (
+    ForwardCorpusRejected,
+    ForwardSealedCorpus,
+    canonical_json,
+)
+from scripts.shadow_autopilot_daemon import (
+    LockBusy,
+    acquire_lock,
+    release_lock,
+)
+
+_PREJUMP_KEYS = {
+    "action",
+    "race_id",
+    "racing_date",
+    "raw_source_path",
+    "sealed_evidence_path",
+    "feature_schema_path",
+    "missingness_policy_path",
+    "source_name",
+    "canonical_source_url",
+    "source_native_race_id",
+    "runners",
+    "meeting_metadata",
+    "race_metadata",
+    "source_observed_at",
+    "feature_frozen_at",
+    "scheduled_jump_at",
+}
+_RESULT_KEYS = {
+    "action",
+    "race_id",
+    "raw_result_path",
+    "source_name",
+    "canonical_source_url",
+    "source_native_race_id",
+    "runners",
+    "official_order",
+    "result_observed_at",
+    "result_published_at",
+    "publication_timestamp_status",
+}
+
+
+def _object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_bytes())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ForwardCorpusRejected("iteration file is not valid JSON") from error
+    if type(value) is not dict:
+        raise ForwardCorpusRejected("iteration must be one JSON object")
+    return value
+
+
+def _input_bytes(iteration_path: Path, value: Any, name: str) -> bytes:
+    if type(value) is not str or not value.strip():
+        raise ForwardCorpusRejected(f"{name} path is missing")
+    path = Path(value)
+    if not path.is_absolute():
+        path = iteration_path.parent / path
+    try:
+        return path.read_bytes()
+    except OSError as error:
+        raise ForwardCorpusRejected(f"{name} bytes are unavailable") from error
+
+
+def _strict(value: Mapping[str, Any], expected: set[str], action: str) -> None:
+    if set(value) != expected:
+        raise ForwardCorpusRejected(f"{action} iteration has unknown or missing keys")
+
+
+def run_iteration(
+    corpus: ForwardSealedCorpus,
+    iteration_path: Path,
+) -> tuple[dict[str, Any], int]:
+    value = _object(iteration_path)
+    action = value.get("action")
+    if action == "prejump":
+        _strict(value, _PREJUMP_KEYS, action)
+        receipt = corpus.capture_prejump(
+            race_id=value["race_id"],
+            racing_date=value["racing_date"],
+            raw_source_bytes=_input_bytes(iteration_path, value["raw_source_path"], "raw source"),
+            sealed_evidence_bytes=_input_bytes(
+                iteration_path, value["sealed_evidence_path"], "sealed evidence"
+            ),
+            feature_schema_bytes=_input_bytes(
+                iteration_path, value["feature_schema_path"], "feature schema"
+            ),
+            missingness_policy_bytes=_input_bytes(
+                iteration_path,
+                value["missingness_policy_path"],
+                "missingness policy",
+            ),
+            source_name=value["source_name"],
+            canonical_source_url=value["canonical_source_url"],
+            source_native_race_id=value["source_native_race_id"],
+            runners=value["runners"],
+            meeting_metadata=value["meeting_metadata"],
+            race_metadata=value["race_metadata"],
+            source_observed_at=value["source_observed_at"],
+            feature_frozen_at=value["feature_frozen_at"],
+            scheduled_jump_at=value["scheduled_jump_at"],
+        )
+        return {
+            "action": action,
+            "decision": "PREJUMP_CAPTURED",
+            "receipt": receipt,
+            "status": corpus.status(),
+        }, 0
+    if action == "result":
+        _strict(value, _RESULT_KEYS, action)
+        receipt = corpus.capture_result(
+            race_id=value["race_id"],
+            raw_result_bytes=_input_bytes(iteration_path, value["raw_result_path"], "raw result"),
+            source_name=value["source_name"],
+            canonical_source_url=value["canonical_source_url"],
+            source_native_race_id=value["source_native_race_id"],
+            runners=value["runners"],
+            official_order=value["official_order"],
+            result_observed_at=value["result_observed_at"],
+            result_published_at=value["result_published_at"],
+            publication_timestamp_status=value["publication_timestamp_status"],
+        )
+        if receipt.get("closure_decision") == "BLOCKED_RESULT_PUBLICATION_TIMESTAMP":
+            return {
+                "action": action,
+                "decision": "BLOCKED_RESULT_PUBLICATION_TIMESTAMP",
+                "receipt": receipt,
+                "status": corpus.status(),
+            }, 2
+        package = corpus.build_package()
+        return {
+            "action": action,
+            "decision": "RACE_CLOSED",
+            "receipt": receipt,
+            "package_checksum": str(package.package_checksum),
+            "manifest_checksum": str(package.manifest_checksum),
+            "status": corpus.status(),
+        }, 0
+    raise ForwardCorpusRejected("iteration action must be prejump or result")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, required=True)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--iteration", type=Path)
+    mode.add_argument("--status", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    corpus = ForwardSealedCorpus(args.root)
+    if args.status:
+        print(canonical_json(corpus.status()).decode())
+        return 0
+
+    run_id = "forward_sealed_corpus_" + datetime.now().astimezone().strftime("%Y%m%dT%H%M%S%z")
+    lock_path = corpus.root / "forward-sealed-corpus.lock"
+    lock_payload = None
+    try:
+        lock_payload = acquire_lock(
+            lock_path=lock_path,
+            run_id=run_id,
+            stale_after_seconds=3600,
+            output_dir=corpus.root,
+        )
+        result, exit_code = run_iteration(corpus, args.iteration)
+        print(canonical_json(result).decode())
+        return exit_code
+    except LockBusy as error:
+        print(
+            canonical_json(
+                {
+                    "decision": "LOCK_BUSY",
+                    "details": error.payload,
+                }
+            ).decode(),
+            file=sys.stderr,
+        )
+        return 3
+    except ForwardCorpusRejected as error:
+        print(
+            canonical_json(
+                {
+                    "decision": "REJECTED",
+                    "error": str(error),
+                }
+            ).decode(),
+            file=sys.stderr,
+        )
+        return 1
+    finally:
+        if lock_payload is not None:
+            release_lock(lock_path, run_id)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/race_collection/test_forward_sealed_corpus.py
+++ b/tests/race_collection/test_forward_sealed_corpus.py
@@ -1,0 +1,511 @@
+import copy
+import hashlib
+import json
+from datetime import datetime
+
+import pytest
+
+from race_collection.domain import ArtifactChecksum
+from race_collection.forward_sealed_corpus import (
+    ForwardCorpusRejected,
+    ForwardSealedCorpus,
+    canonical_json,
+)
+from race_collection.source_admission import (
+    SourceAdmissionRejected,
+    admit_historical_source,
+)
+
+
+def _corpus(path):
+    return ForwardSealedCorpus(
+        path,
+        clock=lambda: datetime.fromisoformat("2026-07-29T09:45:00+10:00"),
+    )
+
+
+def fixture(index=1):
+    day = "2026-07-29"
+    race_id = f"race-{index}"
+    runners = [
+        {"source_native_runner_id": f"dog-{index}-a", "name": f"Dog {index} A"},
+        {"source_native_runner_id": f"dog-{index}-b", "name": f"Dog {index} B"},
+    ]
+    raw_source_bytes = f"<html>source-{index}</html>".encode()
+    raw_source_checksum = "sha256:" + hashlib.sha256(raw_source_bytes).hexdigest()
+    schema = canonical_json(
+        {
+            "bundle_id": "bundle-native-phase7-1",
+            "contract_version": "sealed-race-features-v1",
+            "evidence_schema_version": "race-evidence-v1",
+            "normalization_version": "normalizer-v1",
+            "fields": [
+                {
+                    "name": "speed",
+                    "source_field": "runner_features",
+                    "semantics": "forecast-required",
+                },
+                {
+                    "name": "days_since_run",
+                    "source_field": "runner_features",
+                    "semantics": "optional",
+                },
+            ],
+        }
+    )
+    missingness = canonical_json(
+        {
+            "bundle_id": "bundle-native-phase7-1",
+            "feature_contract_version": "sealed-race-features-v1",
+            "imputation": {"days_since_run": 7.0},
+        }
+    )
+    fields = {
+        "runner_set": [row["source_native_runner_id"] for row in runners],
+        "runner_identity": {row["source_native_runner_id"]: "authoritative" for row in runners},
+        "runner_features": {
+            runners[0]["source_native_runner_id"]: {
+                "speed": 8 + index,
+                "days_since_run": {"missing": True},
+            },
+            runners[1]["source_native_runner_id"]: {
+                "speed": 5 + index,
+                "days_since_run": 3,
+            },
+        },
+    }
+    evidence = canonical_json(
+        {
+            "schema_version": "race-evidence-v1",
+            "normalization_version": "normalizer-v1",
+            "race_id": race_id,
+            "fields": fields,
+            "field_provenance": [
+                {
+                    "field": field,
+                    "authority": "source_card",
+                    "critical": field in {"runner_set", "runner_identity"},
+                    "value": fields[field],
+                    "source": "thedogs-race-card",
+                    "artifact_checksum": raw_source_checksum,
+                }
+                for field in ("runner_set", "runner_identity", "runner_features")
+            ],
+            "freeze": {
+                "at": f"{day}T09:30:00+10:00",
+                "authority": "scheduled_minus_buffer",
+                "odds_checksum": "sha256:" + "a" * 64,
+            },
+        }
+    )
+    prepjump = {
+        "race_id": race_id,
+        "racing_date": day,
+        "raw_source_bytes": raw_source_bytes,
+        "sealed_evidence_bytes": evidence,
+        "feature_schema_bytes": schema,
+        "missingness_policy_bytes": missingness,
+        "source_name": "thedogs-race-card",
+        "canonical_source_url": f"https://www.thedogs.com.au/racing/venue/{day}/{index}",
+        "source_native_race_id": f"thedogs-{day}-{index}",
+        "runners": runners,
+        "meeting_metadata": {
+            "source_native_meeting_id": f"meeting-{day}",
+            "venue": "Sandown",
+        },
+        "race_metadata": {
+            "race_number": index,
+            "distance_metres": 515,
+        },
+        "source_observed_at": f"{day}T09:00:00+10:00",
+        "feature_frozen_at": f"{day}T09:30:00+10:00",
+        "scheduled_jump_at": f"{day}T10:00:00+10:00",
+    }
+    result = {
+        "race_id": race_id,
+        "raw_result_bytes": f"<html>official-result-{index}</html>".encode(),
+        "source_name": "thedogs-official",
+        "canonical_source_url": (f"https://www.thedogs.com.au/racing/venue/{day}/{index}/results"),
+        "source_native_race_id": f"thedogs-{day}-{index}",
+        "runners": runners,
+        "official_order": [
+            runners[1]["source_native_runner_id"],
+            runners[0]["source_native_runner_id"],
+        ],
+        "result_observed_at": f"{day}T10:32:00+10:00",
+        "result_published_at": f"{day}T10:31:00+10:00",
+        "publication_timestamp_status": "source-declared",
+    }
+    return prepjump, result
+
+
+def close(corpus, index=1):
+    prepjump, result = fixture(index)
+    corpus.capture_prejump(**prepjump)
+    corpus.capture_result(**result)
+    return corpus.build_package()
+
+
+def test_synthetic_end_to_end_closes_and_passes_source_admission(tmp_path):
+    corpus = _corpus(tmp_path)
+    package = close(corpus)
+
+    admitted = json.loads(
+        admit_historical_source(package.package_bytes, artifacts=package.artifacts)
+    )
+    assert admitted["admission_decision"] == "TRAINING_ADMISSIBLE"
+    assert admitted["corpus_origin"] == "forward-sealed-corpus-v1"
+    assert admitted["forward_sealed"] is True
+    assert admitted["promotion_evidence_eligible"] is False
+    assert admitted["production_readiness"] is False
+    assert corpus.status()["races"] == [
+        {
+            "race_id": "race-1",
+            "state": "CLOSED",
+            "result_observation_count": 0,
+        }
+    ]
+
+
+def test_prepjump_stage_rejects_late_capture_and_result_leakage(tmp_path):
+    prepjump, _ = fixture()
+    prepjump["feature_frozen_at"] = prepjump["scheduled_jump_at"]
+    with pytest.raises(ForwardCorpusRejected, match="pre-jump"):
+        _corpus(tmp_path / "late").capture_prejump(**prepjump)
+
+    leaking, _ = fixture()
+    evidence = json.loads(leaking["sealed_evidence_bytes"])
+    evidence["fields"]["runner_features"]["dog-1-a"]["finish_position"] = 1
+    leaking["sealed_evidence_bytes"] = canonical_json(evidence)
+    with pytest.raises(ForwardCorpusRejected, match="result-derived"):
+        _corpus(tmp_path / "leak").capture_prejump(**leaking)
+
+
+def test_first_receipt_must_be_published_before_jump_but_exact_retry_remains_idempotent(
+    tmp_path,
+):
+    prepjump, _ = fixture()
+    late = ForwardSealedCorpus(
+        tmp_path / "late",
+        clock=lambda: datetime.fromisoformat("2026-07-29T10:00:00+10:00"),
+    )
+    with pytest.raises(ForwardCorpusRejected, match="prospectively"):
+        late.capture_prejump(**prepjump)
+    assert late.status()["race_count"] == 0
+
+    on_time = _corpus(tmp_path / "retry")
+    receipt = on_time.capture_prejump(**prepjump)
+    after_jump = ForwardSealedCorpus(
+        tmp_path / "retry",
+        clock=lambda: datetime.fromisoformat("2026-07-29T10:30:00+10:00"),
+    )
+    assert after_jump.capture_prejump(**prepjump) == receipt
+
+
+def test_prepjump_requires_exact_bundle_and_source_binding_contracts(tmp_path):
+    prepjump, _ = fixture()
+    policy = json.loads(prepjump["missingness_policy_bytes"])
+    policy["bundle_id"] = "other-bundle"
+    prepjump["missingness_policy_bytes"] = canonical_json(policy)
+    with pytest.raises(ForwardCorpusRejected, match="feature schema"):
+        _corpus(tmp_path / "policy").capture_prejump(**prepjump)
+
+    unbound, _ = fixture()
+    evidence = json.loads(unbound["sealed_evidence_bytes"])
+    evidence["field_provenance"][0]["artifact_checksum"] = "sha256:" + "b" * 64
+    unbound["sealed_evidence_bytes"] = canonical_json(evidence)
+    with pytest.raises(ForwardCorpusRejected, match="not bound"):
+        _corpus(tmp_path / "binding").capture_prejump(**unbound)
+
+    wrong_value, _ = fixture()
+    evidence = json.loads(wrong_value["sealed_evidence_bytes"])
+    evidence["field_provenance"][0]["value"] = []
+    wrong_value["sealed_evidence_bytes"] = canonical_json(evidence)
+    with pytest.raises(ForwardCorpusRejected, match="not bound"):
+        _corpus(tmp_path / "value").capture_prejump(**wrong_value)
+
+
+def test_result_requires_prejump_and_strict_after_jump_order(tmp_path):
+    prepjump, result = fixture()
+    corpus = _corpus(tmp_path)
+    with pytest.raises(ForwardCorpusRejected, match="pre-jump evidence"):
+        corpus.capture_result(**result)
+    corpus.capture_prejump(**prepjump)
+    result["result_observed_at"] = prepjump["scheduled_jump_at"]
+    with pytest.raises(ForwardCorpusRejected, match="after jump"):
+        corpus.capture_result(**result)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("result_observed_at", "2026-07-01T10:32:00"),
+        ("result_published_at", "unknown"),
+        ("result_published_at", 7),
+    ],
+)
+def test_unknown_or_naive_result_timestamps_fail_closed(tmp_path, field, value):
+    prepjump, result = fixture()
+    corpus = _corpus(tmp_path)
+    corpus.capture_prejump(**prepjump)
+    result[field] = value
+    with pytest.raises(ForwardCorpusRejected, match="timestamp"):
+        corpus.capture_result(**result)
+
+
+def test_identity_runner_and_raw_hash_drift_fail_closed(tmp_path):
+    prepjump, result = fixture()
+    corpus = _corpus(tmp_path)
+    corpus.capture_prejump(**prepjump)
+
+    mismatch = copy.deepcopy(result)
+    mismatch["source_native_race_id"] = "other-race"
+    with pytest.raises(ForwardCorpusRejected, match="race identity mismatch"):
+        corpus.capture_result(**mismatch)
+
+    drift = copy.deepcopy(result)
+    drift["runners"][0]["source_native_runner_id"] = "other-runner"
+    with pytest.raises(ForwardCorpusRejected, match="runner drift"):
+        corpus.capture_result(**drift)
+
+    name_drift = copy.deepcopy(result)
+    name_drift["runners"][0]["name"] = "Different Dog"
+    with pytest.raises(ForwardCorpusRejected, match="name drift"):
+        corpus.capture_result(**name_drift)
+
+    blocked = copy.deepcopy(result)
+    blocked["result_published_at"] = None
+    blocked["publication_timestamp_status"] = "not-exposed-by-source"
+    assert (
+        corpus.capture_result(**blocked)["closure_decision"]
+        == "BLOCKED_RESULT_PUBLICATION_TIMESTAMP"
+    )
+    changed = copy.deepcopy(result)
+    changed["raw_result_bytes"] = b"different official bytes"
+    with pytest.raises(ForwardCorpusRejected, match="hash drift"):
+        corpus.capture_result(**changed)
+
+    provenance_drift = copy.deepcopy(result)
+    provenance_drift["canonical_source_url"] += "?different=true"
+    with pytest.raises(ForwardCorpusRejected, match="provenance drift"):
+        corpus.capture_result(**provenance_drift)
+
+
+def test_thedogs_missing_publication_timestamp_is_retained_but_never_closed(tmp_path):
+    prepjump, result = fixture()
+    corpus = _corpus(tmp_path)
+    corpus.capture_prejump(**prepjump)
+    result["result_published_at"] = None
+    result["publication_timestamp_status"] = "not-exposed-by-source"
+
+    blocked = corpus.capture_result(**result)
+
+    assert blocked["result_observed_at"].endswith("+10:00")
+    assert blocked["result_published_at"] is None
+    assert (
+        corpus.artifacts.read(ArtifactChecksum(blocked["raw_result_checksum"]))
+        == result["raw_result_bytes"]
+    )
+    assert corpus.status()["races"][0]["state"] == "BLOCKED_RESULT_PUBLICATION_TIMESTAMP"
+    with pytest.raises(ForwardCorpusRejected, match="no closed races"):
+        corpus.build_package()
+
+
+def test_result_publication_timestamp_must_be_source_declared_and_after_jump(tmp_path):
+    prepjump, result = fixture()
+    corpus = _corpus(tmp_path)
+    corpus.capture_prejump(**prepjump)
+
+    result["result_published_at"] = "2026-07-01T09:59:59+10:00"
+    with pytest.raises(ForwardCorpusRejected, match="temporal order"):
+        corpus.capture_result(**result)
+
+    result["result_published_at"] = None
+    result["publication_timestamp_status"] = "unknown"
+    with pytest.raises(ForwardCorpusRejected, match="unsupported"):
+        corpus.capture_result(**result)
+
+
+def test_blocked_result_closes_only_after_same_bytes_gain_source_timestamp(tmp_path):
+    prepjump, result = fixture()
+    corpus = _corpus(tmp_path)
+    corpus.capture_prejump(**prepjump)
+    blocked = copy.deepcopy(result)
+    blocked["result_published_at"] = None
+    blocked["publication_timestamp_status"] = "not-exposed-by-source"
+    blocked_receipt = corpus.capture_result(**blocked)
+
+    closure = corpus.capture_result(**result)
+
+    assert closure["schema_version"] == "forward-race-closure-v1"
+    assert corpus.status()["races"][0]["state"] == "CLOSED"
+    package_race = json.loads(corpus.build_package().package_bytes)["manifest"]["races"][0]
+    assert package_race["raw_result_checksum"] == blocked_receipt["raw_result_checksum"]
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("source_observed_at", "2026-07-01T09:00:00"),
+        ("feature_frozen_at", "unknown"),
+        ("scheduled_jump_at", 7),
+    ],
+)
+def test_unknown_or_naive_prejump_timestamps_fail_closed(tmp_path, field, value):
+    prepjump, _ = fixture()
+    prepjump[field] = value
+    with pytest.raises(ForwardCorpusRejected, match="timestamp"):
+        _corpus(tmp_path).capture_prejump(**prepjump)
+
+
+def test_exact_replay_is_idempotent_and_conflicting_duplicate_closure_fails(tmp_path):
+    prepjump, result = fixture()
+    corpus = _corpus(tmp_path)
+    first_prejump = corpus.capture_prejump(**prepjump)
+    assert corpus.capture_prejump(**prepjump) == first_prejump
+    first_closure = corpus.capture_result(**result)
+    assert corpus.capture_result(**result) == first_closure
+
+    conflict = copy.deepcopy(result)
+    conflict["official_order"].reverse()
+    with pytest.raises(ForwardCorpusRejected, match="append-only receipt conflict"):
+        corpus.capture_result(**conflict)
+
+
+def test_closed_result_rejects_raw_hash_drift_and_later_blocked_observation(tmp_path):
+    prepjump, result = fixture()
+    corpus = _corpus(tmp_path)
+    corpus.capture_prejump(**prepjump)
+    corpus.capture_result(**result)
+
+    drift = copy.deepcopy(result)
+    drift["raw_result_bytes"] = b"different official bytes"
+    with pytest.raises(ForwardCorpusRejected, match="hash drift"):
+        corpus.capture_result(**drift)
+
+    blocked = copy.deepcopy(result)
+    blocked["result_published_at"] = None
+    blocked["publication_timestamp_status"] = "not-exposed-by-source"
+    with pytest.raises(ForwardCorpusRejected, match="closed result"):
+        corpus.capture_result(**blocked)
+
+
+def test_partial_write_recovery_reuses_objects_and_completes_receipt(tmp_path, monkeypatch):
+    prepjump, _ = fixture()
+    corpus = _corpus(tmp_path)
+    original = ForwardSealedCorpus._publish_once
+    failed = False
+
+    def fail_receipt(path, content):
+        nonlocal failed
+        if path.name == "prejump.json" and not failed:
+            failed = True
+            raise OSError("simulated receipt publication crash")
+        return original(path, content)
+
+    monkeypatch.setattr(ForwardSealedCorpus, "_publish_once", staticmethod(fail_receipt))
+    with pytest.raises(OSError, match="simulated"):
+        corpus.capture_prejump(**prepjump)
+    monkeypatch.setattr(ForwardSealedCorpus, "_publish_once", staticmethod(original))
+
+    receipt = corpus.capture_prejump(**prepjump)
+
+    assert corpus.status()["races"][0]["state"] == "PREJUMP_CAPTURED"
+    assert corpus.artifacts.read(ArtifactChecksum(receipt["raw_source_checksum"]))
+
+
+def test_result_receipt_crash_recovers_to_same_closure(tmp_path, monkeypatch):
+    prepjump, result = fixture()
+    corpus = _corpus(tmp_path)
+    corpus.capture_prejump(**prepjump)
+    original = ForwardSealedCorpus._close
+    failed = False
+
+    def fail_close(self, pre, result_receipt):
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise OSError("simulated close crash")
+        return original(self, pre, result_receipt)
+
+    monkeypatch.setattr(ForwardSealedCorpus, "_close", fail_close)
+    with pytest.raises(OSError, match="simulated"):
+        corpus.capture_result(**result)
+    monkeypatch.setattr(ForwardSealedCorpus, "_close", original)
+
+    closure = corpus.capture_result(**result)
+
+    assert closure["schema_version"] == "forward-race-closure-v1"
+    assert corpus.status()["races"][0]["state"] == "CLOSED"
+
+
+def test_race_and_input_reordering_produce_identical_package_bytes(tmp_path):
+    first = _corpus(tmp_path / "first")
+    second = _corpus(tmp_path / "second")
+    for index in (1, 2):
+        prepjump, result = fixture(index)
+        first.capture_prejump(**prepjump)
+        first.capture_result(**result)
+    for index in (2, 1):
+        prepjump, result = fixture(index)
+        prepjump["runners"].reverse()
+        result["runners"].reverse()
+        second.capture_prejump(**prepjump)
+        second.capture_result(**result)
+
+    assert first.build_package().package_bytes == second.build_package().package_bytes
+
+
+def test_shared_meeting_source_and_result_bytes_remain_content_addressed(tmp_path):
+    first_prejump, first_result = fixture(1)
+    second_prejump, second_result = fixture(2)
+    second_prejump["raw_source_bytes"] = first_prejump["raw_source_bytes"]
+    shared_source_checksum = (
+        "sha256:" + hashlib.sha256(first_prejump["raw_source_bytes"]).hexdigest()
+    )
+    second_evidence = json.loads(second_prejump["sealed_evidence_bytes"])
+    for item in second_evidence["field_provenance"]:
+        item["artifact_checksum"] = shared_source_checksum
+    second_prejump["sealed_evidence_bytes"] = canonical_json(second_evidence)
+    second_prejump["canonical_source_url"] = first_prejump["canonical_source_url"]
+    second_result["raw_result_bytes"] = first_result["raw_result_bytes"]
+    second_result["canonical_source_url"] = first_result["canonical_source_url"]
+
+    corpus = _corpus(tmp_path)
+    for prepjump, result in (
+        (first_prejump, first_result),
+        (second_prejump, second_result),
+    ):
+        corpus.capture_prejump(**prepjump)
+        corpus.capture_result(**result)
+
+    package = corpus.build_package()
+    admitted = json.loads(
+        admit_historical_source(package.package_bytes, artifacts=package.artifacts)
+    )
+    assert admitted["race_ids"] == ["race-1", "race-2"]
+
+
+def test_source_admission_detects_missing_raw_bytes_and_hash_drift(tmp_path):
+    package = close(_corpus(tmp_path))
+    missing = dict(package.artifacts)
+    raw_checksum = json.loads(package.package_bytes)["manifest"]["races"][0]["raw_source_checksum"]
+    missing.pop(raw_checksum)
+    with pytest.raises(SourceAdmissionRejected, match="inventory"):
+        admit_historical_source(package.package_bytes, artifacts=missing)
+
+    drift = dict(package.artifacts)
+    drift[raw_checksum] += b"changed"
+    with pytest.raises(SourceAdmissionRejected, match="checksum"):
+        admit_historical_source(package.package_bytes, artifacts=drift)
+
+
+def test_status_detects_stored_artifact_hash_drift(tmp_path):
+    corpus = _corpus(tmp_path)
+    prepjump, _ = fixture()
+    receipt = corpus.capture_prejump(**prepjump)
+    raw_checksum = ArtifactChecksum(receipt["raw_source_checksum"])
+    corpus.artifacts.path_for(raw_checksum).write_bytes(b"drift")
+
+    with pytest.raises(ForwardCorpusRejected, match="hash drift"):
+        corpus.status()


### PR DESCRIPTION
## Summary

- add append-only prospective pre-jump source and production-feature capture
- retain immutable official-result bytes and close only source-timestamped aligned races
- emit deterministic `historical-training-example-v1` packages only after `race_collection.source_admission` accepts the complete artifact inventory
- add a bounded one-iteration/status CLI using the existing lock pattern
- document the explicit TheDogs publication-timestamp non-closure decision

## Validation

- 33 exact final forward-corpus and source-admission tests passed
- 171 Phase 4/5/6 regressions passed within a 202-test combined run
- temporary-database schema validation and CLI status smoke passed
- fatal flake8, Black, isort, `py_compile`, and `git diff --check` passed
- fresh read-only review: 0 critical findings, 0 warnings, 0 suggestions

## Safety

No live capture, historical reconstruction, database mutation, service/timer action, training, calibration, model export/registration, prediction, promotion, betting, deployment, activation, merge, or runtime action was performed.