### PR TITLE
Make Forecasting acceptance path-aware

### DIFF
--- a/.github/forecasting-paths.ini
+++ b/.github/forecasting-paths.ini
@@ -1,0 +1,71 @@
+[metadata]
+schema_version = forecasting-change-rules-v1
+
+[full_forecasting]
+patterns =
+    .github/**
+    AGENTS.md
+    artifacts/frozen_models/**
+    configs/prediction/schemas/**
+    constraints*.txt
+    docs/**/*FORECAST*.md
+    docs/**/*forecast*.md
+    docs/FORECASTING*.md
+    docs/*forecast*.md
+    docs/forecasting_validation_logs/**
+    environment*.yml
+    models/**
+    poetry.lock
+    Pipfile
+    Pipfile.lock
+    pyproject.toml
+    race_collection/**
+    requirements/**
+    requirements*.in
+    requirements*.lock
+    requirements*.txt
+    scripts/ci/**
+    scripts/*forecast*.py
+    scripts/*model*.py
+    scripts/*train*.py
+    setup.cfg
+    setup.py
+    src/predictor/feature_builders/**
+    tests/ci/**
+    tests/race_collection/**
+    tests/*forecast*.py
+    tests/*model*.py
+    tests/*train*.py
+    tox.ini
+    utils/**
+    uv.lock
+
+[manual_prediction]
+patterns =
+    configs/prediction/manual-default.json
+    configs/prediction/market-only.json
+    docs/manual_live_market_form_residual_prediction.md
+    docs/manual_market_form_residual_prediction.md
+    docs/on_demand_race_prediction.md
+    scripts/predict_market_form_residual.py
+    scripts/predict_race_now.py
+    src/predictor/market_form_residual.py
+    src/predictor/on_demand.py
+    tests/test_market_form_residual.py
+    tests/test_market_form_residual_portability.py
+    tests/test_predict_market_form_residual.py
+    tests/test_predict_race_now.py
+
+[non_forecasting]
+patterns =
+    .editorconfig
+    .gitignore
+    CHANGELOG.md
+    LICENSE
+    LICENSE.*
+    README.md
+    cypress/**
+    docs/**
+    static/**
+    templates/**
+    tests/playwright/**

--- a/.github/workflows/forecasting-tests.yml
+++ b/.github/workflows/forecasting-tests.yml
@@ -10,41 +10,133 @@ permissions:
   contents: read
 
 jobs:
-  forecasting-suite:
+  classify:
+    name: forecasting-change-classifier
+    runs-on: ubuntu-latest
+    outputs:
+      tier: ${{ steps.classify.outputs.tier }}
+      reason: ${{ steps.classify.outputs.reason }}
+
+    steps:
+      - name: Check out exact pull-request head with history
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Validate classifier contract
+        run: python3 tests/ci/test_forecasting_change_classifier.py
+
+      - name: Classify changed paths
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        shell: bash
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            python3 scripts/ci/classify_forecasting_changes.py \
+              --base "$BASE_SHA" \
+              --head "$HEAD_SHA" \
+              --github-output "$GITHUB_OUTPUT"
+          else
+            python3 scripts/ci/classify_forecasting_changes.py \
+              --force-full \
+              --github-output "$GITHUB_OUTPUT"
+          fi
+
+      - name: Summarize classification
+        env:
+          CLASSIFICATION_REASON: ${{ steps.classify.outputs.reason }}
+          FORECASTING_TIER: ${{ steps.classify.outputs.tier }}
+        run: |
+          {
+            echo "### Forecasting change classification"
+            echo
+            echo "- Tier: \`$FORECASTING_TIER\`"
+            echo "- Reason: \`$CLASSIFICATION_REASON\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  forecasting-gate:
     name: tests-race-collection
+    needs: classify
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+      - name: Enforce trustworthy classification
+        if: >-
+          needs.classify.result != 'success' ||
+          !contains(fromJSON('["full_forecasting","manual_prediction","non_forecasting"]'),
+          needs.classify.outputs.tier)
+        env:
+          CLASSIFIER_RESULT: ${{ needs.classify.result }}
+          FORECASTING_TIER: ${{ needs.classify.outputs.tier }}
+        run: |
+          echo "Change classification did not produce a trusted tier."
+          echo "classifier_result=$CLASSIFIER_RESULT tier=$FORECASTING_TIER"
+          exit 1
+
+      - name: No forecasting contracts changed
+        if: needs.classify.outputs.tier == 'non_forecasting'
+        run: |
+          echo "No forecasting-relevant paths changed; full and focused suites skipped."
+
       - name: Check out exact pull-request head
+        if: >-
+          needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'manual_prediction'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python 3.13
+        if: >-
+          needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'manual_prediction'
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
       - name: Set up uv
+        if: >-
+          needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'manual_prediction'
         uses: astral-sh/setup-uv@v6
 
-      - name: Run complete forecasting suite
+      - name: Run selected forecasting suite
+        if: >-
+          needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'manual_prediction'
         id: forecasting
         continue-on-error: true
+        env:
+          FORECASTING_TIER: ${{ needs.classify.outputs.tier }}
         shell: bash
         run: |
           set -o pipefail
           evidence_dir="${RUNNER_TEMP}/forecasting-acceptance-${GITHUB_RUN_ID}"
           mkdir -p "$evidence_dir"
-          uv run --no-project --with-requirements requirements/all.in \
-            python -m pytest -q --noconftest tests/race_collection \
-            2>&1 | tee "$evidence_dir/forecasting-suite.log"
+          if [[ "$FORECASTING_TIER" == "full_forecasting" ]]; then
+            uv run --no-project --with-requirements requirements/all.in \
+              python -m pytest -q --noconftest tests/race_collection
+          else
+            uv run --no-project --with-requirements requirements/all.in \
+              python -m pytest -q --noconftest \
+              tests/test_predict_race_now.py \
+              tests/test_predict_market_form_residual.py
+          fi 2>&1 | tee "$evidence_dir/forecasting-suite.log"
 
       - name: Bind validation evidence to exact commit and tree
-        if: always()
+        if: >-
+          always() &&
+          (needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'manual_prediction')
         env:
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+          FORECASTING_TIER: ${{ needs.classify.outputs.tier }}
           SUITE_OUTCOME: ${{ steps.forecasting.outcome }}
         shell: bash
         run: |
@@ -61,12 +153,22 @@ jobs:
               / f"forecasting-acceptance-{os.environ['GITHUB_RUN_ID']}"
           )
           log = evidence_dir / "forecasting-suite.log"
-          evidence = {
-              "schema_version": "forecasting-ci-attestation-v1",
-              "command": (
+          commands = {
+              "full_forecasting": (
                   "uv run --no-project --with-requirements requirements/all.in "
                   "python -m pytest -q --noconftest tests/race_collection"
               ),
+              "manual_prediction": (
+                  "uv run --no-project --with-requirements requirements/all.in "
+                  "python -m pytest -q --noconftest "
+                  "tests/test_predict_race_now.py "
+                  "tests/test_predict_market_form_residual.py"
+              ),
+          }
+          evidence = {
+              "schema_version": "forecasting-ci-attestation-v1",
+              "tier": os.environ["FORECASTING_TIER"],
+              "command": commands[os.environ["FORECASTING_TIER"]],
               "outcome": os.environ["SUITE_OUTCOME"],
               "event_sha": os.environ["GITHUB_SHA"],
               "expected_head": os.environ["EXPECTED_HEAD"],
@@ -89,7 +191,10 @@ jobs:
           PY
 
       - name: Upload exact-head validation evidence
-        if: always()
+        if: >-
+          always() &&
+          (needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'manual_prediction')
         uses: actions/upload-artifact@v4
         with:
           name: forecasting-acceptance-${{ github.run_id }}
@@ -99,5 +204,8 @@ jobs:
             ${{ runner.temp }}/forecasting-acceptance-${{ github.run_id }}/forecasting-ci-attestation.json
 
       - name: Enforce forecasting acceptance gate
-        if: steps.forecasting.outcome != 'success'
+        if: >-
+          (needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'manual_prediction') &&
+          steps.forecasting.outcome != 'success'
         run: exit 1

--- a/docs/FORECASTING_PUBLICATION_VALIDATION.md
+++ b/docs/FORECASTING_PUBLICATION_VALIDATION.md
@@ -14,21 +14,46 @@ replace its canonical controls, migrations, schemas, or post-base master work.
 
 ## Exact-head evidence contract
 
-Historical candidate logs are not release evidence for a later commit. The
-blocking `Forecasting acceptance / tests-race-collection` GitHub Actions job
-checks out the pull-request head explicitly, runs the complete
-`tests/race_collection` suite, and uploads:
+Historical candidate logs are not release evidence for a later commit. Every
+pull request to `master` receives the stable
+`Forecasting acceptance / tests-race-collection` GitHub Actions check. A
+lightweight classifier compares the exact pull-request base and head, validates
+its checked-in fixture cases, and selects the broadest applicable tier:
+
+- `full_forecasting` for forecasting core and shared contracts, feature schemas,
+  model/training/source-admission surfaces, common dependencies, test
+  infrastructure, workflow/classifier changes, forecasting contract docs, or
+  any unknown path;
+- `manual_prediction` for the on-demand predictor, its two checked-in configs,
+  operator docs, residual scorer, and directly associated tests; or
+- `non_forecasting` only for explicitly allowlisted unrelated docs and UI
+  surfaces.
+
+Renames and copies classify both old and new paths. Deletions retain their
+deleted path. Empty, malformed, unmatched, mixed, or overlapping changes select
+the broader tier, with uncertainty selecting `full_forecasting`.
+
+The stable gate checks out the pull-request head explicitly. The full tier runs
+the complete `tests/race_collection` suite. The manual tier runs:
+
+```text
+uv run --no-project --with-requirements requirements/all.in python -m pytest -q --noconftest tests/test_predict_race_now.py tests/test_predict_market_form_residual.py
+```
+
+Both relevant tiers upload:
 
 - `forecasting-suite.log`, the complete combined test output; and
 - `forecasting-ci-attestation.json`, containing the exact expected head, checked
-  out commit, tree, command, result, Python/platform/uv environment, and log
-  SHA-256.
+  out commit, tree, selected tier and command, result, Python/platform/uv
+  environment, and log SHA-256.
 
-The job fails if checkout does not equal the pull-request head, the suite exits
-nonzero, evidence cannot be generated, or the evidence artifact cannot be
-uploaded. Because a tracked file cannot contain the identity of the commit that
-contains itself, the CI attestation and the reviewer-local post-commit report
-are the authoritative exact-head evidence surfaces.
+The unrelated tier returns successfully without dependency setup after stating
+that no forecasting contracts changed. The stable job fails if classification
+does not produce a trusted tier, checkout does not equal the pull-request head,
+the selected suite exits nonzero, evidence cannot be generated, or the evidence
+artifact cannot be uploaded. Because a tracked file cannot contain the identity
+of the commit that contains itself, the CI attestation and the reviewer-local
+post-commit report are the authoritative exact-head evidence surfaces.
 
 ## Required local acceptance
 

--- a/scripts/ci/classify_forecasting_changes.py
+++ b/scripts/ci/classify_forecasting_changes.py
@@ -1,0 +1,222 @@
+"""Classify changed paths for the stable Forecasting acceptance gate."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import fnmatch
+import json
+import subprocess
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_RULES = ROOT / ".github/forecasting-paths.ini"
+TIERS = ("non_forecasting", "manual_prediction", "full_forecasting")
+TIER_RANK = {tier: rank for rank, tier in enumerate(TIERS)}
+KNOWN_STATUS_PREFIXES = frozenset({"A", "C", "D", "M", "R", "T"})
+
+
+class ClassificationError(RuntimeError):
+    """The change set or rules cannot be classified safely."""
+
+
+@dataclass(frozen=True)
+class Change:
+    status: str
+    paths: tuple[str, ...]
+
+
+def _normalize_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    candidate = PurePosixPath(normalized)
+    if (
+        not normalized
+        or normalized.startswith("/")
+        or any(part in {"", ".", ".."} for part in candidate.parts)
+    ):
+        raise ClassificationError(f"unsafe changed path: {path!r}")
+    return candidate.as_posix()
+
+
+def load_rules(path: Path = DEFAULT_RULES) -> dict[str, tuple[str, ...]]:
+    parser = configparser.ConfigParser(interpolation=None)
+    try:
+        with path.open(encoding="utf-8") as rules_file:
+            parser.read_file(rules_file)
+    except (OSError, configparser.Error) as exc:
+        raise ClassificationError(f"unable to load classifier rules: {exc}") from exc
+    if parser.get("metadata", "schema_version", fallback=None) != (
+        "forecasting-change-rules-v1"
+    ):
+        raise ClassificationError("unsupported classifier rules schema")
+    tier_sections = set(parser.sections()) - {"metadata"}
+    if tier_sections != set(TIERS):
+        raise ClassificationError(
+            "classifier rules must define exactly the three tiers"
+        )
+    validated: dict[str, tuple[str, ...]] = {}
+    for tier in TIERS:
+        patterns = tuple(
+            line.strip()
+            for line in parser.get(tier, "patterns", fallback="").splitlines()
+            if line.strip()
+        )
+        if not patterns:
+            raise ClassificationError(f"invalid patterns for {tier}")
+        validated[tier] = patterns
+    return validated
+
+
+def _path_tier(
+    path: str, rules: Mapping[str, Sequence[str]]
+) -> tuple[str, tuple[str, ...]]:
+    normalized = _normalize_path(path)
+    matched = tuple(
+        tier
+        for tier in TIERS
+        if any(fnmatch.fnmatchcase(normalized, pattern) for pattern in rules[tier])
+    )
+    if not matched:
+        return "full_forecasting", ()
+    return max(matched, key=TIER_RANK.__getitem__), matched
+
+
+def classify_changes(
+    changes: Iterable[Change], rules: Mapping[str, Sequence[str]]
+) -> dict[str, Any]:
+    change_list = list(changes)
+    if not change_list:
+        return {
+            "tier": "full_forecasting",
+            "reason": "empty_change_set_defaults_to_full",
+            "paths": [],
+        }
+
+    classified_paths: list[dict[str, Any]] = []
+    selected = "non_forecasting"
+    for change in change_list:
+        prefix = change.status[:1]
+        if prefix not in KNOWN_STATUS_PREFIXES or not change.paths:
+            return {
+                "tier": "full_forecasting",
+                "reason": f"unknown_change_status:{change.status or 'empty'}",
+                "paths": classified_paths,
+            }
+        for path in change.paths:
+            try:
+                tier, matched = _path_tier(path, rules)
+            except ClassificationError as exc:
+                return {
+                    "tier": "full_forecasting",
+                    "reason": f"uncertain_path:{exc}",
+                    "paths": classified_paths,
+                }
+            classified_paths.append(
+                {
+                    "path": _normalize_path(path),
+                    "status": change.status,
+                    "tier": tier,
+                    "matched_tiers": list(matched),
+                    "defaulted_to_full": not matched,
+                }
+            )
+            if TIER_RANK[tier] > TIER_RANK[selected]:
+                selected = tier
+
+    reason = (
+        "unknown_path_defaults_to_full"
+        if any(item["defaulted_to_full"] for item in classified_paths)
+        else "broadest_matching_tier"
+    )
+    return {"tier": selected, "reason": reason, "paths": classified_paths}
+
+
+def parse_name_status(raw: bytes) -> list[Change]:
+    tokens = raw.split(b"\0")
+    if tokens and tokens[-1] == b"":
+        tokens.pop()
+    changes: list[Change] = []
+    index = 0
+    try:
+        while index < len(tokens):
+            status = tokens[index].decode("utf-8")
+            index += 1
+            path_count = 2 if status[:1] in {"R", "C"} else 1
+            paths = tuple(
+                tokens[position].decode("utf-8")
+                for position in range(index, index + path_count)
+            )
+            index += path_count
+            changes.append(Change(status=status, paths=paths))
+    except (IndexError, UnicodeDecodeError) as exc:
+        raise ClassificationError("malformed git name-status output") from exc
+    if index != len(tokens):
+        raise ClassificationError("trailing git name-status fields")
+    return changes
+
+
+def git_changes(base: str, head: str) -> list[Change]:
+    command = [
+        "git",
+        "diff",
+        "--name-status",
+        "-z",
+        "--find-renames",
+        "--find-copies",
+        f"{base}...{head}",
+    ]
+    try:
+        raw = subprocess.check_output(command)
+    except subprocess.CalledProcessError as exc:
+        raise ClassificationError(
+            f"git diff failed with exit {exc.returncode}"
+        ) from exc
+    return parse_name_status(raw)
+
+
+def write_github_output(path: Path, result: Mapping[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        output.write(f"tier={result['tier']}\n")
+        output.write(f"reason={result['reason']}\n")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base")
+    parser.add_argument("--head")
+    parser.add_argument("--force-full", action="store_true")
+    parser.add_argument("--rules", type=Path, default=DEFAULT_RULES)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args(argv)
+    if not args.force_full and not (args.base and args.head):
+        parser.error("--base and --head are required unless --force-full is used")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        rules = load_rules(args.rules)
+        if args.force_full:
+            result = {
+                "tier": "full_forecasting",
+                "reason": "non_pull_request_event_defaults_to_full",
+                "paths": [],
+            }
+        else:
+            result = classify_changes(git_changes(args.base, args.head), rules)
+    except ClassificationError as exc:
+        print(f"classifier error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if args.github_output:
+        write_github_output(args.github_output, result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_forecasting_change_classifier.py
+++ b/tests/ci/test_forecasting_change_classifier.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "classify_forecasting_changes",
+    ROOT / "scripts/ci/classify_forecasting_changes.py",
+)
+assert SPEC and SPEC.loader
+CLASSIFIER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CLASSIFIER
+SPEC.loader.exec_module(CLASSIFIER)
+
+
+class ForecastingChangeClassifierTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rules = CLASSIFIER.load_rules()
+
+    def test_fixture_tiers(self):
+        fixtures = [
+            (
+                "manual-only",
+                [
+                    ("M", "scripts/predict_race_now.py"),
+                    ("M", "configs/prediction/manual-default.json"),
+                    ("M", "docs/on_demand_race_prediction.md"),
+                    ("M", "tests/test_predict_race_now.py"),
+                ],
+                "manual_prediction",
+            ),
+            (
+                "core-only",
+                [("M", "race_collection/forecasting.py")],
+                "full_forecasting",
+            ),
+            (
+                "mixed",
+                [
+                    ("M", "scripts/predict_race_now.py"),
+                    ("M", "race_collection/source_admission.py"),
+                ],
+                "full_forecasting",
+            ),
+            (
+                "workflow-only",
+                [("M", ".github/workflows/forecasting-tests.yml")],
+                "full_forecasting",
+            ),
+            (
+                "forecasting-contract-doc",
+                [("M", "docs/FORECASTING_PUBLICATION_VALIDATION.md")],
+                "full_forecasting",
+            ),
+            (
+                "docs-only",
+                [("M", "docs/race_evidence_inventory.md")],
+                "non_forecasting",
+            ),
+            (
+                "rename",
+                [
+                    (
+                        "R100",
+                        "scripts/predict_race_now.py",
+                        "archive/manual_predictor.py",
+                    )
+                ],
+                "full_forecasting",
+            ),
+            (
+                "delete",
+                [("D", "race_collection/model_bundle.py")],
+                "full_forecasting",
+            ),
+            (
+                "unknown",
+                [("A", "new_subsystem/adapter.py")],
+                "full_forecasting",
+            ),
+            (
+                "generated-dependency",
+                [("M", "requirements.lock")],
+                "full_forecasting",
+            ),
+            (
+                "shared-import",
+                [("M", "utils/csv_metadata.py")],
+                "full_forecasting",
+            ),
+        ]
+        for name, changes, expected in fixtures:
+            with self.subTest(name=name):
+                values = [
+                    CLASSIFIER.Change(status=change[0], paths=tuple(change[1:]))
+                    for change in changes
+                ]
+                self.assertEqual(
+                    CLASSIFIER.classify_changes(values, self.rules)["tier"],
+                    expected,
+                )
+
+    def test_overlap_selects_broader_tier(self):
+        result = CLASSIFIER.classify_changes(
+            [
+                CLASSIFIER.Change(
+                    status="M", paths=("docs/on_demand_race_prediction.md",)
+                )
+            ],
+            self.rules,
+        )
+        self.assertEqual(result["tier"], "manual_prediction")
+        self.assertEqual(
+            result["paths"][0]["matched_tiers"],
+            ["non_forecasting", "manual_prediction"],
+        )
+
+    def test_empty_or_unknown_status_defaults_to_full(self):
+        self.assertEqual(
+            CLASSIFIER.classify_changes([], self.rules)["tier"], "full_forecasting"
+        )
+        for status in ("?", "X"):
+            with self.subTest(status=status):
+                self.assertEqual(
+                    CLASSIFIER.classify_changes(
+                        [CLASSIFIER.Change(status=status, paths=("README.md",))],
+                        self.rules,
+                    )["tier"],
+                    "full_forecasting",
+                )
+
+    def test_name_status_parser_keeps_both_rename_paths(self):
+        changes = CLASSIFIER.parse_name_status(
+            b"R100\0scripts/predict_race_now.py\0archive/manual_predictor.py\0"
+            b"D\0race_collection/source_admission.py\0"
+        )
+        self.assertEqual(
+            changes,
+            [
+                CLASSIFIER.Change(
+                    status="R100",
+                    paths=(
+                        "scripts/predict_race_now.py",
+                        "archive/manual_predictor.py",
+                    ),
+                ),
+                CLASSIFIER.Change(
+                    status="D", paths=("race_collection/source_admission.py",)
+                ),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- keep one stable `Forecasting acceptance / tests-race-collection` check on every pull request to `master`
- classify exact base-to-head changes into `full_forecasting`, `manual_prediction`, or `non_forecasting`
- preserve the complete existing `tests/race_collection` command for forecasting-core changes
- run the PR #69-relevant on-demand/exact-receipt/lock/bundle/replay/config modules for manual-predictor-only changes
- fail closed for mixed, unknown, empty, malformed, rename/copy/delete, workflow, classifier, dependency, test-infrastructure, shared-import, schema, model, training, provenance, observation-authority, and source-admission changes

## Root cause

The Forecasting acceptance workflow had an unconditional `pull_request` job. PR #69 changed only manual predictor/config/docs/tests, but it still launched the complete forecasting suite. Recent completed Forecasting acceptance jobs took 72m31s to 81m03s, while the exact focused PR #69 command ran 359 tests locally under Python 3.13 in 4.71s (5.54s command wall time). This is not a post-change CI savings claim; no focused-tier CI run exists yet.

## Tier behavior

| Change set | Selected work |
| --- | --- |
| Forecasting core/shared/unknown/mixed | Complete existing `tests/race_collection` suite and exact-head attestation |
| Manual predictor/config/docs/direct tests | `tests/test_predict_race_now.py` plus `tests/test_predict_market_form_residual.py` and exact-head attestation |
| Explicitly unrelated docs/UI paths | Fast successful stable gate stating no forecasting contracts changed |
| Classifier failure or invalid tier | Stable gate fails |

The classifier validates its dependency-free fixture suite before classifying. It evaluates both paths for renames/copies, retains deleted paths, ranks overlap to the broader tier, and defaults unmatched paths to full.

## Validation

- classifier contract fixtures passed: manual-only, core-only, mixed, workflow-only, forecasting-contract-doc, unrelated docs-only, rename, delete, unknown, generated dependency, shared import, overlap, empty set, and unknown status
- PR #69 exact diff classified as `manual_prediction`
- PR #69 exact focused suite on Python 3.13: `359 passed in 4.71s`; measured command wall time `5.54s`
- Ruff check and format check passed
- Python compile passed
- actionlint 1.7.12 passed for the changed workflow
- repository-wide actionlint reported only pre-existing old-action-version findings in untouched workflows
- `git diff --check` passed
- fresh final read-only fail-open review: accepted with no remaining findings

## Boundaries

No backend or hardening workflow was tiered. No runtime, data, model, training, prediction, promotion, branch-protection, or merge action was performed.

The repository currently has no `master` branch protection and no rulesets. After this PR is accepted, making `tests-race-collection` required is a separate branch-protection follow-up; this PR preserves that stable check name but does not mutate protection.