### PR TITLE
Use persistent session for TheDogs results

### DIFF
--- a/scripts/autonomous_official_result_capture.py
+++ b/scripts/autonomous_official_result_capture.py
@@ -1313,15 +1313,16 @@ def run_shadow_run_official_dry_run(
         active_row=None,
     )
     if candidates:
+        if not db_path.exists():
+            raise FileNotFoundError(f"db_path_not_found:{db_path}")
         driver, By, browser_error = ingest.optional_browser_driver(headless=True)
+        public_http = ingest._PersistentPublicHttpClient()
         thedogs = ingest.TheDogsResultFetcher(
             driver,
             by=By,
-            http_session=ingest._StatelessPublicHttpClient(),
+            http_session=public_http,
         )
         sportsbet = ingest.SportsbetResultFetcher(driver, target_date, by=By) if driver else None
-        if not db_path.exists():
-            raise FileNotFoundError(f"db_path_not_found:{db_path}")
         conn = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
         try:
             for index, candidate in enumerate(candidates, start=1):
@@ -1412,6 +1413,7 @@ def run_shadow_run_official_dry_run(
                 )
         finally:
             conn.close()
+            public_http.close()
             if driver is not None:
                 try:
                     driver.quit()

--- a/scripts/collect_expert_form_official_result_labels_report_only.py
+++ b/scripts/collect_expert_form_official_result_labels_report_only.py
@@ -286,42 +286,46 @@ def fetch_official_result(
     *,
     use_browser_fallback: bool,
 ) -> tuple[ingest.SourceResult, str | None]:
-    fetcher = ingest.TheDogsResultFetcher(
-        None,
-        http_session=ingest._StatelessPublicHttpClient(),  # noqa: SLF001
-    )
-    if not use_browser_fallback:
-        urls = fetcher._result_urls(candidate)  # noqa: SLF001
-        http_result = fetcher._fetch_via_http(candidate, urls)  # noqa: SLF001
-        if http_result:
-            return http_result, None
-        return (
-            ingest.SourceResult(
-                source="thedogs_official",
-                status="error",
-                source_url=urls[0] if urls else None,
-                positions_by_box={},
-                raw_order=[],
-                error="no_thedogs_result_response",
-                attempted_urls=[],
-            ),
-            None,
-        )
-
-    driver, By, browser_error = ingest.optional_browser_driver(headless=True)
+    public_http = ingest._PersistentPublicHttpClient()  # noqa: SLF001
     try:
         fetcher = ingest.TheDogsResultFetcher(
-            driver,
-            by=By,
-            http_session=ingest._StatelessPublicHttpClient(),  # noqa: SLF001
+            None,
+            http_session=public_http,
         )
-        return fetcher.fetch(candidate), browser_error
+        if not use_browser_fallback:
+            urls = fetcher._result_urls(candidate)  # noqa: SLF001
+            http_result = fetcher._fetch_via_http(candidate, urls)  # noqa: SLF001
+            if http_result:
+                return http_result, None
+            return (
+                ingest.SourceResult(
+                    source="thedogs_official",
+                    status="error",
+                    source_url=urls[0] if urls else None,
+                    positions_by_box={},
+                    raw_order=[],
+                    error="no_thedogs_result_response",
+                    attempted_urls=[],
+                ),
+                None,
+            )
+
+        driver, By, browser_error = ingest.optional_browser_driver(headless=True)
+        try:
+            fetcher = ingest.TheDogsResultFetcher(
+                driver,
+                by=By,
+                http_session=public_http,
+            )
+            return fetcher.fetch(candidate), browser_error
+        finally:
+            if driver is not None:
+                try:
+                    driver.quit()
+                except Exception:
+                    pass
     finally:
-        if driver is not None:
-            try:
-                driver.quit()
-            except Exception:
-                pass
+        public_http.close()
 
 
 def artifact_rows_for_result(

--- a/scripts/ingest_results_for_date.py
+++ b/scripts/ingest_results_for_date.py
@@ -96,13 +96,18 @@ class _SeleniumByFallback:
     CSS_SELECTOR = "css selector"
 
 
-class _StatelessPublicHttpClient:
+class _PersistentPublicHttpClient:
+    def __init__(self):
+        self.session = requests.Session()
+        self.session.trust_env = False
+        self.session.cookies.clear()
+
     def get(self, url: str, **kwargs):
         kwargs.pop("cookies", None)
-        with requests.Session() as session:
-            session.trust_env = False
-            session.cookies.clear()
-            return session.get(url, cookies={}, **kwargs)
+        return self.session.get(url, cookies={}, **kwargs)
+
+    def close(self):
+        self.session.close()
 
 
 VENUE_TO_THEDOGS_SLUG = {
@@ -938,12 +943,34 @@ class TheDogsResultFetcher:
         self.by = by or _SeleniumByFallback
         self.http_session = http_session
         self._meeting_url_cache: Dict[tuple, List[str]] = {}
+        self._warmed_race_dates: set[str] = set()
+
+    def _warm_date_index(self, candidate: RaceCandidate) -> None:
+        if self.http_session is None or candidate.race_date in self._warmed_race_dates:
+            return
+
+        response = None
+        try:
+            response = self.http_session.get(
+                f"{THEDOGS_BASE}/racing/{candidate.race_date}",
+                headers=THEDOGS_PUBLIC_HEADERS,
+                timeout=20,
+                allow_redirects=True,
+            )
+            self._warmed_race_dates.add(candidate.race_date)
+        except Exception:
+            return
+        finally:
+            close = getattr(response, "close", None)
+            if callable(close):
+                close()
 
     def _result_urls(self, candidate: RaceCandidate) -> List[str]:
         slug = candidate.thedogs_slug
         if not slug:
             return []
 
+        self._warm_date_index(candidate)
         urls: List[str] = []
         urls.extend(thedogs_result_urls_from_race_url(candidate.canonical_thedogs_url or ""))
         urls.extend(self._discover_meeting_race_urls(candidate))
@@ -2595,11 +2622,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         print(f"Browser fallback unavailable: {browser_error}", file=sys.stderr)
     ingested: List[dict] = []
     failed: List[dict] = []
+    public_http = _PersistentPublicHttpClient()
     try:
         thedogs = TheDogsResultFetcher(
             driver,
             by=By,
-            http_session=_StatelessPublicHttpClient(),
+            http_session=public_http,
         )
         sportsbet = SportsbetResultFetcher(driver, args.date, by=By) if driver else None
 
@@ -2658,6 +2686,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         finally:
             conn.close()
     finally:
+        public_http.close()
         if driver is not None:
             driver.quit()
 

--- a/tests/test_results_ingest_official_first.py
+++ b/tests/test_results_ingest_official_first.py
@@ -870,8 +870,9 @@ def test_thedogs_fetch_discovers_public_result_route_before_selenium(tmp_path):
         http_session=session,
     ).fetch(candidate)
 
-    assert session.urls[0] == "https://www.thedogs.com.au/racing/warragul/2026-05-21?trial=false"
-    assert session.urls[1] == (
+    assert session.urls[0] == "https://www.thedogs.com.au/racing/2026-05-21"
+    assert session.urls[1] == "https://www.thedogs.com.au/racing/warragul/2026-05-21?trial=false"
+    assert session.urls[2] == (
         "https://www.thedogs.com.au/racing/warragul/2026-05-21/4/"
         "barn-function-area?trial=false"
     )
@@ -926,7 +927,8 @@ def test_thedogs_fetch_tries_public_result_url_after_forbidden_meeting_discovery
         http_session=session,
     ).fetch(candidate)
 
-    assert session.urls[:2] == [
+    assert session.urls[:3] == [
+        "https://www.thedogs.com.au/racing/2026-05-21",
         "https://www.thedogs.com.au/racing/warragul/2026-05-21?trial=false",
         "https://www.thedogs.com.au/racing/warragul/2026-05-21/4/results?trial=false",
     ]
@@ -1046,16 +1048,76 @@ def test_thedogs_http_404_is_reported_without_selenium_fallback(tmp_path):
     assert diagnostic["attempted_urls"] == result.attempted_urls
 
 
-def test_thedogs_public_http_client_is_stateless(monkeypatch):
+def test_thedogs_fetch_warms_date_index_once_per_date(tmp_path):
     module = _load_ingest_module()
-    observed = {}
+    candidate = _candidate(module, tmp_path)
+
+    class Response:
+        def __init__(self, url, text, status_code=200):
+            self.url = url
+            self.text = text
+            self.status_code = status_code
+
+        def close(self):
+            return None
+
+    class Session:
+        def __init__(self):
+            self.urls = []
+
+        def get(self, url, **_kwargs):
+            self.urls.append(url)
+            if url.endswith("/racing/warragul/2026-05-21?trial=false"):
+                return Response(
+                    url,
+                    """
+                    <a href="/racing/warragul/2026-05-21/4/barn-function-area?trial=false">R4</a>
+                    """,
+                )
+            if url == "https://www.thedogs.com.au/racing/2026-05-21":
+                return Response(url, "<html><body>Race date index</body></html>")
+            return Response(
+                url,
+                """
+                <html><body>
+                Results
+                1st
+                6. Foxtrot Runner
+                2nd
+                8. Hotel Runner
+                </body></html>
+                """,
+            )
+
+    class Driver:
+        def get(self, _url):
+            raise AssertionError("Selenium should not be used when public HTML succeeds")
+
+    session = Session()
+    fetcher = module.TheDogsResultFetcher(
+        Driver(),
+        wait_seconds=0,
+        http_session=session,
+    )
+
+    first = fetcher.fetch(candidate)
+    second = fetcher.fetch(candidate)
+
+    assert first.status == "resulted"
+    assert second.status == "resulted"
+    assert session.urls.count("https://www.thedogs.com.au/racing/2026-05-21") == 1
+
+
+def test_thedogs_public_http_client_reuses_clean_session(monkeypatch):
+    module = _load_ingest_module()
+    observed = {"sessions": 0, "requests": [], "closed": False}
 
     class Cookies:
         def __init__(self):
-            self.cleared = False
+            self.clear_count = 0
 
         def clear(self):
-            self.cleared = True
+            self.clear_count += 1
 
     class Response:
         status_code = 200
@@ -1064,35 +1126,55 @@ def test_thedogs_public_http_client_is_stateless(monkeypatch):
 
     class Session:
         def __init__(self):
+            observed["sessions"] += 1
             self.trust_env = True
             self.cookies = Cookies()
 
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_args):
-            return None
-
         def get(self, url, **kwargs):
-            observed["url"] = url
-            observed["trust_env"] = self.trust_env
-            observed["cookies_cleared"] = self.cookies.cleared
-            observed["request_cookies"] = kwargs.get("cookies")
+            observed["requests"].append(
+                {
+                    "url": url,
+                    "trust_env": self.trust_env,
+                    "cookie_clear_count": self.cookies.clear_count,
+                    "request_cookies": kwargs.get("cookies"),
+                }
+            )
             return Response()
+
+        def close(self):
+            observed["closed"] = True
 
     monkeypatch.setattr(module.requests, "Session", Session)
 
-    response = module._StatelessPublicHttpClient().get(
+    client = module._PersistentPublicHttpClient()
+    first = client.get(
         "https://www.thedogs.com.au/racing/warragul/2026-05-21?trial=false",
         cookies={"session": "should-not-be-sent"},
     )
+    second = client.get(
+        "https://www.thedogs.com.au/racing/warragul/2026-05-21/4/results",
+    )
+    client.close()
 
-    assert response.status_code == 200
+    assert first.status_code == 200
+    assert second.status_code == 200
     assert observed == {
-        "url": "https://www.thedogs.com.au/racing/warragul/2026-05-21?trial=false",
-        "trust_env": False,
-        "cookies_cleared": True,
-        "request_cookies": {},
+        "sessions": 1,
+        "requests": [
+            {
+                "url": "https://www.thedogs.com.au/racing/warragul/2026-05-21?trial=false",
+                "trust_env": False,
+                "cookie_clear_count": 1,
+                "request_cookies": {},
+            },
+            {
+                "url": "https://www.thedogs.com.au/racing/warragul/2026-05-21/4/results",
+                "trust_env": False,
+                "cookie_clear_count": 1,
+                "request_cookies": {},
+            },
+        ],
+        "closed": True,
     }
 
 
@@ -1468,7 +1550,10 @@ def test_result_ingest_main_dry_run_can_use_official_http_without_selenium(
                 """,
             )
 
-    monkeypatch.setattr(module, "_StatelessPublicHttpClient", Session)
+        def close(self):
+            return None
+
+    monkeypatch.setattr(module, "_PersistentPublicHttpClient", Session)
     report_path = tmp_path / "dry_run_report.json"
 
     rc = module.main(


### PR DESCRIPTION
## What changed

- replace the per-request TheDogs public HTTP client with one persistent anonymous `requests.Session`
- warm the race-date index once per date before meeting and result requests
- reuse and close that client in standard result ingestion, autonomous report-only capture, and expert-form official-result collection
- preserve the existing public headers, no-proxy behavior, result parsing, validation, and browser fallback
- add regression tests for date-index request ordering, once-per-date warm-up, persistent session reuse, cookie isolation, and cleanup

## Why

A bounded diagnostic showed that the retained historical TheDogs result URL succeeds when requested after the race-date index in the same HTTP session, while the collector's official-result paths created a fresh session for every GET. Existing form collection already uses a persistent session and date-index flow. This change aligns the result transport with that working behavior without changing source interpretation or write authority.

## Impact and limits

This should remove the collector-specific session/request-sequence cause of generic HTTP 403 responses. It does not deploy or activate anything, perform a live result fetch, write a database, fabricate historical timestamps, or make historical evidence training-admissible. Authentic immutable result bytes, hashes, source-declared `published_at`, and the separate pre-jump evidence pillars remain independent collection/admission requirements.

## Validation

- `98 passed` across:
  - `tests/test_results_ingest_official_first.py`
  - `tests/test_autonomous_official_result_capture.py`
  - `tests/test_expert_form_official_result_labels_packet.py`
- `flake8 --select E9,F63,F7,F82` passed for all four changed files
- `git diff --check` passed
- focused code review found no remaining critical issues or warnings

Repository-wide Black drift predates this change and was intentionally not normalized.