### PR TITLE
Add focused official-results CI tier

### DIFF
--- a/.github/forecasting-paths.ini
+++ b/.github/forecasting-paths.ini
@@ -56,6 +56,15 @@ patterns =
     tests/test_predict_market_form_residual.py
     tests/test_predict_race_now.py
 
+[official_results]
+patterns =
+    scripts/autonomous_official_result_capture.py
+    scripts/collect_expert_form_official_result_labels_report_only.py
+    scripts/ingest_results_for_date.py
+    tests/test_autonomous_official_result_capture.py
+    tests/test_expert_form_official_result_labels_packet.py
+    tests/test_results_ingest_official_first.py
+
 [non_forecasting]
 patterns =
     .editorconfig

--- a/.github/workflows/forecasting-tests.yml
+++ b/.github/workflows/forecasting-tests.yml
@@ -2,8 +2,6 @@ name: Forecasting acceptance
 
 on:
   pull_request:
-    branches:
-      - master
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/forecasting-tests.yml
+++ b/.github/workflows/forecasting-tests.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Enforce trustworthy classification
         if: >-
           needs.classify.result != 'success' ||
-          !contains(fromJSON('["full_forecasting","manual_prediction","non_forecasting"]'),
+          !contains(fromJSON('["full_forecasting","official_results","manual_prediction","non_forecasting"]'),
           needs.classify.outputs.tier)
         env:
           CLASSIFIER_RESULT: ${{ needs.classify.result }}
@@ -87,6 +87,7 @@ jobs:
       - name: Check out exact pull-request head
         if: >-
           needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'official_results' ||
           needs.classify.outputs.tier == 'manual_prediction'
         uses: actions/checkout@v4
         with:
@@ -95,6 +96,7 @@ jobs:
       - name: Set up Python 3.13
         if: >-
           needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'official_results' ||
           needs.classify.outputs.tier == 'manual_prediction'
         uses: actions/setup-python@v5
         with:
@@ -103,12 +105,14 @@ jobs:
       - name: Set up uv
         if: >-
           needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'official_results' ||
           needs.classify.outputs.tier == 'manual_prediction'
         uses: astral-sh/setup-uv@v6
 
       - name: Run selected forecasting suite
         if: >-
           needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'official_results' ||
           needs.classify.outputs.tier == 'manual_prediction'
         id: forecasting
         continue-on-error: true
@@ -122,6 +126,12 @@ jobs:
           if [[ "$FORECASTING_TIER" == "full_forecasting" ]]; then
             uv run --no-project --with-requirements requirements/all.in \
               python -m pytest -q --noconftest tests/race_collection
+          elif [[ "$FORECASTING_TIER" == "official_results" ]]; then
+            uv run --no-project --with-requirements requirements/all.in \
+              python -m pytest -q \
+              tests/test_results_ingest_official_first.py \
+              tests/test_autonomous_official_result_capture.py \
+              tests/test_expert_form_official_result_labels_packet.py
           else
             uv run --no-project --with-requirements requirements/all.in \
               python -m pytest -q --noconftest \
@@ -133,6 +143,7 @@ jobs:
         if: >-
           always() &&
           (needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'official_results' ||
           needs.classify.outputs.tier == 'manual_prediction')
         env:
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -157,6 +168,13 @@ jobs:
               "full_forecasting": (
                   "uv run --no-project --with-requirements requirements/all.in "
                   "python -m pytest -q --noconftest tests/race_collection"
+              ),
+              "official_results": (
+                  "uv run --no-project --with-requirements requirements/all.in "
+                  "python -m pytest -q "
+                  "tests/test_results_ingest_official_first.py "
+                  "tests/test_autonomous_official_result_capture.py "
+                  "tests/test_expert_form_official_result_labels_packet.py"
               ),
               "manual_prediction": (
                   "uv run --no-project --with-requirements requirements/all.in "
@@ -194,6 +212,7 @@ jobs:
         if: >-
           always() &&
           (needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'official_results' ||
           needs.classify.outputs.tier == 'manual_prediction')
         uses: actions/upload-artifact@v4
         with:
@@ -206,6 +225,7 @@ jobs:
       - name: Enforce forecasting acceptance gate
         if: >-
           (needs.classify.outputs.tier == 'full_forecasting' ||
+          needs.classify.outputs.tier == 'official_results' ||
           needs.classify.outputs.tier == 'manual_prediction') &&
           steps.forecasting.outcome != 'success'
         run: exit 1

--- a/scripts/ci/classify_forecasting_changes.py
+++ b/scripts/ci/classify_forecasting_changes.py
@@ -15,9 +15,16 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_RULES = ROOT / ".github/forecasting-paths.ini"
-TIERS = ("non_forecasting", "manual_prediction", "full_forecasting")
+TIERS = (
+    "non_forecasting",
+    "manual_prediction",
+    "official_results",
+    "full_forecasting",
+)
 TIER_RANK = {tier: rank for rank, tier in enumerate(TIERS)}
 KNOWN_STATUS_PREFIXES = frozenset({"A", "C", "D", "M", "R", "T"})
+DESTRUCTIVE_STATUS_PREFIXES = frozenset({"C", "D", "R", "T"})
+FOCUSED_TIERS = frozenset({"manual_prediction", "official_results"})
 
 
 class ClassificationError(RuntimeError):
@@ -56,7 +63,7 @@ def load_rules(path: Path = DEFAULT_RULES) -> dict[str, tuple[str, ...]]:
     tier_sections = set(parser.sections()) - {"metadata"}
     if tier_sections != set(TIERS):
         raise ClassificationError(
-            "classifier rules must define exactly the three tiers"
+            "classifier rules must define exactly the configured tiers"
         )
     validated: dict[str, tuple[str, ...]] = {}
     for tier in TIERS:
@@ -98,6 +105,8 @@ def classify_changes(
 
     classified_paths: list[dict[str, Any]] = []
     selected = "non_forecasting"
+    selected_tiers: set[str] = set()
+    destructive_change = False
     for change in change_list:
         prefix = change.status[:1]
         if prefix not in KNOWN_STATUS_PREFIXES or not change.paths:
@@ -106,6 +115,9 @@ def classify_changes(
                 "reason": f"unknown_change_status:{change.status or 'empty'}",
                 "paths": classified_paths,
             }
+        destructive_change = (
+            destructive_change or prefix in DESTRUCTIVE_STATUS_PREFIXES
+        )
         for path in change.paths:
             try:
                 tier, matched = _path_tier(path, rules)
@@ -124,14 +136,21 @@ def classify_changes(
                     "defaulted_to_full": not matched,
                 }
             )
+            selected_tiers.add(tier)
             if TIER_RANK[tier] > TIER_RANK[selected]:
                 selected = tier
 
-    reason = (
-        "unknown_path_defaults_to_full"
-        if any(item["defaulted_to_full"] for item in classified_paths)
-        else "broadest_matching_tier"
-    )
+    focused_tiers = selected_tiers & FOCUSED_TIERS
+    if destructive_change:
+        selected = "full_forecasting"
+        reason = "destructive_change_defaults_to_full"
+    elif len(focused_tiers) > 1:
+        selected = "full_forecasting"
+        reason = "mixed_focused_tiers_default_to_full"
+    elif any(item["defaulted_to_full"] for item in classified_paths):
+        reason = "unknown_path_defaults_to_full"
+    else:
+        reason = "broadest_matching_tier"
     return {"tier": selected, "reason": reason, "paths": classified_paths}
 
 

--- a/tests/ci/test_forecasting_change_classifier.py
+++ b/tests/ci/test_forecasting_change_classifier.py
@@ -34,6 +34,24 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
                 "manual_prediction",
             ),
             (
+                "official-results-only",
+                [
+                    ("M", "scripts/ingest_results_for_date.py"),
+                    ("M", "scripts/autonomous_official_result_capture.py"),
+                    (
+                        "M",
+                        "scripts/collect_expert_form_official_result_labels_report_only.py",
+                    ),
+                    ("M", "tests/test_results_ingest_official_first.py"),
+                    ("M", "tests/test_autonomous_official_result_capture.py"),
+                    (
+                        "M",
+                        "tests/test_expert_form_official_result_labels_packet.py",
+                    ),
+                ],
+                "official_results",
+            ),
+            (
                 "core-only",
                 [("M", "race_collection/forecasting.py")],
                 "full_forecasting",
@@ -118,6 +136,42 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
             result["paths"][0]["matched_tiers"],
             ["non_forecasting", "manual_prediction"],
         )
+
+    def test_mixed_focused_tiers_default_to_full(self):
+        result = CLASSIFIER.classify_changes(
+            [
+                CLASSIFIER.Change(
+                    status="M", paths=("scripts/predict_race_now.py",)
+                ),
+                CLASSIFIER.Change(
+                    status="M", paths=("scripts/ingest_results_for_date.py",)
+                ),
+            ],
+            self.rules,
+        )
+        self.assertEqual(result["tier"], "full_forecasting")
+        self.assertEqual(result["reason"], "mixed_focused_tiers_default_to_full")
+
+    def test_destructive_official_result_changes_default_to_full(self):
+        for change in (
+            CLASSIFIER.Change(
+                status="D", paths=("scripts/ingest_results_for_date.py",)
+            ),
+            CLASSIFIER.Change(
+                status="R100",
+                paths=(
+                    "scripts/ingest_results_for_date.py",
+                    "scripts/autonomous_official_result_capture.py",
+                ),
+            ),
+        ):
+            with self.subTest(status=change.status):
+                result = CLASSIFIER.classify_changes([change], self.rules)
+                self.assertEqual(result["tier"], "full_forecasting")
+                self.assertEqual(
+                    result["reason"],
+                    "destructive_change_defaults_to_full",
+                )
 
     def test_empty_or_unknown_status_defaults_to_full(self):
         self.assertEqual(


### PR DESCRIPTION
## What changed

- add an `official_results` forecasting-change tier
- exactly allowlist the three official-result collector scripts and their three focused test files
- route that tier to the official-result test surface instead of all `tests/race_collection`
- preserve exact-head validation evidence and the existing enforcement gate
- force mixed focused tiers, renames, copies, deletions, type changes, unknown paths, shared paths, and workflow changes to `full_forecasting`
- add classifier contract coverage for official-result-only, mixed, rename, and deletion cases

## Why

Official-result transport and parsing changes currently match no configured path rule, so the classifier reports `unknown_path_defaults_to_full` and runs the entire race-collection forecasting suite. PR #72 is a concrete example: its four official-result-only files trigger a gate that recently took roughly 75 minutes even though the affected 97-test official-result surface completes in under a minute locally.

The collector needs a focused tier rather than classifying these files as non-forecasting: official results become training labels, so they still require a dedicated fail-closed validation gate.

## Impact

Replaying PR #72's exact base/head through this classifier selects `official_results` with every path explicitly matched. The new command ran 97 tests from current `master` in 45.82 seconds; PR #72 adds one further regression test, yielding the previously validated 98-test surface. Normal backend CI remains unchanged.

This policy PR changes `.github`, `scripts/ci`, and `tests/ci`, so it intentionally classifies itself as `full_forecasting` for one final full validation. Unknown or cross-domain future changes continue to receive the full gate.

## Validation

- classifier contract: `6 tests passed`
- exact official-result gate: `97 passed in 45.82s`
- PR #72 exact base/head replay: `tier=official_results`, `reason=broadest_matching_tier`
- mixed manual-prediction plus official-result change: `full_forecasting`
- official-result rename/deletion: `full_forecasting`
- workflow YAML parsed successfully
- Python compilation passed
- fatal flake8 checks passed
- `git diff --check` passed
- focused code review completed with no remaining findings