### PR TITLE
Make Forecasting validation proportional to change risk

### DIFF
--- a/.github/forecasting-paths.ini
+++ b/.github/forecasting-paths.ini
@@ -87,7 +87,8 @@ patterns =
     .gitignore
     CHANGELOG.md
     LICENSE
-    LICENSE.*
+    LICENSE.md
+    LICENSE.txt
     README.md
     cypress/**
     docs/**

--- a/.github/forecasting-paths.ini
+++ b/.github/forecasting-paths.ini
@@ -1,52 +1,58 @@
 [metadata]
-schema_version = forecasting-change-rules-v1
+schema_version = forecasting-change-rules-v2
 
 [full_forecasting]
+suite = full_forecasting
+command = uv run --no-project --with-requirements requirements/all.in python -m pytest -q --noconftest tests/race_collection
 patterns =
     .github/**
     AGENTS.md
+    alembic/**
     artifacts/frozen_models/**
     configs/prediction/schemas/**
+    conftest.py
     constraints*.txt
-    docs/**/*FORECAST*.md
-    docs/**/*forecast*.md
-    docs/FORECASTING*.md
-    docs/*forecast*.md
-    docs/forecasting_validation_logs/**
     environment*.yml
+    migrations/**
     models/**
-    poetry.lock
     Pipfile
     Pipfile.lock
+    poetry.lock
     pyproject.toml
-    race_collection/**
+    race_collection/artifacts.py
+    race_collection/domain.py
+    race_collection/manual_prediction_collector_request.py
     requirements/**
     requirements*.in
     requirements*.lock
     requirements*.txt
     scripts/ci/**
+    scripts/*evaluate*.py
     scripts/*forecast*.py
     scripts/*model*.py
+    scripts/*promot*.py
     scripts/*train*.py
     setup.cfg
     setup.py
     src/predictor/feature_builders/**
     tests/ci/**
+    tests/conftest.py
     tests/race_collection/**
+    tests/*evaluate*.py
     tests/*forecast*.py
     tests/*model*.py
+    tests/*promot*.py
     tests/*train*.py
     tox.ini
     utils/**
     uv.lock
 
-[manual_prediction]
+[focused.manual_prediction]
+suite = manual_prediction
+command = uv run --no-project --with-requirements requirements/all.in python -m pytest -q --noconftest tests/test_predict_race_now.py tests/test_predict_market_form_residual.py
 patterns =
     configs/prediction/manual-default.json
     configs/prediction/market-only.json
-    docs/manual_live_market_form_residual_prediction.md
-    docs/manual_market_form_residual_prediction.md
-    docs/on_demand_race_prediction.md
     scripts/predict_market_form_residual.py
     scripts/predict_race_now.py
     src/predictor/market_form_residual.py
@@ -56,7 +62,9 @@ patterns =
     tests/test_predict_market_form_residual.py
     tests/test_predict_race_now.py
 
-[official_results]
+[focused.official_results]
+suite = official_results
+command = uv run --no-project --with-requirements requirements/all.in python -m pytest -q tests/test_results_ingest_official_first.py tests/test_autonomous_official_result_capture.py tests/test_expert_form_official_result_labels_packet.py
 patterns =
     scripts/autonomous_official_result_capture.py
     scripts/collect_expert_form_official_result_labels_report_only.py
@@ -65,7 +73,15 @@ patterns =
     tests/test_expert_form_official_result_labels_packet.py
     tests/test_results_ingest_official_first.py
 
+[focused.race_collection_inventory]
+suite = race_collection_inventory
+command = uv run --no-project --with-requirements requirements/all.in python -m pytest -q --noconftest tests/race_collection/test_phase2_domain.py
+patterns =
+    race_collection/inventory.py
+
 [non_forecasting]
+suite =
+command =
 patterns =
     .editorconfig
     .gitignore
@@ -75,6 +91,8 @@ patterns =
     README.md
     cypress/**
     docs/**
+    frontend/**
     static/**
     templates/**
     tests/playwright/**
+    ui/**

--- a/.github/workflows/forecasting-tests.yml
+++ b/.github/workflows/forecasting-tests.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tier: ${{ steps.classify.outputs.tier }}
+      suite: ${{ steps.classify.outputs.suite }}
       reason: ${{ steps.classify.outputs.reason }}
 
     steps:
@@ -37,24 +38,14 @@ jobs:
             python3 scripts/ci/classify_forecasting_changes.py \
               --base "$BASE_SHA" \
               --head "$HEAD_SHA" \
-              --github-output "$GITHUB_OUTPUT"
+              --github-output "$GITHUB_OUTPUT" \
+              --github-summary "$GITHUB_STEP_SUMMARY"
           else
             python3 scripts/ci/classify_forecasting_changes.py \
               --force-full \
-              --github-output "$GITHUB_OUTPUT"
+              --github-output "$GITHUB_OUTPUT" \
+              --github-summary "$GITHUB_STEP_SUMMARY"
           fi
-
-      - name: Summarize classification
-        env:
-          CLASSIFICATION_REASON: ${{ steps.classify.outputs.reason }}
-          FORECASTING_TIER: ${{ steps.classify.outputs.tier }}
-        run: |
-          {
-            echo "### Forecasting change classification"
-            echo
-            echo "- Tier: \`$FORECASTING_TIER\`"
-            echo "- Reason: \`$CLASSIFICATION_REASON\`"
-          } >> "$GITHUB_STEP_SUMMARY"
 
   forecasting-gate:
     name: tests-race-collection
@@ -65,86 +56,95 @@ jobs:
 
     steps:
       - name: Enforce trustworthy classification
-        if: >-
-          needs.classify.result != 'success' ||
-          !contains(fromJSON('["full_forecasting","official_results","manual_prediction","non_forecasting"]'),
-          needs.classify.outputs.tier)
         env:
           CLASSIFIER_RESULT: ${{ needs.classify.result }}
+          FORECASTING_SUITE: ${{ needs.classify.outputs.suite }}
           FORECASTING_TIER: ${{ needs.classify.outputs.tier }}
+        shell: bash
         run: |
-          echo "Change classification did not produce a trusted tier."
-          echo "classifier_result=$CLASSIFIER_RESULT tier=$FORECASTING_TIER"
-          exit 1
+          if [[ "$CLASSIFIER_RESULT" != "success" ]]; then
+            echo "Forecasting classifier failed: $CLASSIFIER_RESULT"
+            exit 1
+          fi
+          case "$FORECASTING_TIER:$FORECASTING_SUITE" in
+            "non_forecasting:" | \
+            "focused_forecasting:manual_prediction" | \
+            "focused_forecasting:official_results" | \
+            "focused_forecasting:race_collection_inventory" | \
+            "full_forecasting:full_forecasting")
+              ;;
+            *)
+              echo "Untrusted forecasting selection: tier=$FORECASTING_TIER suite=$FORECASTING_SUITE"
+              exit 1
+              ;;
+          esac
 
       - name: No forecasting contracts changed
         if: needs.classify.outputs.tier == 'non_forecasting'
         run: |
-          echo "No forecasting-relevant paths changed; full and focused suites skipped."
+          echo "No forecasting-relevant paths changed; forecasting tests skipped."
 
       - name: Check out exact pull-request head
-        if: >-
-          needs.classify.outputs.tier == 'full_forecasting' ||
-          needs.classify.outputs.tier == 'official_results' ||
-          needs.classify.outputs.tier == 'manual_prediction'
+        if: needs.classify.outputs.tier != 'non_forecasting'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python 3.13
-        if: >-
-          needs.classify.outputs.tier == 'full_forecasting' ||
-          needs.classify.outputs.tier == 'official_results' ||
-          needs.classify.outputs.tier == 'manual_prediction'
+        if: needs.classify.outputs.tier != 'non_forecasting'
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
       - name: Set up uv
-        if: >-
-          needs.classify.outputs.tier == 'full_forecasting' ||
-          needs.classify.outputs.tier == 'official_results' ||
-          needs.classify.outputs.tier == 'manual_prediction'
+        if: needs.classify.outputs.tier != 'non_forecasting'
         uses: astral-sh/setup-uv@v6
 
       - name: Run selected forecasting suite
-        if: >-
-          needs.classify.outputs.tier == 'full_forecasting' ||
-          needs.classify.outputs.tier == 'official_results' ||
-          needs.classify.outputs.tier == 'manual_prediction'
+        if: needs.classify.outputs.tier != 'non_forecasting'
         id: forecasting
         continue-on-error: true
         env:
-          FORECASTING_TIER: ${{ needs.classify.outputs.tier }}
+          FORECASTING_SUITE: ${{ needs.classify.outputs.suite }}
         shell: bash
         run: |
           set -o pipefail
           evidence_dir="${RUNNER_TEMP}/forecasting-acceptance-${GITHUB_RUN_ID}"
           mkdir -p "$evidence_dir"
-          if [[ "$FORECASTING_TIER" == "full_forecasting" ]]; then
-            uv run --no-project --with-requirements requirements/all.in \
-              python -m pytest -q --noconftest tests/race_collection
-          elif [[ "$FORECASTING_TIER" == "official_results" ]]; then
-            uv run --no-project --with-requirements requirements/all.in \
-              python -m pytest -q \
-              tests/test_results_ingest_official_first.py \
-              tests/test_autonomous_official_result_capture.py \
-              tests/test_expert_form_official_result_labels_packet.py
-          else
-            uv run --no-project --with-requirements requirements/all.in \
-              python -m pytest -q --noconftest \
-              tests/test_predict_race_now.py \
-              tests/test_predict_market_form_residual.py
-          fi 2>&1 | tee "$evidence_dir/forecasting-suite.log"
+          case "$FORECASTING_SUITE" in
+            full_forecasting)
+              uv run --no-project --with-requirements requirements/all.in \
+                python -m pytest -q --noconftest tests/race_collection
+              ;;
+            official_results)
+              uv run --no-project --with-requirements requirements/all.in \
+                python -m pytest -q \
+                tests/test_results_ingest_official_first.py \
+                tests/test_autonomous_official_result_capture.py \
+                tests/test_expert_form_official_result_labels_packet.py
+              ;;
+            manual_prediction)
+              uv run --no-project --with-requirements requirements/all.in \
+                python -m pytest -q --noconftest \
+                tests/test_predict_race_now.py \
+                tests/test_predict_market_form_residual.py
+              ;;
+            race_collection_inventory)
+              uv run --no-project --with-requirements requirements/all.in \
+                python -m pytest -q --noconftest \
+                tests/race_collection/test_phase2_domain.py
+              ;;
+            *)
+              echo "Refusing untrusted forecasting suite: $FORECASTING_SUITE"
+              exit 1
+              ;;
+          esac 2>&1 | tee "$evidence_dir/forecasting-suite.log"
 
       - name: Bind validation evidence to exact commit and tree
-        if: >-
-          always() &&
-          (needs.classify.outputs.tier == 'full_forecasting' ||
-          needs.classify.outputs.tier == 'official_results' ||
-          needs.classify.outputs.tier == 'manual_prediction')
+        if: always() && needs.classify.outputs.tier != 'non_forecasting'
         env:
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+          FORECASTING_SUITE: ${{ needs.classify.outputs.suite }}
           FORECASTING_TIER: ${{ needs.classify.outputs.tier }}
           SUITE_OUTCOME: ${{ steps.forecasting.outcome }}
         shell: bash
@@ -180,11 +180,17 @@ jobs:
                   "tests/test_predict_race_now.py "
                   "tests/test_predict_market_form_residual.py"
               ),
+              "race_collection_inventory": (
+                  "uv run --no-project --with-requirements requirements/all.in "
+                  "python -m pytest -q --noconftest "
+                  "tests/race_collection/test_phase2_domain.py"
+              ),
           }
           evidence = {
               "schema_version": "forecasting-ci-attestation-v1",
               "tier": os.environ["FORECASTING_TIER"],
-              "command": commands[os.environ["FORECASTING_TIER"]],
+              "suite": os.environ["FORECASTING_SUITE"],
+              "command": commands[os.environ["FORECASTING_SUITE"]],
               "outcome": os.environ["SUITE_OUTCOME"],
               "event_sha": os.environ["GITHUB_SHA"],
               "expected_head": os.environ["EXPECTED_HEAD"],
@@ -207,11 +213,7 @@ jobs:
           PY
 
       - name: Upload exact-head validation evidence
-        if: >-
-          always() &&
-          (needs.classify.outputs.tier == 'full_forecasting' ||
-          needs.classify.outputs.tier == 'official_results' ||
-          needs.classify.outputs.tier == 'manual_prediction')
+        if: always() && needs.classify.outputs.tier != 'non_forecasting'
         uses: actions/upload-artifact@v4
         with:
           name: forecasting-acceptance-${{ github.run_id }}
@@ -222,8 +224,6 @@ jobs:
 
       - name: Enforce forecasting acceptance gate
         if: >-
-          (needs.classify.outputs.tier == 'full_forecasting' ||
-          needs.classify.outputs.tier == 'official_results' ||
-          needs.classify.outputs.tier == 'manual_prediction') &&
+          needs.classify.outputs.tier != 'non_forecasting' &&
           steps.forecasting.outcome != 'success'
         run: exit 1

--- a/scripts/ci/classify_forecasting_changes.py
+++ b/scripts/ci/classify_forecasting_changes.py
@@ -1,4 +1,4 @@
-"""Classify changed paths for the stable Forecasting acceptance gate."""
+"""Select trusted proportional validation for the stable Forecasting gate."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import argparse
 import configparser
 import fnmatch
 import json
+import re
 import subprocess
 import sys
 from collections.abc import Iterable, Mapping, Sequence
@@ -15,16 +16,44 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_RULES = ROOT / ".github/forecasting-paths.ini"
-TIERS = (
-    "non_forecasting",
+SCHEMA_VERSION = "forecasting-change-rules-v2"
+FULL_COMMAND = (
+    "uv run --no-project --with-requirements requirements/all.in "
+    "python -m pytest -q --noconftest tests/race_collection"
+)
+TRUSTED_COMMANDS = {
+    "full_forecasting": FULL_COMMAND,
+    "manual_prediction": (
+        "uv run --no-project --with-requirements requirements/all.in "
+        "python -m pytest -q --noconftest tests/test_predict_race_now.py "
+        "tests/test_predict_market_form_residual.py"
+    ),
+    "official_results": (
+        "uv run --no-project --with-requirements requirements/all.in "
+        "python -m pytest -q tests/test_results_ingest_official_first.py "
+        "tests/test_autonomous_official_result_capture.py "
+        "tests/test_expert_form_official_result_labels_packet.py"
+    ),
+    "race_collection_inventory": (
+        "uv run --no-project --with-requirements requirements/all.in "
+        "python -m pytest -q --noconftest "
+        "tests/race_collection/test_phase2_domain.py"
+    ),
+}
+FOCUSED_SUITES = (
     "manual_prediction",
     "official_results",
-    "full_forecasting",
+    "race_collection_inventory",
 )
-TIER_RANK = {tier: rank for rank, tier in enumerate(TIERS)}
+SECTIONS = (
+    "metadata",
+    "full_forecasting",
+    *(f"focused.{suite}" for suite in FOCUSED_SUITES),
+    "non_forecasting",
+)
 KNOWN_STATUS_PREFIXES = frozenset({"A", "C", "D", "M", "R", "T"})
-DESTRUCTIVE_STATUS_PREFIXES = frozenset({"C", "D", "R", "T"})
-FOCUSED_TIERS = frozenset({"manual_prediction", "official_results"})
+UNSAFE_STATUS_PREFIXES = frozenset({"C", "D", "R", "T"})
+VALID_STATUS = re.compile(r"(?:A|D|M|T|[CR](?:[1-9][0-9]?|100))\Z")
 
 
 class ClassificationError(RuntimeError):
@@ -37,121 +66,203 @@ class Change:
     paths: tuple[str, ...]
 
 
-def _normalize_path(path: str) -> str:
-    normalized = path.replace("\\", "/")
-    candidate = PurePosixPath(normalized)
+@dataclass(frozen=True)
+class RuleGroup:
+    tier: str
+    suite: str
+    command: str
+    patterns: tuple[str, ...]
+
+
+def _validated_path(path: str) -> str:
+    candidate = PurePosixPath(path)
     if (
-        not normalized
-        or normalized.startswith("/")
+        not path
+        or "\\" in path
+        or path.startswith("/")
         or any(part in {"", ".", ".."} for part in candidate.parts)
     ):
-        raise ClassificationError(f"unsafe changed path: {path!r}")
-    return candidate.as_posix()
+        raise ClassificationError(f"unsafe or non-POSIX changed path: {path!r}")
+    return path
 
 
-def load_rules(path: Path = DEFAULT_RULES) -> dict[str, tuple[str, ...]]:
+def _patterns(parser: configparser.ConfigParser, section: str) -> tuple[str, ...]:
+    patterns = tuple(
+        line.strip()
+        for line in parser.get(section, "patterns", fallback="").splitlines()
+        if line.strip()
+    )
+    if not patterns:
+        raise ClassificationError(f"invalid patterns for {section}")
+    for pattern in patterns:
+        if (
+            "\\" in pattern
+            or pattern.startswith(("/", "!", "-"))
+            or ".." in PurePosixPath(pattern).parts
+            or "\0" in pattern
+        ):
+            raise ClassificationError(f"unsafe pattern in {section}: {pattern!r}")
+    return patterns
+
+
+def load_rules(path: Path = DEFAULT_RULES) -> tuple[RuleGroup, ...]:
     parser = configparser.ConfigParser(interpolation=None)
     try:
         with path.open(encoding="utf-8") as rules_file:
             parser.read_file(rules_file)
-    except (OSError, configparser.Error) as exc:
+    except (OSError, configparser.Error, UnicodeError) as exc:
         raise ClassificationError(f"unable to load classifier rules: {exc}") from exc
-    if parser.get("metadata", "schema_version", fallback=None) != (
-        "forecasting-change-rules-v1"
-    ):
+    if tuple(parser.sections()) != SECTIONS:
+        raise ClassificationError("classifier rules sections or order are invalid")
+    if set(parser["metadata"]) != {"schema_version"}:
+        raise ClassificationError("metadata options are invalid")
+    if parser["metadata"]["schema_version"] != SCHEMA_VERSION:
         raise ClassificationError("unsupported classifier rules schema")
-    tier_sections = set(parser.sections()) - {"metadata"}
-    if tier_sections != set(TIERS):
-        raise ClassificationError(
-            "classifier rules must define exactly the configured tiers"
-        )
-    validated: dict[str, tuple[str, ...]] = {}
-    for tier in TIERS:
-        patterns = tuple(
-            line.strip()
-            for line in parser.get(tier, "patterns", fallback="").splitlines()
-            if line.strip()
-        )
-        if not patterns:
-            raise ClassificationError(f"invalid patterns for {tier}")
-        validated[tier] = patterns
-    return validated
 
-
-def _path_tier(
-    path: str, rules: Mapping[str, Sequence[str]]
-) -> tuple[str, tuple[str, ...]]:
-    normalized = _normalize_path(path)
-    matched = tuple(
-        tier
-        for tier in TIERS
-        if any(fnmatch.fnmatchcase(normalized, pattern) for pattern in rules[tier])
+    groups: list[RuleGroup] = []
+    configured = (
+        ("full_forecasting", "full_forecasting", "full_forecasting"),
+        *(
+            (f"focused.{suite}", "focused_forecasting", suite)
+            for suite in FOCUSED_SUITES
+        ),
+        ("non_forecasting", "non_forecasting", ""),
     )
-    if not matched:
-        return "full_forecasting", ()
-    return max(matched, key=TIER_RANK.__getitem__), matched
+    for section, tier, expected_suite in configured:
+        if set(parser[section]) != {"suite", "command", "patterns"}:
+            raise ClassificationError(f"invalid options for {section}")
+        suite = parser[section]["suite"].strip()
+        command = " ".join(parser[section]["command"].split())
+        expected_command = TRUSTED_COMMANDS.get(expected_suite, "")
+        if suite != expected_suite or command != expected_command:
+            raise ClassificationError(f"untrusted suite or command in {section}")
+        groups.append(RuleGroup(tier, suite, command, _patterns(parser, section)))
+    return tuple(groups)
+
+
+def _classify_path(path: str, rules: Sequence[RuleGroup]) -> dict[str, Any]:
+    exact_path = _validated_path(path)
+    matches = [
+        group
+        for group in rules
+        if any(fnmatch.fnmatchcase(exact_path, pattern) for pattern in group.patterns)
+    ]
+    if not matches:
+        return {
+            "path": exact_path,
+            "rule_tier": "full_forecasting",
+            "rule_suite": "full_forecasting",
+            "matched_groups": [],
+            "defaulted_to_full": True,
+        }
+    rank = {"non_forecasting": 0, "focused_forecasting": 1, "full_forecasting": 2}
+    selected = max(matches, key=lambda group: rank[group.tier])
+    return {
+        "path": exact_path,
+        "rule_tier": selected.tier,
+        "rule_suite": selected.suite,
+        "matched_groups": [group.suite or "non_forecasting" for group in matches],
+        "defaulted_to_full": False,
+    }
+
+
+def _selection(tier: str, suite: str, reason: str, paths: list[dict[str, Any]]):
+    return {
+        "tier": tier,
+        "suite": suite,
+        "command": TRUSTED_COMMANDS.get(suite, ""),
+        "reason": reason,
+        "paths": paths,
+    }
+
+
+def force_full_result() -> dict[str, Any]:
+    return _selection(
+        "full_forecasting", "full_forecasting", "manual_dispatch_forces_full", []
+    )
 
 
 def classify_changes(
-    changes: Iterable[Change], rules: Mapping[str, Sequence[str]]
+    changes: Iterable[Change], rules: Sequence[RuleGroup]
 ) -> dict[str, Any]:
     change_list = list(changes)
     if not change_list:
-        return {
-            "tier": "full_forecasting",
-            "reason": "empty_change_set_defaults_to_full",
-            "paths": [],
-        }
+        return _selection(
+            "full_forecasting",
+            "full_forecasting",
+            "empty_change_set_forces_full",
+            [],
+        )
 
-    classified_paths: list[dict[str, Any]] = []
-    selected = "non_forecasting"
-    selected_tiers: set[str] = set()
-    destructive_change = False
+    classified: list[dict[str, Any]] = []
+    unsafe_status = False
+    malformed_status = False
     for change in change_list:
         prefix = change.status[:1]
-        if prefix not in KNOWN_STATUS_PREFIXES or not change.paths:
-            return {
-                "tier": "full_forecasting",
-                "reason": f"unknown_change_status:{change.status or 'empty'}",
-                "paths": classified_paths,
-            }
-        destructive_change = (
-            destructive_change or prefix in DESTRUCTIVE_STATUS_PREFIXES
+        status_is_valid = (
+            bool(change.paths)
+            and prefix in KNOWN_STATUS_PREFIXES
+            and bool(VALID_STATUS.fullmatch(change.status))
         )
+        if not status_is_valid:
+            malformed_status = True
+        if not change.paths:
+            continue
+        if status_is_valid and prefix in UNSAFE_STATUS_PREFIXES:
+            unsafe_status = True
         for path in change.paths:
             try:
-                tier, matched = _path_tier(path, rules)
-            except ClassificationError as exc:
-                return {
-                    "tier": "full_forecasting",
-                    "reason": f"uncertain_path:{exc}",
-                    "paths": classified_paths,
+                item = _classify_path(path, rules)
+            except ClassificationError:
+                item = {
+                    "path": path,
+                    "rule_tier": "full_forecasting",
+                    "rule_suite": "full_forecasting",
+                    "matched_groups": [],
+                    "defaulted_to_full": True,
                 }
-            classified_paths.append(
-                {
-                    "path": _normalize_path(path),
-                    "status": change.status,
-                    "tier": tier,
-                    "matched_tiers": list(matched),
-                    "defaulted_to_full": not matched,
-                }
-            )
-            selected_tiers.add(tier)
-            if TIER_RANK[tier] > TIER_RANK[selected]:
-                selected = tier
+            item["status"] = change.status
+            classified.append(item)
 
-    focused_tiers = selected_tiers & FOCUSED_TIERS
-    if destructive_change:
-        selected = "full_forecasting"
-        reason = "destructive_change_defaults_to_full"
-    elif len(focused_tiers) > 1:
-        selected = "full_forecasting"
-        reason = "mixed_focused_tiers_default_to_full"
-    elif any(item["defaulted_to_full"] for item in classified_paths):
-        reason = "unknown_path_defaults_to_full"
-    else:
-        reason = "broadest_matching_tier"
-    return {"tier": selected, "reason": reason, "paths": classified_paths}
+    if malformed_status:
+        return _selection(
+            "full_forecasting",
+            "full_forecasting",
+            "invalid_git_status_forces_full",
+            classified,
+        )
+    if unsafe_status:
+        return _selection(
+            "full_forecasting",
+            "full_forecasting",
+            "unsafe_git_status_forces_full",
+            classified,
+        )
+    if any(item["rule_tier"] == "full_forecasting" for item in classified):
+        reason = (
+            "unknown_or_ambiguous_path_forces_full"
+            if any(item["defaulted_to_full"] for item in classified)
+            else "full_rule_match"
+        )
+        return _selection("full_forecasting", "full_forecasting", reason, classified)
+    focused = {
+        item["rule_suite"]
+        for item in classified
+        if item["rule_tier"] == "focused_forecasting"
+    }
+    if len(focused) > 1:
+        return _selection(
+            "full_forecasting",
+            "full_forecasting",
+            "multiple_focused_subsystems_force_full",
+            classified,
+        )
+    if focused:
+        suite = focused.pop()
+        return _selection(
+            "focused_forecasting", suite, "single_focused_subsystem", classified
+        )
+    return _selection("non_forecasting", "", "only_non_forecasting_paths", classified)
 
 
 def parse_name_status(raw: bytes) -> list[Change]:
@@ -170,7 +281,7 @@ def parse_name_status(raw: bytes) -> list[Change]:
                 for position in range(index, index + path_count)
             )
             index += path_count
-            changes.append(Change(status=status, paths=paths))
+            changes.append(Change(status, paths))
     except (IndexError, UnicodeDecodeError) as exc:
         raise ClassificationError("malformed git name-status output") from exc
     if index != len(tokens):
@@ -189,17 +300,62 @@ def git_changes(base: str, head: str) -> list[Change]:
         f"{base}...{head}",
     ]
     try:
-        raw = subprocess.check_output(command)
+        return parse_name_status(subprocess.check_output(command))
     except subprocess.CalledProcessError as exc:
         raise ClassificationError(
             f"git diff failed with exit {exc.returncode}"
         ) from exc
-    return parse_name_status(raw)
+
+
+def _summary_code(value: object) -> str:
+    encoded = "".join(f"&#{ord(character)};" for character in str(value))
+    return f"<code>{encoded}</code>"
+
+
+def github_summary(result: Mapping[str, Any]) -> str:
+    lines = [
+        "### Forecasting change classification",
+        "",
+        "#### Rule classification",
+        "",
+        "| Status | Exact changed path | Rule tier | Rule suite |",
+        "| --- | --- | --- | --- |",
+    ]
+    for item in result["paths"]:
+        lines.append(
+            "| "
+            + " | ".join(
+                _summary_code(value)
+                for value in (
+                    item["status"],
+                    item["path"],
+                    item["rule_tier"],
+                    item["rule_suite"] or "none",
+                )
+            )
+            + " |"
+        )
+    if not result["paths"]:
+        lines.append("| none | none | none | none |")
+    lines.extend(
+        [
+            "",
+            "#### Effective trusted execution selection",
+            "",
+            f"- Tier: {_summary_code(result['tier'])}",
+            f"- Focused suite: {_summary_code(result['suite'] or 'none')}",
+            f"- Exact command: {_summary_code(result['command'] or 'none')}",
+            f"- Reason: {_summary_code(result['reason'])}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
 
 
 def write_github_output(path: Path, result: Mapping[str, Any]) -> None:
     with path.open("a", encoding="utf-8") as output:
         output.write(f"tier={result['tier']}\n")
+        output.write(f"suite={result['suite']}\n")
         output.write(f"reason={result['reason']}\n")
 
 
@@ -210,6 +366,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--force-full", action="store_true")
     parser.add_argument("--rules", type=Path, default=DEFAULT_RULES)
     parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--github-summary", type=Path)
     args = parser.parse_args(argv)
     if not args.force_full and not (args.base and args.head):
         parser.error("--base and --head are required unless --force-full is used")
@@ -220,20 +377,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     try:
         rules = load_rules(args.rules)
-        if args.force_full:
-            result = {
-                "tier": "full_forecasting",
-                "reason": "non_pull_request_event_defaults_to_full",
-                "paths": [],
-            }
-        else:
-            result = classify_changes(git_changes(args.base, args.head), rules)
+        result = (
+            force_full_result()
+            if args.force_full
+            else classify_changes(git_changes(args.base, args.head), rules)
+        )
     except ClassificationError as exc:
         print(f"classifier error: {exc}", file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     if args.github_output:
         write_github_output(args.github_output, result)
+    if args.github_summary:
+        with args.github_summary.open("a", encoding="utf-8") as summary:
+            summary.write(github_summary(result))
     return 0
 
 

--- a/tests/ci/test_forecasting_change_classifier.py
+++ b/tests/ci/test_forecasting_change_classifier.py
@@ -169,6 +169,20 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
             with self.subTest(path=path):
                 self.assert_selection("non_forecasting", "", ("M", path))
 
+    def test_only_explicit_license_documentation_paths_are_non_forecasting(self):
+        for path in ("LICENSE", "LICENSE.md", "LICENSE.txt"):
+            with self.subTest(path=path):
+                self.assert_selection("non_forecasting", "", ("M", path))
+
+        for path in ("LICENSE.py", "LICENSE.docs/runtime.py"):
+            with self.subTest(path=path):
+                result = self.assert_selection(
+                    "full_forecasting", "full_forecasting", ("M", path)
+                )
+                self.assertEqual(
+                    result["reason"], "unknown_or_ambiguous_path_forces_full"
+                )
+
     def test_destructive_and_ambiguous_changes_force_full(self):
         for item in (
             ("R100", "scripts/predict_race_now.py", "archive/predict.py"),

--- a/tests/ci/test_forecasting_change_classifier.py
+++ b/tests/ci/test_forecasting_change_classifier.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import html
 import importlib.util
+import re
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -16,197 +19,299 @@ sys.modules[SPEC.name] = CLASSIFIER
 SPEC.loader.exec_module(CLASSIFIER)
 
 
+def changes(*items: tuple[str, ...]):
+    return [CLASSIFIER.Change(status=item[0], paths=tuple(item[1:])) for item in items]
+
+
 class ForecastingChangeClassifierTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.rules = CLASSIFIER.load_rules()
 
-    def test_fixture_tiers(self):
+    def assert_selection(
+        self,
+        expected_tier: str,
+        expected_suite: str,
+        *items: tuple[str, ...],
+    ):
+        result = CLASSIFIER.classify_changes(changes(*items), self.rules)
+        self.assertEqual(result["tier"], expected_tier)
+        self.assertEqual(result["suite"], expected_suite)
+        return result
+
+    def test_representative_deterministic_matrix(self):
         fixtures = [
+            ("ordinary-docs", "non_forecasting", "", ("M", "docs/guide.md")),
             (
-                "manual-only",
-                [
-                    ("M", "scripts/predict_race_now.py"),
-                    ("M", "configs/prediction/manual-default.json"),
-                    ("M", "docs/on_demand_race_prediction.md"),
-                    ("M", "tests/test_predict_race_now.py"),
-                ],
-                "manual_prediction",
-            ),
-            (
-                "official-results-only",
-                [
-                    ("M", "scripts/ingest_results_for_date.py"),
-                    ("M", "scripts/autonomous_official_result_capture.py"),
-                    (
-                        "M",
-                        "scripts/collect_expert_form_official_result_labels_report_only.py",
-                    ),
-                    ("M", "tests/test_results_ingest_official_first.py"),
-                    ("M", "tests/test_autonomous_official_result_capture.py"),
-                    (
-                        "M",
-                        "tests/test_expert_form_official_result_labels_packet.py",
-                    ),
-                ],
-                "official_results",
-            ),
-            (
-                "core-only",
-                [("M", "race_collection/forecasting.py")],
-                "full_forecasting",
-            ),
-            (
-                "mixed",
-                [
-                    ("M", "scripts/predict_race_now.py"),
-                    ("M", "race_collection/source_admission.py"),
-                ],
-                "full_forecasting",
-            ),
-            (
-                "workflow-only",
-                [("M", ".github/workflows/forecasting-tests.yml")],
-                "full_forecasting",
-            ),
-            (
-                "forecasting-contract-doc",
-                [("M", "docs/FORECASTING_PUBLICATION_VALIDATION.md")],
-                "full_forecasting",
-            ),
-            (
-                "docs-only",
-                [("M", "docs/race_evidence_inventory.md")],
+                "on-demand-docs",
                 "non_forecasting",
+                "",
+                ("M", "docs/on_demand_race_prediction.md"),
+            ),
+            ("frontend", "non_forecasting", "", ("M", "frontend/src/App.tsx")),
+            ("ui", "non_forecasting", "", ("M", "ui/prediction/card.ts")),
+            ("static", "non_forecasting", "", ("M", "static/site.css")),
+            (
+                "manual-source",
+                "focused_forecasting",
+                "manual_prediction",
+                ("M", "scripts/predict_race_now.py"),
             ),
             (
-                "rename",
-                [
-                    (
-                        "R100",
-                        "scripts/predict_race_now.py",
-                        "archive/manual_predictor.py",
-                    )
-                ],
-                "full_forecasting",
+                "official-results",
+                "focused_forecasting",
+                "official_results",
+                ("M", "scripts/ingest_results_for_date.py"),
             ),
             (
-                "delete",
-                [("D", "race_collection/model_bundle.py")],
-                "full_forecasting",
+                "inventory",
+                "focused_forecasting",
+                "race_collection_inventory",
+                ("M", "race_collection/inventory.py"),
             ),
             (
-                "unknown",
-                [("A", "new_subsystem/adapter.py")],
+                "two-focused-subsystems",
                 "full_forecasting",
+                "full_forecasting",
+                ("M", "scripts/predict_race_now.py"),
+                ("M", "scripts/ingest_results_for_date.py"),
             ),
             (
-                "generated-dependency",
-                [("M", "requirements.lock")],
+                "shared-domain",
                 "full_forecasting",
+                "full_forecasting",
+                ("M", "race_collection/domain.py"),
             ),
             (
-                "shared-import",
-                [("M", "utils/csv_metadata.py")],
+                "shared-artifacts",
                 "full_forecasting",
+                "full_forecasting",
+                ("M", "race_collection/artifacts.py"),
+            ),
+            (
+                "collector-protocol",
+                "full_forecasting",
+                "full_forecasting",
+                ("M", "race_collection/manual_prediction_collector_request.py"),
+            ),
+            (
+                "migration-schema",
+                "full_forecasting",
+                "full_forecasting",
+                ("M", "migrations/001_forecasting.sql"),
+            ),
+            (
+                "dependency",
+                "full_forecasting",
+                "full_forecasting",
+                ("M", "requirements.lock"),
+            ),
+            (
+                "rules-control",
+                "full_forecasting",
+                "full_forecasting",
+                ("M", ".github/forecasting-paths.ini"),
+            ),
+            (
+                "classifier-control",
+                "full_forecasting",
+                "full_forecasting",
+                ("M", "scripts/ci/classify_forecasting_changes.py"),
+            ),
+            (
+                "workflow-control",
+                "full_forecasting",
+                "full_forecasting",
+                ("M", ".github/workflows/forecasting-tests.yml"),
+            ),
+            (
+                "unknown-source",
+                "full_forecasting",
+                "full_forecasting",
+                ("A", "new_subsystem/adapter.py"),
+            ),
+            (
+                "literal-backslash",
+                "full_forecasting",
+                "full_forecasting",
+                ("A", r"docs\forecasting.md"),
             ),
         ]
-        for name, changes, expected in fixtures:
+        for name, tier, suite, *items in fixtures:
             with self.subTest(name=name):
-                values = [
-                    CLASSIFIER.Change(status=change[0], paths=tuple(change[1:]))
-                    for change in changes
-                ]
+                result = self.assert_selection(tier, suite, *items)
                 self.assertEqual(
-                    CLASSIFIER.classify_changes(values, self.rules)["tier"],
-                    expected,
+                    [path["path"] for path in result["paths"]],
+                    [path for item in items for path in item[1:]],
                 )
 
-    def test_overlap_selects_broader_tier(self):
-        result = CLASSIFIER.classify_changes(
-            [
-                CLASSIFIER.Change(
-                    status="M", paths=("docs/on_demand_race_prediction.md",)
-                )
-            ],
-            self.rules,
+    def test_every_docs_only_path_is_non_forecasting(self):
+        focused_patterns = [
+            pattern
+            for group in self.rules
+            if group.tier == "focused_forecasting"
+            for pattern in group.patterns
+        ]
+        self.assertFalse(
+            any(
+                pattern == "docs" or pattern.startswith("docs/")
+                for pattern in focused_patterns
+            )
         )
-        self.assertEqual(result["tier"], "manual_prediction")
-        self.assertEqual(
-            result["paths"][0]["matched_tiers"],
-            ["non_forecasting", "manual_prediction"],
-        )
-
-    def test_mixed_focused_tiers_default_to_full(self):
-        result = CLASSIFIER.classify_changes(
-            [
-                CLASSIFIER.Change(
-                    status="M", paths=("scripts/predict_race_now.py",)
-                ),
-                CLASSIFIER.Change(
-                    status="M", paths=("scripts/ingest_results_for_date.py",)
-                ),
-            ],
-            self.rules,
-        )
-        self.assertEqual(result["tier"], "full_forecasting")
-        self.assertEqual(result["reason"], "mixed_focused_tiers_default_to_full")
-
-    def test_destructive_official_result_changes_default_to_full(self):
-        for change in (
-            CLASSIFIER.Change(
-                status="D", paths=("scripts/ingest_results_for_date.py",)
-            ),
-            CLASSIFIER.Change(
-                status="R100",
-                paths=(
-                    "scripts/ingest_results_for_date.py",
-                    "scripts/autonomous_official_result_capture.py",
-                ),
-            ),
+        for path in (
+            "docs/on_demand_race_prediction.md",
+            "docs/manual_market_form_residual_prediction.md",
+            "docs/manual_live_market_form_residual_prediction.md",
+            "docs/FORECASTING_PUBLICATION_VALIDATION.md",
+            "docs/forecasting_validation_logs/current.md",
+            "docs/nested/prediction.md",
         ):
-            with self.subTest(status=change.status):
-                result = CLASSIFIER.classify_changes([change], self.rules)
+            with self.subTest(path=path):
+                self.assert_selection("non_forecasting", "", ("M", path))
+
+    def test_destructive_and_ambiguous_changes_force_full(self):
+        for item in (
+            ("R100", "scripts/predict_race_now.py", "archive/predict.py"),
+            ("C100", "scripts/predict_race_now.py", "scripts/copy.py"),
+            ("D", "scripts/predict_race_now.py"),
+            ("T", "docs/guide.md"),
+        ):
+            with self.subTest(status=item[0]):
+                result = self.assert_selection(
+                    "full_forecasting", "full_forecasting", item
+                )
+                self.assertEqual(result["reason"], "unsafe_git_status_forces_full")
+
+    def test_malformed_status_and_change_set_force_full(self):
+        for values in (
+            [],
+            changes(("X", "docs/guide.md")),
+            changes(("", "README.md")),
+            changes(("M100", "scripts/predict_race_now.py")),
+            changes(("R101", "docs/old.md", "docs/new.md")),
+        ):
+            with self.subTest(values=values):
+                result = CLASSIFIER.classify_changes(values, self.rules)
                 self.assertEqual(result["tier"], "full_forecasting")
-                self.assertEqual(
-                    result["reason"],
-                    "destructive_change_defaults_to_full",
-                )
+                self.assertEqual(result["suite"], "full_forecasting")
 
-    def test_empty_or_unknown_status_defaults_to_full(self):
-        self.assertEqual(
-            CLASSIFIER.classify_changes([], self.rules)["tier"], "full_forecasting"
-        )
-        for status in ("?", "X"):
-            with self.subTest(status=status):
-                self.assertEqual(
-                    CLASSIFIER.classify_changes(
-                        [CLASSIFIER.Change(status=status, paths=("README.md",))],
-                        self.rules,
-                    )["tier"],
-                    "full_forecasting",
-                )
-
-    def test_name_status_parser_keeps_both_rename_paths(self):
-        changes = CLASSIFIER.parse_name_status(
-            b"R100\0scripts/predict_race_now.py\0archive/manual_predictor.py\0"
-            b"D\0race_collection/source_admission.py\0"
+    def test_rule_classification_is_distinct_from_escalated_selection(self):
+        result = self.assert_selection(
+            "full_forecasting",
+            "full_forecasting",
+            ("M", "scripts/predict_race_now.py"),
+            ("M", "scripts/ingest_results_for_date.py"),
         )
         self.assertEqual(
-            changes,
-            [
-                CLASSIFIER.Change(
-                    status="R100",
-                    paths=(
-                        "scripts/predict_race_now.py",
-                        "archive/manual_predictor.py",
-                    ),
-                ),
-                CLASSIFIER.Change(
-                    status="D", paths=("race_collection/source_admission.py",)
-                ),
+            [item["rule_tier"] for item in result["paths"]],
+            ["focused_forecasting", "focused_forecasting"],
+        )
+        self.assertEqual(
+            [item["rule_suite"] for item in result["paths"]],
+            ["manual_prediction", "official_results"],
+        )
+        self.assertEqual(result["reason"], "multiple_focused_subsystems_force_full")
+
+    def test_force_full_selection(self):
+        result = CLASSIFIER.force_full_result()
+        self.assertEqual(result["tier"], "full_forecasting")
+        self.assertEqual(result["suite"], "full_forecasting")
+        self.assertEqual(result["reason"], "manual_dispatch_forces_full")
+
+    def test_name_status_parser_keeps_exact_posix_filenames(self):
+        parsed = CLASSIFIER.parse_name_status(
+            b"M\0docs\\forecasting.md\0"
+            b"R100\0scripts/predict_race_now.py\0archive/predict.py\0"
+        )
+        self.assertEqual(parsed[0].paths, (r"docs\forecasting.md",))
+        self.assertEqual(len(parsed[1].paths), 2)
+        with self.assertRaises(CLASSIFIER.ClassificationError):
+            CLASSIFIER.parse_name_status(b"R100\0only-one-path\0")
+        with self.assertRaises(CLASSIFIER.ClassificationError):
+            CLASSIFIER.parse_name_status(b"M\0invalid-\xff\0")
+
+    def test_configuration_is_fail_closed(self):
+        original = Path(CLASSIFIER.DEFAULT_RULES).read_text(encoding="utf-8")
+        malformed = {
+            "missing-section": original.replace("[non_forecasting]", "[wrong]"),
+            "unknown-suite": original.replace(
+                "suite = manual_prediction", "suite = injected"
+            ),
+            "substituted-command": original.replace(
+                "tests/test_predict_race_now.py", "tests/injected.py", 1
+            ),
+            "unknown-option": original.replace(
+                "[metadata]", "[metadata]\nextra = value"
+            ),
+            "unsafe-pattern": original.replace("    docs/**", "    ../docs/**", 1),
+        }
+        for name, contents in malformed.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                path = Path(directory) / "rules.ini"
+                path.write_text(contents, encoding="utf-8")
+                with self.assertRaises(CLASSIFIER.ClassificationError):
+                    CLASSIFIER.load_rules(path)
+
+    def test_summary_renders_every_dynamic_value_as_inert_exact_code(self):
+        dynamic_values = [
+            "M![status](https://example.invalid/status)",
+            "odd\\name|`![image](https://example.invalid/image)<img src=x>\r\n.md",
+            "tier [link](https://example.invalid/tier)",
+            "suite <script>alert(1)</script>",
+            "selected_tier ![image](https://example.invalid/selected)",
+            "selected_suite [link](https://example.invalid/suite)",
+            "command `unsafe` | <b>html</b>",
+            "reason\\with\r\nnewlines",
+        ]
+        result = {
+            "paths": [
+                {
+                    "status": dynamic_values[0],
+                    "path": dynamic_values[1],
+                    "rule_tier": dynamic_values[2],
+                    "rule_suite": dynamic_values[3],
+                }
             ],
+            "tier": dynamic_values[4],
+            "suite": dynamic_values[5],
+            "command": dynamic_values[6],
+            "reason": dynamic_values[7],
+        }
+        summary = CLASSIFIER.github_summary(result)
+        encoded_values = re.findall(r"<code>((?:&#[0-9]+;)*)</code>", summary)
+        self.assertEqual(
+            [html.unescape(value) for value in encoded_values],
+            dynamic_values,
         )
+        for active_syntax in (
+            "![image](",
+            "[link](",
+            "<img",
+            "<script>",
+            "`unsafe`",
+            "reason\\with",
+        ):
+            self.assertNotIn(active_syntax, summary)
+        self.assertIn("Rule classification", summary)
+        self.assertIn("Effective trusted execution selection", summary)
+
+    def test_github_outputs_include_only_trusted_selection(self):
+        result = self.assert_selection(
+            "focused_forecasting",
+            "race_collection_inventory",
+            ("M", "race_collection/inventory.py"),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "output"
+            CLASSIFIER.write_github_output(path, result)
+            self.assertEqual(
+                path.read_text(encoding="utf-8").splitlines(),
+                [
+                    "tier=focused_forecasting",
+                    "suite=race_collection_inventory",
+                    f"reason={result['reason']}",
+                ],
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Replace the coarse Forecasting CI path rule with deterministic risk-based validation tiers while preserving the stable `tests-race-collection` gate:

- `non_forecasting`: known docs and UI-only changes run no Forecasting tests.
- `focused_forecasting`: one supported narrow subsystem runs its explicit existing suite.
- `full_forecasting`: shared/high-risk, unknown, ambiguous, destructive, multi-subsystem, dependency, schema/migration, model/training/evaluation/promotion, classifier/workflow/rules, and manual-dispatch changes run all `tests/race_collection` tests.

The classifier reports each changed path, selected tier, exact trusted command, and reason in the GitHub summary. Dynamic filenames and values are rendered inert while preserving exact display.

## Why

The previous mapping sent broad source and test roots to the complete Forecasting suite. Historical full jobs took about 63–85 minutes, including a 1:08:00 run for 457 tests, even for narrow changes. This keeps the complete gate for risky changes while allowing supported focused groups to finish proportionally.

## Validation

- Classifier unittest: 10 tests
- Classifier pytest: 10 passed
- Manual prediction focused suite: 354 passed in 5.02s
- Official results focused suite: 98 passed in 34.78s
- Race-collection inventory focused suite: 27 passed in 0.11s
- Ruff check and format check
- Workflow YAML parse and stable `tests-race-collection` check-name assertion
- Python byte compilation and `git diff --check`
- Independent read-only review: ACCEPT, no findings
- Adversarial matrix over 5,320 tracked paths: no focused-group overlap

This PR itself changes the classifier, workflow, rules, and classifier tests, so it intentionally selects `full_forecasting`. Scheduled/manual runs also remain full.

## Boundaries

CI-only change. No product/runtime behavior, database, model, service, deployment, branch-protection, merge, or live-capture mutation.