### PR TITLE
Fix scheduled collector lock authority

### DIFF
--- a/docs/on_demand_race_prediction.md
+++ b/docs/on_demand_race_prediction.md
@@ -43,8 +43,12 @@ unexpired unanswered manual request is supported.
 
 The scheduled collector remains the sole browser and capture-lock authority.
 At the start of a collector cycle, after its daemon parent has acquired the
-existing shared lock, it may atomically claim one request. It never checks or
-claims during an active capture. The normal refresh and fixed-window plan put
+existing shared lock, the daemon passes that exact resolved lock path to its
+direct autopilot child. The child validates the non-symlink regular file,
+parent PID, hostname, and run ID before it may atomically claim one request.
+Direct compatibility invocations without an explicit path continue to infer
+the lock beneath the evidence root. It never checks or claims during an active
+capture. The normal refresh and fixed-window plan put
 the requested exact race first, but the request cannot bypass race, URL, jump,
 runner, time-window, Sportsbet validation, or append-only persistence checks.
 The collector writes one attempt marker before capture and exactly one terminal

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -1578,6 +1578,7 @@ def odds_capture_only_autopilot_command(
     *,
     run_id: str,
     evidence_root: Path,
+    lock_path: Path,
     current_time: str,
     db_path: Path,
     days_ahead: int,
@@ -1596,6 +1597,8 @@ def odds_capture_only_autopilot_command(
         run_id,
         "--evidence-root",
         str(evidence_root),
+        "--collector-lock-path",
+        str(lock_path),
         "--current-time",
         current_time,
         "--db",
@@ -3320,6 +3323,7 @@ def run_odds_capture_once(args: argparse.Namespace) -> dict[str, Any]:
     current_dt = parse_datetime_value(current_time, default_tz=generated_at.tzinfo) or generated_at
     run_id = args.run_id or f"{now_id(generated_at)}_odds_capture"
     evidence_root = args.evidence_root
+    lock_path = (args.lock_path or DEFAULT_LOCK_PATH).resolve()
     output_dir = args.output_dir or (
         evidence_root / f"shadow_autopilot_daemonization_v1_{run_id}"
     )
@@ -3339,7 +3343,7 @@ def run_odds_capture_once(args: argparse.Namespace) -> dict[str, Any]:
             **odds_capture_only_operator_fields("ODDS_CAPTURE_ONLY_WAITING_FOR_WINDOW"),
             "output_dir": relpath(output_dir),
             "autopilot_output_dir": None,
-            "lock_path": relpath(args.lock_path or DEFAULT_LOCK_PATH),
+            "lock_path": relpath(lock_path),
             "lock": None,
             "lock_release": None,
             "steps": [],
@@ -3403,7 +3407,6 @@ def run_odds_capture_once(args: argparse.Namespace) -> dict[str, Any]:
                 },
             )
         return report
-    lock_path = args.lock_path or DEFAULT_LOCK_PATH
     lock_payload: dict[str, Any] | None = None
     release: dict[str, Any] | None = None
     steps: list[dict[str, Any]] = []
@@ -3443,6 +3446,7 @@ def run_odds_capture_once(args: argparse.Namespace) -> dict[str, Any]:
         command = odds_capture_only_autopilot_command(
             run_id=f"{run_id}_autopilot",
             evidence_root=evidence_root,
+            lock_path=lock_path,
             current_time=current_time,
             db_path=args.db,
             days_ahead=args.days_ahead,
@@ -8975,7 +8979,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
     output_dir = unique_dir(output_dir)
     output_dir.mkdir(parents=True, exist_ok=False)
     current_time = args.current_time or generated_at.isoformat()
-    lock_path = args.lock_path or DEFAULT_LOCK_PATH
+    lock_path = (args.lock_path or DEFAULT_LOCK_PATH).resolve()
     state_path = args.state_path or DEFAULT_STATE_PATH
     odds_state_path = args.odds_capture_state_path or DEFAULT_ODDS_CAPTURE_ONLY_STATE_PATH
     write_json(
@@ -9125,6 +9129,8 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
             autopilot_run_id,
             "--evidence-root",
             str(evidence_root),
+            "--collector-lock-path",
+            str(lock_path),
             "--current-time",
             current_time,
             "--db",

--- a/scripts/shadow_autopilot_v1.py
+++ b/scripts/shadow_autopilot_v1.py
@@ -20,6 +20,7 @@ import json
 import os
 import shutil
 import socket
+import stat
 import subprocess
 import sys
 import time
@@ -6457,17 +6458,30 @@ def final_verdict_for(
 
 def scheduled_collector_authority(
     evidence_root: Path,
+    *,
+    lock_path: Path | None = None,
 ) -> dict[str, Any] | None:
     """Prove this process is the direct child of the current shared-lock owner."""
 
-    lock_path = (
-        evidence_root
-        / "shadow_autopilot_daemon_runtime"
-        / "shadow_autopilot.lock"
+    lock_path = lock_path or (
+        evidence_root / "shadow_autopilot_daemon_runtime" / "shadow_autopilot.lock"
     )
-    if lock_path.is_symlink():
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            lock_path,
+            os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK,
+        )
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            return None
+        with os.fdopen(descriptor, encoding="utf-8") as lock_file:
+            descriptor = -1
+            payload = json.load(lock_file)
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
         return None
-    payload = load_json(lock_path)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
     if (
         not isinstance(payload, Mapping)
         or payload.get("pid") != os.getppid()
@@ -6611,7 +6625,10 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
         "status": "NOT_CLAIMED",
         "reason": "scheduled_collector_authority_unavailable",
     }
-    collector_authority = scheduled_collector_authority(evidence_root)
+    collector_authority = scheduled_collector_authority(
+        evidence_root,
+        lock_path=args.collector_lock_path,
+    )
     if (
         args.enable_autonomous_odds_capture
         and args.execute_autonomous_odds_capture
@@ -8436,6 +8453,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--run-id")
     parser.add_argument("--evidence-root", type=Path, default=DEFAULT_EVIDENCE_ROOT)
+    parser.add_argument("--collector-lock-path", type=Path)
     parser.add_argument("--output-dir", type=Path)
     parser.add_argument("--current-time")
     parser.add_argument("--db", type=Path, default=ROOT / "greyhound_racing_data.db")

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -243,10 +243,17 @@ def test_run_once_exception_writes_terminal_daemon_report(tmp_path, monkeypatch)
 
     def failing_run_command(**kwargs):
         assert kwargs["name"] == "autopilot_cycle"
+        command = kwargs["command"]
+        assert command[command.index("--collector-lock-path") + 1] == str(
+            launch_dir / "shared-runtime" / "shadow_autopilot.lock"
+        )
         raise RuntimeError("synthetic daemon failure")
 
     monkeypatch.setattr(daemon, "run_command", failing_run_command)
 
+    launch_dir = tmp_path / "launch"
+    launch_dir.mkdir()
+    monkeypatch.chdir(launch_dir)
     args = daemon.parse_args(
         [
             "run-once",
@@ -261,7 +268,7 @@ def test_run_once_exception_writes_terminal_daemon_report(tmp_path, monkeypatch)
             "--shadow-model",
             str(shadow_model),
             "--lock-path",
-            str(tmp_path / "shared-runtime" / "shadow_autopilot.lock"),
+            "shared-runtime/shadow_autopilot.lock",
         ]
     )
 
@@ -274,7 +281,7 @@ def test_run_once_exception_writes_terminal_daemon_report(tmp_path, monkeypatch)
     assert report["exception_message"] == "synthetic daemon failure"
     assert written["runtime_action"] == "CHECK_DAEMON_EXCEPTION"
     assert generated["pause_path"] == (
-        tmp_path / "shared-runtime" / "pause-heavy-scheduling"
+        launch_dir / "shared-runtime" / "pause-heavy-scheduling"
     )
     assert (output_dir / "final_status.txt").read_text(encoding="utf-8") == (
         "PARTIAL_DAEMONIZATION\n"
@@ -1170,6 +1177,7 @@ def test_odds_capture_only_autopilot_command_is_narrow_and_append_only():
     command = daemon.odds_capture_only_autopilot_command(
         run_id="odds_only_autopilot",
         evidence_root=Path("/evidence"),
+        lock_path=Path("/runtime/shared.lock"),
         current_time="2026-06-12T09:48:00+10:00",
         db_path=Path("/data/greyhound_racing_data.db"),
         days_ahead=1,
@@ -1192,11 +1200,15 @@ def test_odds_capture_only_autopilot_command_is_narrow_and_append_only():
     assert "--skip-status" in command
     assert "--skip-unified-dataset" in command
     assert "--require-safe-refresh-metadata" in command
+    assert command[command.index("--collector-lock-path") + 1] == (
+        "/runtime/shared.lock"
+    )
     assert "--enable-autonomous-result-capture" not in command
 
     permissive_command = daemon.odds_capture_only_autopilot_command(
         run_id="odds_only_autopilot",
         evidence_root=Path("/evidence"),
+        lock_path=Path("/runtime/shared.lock"),
         current_time="2026-06-12T09:48:00+10:00",
         db_path=Path("/data/greyhound_racing_data.db"),
         days_ahead=1,
@@ -2179,11 +2191,14 @@ def test_run_odds_capture_once_uses_lock_and_writes_compact_report(tmp_path, mon
     output_dir = evidence_root / "shadow_autopilot_daemonization_v1_odds_only"
     db_path = tmp_path / "greyhound_racing_data.db"
     db_path.write_text("db", encoding="utf-8")
-    lock_path = tmp_path / "runtime" / "shadow.lock"
+    launch_dir = tmp_path / "launch"
+    launch_dir.mkdir()
+    lock_path = launch_dir / "runtime" / "shadow.lock"
     state_path = tmp_path / "runtime" / "odds_capture_state.json"
     autopilot_dir = evidence_root / "shadow_autopilot_v1_odds_only_autopilot"
 
     monkeypatch.setattr(daemon, "ROOT", tmp_path)
+    monkeypatch.chdir(launch_dir)
 
     def fake_run_command(*, name, command, output_dir, timeout_seconds, cwd=daemon.ROOT):
         assert name == "odds_capture_autopilot_cycle"
@@ -2194,6 +2209,7 @@ def test_run_odds_capture_once_uses_lock_and_writes_compact_report(tmp_path, mon
         assert "--enable-autonomous-odds-capture" in command
         assert "--allow-auto-scrape-odds" in command
         assert "--require-safe-refresh-metadata" in command
+        assert command[command.index("--collector-lock-path") + 1] == str(lock_path)
         running_report = json.loads(
             (output_dir / "odds_capture_only_daemon_report.json").read_text(
                 encoding="utf-8"
@@ -2271,7 +2287,7 @@ def test_run_odds_capture_once_uses_lock_and_writes_compact_report(tmp_path, mon
             "--db",
             str(db_path),
             "--lock-path",
-            str(lock_path),
+            "runtime/shadow.lock",
             "--state-path",
             str(state_path),
         ]

--- a/tests/test_shadow_autopilot_v1.py
+++ b/tests/test_shadow_autopilot_v1.py
@@ -548,6 +548,111 @@ def test_scheduled_collector_authority_requires_direct_shared_lock_owner(
     assert autopilot.scheduled_collector_authority(tmp_path) is None
 
 
+def test_scheduled_collector_authority_uses_explicit_external_lock(tmp_path):
+    evidence_root = tmp_path / "external_evidence"
+    explicit_lock = tmp_path / "daemon_runtime" / "shared.lock"
+    explicit_lock.parent.mkdir()
+    autopilot.write_json(
+        explicit_lock,
+        {
+            "pid": os.getppid(),
+            "hostname": socket.gethostname(),
+            "run_id": "scheduled-run-external",
+        },
+    )
+
+    authority = autopilot.scheduled_collector_authority(
+        evidence_root,
+        lock_path=explicit_lock,
+    )
+
+    assert authority is not None
+    assert authority["run_id"] == "scheduled-run-external"
+
+
+def test_scheduled_collector_authority_parses_from_opened_descriptor(
+    tmp_path, monkeypatch
+):
+    lock_path = tmp_path / "shared.lock"
+    original = {
+        "pid": os.getppid(),
+        "hostname": socket.gethostname(),
+        "run_id": "opened-descriptor-run",
+    }
+    autopilot.write_json(lock_path, original)
+    real_fstat = os.fstat
+
+    def replace_path_after_open(descriptor):
+        metadata = real_fstat(descriptor)
+        lock_path.rename(tmp_path / "opened.lock")
+        autopilot.write_json(
+            lock_path,
+            {
+                **original,
+                "pid": -1,
+                "run_id": "replacement-path-run",
+            },
+        )
+        return metadata
+
+    monkeypatch.setattr(autopilot.os, "fstat", replace_path_after_open)
+
+    authority = autopilot.scheduled_collector_authority(
+        tmp_path,
+        lock_path=lock_path,
+    )
+
+    assert authority is not None
+    assert authority["run_id"] == "opened-descriptor-run"
+
+
+def test_scheduled_collector_authority_rejects_unsafe_explicit_locks(tmp_path):
+    lock_path = tmp_path / "shared.lock"
+    valid = {
+        "pid": os.getppid(),
+        "hostname": socket.gethostname(),
+        "run_id": "scheduled-run-1",
+    }
+
+    assert autopilot.scheduled_collector_authority(
+        tmp_path, lock_path=lock_path
+    ) is None
+
+    lock_path.mkdir()
+    assert autopilot.scheduled_collector_authority(
+        tmp_path, lock_path=lock_path
+    ) is None
+    lock_path.rmdir()
+
+    lock_path.write_text("{malformed", encoding="utf-8")
+    assert autopilot.scheduled_collector_authority(
+        tmp_path, lock_path=lock_path
+    ) is None
+
+    for field in ("pid", "hostname", "run_id"):
+        payload = dict(valid)
+        payload.pop(field)
+        autopilot.write_json(lock_path, payload)
+        assert autopilot.scheduled_collector_authority(
+            tmp_path, lock_path=lock_path
+        ) is None
+
+    for field, value in (("pid", -1), ("hostname", "wrong-host")):
+        payload = {**valid, field: value}
+        autopilot.write_json(lock_path, payload)
+        assert autopilot.scheduled_collector_authority(
+            tmp_path, lock_path=lock_path
+        ) is None
+
+    target = tmp_path / "lock-target"
+    autopilot.write_json(target, valid)
+    lock_path.unlink()
+    lock_path.symlink_to(target)
+    assert autopilot.scheduled_collector_authority(
+        tmp_path, lock_path=lock_path
+    ) is None
+
+
 def test_manual_request_is_deferred_during_active_capture_boundary(tmp_path):
     now = datetime.fromisoformat("2026-06-10T14:00:00+10:00")
     protocol = ManualPredictionCollectorProtocol(


### PR DESCRIPTION
## What

- Resolve the scheduled collector lock path once to an absolute path in the daemon and propagate that same authority through both full and odds-only child paths.
- Harden child lock reads with `O_NOFOLLOW`, regular-file validation through `fstat`, and same-descriptor JSON parsing.
- Preserve existing fallback behavior and PID, hostname, and run-ID validation.
- Add regression coverage for relative working directories, path replacement/TOCTOU, and unsafe lock files; update the operator documentation.

## Why

The daemon accepted a configurable `--lock-path`, while the child could independently infer an evidence-root lock. That mismatch could remove the collector's authority over manual prediction coordination. The repair also closes relative-CWD and path-replacement gaps in the lock handoff.

## Impact

Restores fail-closed, collector-owned coordination for manual prediction requests. This PR does not deploy runtime files, alter services or timers, change models, promote artifacts, emit EV, or enable betting.

## Checks

- Focused pytest: `7 passed, 222 deselected`
- Critical Ruff rules: `E9,F63,F7,F82` passed
- `git diff --check` passed
- Reviewed patch SHA-256: `6e5091f29b5eb4da41f4587d83e5e447f253a1d935a52c32e288cee0f51ef103`
- Final independent Codex X review: `ACCEPT`