### PR TITLE
Surface late collector terminal responses

### DIFF
--- a/scripts/predict_race_now.py
+++ b/scripts/predict_race_now.py
@@ -952,16 +952,21 @@ def _acquire_or_reuse(
             sleep=dependencies.sleep,
         )
         elapsed = max(0.0, dependencies.monotonic() - started)
-        observed_time = min(jump, current_time + timedelta(seconds=elapsed))
+        response_observed_time = current_time + timedelta(seconds=elapsed)
         if response is None:
             raise PredictionBlocked(
                 "COLLECTOR_RESPONSE_TIMEOUT",
                 request_id=published["request_id"],
                 wait_seconds=wait_seconds,
             )
+        response_observed_time = max(
+            response_observed_time,
+            datetime.fromisoformat(str(response["responded_at"])),
+        )
+        observed_time = min(jump, response_observed_time)
         consumed = protocol.consume_response(
             str(published["request_id"]),
-            now=observed_time,
+            now=response_observed_time,
         )
         if response["status"] != RECEIPT_READY:
             raise PredictionBlocked(

--- a/tests/test_predict_race_now.py
+++ b/tests/test_predict_race_now.py
@@ -939,6 +939,49 @@ def test_request_wait_has_finite_deadline_without_lock_attempt(tmp_path: Path):
     assert calls["acquire"] == 0
 
 
+def test_expired_response_after_jump_surfaces_terminal_status(tmp_path: Path):
+    clock = {"value": 0.0}
+    request_root = tmp_path / "collector-requests"
+    protocol = ManualPredictionCollectorProtocol(request_root)
+    collector_response_time = NOW + timedelta(seconds=121)
+
+    def sleep(seconds: float) -> None:
+        clock["value"] += seconds
+        if clock["value"] >= 61:
+            context = protocol.prepare_collector_request(
+                now=collector_response_time,
+                collector_run_id="scheduled-run-1",
+                active_capture=False,
+            )
+            assert context is None
+
+    with pytest.raises(PredictionBlocked) as captured:
+        predict_now._acquire_or_reuse(
+            dependencies(
+                discover=lambda **kwargs: None,
+                monotonic=lambda: clock["value"],
+                sleep=sleep,
+            ),
+            protocol=protocol,
+            target=race("12:01"),
+            odds_source="auto",
+            evidence_roots=(tmp_path / "evidence",),
+            db_path=tmp_path / "source.db",
+            race_id=RACE_ID,
+            jump=NOW + timedelta(minutes=1),
+            current_time=NOW,
+            wait_seconds=120,
+            poll_seconds=61,
+        )
+
+    assert captured.value.code == "REQUEST_EXPIRED"
+    consumed = list((request_root / "consumed").glob("*.json"))
+    assert len(consumed) == 1
+    assert json.loads(consumed[0].read_bytes())["consumed_at"] == (
+        collector_response_time.isoformat()
+    )
+
+
 def test_capture_source_cannot_create_second_capture_authority(tmp_path: Path):
     calls = {"acquire": 0, "fetch": 0}
     deps = dependencies(discover=lambda **kwargs: None)


### PR DESCRIPTION
## What changed

- Record response consumption no earlier than the validated collector `responded_at` timestamp.
- Keep receipt validation bounded by the race jump time.
- Add a regression covering a `REQUEST_EXPIRED` response emitted after jump when schedule-resolution latency predates the request wait clock.

## Why

A research-only runtime proof published a request for Richmond Straight R3 at 12:43:26 with a 12:47 jump. The next safe collector boundary arrived at 12:50:16 and correctly emitted `REQUEST_EXPIRED`. The predictor clipped its consume timestamp to jump and surfaced `COLLECTOR_PROTOCOL_INVALID` / `TIMESTAMP_ORDER_INVALID` instead of the source terminal status.

The predictor's base time is captured before live schedule resolution, while its monotonic wait begins after request publication. The fix therefore uses the later of the monotonic-derived observation time and the already validated response timestamp for consume-once.

## Impact

Late terminal responses now remain fail-closed but surface their exact status, such as `REQUEST_EXPIRED`. Collector-only authority, capture attempts, scoring, production persistence, and betting behavior are unchanged.

## Validation

- Focused predictor/protocol checks: `6 passed`
- Regression demonstrated `COLLECTOR_PROTOCOL_INVALID` before the fix and `REQUEST_EXPIRED` after it
- Ruff `E9,F63,F7,F82`: passed
- `py_compile`: passed
- `git diff --check`: passed
- Fresh two-file diff review: no remaining findings

No live retry, service mutation, database mutation, deployment, training, or betting action was performed as part of this repair.