### PR TITLE
Fix manual collector attempt timestamp ordering

### DIFF
--- a/scripts/shadow_autopilot_v1.py
+++ b/scripts/shadow_autopilot_v1.py
@@ -6792,12 +6792,17 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
         or load_json(output_dir / "refresh_prejump_report.json")
     )
     if args.enable_autonomous_odds_capture:
+        capture_current_time = (
+            str(manual_request.claim["claimed_at"])
+            if manual_request is not None
+            else current_time
+        )
         autonomous_odds_command = autonomous_live_odds_capture_command(
             input_dirs=odds_capture_input_dirs,
             evidence_root=evidence_root,
             capture_dir=autonomous_odds_capture_dir,
             db_path=args.db,
-            current_time=current_time,
+            current_time=capture_current_time,
             limit=autonomous_odds_capture_limit,
             execute=args.execute_autonomous_odds_capture,
             allow_auto_scrape_odds=args.allow_auto_scrape_odds,

--- a/tests/test_shadow_autopilot_v1.py
+++ b/tests/test_shadow_autopilot_v1.py
@@ -739,6 +739,7 @@ def test_capture_only_manual_request_seals_response_without_shadow_model(
     from scripts import predict_race_now
 
     generated_at = datetime.now().astimezone()
+    parent_cycle_time = generated_at - timedelta(seconds=1)
     evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
     db_path = tmp_path / "greyhound_racing_data.db"
     db_path.write_text("db", encoding="utf-8")
@@ -806,7 +807,12 @@ def test_capture_only_manual_request_seals_response_without_shadow_model(
             context = claimed_protocol.claimed_request(
                 command[command.index("--manual-request-id") + 1]
             )
-            captured_at = datetime.now().astimezone()
+            captured_at = datetime.fromisoformat(
+                command[command.index("--current-time") + 1]
+            )
+            assert captured_at == datetime.fromisoformat(
+                str(context.claim["claimed_at"])
+            )
             claimed_protocol.begin_attempt(
                 context,
                 now=captured_at,
@@ -912,7 +918,7 @@ def test_capture_only_manual_request_seals_response_without_shadow_model(
             "--collector-lock-path",
             str(lock_path),
             "--current-time",
-            generated_at.isoformat(),
+            parent_cycle_time.isoformat(),
             "--db",
             str(db_path),
             "--enable-autonomous-odds-capture",
@@ -956,6 +962,9 @@ def test_capture_only_manual_request_seals_response_without_shadow_model(
     assert capture_commands[0][
         capture_commands[0].index("--collector-run-id") + 1
     ] == "scheduled-capture-only"
+    assert datetime.fromisoformat(
+        capture_commands[0][capture_commands[0].index("--current-time") + 1]
+    ) > parent_cycle_time
 
 
 def test_full_shadow_run_without_model_still_fails_closed(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- use the claimed manual-request timestamp for the scheduled autonomous capture child rather than the parent timer cycle timestamp
- preserve the existing timestamp fix already loaded by the active runtime when deploying the synchronous manual capture path
- add a regression proving child `--current-time` equals `claimed_at` and is later than the parent cycle time

## Root cause

The scheduled collector could claim a request after its parent timer cycle began but pass the older parent `current_time` into the capture child. That made request/attempt ordering inaccurate and could make a timely request appear stale.

## Scope

This is an exact replay of live-only commit `c4f306bf372bf7b343dddca90ba6f0ddaac36265` on current master. Stable patch ID: `a49673da91c0632a6c37c3bcd0e5e3e17baa7d63`.

No timer cadence, browser, lock, capture, model, persistence, betting, or service behavior is otherwise changed.

## Validation

- 25 focused scheduled-request, protocol, and synchronous-capture tests passed
- fatal Ruff (`E9,F63,F7,F82`) passed
- `py_compile` passed
- `git diff --check` passed
- exact-diff code review found no critical, warning, or suggestion findings

The fail-closed classifier selects `full_forecasting` because both legacy paths default unknown changes to the full tier. Per owner authorization, publication and merge use the focused validation above rather than waiting for the full suite.