### PR TITLE
Keep capture-one stdout machine-readable

### DIFF
--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -13,6 +13,7 @@ official-result evidence rows.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import json
 import os
@@ -12948,30 +12949,31 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     if args.command == "capture-one":
-        from race_collection.synchronous_manual_capture import (
-            install_cancellation_handlers,
-            restore_signal_handlers,
-            run_capture_one,
-        )
-
-        previous = install_cancellation_handlers()
-        try:
-            result = run_capture_one(
-                protocol_root=args.protocol_root,
-                evidence_root=args.evidence_root,
-                request_id=args.request_id,
-                db_path=args.db,
-                lock_path=args.lock_path,
-                output_dir=args.output_dir,
-                minimum_margin_seconds=args.minimum_margin_seconds,
-                minimum_post_lock_margin_seconds=(
-                    args.minimum_post_lock_margin_seconds
-                ),
-                minimum_fetch_margin_seconds=args.minimum_fetch_margin_seconds,
-                fetch_timeout_seconds=args.fetch_timeout_seconds,
+        with contextlib.redirect_stdout(sys.stderr):
+            from race_collection.synchronous_manual_capture import (
+                install_cancellation_handlers,
+                restore_signal_handlers,
+                run_capture_one,
             )
-        finally:
-            restore_signal_handlers(previous)
+
+            previous = install_cancellation_handlers()
+            try:
+                result = run_capture_one(
+                    protocol_root=args.protocol_root,
+                    evidence_root=args.evidence_root,
+                    request_id=args.request_id,
+                    db_path=args.db,
+                    lock_path=args.lock_path,
+                    output_dir=args.output_dir,
+                    minimum_margin_seconds=args.minimum_margin_seconds,
+                    minimum_post_lock_margin_seconds=(
+                        args.minimum_post_lock_margin_seconds
+                    ),
+                    minimum_fetch_margin_seconds=args.minimum_fetch_margin_seconds,
+                    fetch_timeout_seconds=args.fetch_timeout_seconds,
+                )
+            finally:
+                restore_signal_handlers(previous)
         print(json.dumps(result, sort_keys=True))
         return 0 if result.get("status") == "RECEIPT_READY" else 2
     if args.command == "run-odds-capture-once":

--- a/tests/race_collection/test_synchronous_manual_capture.py
+++ b/tests/race_collection/test_synchronous_manual_capture.py
@@ -413,6 +413,86 @@ def test_capture_one_returns_immediate_busy_with_owner_and_phase(tmp_path: Path)
     assert not protocol.outstanding_request_ids()
 
 
+def test_capture_one_cli_emits_machine_only_busy_json(tmp_path: Path):
+    now = datetime.now().astimezone()
+    jump = now + timedelta(minutes=10)
+    db_path = tmp_path / "greyhound_racing_data.db"
+    db_path.write_bytes(b"")
+    lock_path = (
+        tmp_path
+        / "artifacts/full_evidence_orchestration_20260525/"
+        "shadow_autopilot_daemon_runtime/shadow_autopilot.lock"
+    )
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_bytes(
+        canonical_bytes(
+            {
+                "schema_version": "shadow_autopilot_daemon_lock_v1",
+                "run_id": "scheduled_fixture",
+                "pid": 123,
+                "hostname": "fixture",
+                "started_at": now.isoformat(),
+                "output_dir": str(tmp_path / "scheduled"),
+                "phase": "odds_capture",
+            }
+        )
+    )
+    evidence_root = tmp_path / "evidence"
+    protocol = ManualPredictionCollectorProtocol(
+        evidence_root / "manual_prediction_collector_requests_v1"
+    )
+    request = protocol.publish_request(
+        race={
+            "race_id": f"Race 1 - QOT - {now.date().isoformat()}",
+            "url": (
+                "https://www.thedogs.com.au/racing/ladbrokes-q1-lakeside/"
+                f"{now.date().isoformat()}/1/fixture?trial=false"
+            ),
+            "venue": "QOT",
+            "race_number": 1,
+            "race_date": now.date().isoformat(),
+            "jump_timestamp": jump.isoformat(),
+        },
+        expected_runners=[],
+        created_at=now,
+        expires_at=jump,
+    )
+
+    result = invoke_capture_one(
+        command=[
+            sys.executable,
+            str(Path("scripts/shadow_autopilot_daemon.py").resolve()),
+            "capture-one",
+            "--evidence-root",
+            str(evidence_root),
+            "--protocol-root",
+            str(protocol.root),
+            "--request-id",
+            str(request["request_id"]),
+            "--db",
+            str(db_path),
+            "--lock-path",
+            str(lock_path),
+            "--output-dir",
+            str(evidence_root / "capture-one"),
+            "--minimum-margin-seconds",
+            "114",
+            "--minimum-post-lock-margin-seconds",
+            "113",
+            "--minimum-fetch-margin-seconds",
+            "98",
+            "--fetch-timeout-seconds",
+            "45",
+        ],
+        timeout_seconds=10,
+    )
+
+    assert result["status"] == "BUSY"
+    assert result["busy"]["lock_owner_run_id"] == "scheduled_fixture"
+    assert result["busy"]["lock_owner_phase"] == "odds_capture"
+    assert not protocol.outstanding_request_ids()
+
+
 def test_capture_failure_terminalizes_request_and_releases_lock(tmp_path: Path):
     failed = successful_report()
     failed["final_status"] = "AUTONOMOUS_LIVE_ODDS_CAPTURE_BLOCKED"


### PR DESCRIPTION
## Summary
- isolate capture-one incidental import/runtime logging on stderr
- reserve stdout for the single terminal JSON result consumed by the manual predictor
- add a real subprocess BUSY regression proving owner/phase evidence and request terminalization

## Live failure fixed
The synchronous collector correctly returned BUSY while the scheduled collector held the canonical lock, but structured-logging banners preceded the JSON on stdout. The strict predictor wrapper therefore reported COLLECTOR_PROCESS_INVALID instead of the canonical BUSY result.

## Validation
- focused collector/predictor/daemon tests: 198 passed
- fatal Ruff: passed
- py_compile: passed
- git diff --check: passed

No live race retry, browser capture, timer/service control, DB write, betting, or model change.