### PR TITLE
Fix manual prediction availability with scheduled receipt reuse

### DIFF
--- a/docs/on_demand_race_prediction.md
+++ b/docs/on_demand_race_prediction.md
@@ -40,6 +40,17 @@ report, and pre-jump timestamp. Lookup is confined to that race's directory and
 rejects unsafe paths, changed bytes, malformed records, or more than 32 indexed
 receipts. `receipt` mode is reuse-only.
 
+Successful scheduled appends also publish
+`collector-exact-capture-receipt-v1` records immediately from inside the same
+validated collector capture loop. Each record binds the scheduled collector run,
+exact TheDogs URL/date/race number, canonical race-ID aliases, runner-set hash,
+append timestamp, capture attempt and append report, and immutable form,
+sidecar, and per-attempt source-report bytes. The predictor checks the bounded
+directory for the resolved exact race before requesting a new acquisition.
+This allows a current scheduled capture to be reused while the scheduled batch
+still owns the canonical lock; it does not create another browser, wait for a
+timer boundary, accept an unsealed database row, or weaken `BUSY`.
+
 If no reusable receipt exists, `auto` or `capture` atomically publishes one
 research-only, one-attempt request under
 `artifacts/full_evidence_orchestration_20260525/manual_prediction_collector_requests_v1`.

--- a/race_collection/manual_prediction_collector_request.py
+++ b/race_collection/manual_prediction_collector_request.py
@@ -25,6 +25,7 @@ RESPONSE_SCHEMA = "manual-prediction-collector-response-v1"
 RECEIPT_SCHEMA = "manual-prediction-collector-receipt-v1"
 CONSUME_SCHEMA = "manual-prediction-collector-consume-v1"
 EXACT_RECEIPT_SCHEMA = "manual-prediction-exact-receipt-index-v1"
+COLLECTOR_EXACT_RECEIPT_SCHEMA = "collector-exact-capture-receipt-v1"
 PROTOCOL_DIRECTORY = "manual_prediction_collector_requests_v1"
 
 RECEIPT_READY = "RECEIPT_READY"
@@ -207,6 +208,46 @@ def runner_set_sha256(rows: Sequence[Mapping[str, Any]]) -> str | None:
     return sha256_bytes(canonical_bytes(identities))
 
 
+def _validate_collector_source_report(
+    raw: bytes,
+    *,
+    race_id: str,
+    collector_run_id: str,
+    capture_attempt_sha256: str,
+    append_report_sha256: str,
+) -> None:
+    try:
+        report = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ProtocolRejected("RECORD_MALFORMED") from exc
+    if (
+        type(report) is not dict
+        or canonical_bytes(report) != raw
+        or report.get("schema_version") != "collector_exact_capture_source_v1"
+        or report.get("race_id") != race_id
+        or report.get("collector_run_id") != collector_run_id
+    ):
+        raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
+    attempts = report.get("attempts")
+    matches = [
+        attempt
+        for attempt in attempts or []
+        if isinstance(attempt, Mapping)
+        and attempt.get("race_id") == race_id
+        and attempt.get("status") == "APPENDED"
+    ]
+    if len(matches) != 1:
+        raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
+    attempt = matches[0]
+    append_report = attempt.get("append_report")
+    if (
+        sha256_bytes(canonical_bytes(attempt)) != capture_attempt_sha256
+        or not isinstance(append_report, Mapping)
+        or sha256_bytes(canonical_bytes(append_report)) != append_report_sha256
+    ):
+        raise ProtocolRejected("HASH_DRIFT", field="capture_attempt")
+
+
 class ManualPredictionCollectorProtocol:
     """Atomic request lifecycle with one claim, attempt, response, and consume."""
 
@@ -237,6 +278,18 @@ class ManualPredictionCollectorProtocol:
 
     def exact_receipt_path(self, race_id: str, request_id: str) -> Path:
         return self.exact_receipt_directory(race_id) / f"{request_id}.json"
+
+    def collector_exact_receipt_directory(self, race_id: str) -> Path:
+        name = hashlib.sha256(race_id.encode()).hexdigest()
+        return self.root / "collector-exact-receipts" / name
+
+    def collector_exact_receipt_path(
+        self, race_id: str, capture_attempt_sha256: str
+    ) -> Path:
+        return (
+            self.collector_exact_receipt_directory(race_id)
+            / f"{capture_attempt_sha256}.json"
+        )
 
     def _safe_directory(self, path: Path) -> None:
         try:
@@ -953,6 +1006,286 @@ class ManualPredictionCollectorProtocol:
             duplicate_code="DUPLICATE_RESPONSE",
         )
         return response
+
+    def publish_collector_exact_receipt(
+        self,
+        *,
+        collector_run_id: str,
+        emitted_at: datetime,
+        handoff: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Publish one scheduled collector capture for bounded exact reuse."""
+
+        public_handoff = {
+            str(key): value
+            for key, value in handoff.items()
+            if not str(key).startswith("_")
+        }
+        required_handoff = {
+            "schema_version",
+            "race_id",
+            "race",
+            "append_timestamp",
+            "runner_set_sha256",
+            "source_report_sha256",
+            "source_form_sha256",
+            "source_sidecar_sha256",
+            "capture_attempt_sha256",
+            "append_report_sha256",
+        }
+        if (
+            set(public_handoff) != required_handoff
+            or public_handoff.get("schema_version")
+            != "on_demand_verified_collector_capture_v2"
+        ):
+            raise ProtocolRejected("RECEIPT_MALFORMED")
+        race = _race(public_handoff["race"])
+        race_id = _known_text(public_handoff["race_id"], "race_id")
+        if race["race_id"] != race_id:
+            raise ProtocolRejected("IDENTITY_MISMATCH")
+        captured, captured_text = _timestamp(
+            public_handoff["append_timestamp"], "append_timestamp"
+        )
+        jump, _ = _timestamp(race["jump_timestamp"], "race.jump_timestamp")
+        emitted, emitted_text = _timestamp(emitted_at, "emitted_at")
+        if captured >= jump or emitted < captured:
+            raise ProtocolRejected("TIMESTAMP_ORDER_INVALID")
+        capture_attempt_sha = _hash(
+            public_handoff["capture_attempt_sha256"],
+            "capture_attempt_sha256",
+        )
+        collector_run = _known_text(collector_run_id, "collector_run_id")
+        for key in (
+            "runner_set_sha256",
+            "source_report_sha256",
+            "source_form_sha256",
+            "source_sidecar_sha256",
+            "append_report_sha256",
+        ):
+            _hash(public_handoff[key], key)
+
+        evidence_root = self.root.parent.resolve()
+        artifacts: dict[str, Any] = {}
+        for label, hash_key in (
+            ("report", "source_report_sha256"),
+            ("form", "source_form_sha256"),
+            ("sidecar", "source_sidecar_sha256"),
+        ):
+            path_value = handoff.get(f"_{label}_path")
+            path = Path(path_value) if isinstance(path_value, (str, Path)) else None
+            if (
+                path is None
+                or path.is_symlink()
+                or not path.is_file()
+                or not path.is_absolute()
+            ):
+                raise ProtocolRejected("SOURCE_FILE_UNSAFE", field=label)
+            resolved = path.resolve()
+            try:
+                relative = resolved.relative_to(evidence_root)
+            except ValueError as exc:
+                raise ProtocolRejected("SOURCE_FILE_UNSAFE", field=label) from exc
+            raw = path.read_bytes()
+            expected_hash = _hash(public_handoff[hash_key], hash_key)
+            if sha256_bytes(raw) != expected_hash:
+                raise ProtocolRejected("HASH_DRIFT", field=hash_key)
+            artifacts[label] = {
+                "path": relative.as_posix(),
+                "sha256": expected_hash,
+            }
+        _validate_collector_source_report(
+            Path(handoff["_report_path"]).read_bytes(),
+            race_id=race_id,
+            collector_run_id=collector_run,
+            capture_attempt_sha256=capture_attempt_sha,
+            append_report_sha256=public_handoff["append_report_sha256"],
+        )
+
+        payload = {
+            "schema_version": COLLECTOR_EXACT_RECEIPT_SCHEMA,
+            "race_id": race_id,
+            "collector_run_id": collector_run,
+            "captured_at": captured_text,
+            "emitted_at": emitted_text,
+            "sealed_handoff": public_handoff,
+            "artifacts": artifacts,
+            "form_name": _known_text(handoff.get("_form_name"), "form_name"),
+        }
+        self._publish_once(
+            self.collector_exact_receipt_path(race_id, capture_attempt_sha),
+            payload,
+            duplicate_code="DUPLICATE_COLLECTOR_EXACT_RECEIPT",
+            exact_recovery=True,
+        )
+        return payload
+
+    def discover_collector_exact_handoff(
+        self,
+        *,
+        race_id: str,
+        current_time: datetime,
+        max_age_seconds: int,
+    ) -> dict[str, Any] | None:
+        """Load one exact scheduled capture without scanning other races."""
+
+        if max_age_seconds <= 0:
+            raise ProtocolRejected("RECEIPT_MAX_AGE_INVALID")
+        now, _ = _timestamp(current_time, "current_time")
+        race_id = _known_text(race_id, "race_id")
+        directory = self.collector_exact_receipt_directory(race_id)
+        if not directory.exists():
+            return None
+        if directory.is_symlink() or not directory.is_dir():
+            raise ProtocolRejected("PROTOCOL_PATH_UNSAFE")
+        paths = sorted(directory.glob("*.json"), reverse=True)
+        if len(paths) > 32:
+            raise ProtocolRejected("EXACT_RECEIPT_INDEX_UNBOUNDED")
+
+        evidence_root = self.root.parent.resolve()
+        candidates: list[tuple[datetime, dict[str, Any]]] = []
+        for path in paths:
+            value, _ = self._load_object(
+                path, "COLLECTOR_EXACT_RECEIPT_NOT_FOUND"
+            )
+            expected_keys = {
+                "schema_version",
+                "race_id",
+                "collector_run_id",
+                "captured_at",
+                "emitted_at",
+                "sealed_handoff",
+                "artifacts",
+                "form_name",
+            }
+            if (
+                set(value) != expected_keys
+                or value.get("schema_version")
+                != COLLECTOR_EXACT_RECEIPT_SCHEMA
+                or value.get("race_id") != race_id
+            ):
+                raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
+            _known_text(value["collector_run_id"], "collector_run_id")
+            captured, _ = _timestamp(value["captured_at"], "captured_at")
+            emitted, _ = _timestamp(value["emitted_at"], "emitted_at")
+            age = (now - captured).total_seconds()
+            if emitted < captured or emitted > now or age < 0:
+                raise ProtocolRejected("TIMESTAMP_ORDER_INVALID")
+            if age > max_age_seconds:
+                continue
+            handoff = value.get("sealed_handoff")
+            required_handoff = {
+                "schema_version",
+                "race_id",
+                "race",
+                "append_timestamp",
+                "runner_set_sha256",
+                "source_report_sha256",
+                "source_form_sha256",
+                "source_sidecar_sha256",
+                "capture_attempt_sha256",
+                "append_report_sha256",
+            }
+            if (
+                type(handoff) is not dict
+                or set(handoff) != required_handoff
+                or handoff.get("schema_version")
+                != "on_demand_verified_collector_capture_v2"
+                or handoff.get("race_id") != race_id
+                or handoff.get("append_timestamp") != value["captured_at"]
+            ):
+                raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
+            race = _race(handoff["race"])
+            jump, _ = _timestamp(
+                race["jump_timestamp"], "race.jump_timestamp"
+            )
+            if race["race_id"] != race_id or captured >= jump:
+                raise ProtocolRejected("IDENTITY_MISMATCH")
+            capture_attempt_sha = _hash(
+                handoff.get("capture_attempt_sha256"),
+                "capture_attempt_sha256",
+            )
+            for key in (
+                "runner_set_sha256",
+                "source_report_sha256",
+                "source_form_sha256",
+                "source_sidecar_sha256",
+                "append_report_sha256",
+            ):
+                _hash(handoff[key], key)
+            if path != self.collector_exact_receipt_path(
+                race_id, capture_attempt_sha
+            ):
+                raise ProtocolRejected("PROTOCOL_PATH_UNSAFE")
+
+            artifacts = value.get("artifacts")
+            if type(artifacts) is not dict or set(artifacts) != {
+                "report",
+                "form",
+                "sidecar",
+            }:
+                raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
+            raw_artifacts: dict[str, bytes] = {}
+            artifact_paths: dict[str, Path] = {}
+            for label, source_key in (
+                ("report", "source_report_sha256"),
+                ("form", "source_form_sha256"),
+                ("sidecar", "source_sidecar_sha256"),
+            ):
+                artifact = artifacts[label]
+                if type(artifact) is not dict or set(artifact) != {
+                    "path",
+                    "sha256",
+                }:
+                    raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
+                relative = Path(
+                    _known_text(artifact["path"], f"artifacts.{label}.path")
+                )
+                if relative.is_absolute():
+                    raise ProtocolRejected("PROTOCOL_PATH_UNSAFE")
+                artifact_path = evidence_root / relative
+                if artifact_path.is_symlink() or not artifact_path.is_file():
+                    raise ProtocolRejected("SOURCE_FILE_UNSAFE", field=label)
+                resolved = artifact_path.resolve()
+                try:
+                    resolved.relative_to(evidence_root)
+                except ValueError as exc:
+                    raise ProtocolRejected("PROTOCOL_PATH_UNSAFE") from exc
+                raw = artifact_path.read_bytes()
+                expected_hash = _hash(
+                    artifact["sha256"], f"artifacts.{label}.sha256"
+                )
+                if (
+                    sha256_bytes(raw) != expected_hash
+                    or handoff.get(source_key) != expected_hash
+                ):
+                    raise ProtocolRejected("HASH_DRIFT", field=label)
+                raw_artifacts[label] = raw
+                artifact_paths[label] = resolved
+            _validate_collector_source_report(
+                raw_artifacts["report"],
+                race_id=race_id,
+                collector_run_id=value["collector_run_id"],
+                capture_attempt_sha256=capture_attempt_sha,
+                append_report_sha256=handoff["append_report_sha256"],
+            )
+            candidates.append(
+                (
+                    captured,
+                    {
+                        **handoff,
+                        "_report_bytes": raw_artifacts["report"],
+                        "_form_bytes": raw_artifacts["form"],
+                        "_sidecar_bytes": raw_artifacts["sidecar"],
+                        "_report_path": artifact_paths["report"],
+                        "_form_path": artifact_paths["form"],
+                        "_sidecar_path": artifact_paths["sidecar"],
+                        "_form_name": _known_text(
+                            value["form_name"], "form_name"
+                        ),
+                    },
+                )
+            )
+        return max(candidates, key=lambda item: item[0])[1] if candidates else None
 
     def _validate_response(
         self,

--- a/race_collection/synchronous_manual_capture.py
+++ b/race_collection/synchronous_manual_capture.py
@@ -23,6 +23,7 @@ from race_collection.manual_prediction_collector_request import (
     ManualPredictionCollectorProtocol,
     ProtocolRejected,
     canonical_bytes,
+    runner_set_sha256,
 )
 from src.predictor.on_demand import (
     PredictionBlocked,
@@ -682,9 +683,10 @@ def _contains_outcome(value: Any) -> bool:
     return False
 
 
-def seal_capture_handoff(
+def _seal_capture_handoff(
     *,
-    context: CollectorRequest,
+    expected: Mapping[str, Any],
+    expected_runner_hash: str | None,
     plan_item: Mapping[str, Any],
     capture_report: Mapping[str, Any],
     report_path: Path,
@@ -693,7 +695,6 @@ def seal_capture_handoff(
 ) -> dict[str, Any]:
     """Seal one exact append-only capture without invoking prediction scoring."""
 
-    expected = context.request["race"]
     if (
         plan_item.get("race_id") != expected["race_id"]
         or plan_item.get("thedogs_source_url") != expected["url"]
@@ -744,7 +745,6 @@ def seal_capture_handoff(
         validation=validation,
         source_kind="verified_collector_capture_one",
     )
-    expected_runner_hash = context.request["expected_runner_set_sha256"]
     if (
         expected_runner_hash is not None
         and normalized["runner_set_sha256"] != expected_runner_hash
@@ -777,6 +777,176 @@ def seal_capture_handoff(
         "_form_path": form_path.resolve(),
         "_sidecar_path": sidecar_path.resolve(),
         "_form_name": form_path.name,
+    }
+
+
+def seal_capture_handoff(
+    *,
+    context: CollectorRequest,
+    plan_item: Mapping[str, Any],
+    capture_report: Mapping[str, Any],
+    report_path: Path,
+    form_path: Path,
+    sidecar_path: Path,
+) -> dict[str, Any]:
+    """Seal one exact manual capture through the shared collector primitive."""
+
+    return _seal_capture_handoff(
+        expected=context.request["race"],
+        expected_runner_hash=context.request["expected_runner_set_sha256"],
+        plan_item=plan_item,
+        capture_report=capture_report,
+        report_path=report_path,
+        form_path=form_path,
+        sidecar_path=sidecar_path,
+    )
+
+
+def _publish_once_canonical(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(canonical_bytes(payload))
+            handle.flush()
+            os.fsync(handle.fileno())
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except BaseException:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def publish_scheduled_capture_receipts(
+    *,
+    protocol: ManualPredictionCollectorProtocol,
+    evidence_root: Path,
+    collector_run_id: str,
+    plan_item: Mapping[str, Any],
+    attempt: Mapping[str, Any],
+    output_dir: Path,
+    emitted_at: datetime,
+) -> dict[str, Any]:
+    """Publish bounded alias-indexed receipts immediately after one append."""
+
+    evidence_root = evidence_root.resolve()
+    output_dir = output_dir.resolve()
+    if not output_dir.is_relative_to(evidence_root):
+        raise CaptureOneRejected("SOURCE_FILE_UNSAFE", label="output_dir")
+    if attempt.get("status") != "APPENDED":
+        raise CaptureOneRejected(
+            "CAPTURE_FAILED", reason="scheduled_attempt_not_appended"
+        )
+    from scripts.refresh_prejump_upcoming import stable_race_id_variants
+
+    aliases = set(stable_race_id_variants(plan_item))
+    aliases.update(
+        value
+        for value in plan_item.get("race_id_aliases") or []
+        if isinstance(value, str) and value
+    )
+    source_race_id = str(plan_item.get("race_id") or "")
+    if source_race_id and source_race_id not in aliases:
+        aliases.add(source_race_id)
+    if not aliases or len(aliases) > 16:
+        raise CaptureOneRejected(
+            "IDENTITY_MISMATCH",
+            reason="scheduled_receipt_aliases_unbounded",
+            alias_count=len(aliases),
+        )
+    expected_runner_hash = runner_set_sha256(
+        [
+            dict(row)
+            for row in plan_item.get("expected_runners") or []
+            if isinstance(row, Mapping)
+        ]
+    )
+    if expected_runner_hash is None:
+        raise CaptureOneRejected(
+            "IDENTITY_MISMATCH", reason="scheduled_receipt_runners_missing"
+        )
+
+    receipts: list[dict[str, Any]] = []
+    for race_id in sorted(aliases):
+        parts = race_id.split(" - ", 2)
+        if (
+            len(parts) != 3
+            or parts[0] != f"Race {plan_item.get('race_number')}"
+            or parts[2] != str(plan_item.get("race_date"))
+        ):
+            raise CaptureOneRejected(
+                "IDENTITY_MISMATCH", reason="scheduled_receipt_alias_invalid"
+            )
+        adapted_attempt = dict(attempt)
+        adapted_attempt["race_id"] = race_id
+        source_report = {
+            "schema_version": "collector_exact_capture_source_v1",
+            "collector_run_id": collector_run_id,
+            "generated_at": emitted_at.isoformat(),
+            "race_id": race_id,
+            "source_race_id": source_race_id,
+            "source_plan_item": dict(plan_item),
+            "source_attempt": dict(attempt),
+            "attempts": [adapted_attempt],
+        }
+        source_raw = canonical_bytes(source_report)
+        source_path = (
+            output_dir
+            / "collector_exact_receipt_sources"
+            / f"{sha256_bytes(source_raw)}.json"
+        )
+        try:
+            _publish_once_canonical(source_path, source_report)
+        except FileExistsError:
+            if source_path.is_symlink() or source_path.read_bytes() != source_raw:
+                raise CaptureOneRejected("HASH_DRIFT", field="source_report")
+
+        expected = {
+            "race_id": race_id,
+            "url": str(plan_item.get("thedogs_source_url") or ""),
+            "venue": parts[1],
+            "race_number": int(plan_item["race_number"]),
+            "race_date": str(plan_item["race_date"]),
+            "jump_timestamp": str(plan_item["jump_datetime"]),
+        }
+        adapted_plan = dict(plan_item)
+        adapted_plan["race_id"] = race_id
+        adapted_plan["venue"] = parts[1]
+        handoff = _seal_capture_handoff(
+            expected=expected,
+            expected_runner_hash=expected_runner_hash,
+            plan_item=adapted_plan,
+            capture_report=source_report,
+            report_path=source_path,
+            form_path=Path(str(plan_item["csv_path"])).resolve(),
+            sidecar_path=Path(str(plan_item["sidecar_path"])).resolve(),
+        )
+        published = protocol.publish_collector_exact_receipt(
+            collector_run_id=collector_run_id,
+            emitted_at=emitted_at,
+            handoff=handoff,
+        )
+        receipts.append(
+            {
+                "race_id": race_id,
+                "captured_at": published["captured_at"],
+                "capture_attempt_sha256": handoff["capture_attempt_sha256"],
+            }
+        )
+    return {
+        "schema_version": "collector_exact_capture_receipt_publish_v1",
+        "status": "PUBLISHED",
+        "source_race_id": source_race_id,
+        "receipt_count": len(receipts),
+        "receipts": receipts,
     }
 
 

--- a/scripts/autonomous_live_odds_capture.py
+++ b/scripts/autonomous_live_odds_capture.py
@@ -823,6 +823,50 @@ def selected_races_by_key(report: Mapping[str, Any]) -> dict[tuple[str, str], di
     return output
 
 
+def refresh_report_for_input_dir(input_dir: Path) -> dict[str, Any]:
+    candidates = [
+        input_dir / "odds_capture_refresh_report.json",
+        input_dir / "refresh_prejump_report.json",
+        input_dir.parent / "odds_capture_refresh_report.json",
+        input_dir.parent / "refresh_prejump_report.json",
+    ]
+    return next((load_json_object(path) for path in candidates if path.exists()), {})
+
+
+def add_selected_race_aliases(
+    plan_item: Mapping[str, Any],
+    report: Mapping[str, Any],
+) -> dict[str, Any]:
+    enriched = dict(plan_item)
+    source_url = str(plan_item.get("thedogs_source_url") or "").strip()
+    race_number = parse_int_value(plan_item.get("race_number"))
+    race_date = str(plan_item.get("race_date") or "")
+    selected = report.get("selected_races")
+    if not source_url or not isinstance(selected, list):
+        return enriched
+    matches = [
+        row
+        for row in selected
+        if isinstance(row, Mapping)
+        and str(row.get("race_url") or row.get("url") or "").strip() == source_url
+        and race_number_from_selected(row) == race_number
+        and race_date_from_selected(row) == race_date
+    ]
+    if len(matches) != 1:
+        return enriched
+    aliases = {
+        str(value)
+        for value in [
+            matches[0].get("race_id"),
+            *(matches[0].get("race_id_aliases") or []),
+        ]
+        if isinstance(value, str) and value
+    }
+    if len(aliases) <= 16:
+        enriched["race_id_aliases"] = sorted(aliases)
+    return enriched
+
+
 def race_number_from_selected(row: Mapping[str, Any]) -> int | None:
     return parse_int_value(row.get("race_number"))
 
@@ -1116,13 +1160,7 @@ def fallback_plan_items_from_refresh_report(
     *,
     current_time: datetime,
 ) -> list[dict[str, Any]]:
-    candidates = [
-        input_dir / "odds_capture_refresh_report.json",
-        input_dir / "refresh_prejump_report.json",
-        input_dir.parent / "odds_capture_refresh_report.json",
-        input_dir.parent / "refresh_prejump_report.json",
-    ]
-    report = next((load_json_object(path) for path in candidates if path.exists()), {})
+    report = refresh_report_for_input_dir(input_dir)
     if not report:
         return []
     selected_by_key = selected_races_by_key(report)
@@ -1168,6 +1206,7 @@ def build_capture_plan(
     rows: list[dict[str, Any]] = []
     seen_csv_paths: set[Path] = set()
     for input_dir in input_dirs:
+        refresh_report = refresh_report_for_input_dir(Path(input_dir))
         input_dir_row_start = len(rows)
         for csv_path in sorted(Path(input_dir).rglob("*.csv")):
             if {"raw_exports", "quarantine"}.intersection(csv_path.parts):
@@ -1176,7 +1215,12 @@ def build_capture_plan(
             if logical_path in seen_csv_paths:
                 continue
             seen_csv_paths.add(logical_path)
-            rows.append(build_plan_item(csv_path, current_time))
+            rows.append(
+                add_selected_race_aliases(
+                    build_plan_item(csv_path, current_time),
+                    refresh_report,
+                )
+            )
         input_dir_rows = rows[input_dir_row_start:]
         if not any(row.get("status") == "READY_TO_CAPTURE" for row in input_dir_rows):
             rows.extend(
@@ -1247,7 +1291,11 @@ def refresh_plan_item_for_time(
 ) -> dict[str, Any]:
     csv_path = plan_item_csv_path(plan_item)
     if plan_item_should_rebuild_from_csv(plan_item, csv_path):
-        return build_plan_item(csv_path, current_time)
+        rebuilt = build_plan_item(csv_path, current_time)
+        aliases = plan_item.get("race_id_aliases")
+        if isinstance(aliases, list):
+            rebuilt["race_id_aliases"] = list(aliases)
+        return rebuilt
 
     refreshed = dict(plan_item)
     time_blockers = {
@@ -2539,6 +2587,7 @@ def execute_capture_plan(
     current_time_provider: Callable[[], datetime] | None = None,
     fetch_timeout_seconds: float = DEFAULT_FETCH_TIMEOUT_SECONDS,
     progress_dir: Path | None = None,
+    receipt_publisher: Callable[..., Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     time_provider = current_time_provider or (lambda: datetime.now().astimezone())
     attempts: list[dict[str, Any]] = []
@@ -2693,6 +2742,21 @@ def execute_capture_plan(
             if append_report.get("status") == "SUCCESS" and attempt["inserted_rows"] > 0
             else "APPEND_FAILED"
         )
+        if attempt["status"] == "APPENDED" and receipt_publisher is not None:
+            try:
+                attempt["collector_exact_receipt_publish"] = dict(
+                    receipt_publisher(
+                        plan_item=item,
+                        attempt=dict(attempt),
+                        emitted_at=time_provider(),
+                    )
+                )
+            except Exception as exc:
+                attempt["collector_exact_receipt_publish"] = {
+                    "schema_version": "collector_exact_capture_receipt_publish_v1",
+                    "status": "REJECTED",
+                    "reason": type(exc).__name__,
+                }
         attempts.append(attempt)
         flush_attempt_progress(progress_dir, attempts=attempts)
 
@@ -2714,6 +2778,19 @@ def execute_capture_plan(
     ready_count = int(plan.get("ready_count") or 0)
     candidate_count = len([item for item in plan.get("races") or [] if isinstance(item, Mapping)])
     completed_count = len(attempts)
+    receipt_publish_results = [
+        attempt["collector_exact_receipt_publish"]
+        for attempt in attempts
+        if isinstance(attempt.get("collector_exact_receipt_publish"), Mapping)
+    ]
+    receipt_publish_count = sum(
+        int(result.get("receipt_count") or 0)
+        for result in receipt_publish_results
+        if result.get("status") == "PUBLISHED"
+    )
+    receipt_publish_failure_count = sum(
+        1 for result in receipt_publish_results if result.get("status") != "PUBLISHED"
+    )
     ready_race_ids = [
         str(item.get("race_id"))
         for item in plan.get("races") or []
@@ -2757,6 +2834,10 @@ def execute_capture_plan(
         "ready_race_ids": ready_race_ids,
         "validation_pass_count": validation_pass_count,
         "inserted_live_odds_rows": inserted_rows,
+        "collector_exact_receipt_publish_count": receipt_publish_count,
+        "collector_exact_receipt_publish_failure_count": (
+            receipt_publish_failure_count
+        ),
         "fetch_timeout_seconds": fetch_timeout_seconds,
         **next_action,
         "capture_window_coverage": window_coverage,
@@ -2864,6 +2945,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--manual-request-root", type=Path)
     parser.add_argument("--manual-request-id")
+    parser.add_argument("--collector-receipt-root", type=Path)
     parser.add_argument("--collector-run-id")
     return parser.parse_args(argv)
 
@@ -2898,6 +2980,31 @@ def main(argv: Sequence[str] | None = None) -> int:
             execute=args.execute,
             allow_auto_scrape_odds=args.allow_auto_scrape_odds,
         )
+    receipt_publisher = None
+    if args.collector_receipt_root is not None:
+        if (
+            not args.collector_run_id
+            or not args.execute
+            or not args.allow_auto_scrape_odds
+        ):
+            raise ValueError("collector_receipt_authority_missing")
+        from race_collection.synchronous_manual_capture import (
+            publish_scheduled_capture_receipts,
+        )
+
+        receipt_protocol = ManualPredictionCollectorProtocol(
+            args.collector_receipt_root
+        )
+
+        def receipt_publisher(**values: Any) -> Mapping[str, Any]:
+            return publish_scheduled_capture_receipts(
+                protocol=receipt_protocol,
+                evidence_root=evidence_root,
+                collector_run_id=args.collector_run_id,
+                output_dir=output_dir,
+                **values,
+            )
+
     report = execute_capture_plan(
         plan,
         db_path=args.db,
@@ -2906,6 +3013,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         allow_auto_scrape_odds=args.allow_auto_scrape_odds,
         fetch_timeout_seconds=args.fetch_timeout_seconds,
         progress_dir=output_dir,
+        receipt_publisher=receipt_publisher,
     )
     report = {
         **capture_report_identity_fields(output_dir),

--- a/scripts/predict_race_now.py
+++ b/scripts/predict_race_now.py
@@ -605,10 +605,30 @@ def _acquire_or_reuse(
     if odds_source not in {"auto", "capture", "receipt"}:
         raise PredictionBlocked("ODDS_SOURCE_UNSUPPORTED", odds_source=odds_source)
     try:
-        handoff = protocol.discover_exact_handoff(
+        manual_handoff = protocol.discover_exact_handoff(
             race_id=race_id,
             current_time=current_time,
             max_age_seconds=receipt_max_age_seconds,
+        )
+        collector_handoff = protocol.discover_collector_exact_handoff(
+            race_id=race_id,
+            current_time=current_time,
+            max_age_seconds=receipt_max_age_seconds,
+        )
+        available_handoffs = [
+            value
+            for value in (manual_handoff, collector_handoff)
+            if value is not None
+        ]
+        handoff = (
+            max(
+                available_handoffs,
+                key=lambda value: datetime.fromisoformat(
+                    str(value["append_timestamp"])
+                ),
+            )
+            if available_handoffs
+            else None
         )
         if handoff is not None:
             if (jump - current_time).total_seconds() <= latency_budget.reuse_margin_seconds:
@@ -875,6 +895,16 @@ def _run_prediction(
             current_time=receipt_validation_time,
             max_age_seconds=int(config["bundle"]["receipt_max_age_seconds"]),
         )
+        if (
+            receipt.get("race_id") != race_id
+            or (
+                handoff.get("schema_version")
+                == "on_demand_verified_collector_capture_v2"
+                and receipt.get("runner_set_sha256")
+                != handoff.get("runner_set_sha256")
+            )
+        ):
+            raise PredictionBlocked("RECEIPT_INVALID")
         form_name = str(handoff.get("_form_name") or "form.csv")
         if Path(form_name).name != form_name:
             raise PredictionBlocked("RECEIPT_INVALID")

--- a/scripts/shadow_autopilot_v1.py
+++ b/scripts/shadow_autopilot_v1.py
@@ -621,6 +621,7 @@ def autonomous_live_odds_capture_command(
     allow_auto_scrape_odds: bool,
     manual_request_root: Path | None = None,
     manual_request_id: str | None = None,
+    collector_receipt_root: Path | None = None,
     collector_run_id: str | None = None,
     command_prefix: Sequence[str] | None = None,
 ) -> list[str]:
@@ -646,6 +647,19 @@ def autonomous_live_odds_capture_command(
         command.append("--execute")
     if allow_auto_scrape_odds:
         command.append("--allow-auto-scrape-odds")
+    if collector_receipt_root is not None:
+        if (
+            collector_run_id is None
+            or not execute
+            or not allow_auto_scrape_odds
+        ):
+            raise ValueError("collector_receipt_authority_missing")
+        command.extend(
+            [
+                "--collector-receipt-root",
+                str(collector_receipt_root),
+            ]
+        )
     if manual_request_id is not None:
         if manual_request_root is None or collector_run_id is None:
             raise ValueError("manual_request_collector_authority_missing")
@@ -655,10 +669,12 @@ def autonomous_live_odds_capture_command(
                 str(manual_request_root),
                 "--manual-request-id",
                 manual_request_id,
-                "--collector-run-id",
-                collector_run_id,
             ]
         )
+    if collector_run_id is not None and (
+        collector_receipt_root is not None or manual_request_id is not None
+    ):
+        command.extend(["--collector-run-id", collector_run_id])
     return command
 
 
@@ -6629,13 +6645,17 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
         evidence_root,
         lock_path=args.collector_lock_path,
     )
+    collector_run_id = (
+        str(collector_authority["run_id"])
+        if collector_authority is not None
+        else None
+    )
     if (
         args.enable_autonomous_odds_capture
         and args.execute_autonomous_odds_capture
         and args.allow_auto_scrape_odds
         and collector_authority is not None
     ):
-        collector_run_id = str(collector_authority["run_id"])
         try:
             manual_protocol, manual_request = prepare_manual_collector_request(
                 evidence_root=evidence_root,
@@ -6817,6 +6837,15 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
             collector_run_id=(
                 str(manual_request.claim["collector_run_id"])
                 if manual_request is not None
+                else collector_run_id
+            ),
+            collector_receipt_root=(
+                evidence_root / PROTOCOL_DIRECTORY
+                if (
+                    collector_run_id is not None
+                    and args.execute_autonomous_odds_capture
+                    and args.allow_auto_scrape_odds
+                )
                 else None
             ),
         )

--- a/tests/race_collection/test_synchronous_manual_capture.py
+++ b/tests/race_collection/test_synchronous_manual_capture.py
@@ -27,6 +27,7 @@ from race_collection.synchronous_manual_capture import (
     LatencyBudget,
     invoke_capture_one,
     publish_current_race_index,
+    publish_scheduled_capture_receipts,
     run_capture_one,
 )
 from src.predictor.on_demand import canonical_bytes, sha256_bytes
@@ -386,6 +387,89 @@ def test_capture_one_success_is_one_capture_one_receipt_and_one_consumption(
     with pytest.raises(ProtocolRejected, match="RESPONSE_ALREADY_CONSUMED"):
         protocol.consume_response(result["request_id"], now=NOW + timedelta(seconds=4))
     assert not protocol.outstanding_request_ids()
+
+
+def test_scheduled_capture_publishes_bounded_alias_receipts_for_reuse(
+    tmp_path: Path,
+):
+    source_race_id = "Race 2 - LADBROKES-Q1-LAKESIDE - 2026-07-30"
+    alias_race_id = "Race 2 - QOT - 2026-07-30"
+    race_url = "https://www.thedogs.com.au/racing/q-straight/2026-07-30/2"
+    evidence_root = tmp_path / "evidence"
+    protocol = ManualPredictionCollectorProtocol(
+        evidence_root / "manual_prediction_collector_requests_v1"
+    )
+    output_dir = evidence_root / "scheduled-capture"
+    output_dir.mkdir(parents=True)
+    form = output_dir / "Race 1 - WARRNAMBOOL - 2026-07-30.csv"
+    form.write_text("dog_name,box_number\nAlpha,1\nBeta,2\n", encoding="utf-8")
+    sidecar = form.with_name(form.name + ".metadata.json")
+    sidecar.write_bytes(canonical_bytes({"race_id": RACE_ID}))
+    item = {
+        **plan_item(form),
+        "race_id": source_race_id,
+        "race_id_aliases": [
+            alias_race_id,
+            "Race 2 - Q STRAIGHT - 2026-07-30",
+        ],
+        "venue": "LADBROKES-Q1-LAKESIDE",
+        "race_number": 2,
+        "thedogs_source_url": race_url,
+    }
+    attempt = {
+        **successful_report()["attempts"][0],
+        "race_id": source_race_id,
+    }
+    attempt["append_report"] = {
+        **attempt["append_report"],
+        "race_id": source_race_id,
+    }
+
+    result = publish_scheduled_capture_receipts(
+        protocol=protocol,
+        evidence_root=evidence_root,
+        collector_run_id="20260730T165500+1000_odds_capture",
+        plan_item=item,
+        attempt=attempt,
+        output_dir=output_dir,
+        emitted_at=NOW + timedelta(seconds=3),
+    )
+
+    assert result["status"] == "PUBLISHED"
+    assert result["receipt_count"] >= 2
+    reused = protocol.discover_collector_exact_handoff(
+        race_id=alias_race_id,
+        current_time=NOW + timedelta(seconds=4),
+        max_age_seconds=900,
+    )
+    assert reused is not None
+    assert reused["race_id"] == alias_race_id
+    assert reused["race"]["url"] == race_url
+    assert reused["append_timestamp"] == (NOW + timedelta(seconds=2)).isoformat()
+    assert reused["_form_bytes"] == form.read_bytes()
+    assert not protocol.outstanding_request_ids()
+    receipt_path = protocol.collector_exact_receipt_path(
+        alias_race_id,
+        reused["capture_attempt_sha256"],
+    )
+    receipt_raw = receipt_path.read_bytes()
+    receipt_value = json.loads(receipt_raw)
+    receipt_value["sealed_handoff"]["append_report_sha256"] = "f" * 64
+    receipt_path.write_bytes(canonical_bytes(receipt_value))
+    with pytest.raises(ProtocolRejected, match="HASH_DRIFT"):
+        protocol.discover_collector_exact_handoff(
+            race_id=alias_race_id,
+            current_time=NOW + timedelta(seconds=5),
+            max_age_seconds=900,
+        )
+    receipt_path.write_bytes(receipt_raw)
+    form.write_bytes(form.read_bytes() + b"tampered")
+    with pytest.raises(ProtocolRejected, match="HASH_DRIFT"):
+        protocol.discover_collector_exact_handoff(
+            race_id=alias_race_id,
+            current_time=NOW + timedelta(seconds=5),
+            max_age_seconds=900,
+        )
 
 
 def test_capture_one_returns_immediate_busy_with_owner_and_phase(tmp_path: Path):

--- a/tests/test_autonomous_live_odds_capture.py
+++ b/tests/test_autonomous_live_odds_capture.py
@@ -332,6 +332,53 @@ def test_build_capture_plan_discovers_nested_daemon_eligible_inputs(tmp_path):
     )
 
 
+def test_primary_capture_plan_preserves_bounded_index_aliases_through_refresh(
+    tmp_path,
+):
+    run_dir = tmp_path / "shadow_autopilot_v1_unit"
+    input_dir = run_dir / "odds_capture_refreshed_upcoming"
+    csv_path = _write_capture_input(
+        input_dir,
+        venue="LADBROKES-Q1-LAKESIDE",
+        race_number=2,
+    )
+    sidecar_path = capture.sidecar_path_for(csv_path)
+    sidecar = json.loads(sidecar_path.read_bytes())
+    race_url = "https://www.thedogs.com.au/racing/q-straight/2026-06-10/2/example"
+    sidecar["prejump_shadow_metadata"]["source_url"] = race_url
+    capture.write_json(sidecar_path, sidecar)
+    qot_race_id = "Race 2 - QOT - 2026-06-10"
+    capture.write_json(
+        run_dir / "odds_capture_refresh_report.json",
+        {
+            "selected_races": [
+                {
+                    "race_url": race_url,
+                    "race_id": qot_race_id,
+                    "race_id_aliases": [
+                        qot_race_id,
+                        "Race 2 - Q STRAIGHT - 2026-06-10",
+                        "Race 2 - Q1 LAKESIDE - 2026-06-10",
+                    ],
+                    "venue": "QOT",
+                    "race_number": 2,
+                    "date": "2026-06-10",
+                    "jump_datetime": "2026-06-10T15:00:00+10:00",
+                }
+            ]
+        },
+    )
+
+    item = _plan(input_dir)["races"][0]
+    refreshed = capture.refresh_plan_item_for_time(
+        item,
+        datetime.fromisoformat("2026-06-10T14:41:00+10:00"),
+    )
+
+    assert qot_race_id in item["race_id_aliases"]
+    assert refreshed["race_id_aliases"] == item["race_id_aliases"]
+
+
 def test_build_capture_plan_uses_refresh_report_fallback_when_form_csv_quarantined(
     tmp_path,
 ):
@@ -988,6 +1035,7 @@ def test_execute_capture_plan_appends_after_exact_sportsbet_validation(
     input_dir = tmp_path / "upcoming"
     _write_capture_input(input_dir)
     appended = {}
+    published = []
 
     def fake_fetch(db_path, venue, race_number, race_date, allow_auto_scrape_odds):
         win_rows = [
@@ -1039,6 +1087,20 @@ def test_execute_capture_plan_appends_after_exact_sportsbet_validation(
     monkeypatch.setattr(capture, "fetch_odds_for_target_race", fake_fetch)
     monkeypatch.setattr(capture, "append_validated_capture", fake_append)
 
+    def publish_receipt(*, plan_item, attempt, emitted_at):
+        published.append(
+            {
+                "race_id": plan_item["race_id"],
+                "status": attempt["status"],
+                "emitted_at": emitted_at.isoformat(),
+            }
+        )
+        return {
+            "schema_version": "collector_exact_capture_receipt_publish_v1",
+            "status": "PUBLISHED",
+            "receipt_count": 2,
+        }
+
     report = capture.execute_capture_plan(
         _plan(input_dir),
         db_path=tmp_path / "odds.db",
@@ -1046,6 +1108,7 @@ def test_execute_capture_plan_appends_after_exact_sportsbet_validation(
         execute=True,
         allow_auto_scrape_odds=True,
         current_time_provider=lambda: datetime.fromisoformat("2026-06-10T14:40:00+10:00"),
+        receipt_publisher=publish_receipt,
     )
 
     assert report["final_status"] == "AUTONOMOUS_LIVE_ODDS_CAPTURE_APPENDED"
@@ -1055,6 +1118,18 @@ def test_execute_capture_plan_appends_after_exact_sportsbet_validation(
     assert report["skipped_already_captured_count"] == 0
     assert report["validation_pass_count"] == 1
     assert report["inserted_live_odds_rows"] == 4
+    assert report["collector_exact_receipt_publish_count"] == 2
+    assert report["collector_exact_receipt_publish_failure_count"] == 0
+    assert report["attempts"][0]["collector_exact_receipt_publish"]["status"] == (
+        "PUBLISHED"
+    )
+    assert published == [
+        {
+            "race_id": "Race 1 - WPK - 2026-06-10",
+            "status": "APPENDED",
+            "emitted_at": "2026-06-10T14:40:00+10:00",
+        }
+    ]
     assert appended["capture_mode"] == "autonomous_prejump_t30m"
     assert [row["box_number"] for row in appended["rows"]] == [1, 2]
     assert [row["box_number"] for row in appended["place_rows"]] == [1, 2]

--- a/tests/test_predict_race_now.py
+++ b/tests/test_predict_race_now.py
@@ -804,6 +804,95 @@ def test_fixture_e2e_reuses_receipt_seals_features_selects_model_and_bundles(
     assert json.loads((bundle / "result.json").read_bytes()) == result
 
 
+def test_scheduled_exact_receipt_reuses_while_capture_authority_is_busy(
+    tmp_path: Path,
+):
+    protocol_root = tmp_path / "collector-requests"
+    protocol = ManualPredictionCollectorProtocol(protocol_root)
+    value = handoff()
+    collector_run_id = "20260719T115500+1000_odds_capture"
+    source_attempt = {
+        **json.loads(value["_report_bytes"])["attempts"][0],
+        "append_report": {
+            "status": "SUCCESS",
+            "append_only": True,
+            "inserted_rows": 2,
+        },
+    }
+    value["_report_bytes"] = canonical_bytes(
+        {
+            "schema_version": "collector_exact_capture_source_v1",
+            "race_id": RACE_ID,
+            "collector_run_id": collector_run_id,
+            "attempts": [source_attempt],
+        }
+    )
+    value["source_report_sha256"] = sha256_bytes(value["_report_bytes"])
+    paths = {
+        label: tmp_path / name
+        for label, name in (
+            ("report", "scheduled-capture.json"),
+            ("form", "gunnedah-r5.csv"),
+            ("sidecar", "gunnedah-r5.csv.metadata.json"),
+        )
+    }
+    for label, path in paths.items():
+        path.write_bytes(value[f"_{label}_bytes"])
+        value[f"_{label}_path"] = path.resolve()
+    normalized, _, _, _ = receipt_from_handoff(
+        value,
+        current_time=NOW,
+        max_age_seconds=900,
+    )
+    value.update(
+        {
+            "schema_version": "on_demand_verified_collector_capture_v2",
+            "race": {
+                "race_id": RACE_ID,
+                "url": race()["url"],
+                "venue": "GUNN",
+                "race_number": 5,
+                "race_date": "2026-07-19",
+                "jump_timestamp": "2026-07-19T13:00:00+10:00",
+            },
+            "runner_set_sha256": normalized["runner_set_sha256"],
+            "capture_attempt_sha256": sha256_bytes(
+                canonical_bytes(source_attempt)
+            ),
+            "append_report_sha256": sha256_bytes(
+                canonical_bytes(source_attempt["append_report"])
+            ),
+        }
+    )
+    protocol.publish_collector_exact_receipt(
+        collector_run_id=collector_run_id,
+        emitted_at=NOW,
+        handoff=value,
+    )
+
+    calls = {"capture": 0, "score": 0}
+    deps = dependencies(
+        capture_one=lambda **_: calls.__setitem__(
+            "capture", calls["capture"] + 1
+        )
+    )
+    original_score = deps.score_residual
+
+    def score(**kwargs: Any) -> Mapping[str, Any]:
+        calls["score"] += 1
+        return original_score(**kwargs)
+
+    deps.score_residual = score
+    result = run_prediction(
+        args(tmp_path, collector_request_root=protocol_root),
+        deps,
+    )
+
+    assert result["status"] == "PREDICTION_READY"
+    assert calls == {"capture": 0, "score": 1}
+    assert not protocol.outstanding_request_ids()
+
+
 def test_operator_cli_emits_one_canonical_fixture_prediction(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_shadow_autopilot_v1.py
+++ b/tests/test_shadow_autopilot_v1.py
@@ -4,6 +4,8 @@ import socket
 from datetime import datetime, timedelta
 from pathlib import Path
 
+import pytest
+
 from race_collection.manual_prediction_collector_request import (
     ManualPredictionCollectorProtocol,
     canonical_bytes,
@@ -498,6 +500,42 @@ def test_autonomous_live_odds_capture_command_requires_explicit_execute_flags():
 
     assert "--execute" in approved
     assert "--allow-auto-scrape-odds" in approved
+
+    receipt_enabled = autopilot.autonomous_live_odds_capture_command(
+        input_dirs=[Path("upcoming_a")],
+        evidence_root=Path("artifacts/full_evidence_orchestration_20260525"),
+        capture_dir=Path(
+            "artifacts/full_evidence_orchestration_20260525/"
+            "autonomous_live_odds_capture_x"
+        ),
+        db_path=Path("greyhound_racing_data.db"),
+        current_time="2026-06-10T14:00:00+10:00",
+        limit=16,
+        execute=True,
+        allow_auto_scrape_odds=True,
+        collector_receipt_root=Path("collector-requests"),
+        collector_run_id="scheduled-run-1",
+    )
+
+    assert receipt_enabled[
+        receipt_enabled.index("--collector-receipt-root") + 1
+    ] == "collector-requests"
+    assert receipt_enabled[
+        receipt_enabled.index("--collector-run-id") + 1
+    ] == "scheduled-run-1"
+    with pytest.raises(ValueError, match="collector_receipt_authority_missing"):
+        autopilot.autonomous_live_odds_capture_command(
+            input_dirs=[Path("upcoming_a")],
+            evidence_root=Path("artifacts/full_evidence_orchestration_20260525"),
+            capture_dir=Path("autonomous_live_odds_capture_x"),
+            db_path=Path("greyhound_racing_data.db"),
+            current_time="2026-06-10T14:00:00+10:00",
+            limit=16,
+            execute=False,
+            allow_auto_scrape_odds=False,
+            collector_receipt_root=Path("collector-requests"),
+            collector_run_id="scheduled-run-1",
+        )
 
 
 def test_manual_request_command_is_bound_to_claimed_collector_run():


### PR DESCRIPTION
## What changed

- Publish bounded, append-only exact-race receipts immediately after successful scheduled collector appends.
- Preserve bounded current-index aliases through scheduled plan refresh, including QOT / Q1 Lakeside identities.
- Reuse the newest valid exact receipt before invoking collector `capture-one`.
- Bind race identity, runner set, source bytes, capture attempt, append report, timestamps, and hashes during publication and reuse.
- Keep scheduled collection on the timer and retain the canonical no-steal lock as the only acquisition authority.

## Root cause

The scheduled collector holds the canonical lock for almost the entire batch and previously did not publish an exact reusable receipt. Manual prediction therefore attempted a second acquisition and correctly failed `BUSY` even when the scheduled batch had already appended odds for the target race.

## Safety

No browser or capture logic was added to the predictor. No lock stealing, timer waiting, service control, model/feature/training/result/cadence changes, production persistence, EV, staking, or betting output were added.

## Validation

- Focused path tests: 6 passed.
- Six affected suites: 351 passed; 2 unchanged baseline failures reproduced on exact master (`DEFAULT_ODDS_CAPTURE_REFRESH_LIMIT` is 16 while old assertions expect 8).
- Classifier: `full_forecasting`.
- Classifier suite reached 383 passes before the unrelated Phase 6 promotion fixture was stopped after 15 minutes of shared CPU/disk contention. An earlier root-`/tmp` run failed only with host disk I/O errors.
- Fatal Ruff on the changed delta, `py_compile`, and `git diff --check`: passed. Full-file Ruff retains 8 pre-existing F541 findings in `shadow_autopilot_v1.py`, reproduced on exact master.

## Claim boundary

Fixture-proven synchronous manual path only. Runtime remains unproven until merge, deployment, a natural scheduled cycle, and one separately authorised live pre-jump prediction.