### PR TITLE
Preserve exact grade proof on matching refresh

### DIFF
--- a/tests/test_upcoming_race_time_mapping.py
+++ b/tests/test_upcoming_race_time_mapping.py
@@ -613,15 +613,30 @@ def test_equivalent_grade_forms_do_not_create_false_conflict():
             "target_grade_source": "canonical_pre_race_page",
         },
         {
+            "grade": "Grade 4",
             "target_grade": "Grade 4",
             "target_grade_source": "thedogs_meeting_card_exact_race",
+            "target_grade_context_schema": "thedogs_meeting_card_exact_race_v1",
             "target_grade_equivalence_key": "GRADE:4",
+            "target_grade_exact_value": "Grade 4",
+            "target_grade_race_date": "2026-07-17",
+            "target_grade_race_number": 10,
+            "target_grade_race_url": race_url,
+            "target_grade_source_url": "https://www.thedogs.com.au/racing/2026-07-17",
+            "target_grade_source_sha256": MEETING_CARD_SHA256,
+            "target_grade_venue": "MAND",
         },
         race_url,
     )
 
-    assert merged["target_grade"] == "4th Grade"
-    assert merged["target_grade_source"] == "canonical_pre_race_page"
+    assert merged["target_grade"] == "Grade 4"
+    assert merged["target_grade_source"] == "thedogs_meeting_card_exact_race"
+    assert merged["target_grade_context_schema"] == (
+        "thedogs_meeting_card_exact_race_v1"
+    )
+    assert merged["target_grade_exact_value"] == "Grade 4"
+    assert merged["target_grade_race_url"] == race_url
+    assert merged["target_grade_source_sha256"] == MEETING_CARD_SHA256
 
 
 def test_current_race_header_accepts_non_graded_class():

--- a/upcoming_race_browser.py
+++ b/upcoming_race_browser.py
@@ -1326,6 +1326,10 @@ class UpcomingRaceBrowser:
         hint_grade_key = (hint_metadata or {}).get(
             "target_grade_equivalence_key"
         ) or target_grade_equivalence_key(hint_grade_raw)
+        hint_grade_is_exact = (
+            (hint_metadata or {}).get("target_grade_source")
+            == "thedogs_meeting_card_exact_race"
+        )
         grades_conflict = bool(
             page_grade
             and hint_grade
@@ -1352,7 +1356,7 @@ class UpcomingRaceBrowser:
             merged["target_grade_source"] = "default_missing_target"
             for key in provenance_keys:
                 merged.pop(key, None)
-        elif not page_grade and hint_grade:
+        elif hint_grade and (not page_grade or hint_grade_is_exact):
             merged.update(
                 {
                     "grade": hint_grade,


### PR DESCRIPTION
## What changed

Preserve the validated exact meeting-card grade proof when the canonical race page reports an equivalent grade label during scheduled refresh.

## Root cause

The merge path retained exact proof only when the page grade was absent. When page and meeting-card grades agreed, it kept the generic page grade and silently dropped the exact-race proof fields required by the residual scorer.

## Safety

Conflicting page and hint grades still fail closed. The existing exact URL, date, race number, venue, source URL, source hash, and equivalence checks remain unchanged.

## Validation

- focused regression changed red to green
- 388 passed, 1 skipped across meeting-card, CSV hardening, residual scorer, and manual predictor tests
- 2 unrelated weather assertions failed identically on exact master
- fatal Ruff passed
- py_compile passed
- git diff --check passed