### PR TITLE
Bind in-link grades to exact race cards

### DIFF
--- a/tests/test_upcoming_race_time_mapping.py
+++ b/tests/test_upcoming_race_time_mapping.py
@@ -508,6 +508,58 @@ def test_live_meeting_card_grade_requires_one_exact_race_scope():
     assert race["target_grade_source_sha256"] == MEETING_CARD_SHA256
 
 
+def test_live_meeting_card_grade_inside_exact_race_link_is_proven():
+    browser = UpcomingRaceBrowser()
+    soup = BeautifulSoup(
+        """
+        <a class="race-card" href="/racing/mandurah/2026-07-17/10/owls-bentley">
+          <span>R10</span>
+          <span class="grade">Grade 5</span>
+        </a>
+        """,
+        "html.parser",
+    )
+    link = soup.find("a")
+
+    race = browser.extract_race_info_from_link(
+        link,
+        link["href"],
+        "2026-07-17",
+        meeting_card_sha256=MEETING_CARD_SHA256,
+    )
+
+    assert race["target_grade"] == "Grade 5"
+    assert race["target_grade_context_schema"] == (
+        "thedogs_meeting_card_exact_race_v1"
+    )
+    assert race["target_grade_race_url"] == (
+        "https://www.thedogs.com.au/racing/mandurah/2026-07-17/10/owls-bentley"
+    )
+
+
+def test_live_meeting_card_does_not_treat_unmarked_race_name_as_grade():
+    browser = UpcomingRaceBrowser()
+    soup = BeautifulSoup(
+        """
+        <a class="race-card" href="/racing/mandurah/2026-07-17/10/open">
+          <span>R10</span>
+          <span class="race-name">Open</span>
+        </a>
+        """,
+        "html.parser",
+    )
+    link = soup.find("a")
+
+    race = browser.extract_race_info_from_link(
+        link,
+        link["href"],
+        "2026-07-17",
+        meeting_card_sha256=MEETING_CARD_SHA256,
+    )
+
+    assert "target_grade_context_schema" not in race
+
+
 def test_live_meeting_card_does_not_borrow_grade_from_multi_race_parent():
     browser = UpcomingRaceBrowser()
     soup = BeautifulSoup(

--- a/upcoming_race_browser.py
+++ b/upcoming_race_browser.py
@@ -1173,7 +1173,27 @@ class UpcomingRaceBrowser:
             if linked_identities == {identity["canonical_url"]}:
                 candidates = []
                 for text_node in scope.find_all(string=True):
-                    if any(
+                    if scope is link_element:
+                        grade_marked = False
+                        for parent in getattr(text_node, "parents", ()):
+                            marker = " ".join(
+                                [
+                                    str(parent.get("id") or ""),
+                                    *[str(value) for value in parent.get("class") or []],
+                                ]
+                            )
+                            if re.search(
+                                r"(?:^|[^a-z0-9])(?:grade|class)(?:$|[^a-z0-9])",
+                                marker,
+                                re.IGNORECASE,
+                            ):
+                                grade_marked = True
+                                break
+                            if parent is link_element:
+                                break
+                        if not grade_marked:
+                            continue
+                    elif any(
                         getattr(parent, "name", None) == "a"
                         for parent in getattr(text_node, "parents", ())
                     ):


### PR DESCRIPTION
## What changed

Admit a whole-value meeting-card grade when it is nested inside the exact canonical race link and a containing class or id explicitly marks the text as grade/class metadata.

## Root cause

Production meeting cards place grade metadata inside the race link. The extractor excluded all anchor-contained text, so scheduled sidecars lost the exact-race grade proof required by the residual scorer.

## Safety

Unmarked race names remain rejected. Parent scopes still exclude anchor text, multi-race parents remain rejected, and exact URL/date/race/venue/source-hash/equivalence gates are unchanged.

## Validation

- production-shape regression changed red to green
- 6 focused scope/conflict/provenance tests passed
- fatal Ruff passed
- py_compile passed
- git diff --check passed