### PR TITLE
Bind live grade proof to exact race page

### DIFF
--- a/scripts/predict_market_form_residual.py
+++ b/scripts/predict_market_form_residual.py
@@ -46,6 +46,7 @@ from src.predictor.market_form_residual import (  # noqa: E402
 )
 from config.venue_mapping import normalize_venue  # noqa: E402
 from utils.csv_metadata import (  # noqa: E402
+    THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE,
     THEDOGS_MEETING_CARD_GRADE_SOURCE,
     canonical_thedogs_meeting_card_url,
     canonical_thedogs_race_identity,
@@ -1288,10 +1289,31 @@ def _sidecar_context(sidecar: Mapping[str, Any]) -> dict[str, Any]:
     )
     grade_venue = _agreed_sidecar_value(sidecar, "target_grade_venue")
     grade_identity = canonical_thedogs_race_identity(grade_race_url)
+    grade_source_identity = canonical_thedogs_race_identity(grade_source_url)
     normalized_exact_grade = normalize_exact_target_grade(grade_exact_value)
+    expected_grade_schema = {
+        THEDOGS_MEETING_CARD_GRADE_SOURCE: "thedogs_meeting_card_exact_race_v1",
+        THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE: "thedogs_exact_race_page_v1",
+    }.get(grade_source)
+    grade_source_url_valid = bool(
+        (
+            grade_source == THEDOGS_MEETING_CARD_GRADE_SOURCE
+            and canonical_thedogs_meeting_card_url(
+                grade_source_url,
+                race_date=source_identity["race_date"],
+            )
+            is not None
+        )
+        or (
+            grade_source == THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE
+            and grade_source_identity is not None
+            and grade_source_identity["canonical_url"]
+            == source_identity["canonical_url"]
+        )
+    )
     if (
-        grade_source != THEDOGS_MEETING_CARD_GRADE_SOURCE
-        or grade_schema != "thedogs_meeting_card_exact_race_v1"
+        expected_grade_schema is None
+        or grade_schema != expected_grade_schema
         or grade_identity is None
         or grade_identity["canonical_url"] != source_identity["canonical_url"]
         or target_date.isoformat() != source_identity["race_date"]
@@ -1305,11 +1327,7 @@ def _sidecar_context(sidecar: Mapping[str, Any]) -> dict[str, Any]:
         or normalized_exact_grade is None
         or target_grade_equivalence_key(grade_exact_value) != grade_proof_key
         or target_grade_equivalence_key(target_grade_value) != grade_proof_key
-        or canonical_thedogs_meeting_card_url(
-            grade_source_url,
-            race_date=source_identity["race_date"],
-        )
-        is None
+        or not grade_source_url_valid
         or not re.fullmatch(r"[0-9a-f]{64}", grade_source_sha256)
     ):
         raise ManualPredictionError("target_grade_proof_mismatch")

--- a/tests/test_predict_market_form_residual.py
+++ b/tests/test_predict_market_form_residual.py
@@ -333,6 +333,13 @@ def _set_exact_sidecar_grade(sidecar: dict, grade: str) -> None:
         proof_scope["target_grade_equivalence_key"] = proof_key
 
 
+def _set_exact_race_page_grade_source(sidecar: dict) -> None:
+    for proof_scope in (sidecar, sidecar["race_info"]):
+        proof_scope["target_grade_source"] = "thedogs_exact_race_page"
+        proof_scope["target_grade_context_schema"] = "thedogs_exact_race_page_v1"
+        proof_scope["target_grade_source_url"] = SOURCE_URL
+
+
 def _reseal(paths: dict[str, Path], mutate) -> None:
     rows = _json(paths["feature_rows"])
     manifest = _json(paths["feature_manifest"])
@@ -432,6 +439,37 @@ def test_scores_exact_packet_deterministically(tmp_path):
     assert len(first["predictions"]) == 3
     for key in ("market", "half", "full"):
         assert first["probability_sums"][key] == pytest.approx(1.0)
+
+
+def test_scores_hash_bound_exact_race_page_grade(tmp_path):
+    paths = _write_fixture(tmp_path)
+    sidecar = _json(paths["sidecar"])
+    _set_exact_race_page_grade_source(sidecar)
+    _write_json(paths["sidecar"], sidecar)
+
+    prediction = _score_paths(paths)
+
+    assert prediction["target_grade_proof_key"] == "GRADE:5"
+    assert prediction["target_grade_source_sha256"] == MEETING_CARD_SHA256
+    assert prediction["activation"] is False
+    assert prediction["persisted"] is False
+
+
+def test_rejects_exact_race_page_grade_bound_to_other_race(
+    tmp_path, monkeypatch
+):
+    paths = _write_fixture(tmp_path)
+    sidecar = _json(paths["sidecar"])
+    _set_exact_race_page_grade_source(sidecar)
+    for proof_scope in (sidecar, sidecar["race_info"]):
+        proof_scope["target_grade_source_url"] = (
+            "https://www.thedogs.com.au/racing/sandown/2026-07-16/3/other"
+        )
+    _write_json(paths["sidecar"], sidecar)
+
+    _assert_score_rejected_without_side_effects(
+        paths, monkeypatch, "target_grade_proof_mismatch"
+    )
 
 
 def test_scores_when_strict_odds_capture_precedes_feature_generation(tmp_path):

--- a/tests/test_upcoming_race_time_mapping.py
+++ b/tests/test_upcoming_race_time_mapping.py
@@ -216,6 +216,48 @@ def test_canonical_pre_race_page_distance_and_grade_are_safe_metadata():
     assert metadata["metadata_is_leakage_safe"] is True
 
 
+def test_exact_race_page_grade_carries_hash_bound_identity_proof():
+    browser = UpcomingRaceBrowser()
+    race_url = (
+        "https://www.thedogs.com.au/racing/the-meadows/2026-05-21/7/example"
+    )
+    source_sha256 = "c" * 64
+    soup = BeautifulSoup(
+        """
+        <html>
+          <body>
+            <section class="race-card">
+              <dl>
+                <dt>Race Distance</dt><dd>520m</dd>
+                <dt>Race Grade</dt><dd>Grade 5</dd>
+              </dl>
+            </section>
+          </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    metadata = browser._extract_safe_target_metadata_from_page(
+        soup,
+        race_url,
+        source_sha256=source_sha256,
+    )
+
+    assert metadata["target_grade"] == "Grade 5"
+    assert metadata["target_grade_source"] == "thedogs_exact_race_page"
+    assert metadata["target_grade_context_schema"] == "thedogs_exact_race_page_v1"
+    assert metadata["target_grade_equivalence_key"] == "GRADE:5"
+    assert metadata["target_grade_exact_value"] == "Grade 5"
+    assert metadata["target_grade_race_date"] == "2026-05-21"
+    assert metadata["target_grade_race_number"] == 7
+    assert metadata["target_grade_race_url"] == race_url
+    assert metadata["target_grade_source_url"] == race_url
+    assert metadata["target_grade_source_sha256"] == source_sha256
+    assert metadata["target_grade_venue"] == "MEA"
+    assert metadata["metadata_is_leakage_safe"] is True
+
+
 def test_current_race_header_distance_and_grade_are_safe_metadata():
     browser = UpcomingRaceBrowser()
     soup = BeautifulSoup(

--- a/upcoming_race_browser.py
+++ b/upcoming_race_browser.py
@@ -34,6 +34,7 @@ from utils.runner_completeness import (
     quarantine_existing_file,
 )
 from utils.csv_metadata import (
+    THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE,
     build_csv_download_provenance_payload,
     build_safe_weather_track_metadata_payload,
     build_safe_target_metadata_payload,
@@ -1442,7 +1443,9 @@ class UpcomingRaceBrowser:
             return None
         return None
 
-    def _extract_safe_target_metadata_from_page(self, soup, race_url):
+    def _extract_safe_target_metadata_from_page(
+        self, soup, race_url, *, source_sha256=None
+    ):
         """Extract only explicit current-race distance/grade from a canonical race page."""
 
         if soup is None:
@@ -1478,15 +1481,18 @@ class UpcomingRaceBrowser:
             grade_without_distance = re.sub(
                 r"\b\d{3,4}\s*m\b", "", grade_text, flags=re.I
             ).strip(" -–—|")
-            grade = normalize_target_grade(grade_without_distance) or normalize_target_grade(
-                grade_text
-            ) or normalize_target_grade(name_text)
+            explicit_grade = normalize_target_grade(
+                grade_without_distance
+            ) or normalize_target_grade(grade_text)
+            grade = explicit_grade or normalize_target_grade(name_text)
 
             header_found = {}
             if distance:
                 header_found["distance"] = distance
             if grade:
                 header_found["grade"] = grade
+            if explicit_grade:
+                header_found["_grade_from_explicit_field"] = True
             return header_found
 
         found.update(_extract_current_race_header_metadata())
@@ -1538,6 +1544,7 @@ class UpcomingRaceBrowser:
                             grade = normalize_target_grade(value)
                             if grade and "grade" not in found:
                                 found["grade"] = grade
+                                found["_grade_from_explicit_field"] = True
                         if normalized_key in {"name", "title"} and "grade" not in found:
                             grade = normalize_target_grade(value)
                             if grade:
@@ -1647,9 +1654,40 @@ class UpcomingRaceBrowser:
             )
             if grade:
                 found["grade"] = grade
+                found["_grade_from_explicit_field"] = True
 
         if not any(key in found for key in ("distance", "grade")):
             return {}
+
+        identity = canonical_thedogs_race_identity(race_url)
+        source_hash = str(source_sha256 or "").strip().lower()
+        exact_grade = normalize_exact_target_grade(found.get("grade"))
+        exact_grade_key = target_grade_equivalence_key(found.get("grade"))
+        if (
+            identity is not None
+            and found.get("_grade_from_explicit_field") is True
+            and exact_grade is not None
+            and exact_grade_key is not None
+            and re.fullmatch(r"[0-9a-f]{64}", source_hash)
+        ):
+            found.update(
+                {
+                    "grade": exact_grade,
+                    "target_grade": exact_grade,
+                    "target_grade_source": THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE,
+                    "target_grade_context_schema": "thedogs_exact_race_page_v1",
+                    "target_grade_equivalence_key": exact_grade_key,
+                    "target_grade_exact_value": exact_grade,
+                    "target_grade_race_date": identity["race_date"],
+                    "target_grade_race_number": identity["race_number"],
+                    "target_grade_race_url": identity["canonical_url"],
+                    "target_grade_source_url": identity["canonical_url"],
+                    "target_grade_source_sha256": source_hash,
+                    "target_grade_venue": self._canonical_hint_venue(
+                        identity["venue_slug"]
+                    ),
+                }
+            )
 
         metadata = build_safe_target_metadata_payload(
             found,
@@ -1667,6 +1705,21 @@ class UpcomingRaceBrowser:
                 "target_grade_source": metadata.get("target_grade_source"),
                 "metadata_is_leakage_safe": metadata.get("metadata_is_leakage_safe"),
                 "metadata_source_url": metadata.get("metadata_source_url"),
+                "target_grade_context_schema": found.get(
+                    "target_grade_context_schema"
+                ),
+                "target_grade_equivalence_key": found.get(
+                    "target_grade_equivalence_key"
+                ),
+                "target_grade_exact_value": found.get("target_grade_exact_value"),
+                "target_grade_race_date": found.get("target_grade_race_date"),
+                "target_grade_race_number": found.get("target_grade_race_number"),
+                "target_grade_race_url": found.get("target_grade_race_url"),
+                "target_grade_source_url": found.get("target_grade_source_url"),
+                "target_grade_source_sha256": found.get(
+                    "target_grade_source_sha256"
+                ),
+                "target_grade_venue": found.get("target_grade_venue"),
             }.items()
             if value not in (None, "", "default_missing_target")
         }
@@ -1964,7 +2017,9 @@ class UpcomingRaceBrowser:
 
                 if bs4 is None:
                     raise RuntimeError("BeautifulSoup (bs4) is required. Install with 'pip install beautifulsoup4'.")
-                soup = bs4.BeautifulSoup(response.content, "html.parser")
+                race_page_content = response.content
+                race_page_sha256 = hashlib.sha256(race_page_content).hexdigest()
+                soup = bs4.BeautifulSoup(race_page_content, "html.parser")
             finally:
                 if response is not None:
                     try:
@@ -1978,7 +2033,7 @@ class UpcomingRaceBrowser:
             if not race_info:
                 return {"success": False, "error": "Could not extract race information"}
             page_target_metadata = self._extract_safe_target_metadata_from_page(
-                soup, race_url
+                soup, race_url, source_sha256=race_page_sha256
             )
             hinted_target_grade = self._extract_safe_target_grade_from_hint(
                 race_info_hint, race_url

--- a/utils/csv_metadata.py
+++ b/utils/csv_metadata.py
@@ -49,6 +49,13 @@ CANONICAL_SIDECAR_TARGET_SOURCES = {
     "sidecar_target_metadata",
 }
 THEDOGS_MEETING_CARD_GRADE_SOURCE = "thedogs_meeting_card_exact_race"
+THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE = "thedogs_exact_race_page"
+THEDOGS_EXACT_GRADE_SOURCES = frozenset(
+    {
+        THEDOGS_MEETING_CARD_GRADE_SOURCE,
+        THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE,
+    }
+)
 THEDOGS_VENUE_CODE_OVERRIDES = {
     "ALBION": "ALBION",
     "ALBIONPARK": "ALBION",
@@ -728,13 +735,14 @@ def _safe_int(value: Any) -> Optional[int]:
         return None
 
 
-def _meeting_card_grade_provenance_is_valid(
+def _exact_grade_provenance_is_valid(
     payload: Mapping[str, Any],
     *,
+    grade_source: str,
     canonical_race_url: Any,
     grade_value: Any,
 ) -> bool:
-    """Validate every field required by the exact live meeting-card grade source."""
+    """Validate every field required by an exact hash-bound live grade source."""
 
     race_info = (
         payload.get("race_info")
@@ -765,10 +773,34 @@ def _meeting_card_grade_provenance_is_valid(
     ).strip().lower()
     requested_identity = canonical_thedogs_race_identity(canonical_race_url)
     target_identity = canonical_thedogs_race_identity(target_race_url)
+    grade_source_identity = canonical_thedogs_race_identity(grade_source_url)
     normalized_exact = normalize_exact_target_grade(exact_value)
     normalized_grade = normalize_exact_target_grade(grade_value)
+    expected_schema = {
+        THEDOGS_MEETING_CARD_GRADE_SOURCE: "thedogs_meeting_card_exact_race_v1",
+        THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE: "thedogs_exact_race_page_v1",
+    }.get(grade_source)
+    source_url_is_valid = bool(
+        (
+            grade_source == THEDOGS_MEETING_CARD_GRADE_SOURCE
+            and requested_identity is not None
+            and canonical_thedogs_meeting_card_url(
+                grade_source_url,
+                race_date=str(requested_identity["race_date"]),
+            )
+            is not None
+        )
+        or (
+            grade_source == THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE
+            and requested_identity is not None
+            and grade_source_identity is not None
+            and grade_source_identity["canonical_url"]
+            == requested_identity["canonical_url"]
+        )
+    )
     if (
-        schema != "thedogs_meeting_card_exact_race_v1"
+        expected_schema is None
+        or schema != expected_schema
         or requested_identity is None
         or target_identity is None
         or target_identity["canonical_url"] != requested_identity["canonical_url"]
@@ -780,11 +812,7 @@ def _meeting_card_grade_provenance_is_valid(
         or normalized_grade != normalized_exact
         or declared_key != target_grade_equivalence_key(exact_value)
         or re.fullmatch(r"[0-9a-f]{64}", grade_source_sha256) is None
-        or canonical_thedogs_meeting_card_url(
-            grade_source_url,
-            race_date=str(requested_identity["race_date"]),
-        )
-        is None
+        or not source_url_is_valid
     ):
         return False
     race_dates = [
@@ -835,9 +863,10 @@ def _grade_source_is_safe(
     canonical: bool = False,
 ) -> bool:
     text = str(source or "").strip()
-    if text == THEDOGS_MEETING_CARD_GRADE_SOURCE:
-        return _meeting_card_grade_provenance_is_valid(
+    if text in THEDOGS_EXACT_GRADE_SOURCES:
+        return _exact_grade_provenance_is_valid(
             payload,
+            grade_source=text,
             canonical_race_url=canonical_race_url,
             grade_value=grade_value,
         )
@@ -935,7 +964,7 @@ def verify_canonical_sidecar_payload(
     grade_value = payload_dict.get("target_grade")
     grade = (
         normalize_exact_target_grade(grade_value)
-        if grade_source == THEDOGS_MEETING_CARD_GRADE_SOURCE
+        if grade_source in THEDOGS_EXACT_GRADE_SOURCES
         else normalize_target_grade(grade_value)
     )
     leakage_safe = payload_dict.get("metadata_is_leakage_safe") is True
@@ -1094,7 +1123,7 @@ def build_safe_target_metadata_payload(
     distance = normalize_target_distance(distance_value)
     grade = (
         normalize_exact_target_grade(grade_value)
-        if grade_source == THEDOGS_MEETING_CARD_GRADE_SOURCE
+        if grade_source in THEDOGS_EXACT_GRADE_SOURCES
         else normalize_target_grade(grade_value)
     )
     payload: Dict[str, Any] = {
@@ -1606,7 +1635,7 @@ def build_prejump_shadow_metadata_payload(payload: Mapping[str, Any]) -> Dict[st
     target_grade_value = payload.get("target_grade")
     target_grade = (
         normalize_exact_target_grade(target_grade_value)
-        if grade_source == THEDOGS_MEETING_CARD_GRADE_SOURCE
+        if grade_source in THEDOGS_EXACT_GRADE_SOURCES
         else normalize_target_grade(target_grade_value)
     )
     participants = _participant_box_name_list(payload)
@@ -1978,7 +2007,7 @@ def load_safe_sidecar_target_metadata(csv_path: Union[str, os.PathLike]) -> Dict
     )
     grade = (
         normalize_exact_target_grade(grade_value)
-        if grade_source == THEDOGS_MEETING_CARD_GRADE_SOURCE
+        if grade_source in THEDOGS_EXACT_GRADE_SOURCES
         else normalize_target_grade(grade_value)
     )
     if grade and leakage_safe and _grade_source_is_safe(


### PR DESCRIPTION
## Summary
- hash-bind grade metadata to the already-fetched canonical exact race page
- validate the exact race identity, date, race number, venue, grade equivalence, schema and source hash
- allow the read-only residual scorer to consume that sealed provenance source

## Validation
- 14 focused provenance and scoring tests passed
- fatal Ruff passed
- py_compile passed
- git diff --check passed

Research-only manual prediction path; no model, cadence, persistence, EV or betting changes.