### PR TITLE
Publish manual race index after refresh

### DIFF
--- a/docs/on_demand_race_prediction.md
+++ b/docs/on_demand_race_prediction.md
@@ -26,7 +26,10 @@ Race resolution reads one collector-owned
 packet beneath the first `--capture-evidence-root` (or the explicit
 `--current-race-index`). A successful scheduled odds-refresh cycle atomically
 replaces this fixed packet with at most 32 selected races and seals the source
-refresh-report path and SHA-256. The predictor validates the packet schema,
+refresh-report path and SHA-256. Publication occurs immediately after that
+bounded refresh completes, before the slower multi-race odds-capture batch, so
+a later batch timeout cannot leave discovery dependent on an older index. The
+predictor validates the packet schema,
 canonical bytes, source path and hash, exact TheDogs identities, timezone-aware
 jump timestamps, uniqueness, row bound, and configured 1,200-second maximum
 source age. It does not browse, scan race/evidence directories, publish a timer

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -1588,6 +1588,7 @@ def odds_capture_only_autopilot_command(
     odds_capture_max_minutes: float,
     odds_capture_refresh_limit: int,
     timeout_seconds: int,
+    state_path: Path | None = None,
     refresh_command_mode: str = "auto",
     require_safe_refresh_metadata: bool = True,
 ) -> list[str]:
@@ -1631,6 +1632,8 @@ def odds_capture_only_autopilot_command(
     ]
     if require_safe_refresh_metadata:
         command.append("--require-safe-refresh-metadata")
+    if state_path is not None:
+        command.extend(["--current-race-index-state-path", str(state_path)])
     return command
 
 
@@ -3456,6 +3459,7 @@ def run_odds_capture_once(args: argparse.Namespace) -> dict[str, Any]:
             odds_capture_max_minutes=args.odds_capture_max_minutes,
             odds_capture_refresh_limit=args.odds_capture_refresh_limit,
             timeout_seconds=args.timeout_seconds,
+            state_path=args.state_path,
             refresh_command_mode=args.refresh_command_mode,
             require_safe_refresh_metadata=args.require_safe_refresh_metadata,
         )

--- a/scripts/shadow_autopilot_v1.py
+++ b/scripts/shadow_autopilot_v1.py
@@ -41,6 +41,9 @@ from race_collection.manual_prediction_collector_request import (  # noqa: E402
     ProtocolRejected,
     canonical_bytes,
 )
+from race_collection.synchronous_manual_capture import (  # noqa: E402
+    publish_current_race_index,
+)
 from scripts.shadow_feature_audit_packet import feature_activation_gate_input_paths  # noqa: E402
 
 
@@ -6620,6 +6623,31 @@ def finalize_manual_collector_request(
         )
 
 
+def publish_current_race_index_after_refresh(
+    *,
+    state_path: Path | None,
+    evidence_root: Path,
+    output_dir: Path,
+    run_id: str,
+) -> dict[str, Any]:
+    """Publish the bounded index before the slower odds-capture batch begins."""
+
+    if state_path is None:
+        return {
+            "schema_version": "collector_current_race_index_publish_v1",
+            "status": "SKIPPED",
+            "reason": "state_path_missing",
+        }
+    return publish_current_race_index(
+        state_path=state_path,
+        evidence_root=evidence_root,
+        source_refresh_report_path=(
+            output_dir / "odds_capture_refresh_report.json"
+        ),
+        run_id=run_id,
+    )
+
+
 def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
     generated_at = datetime.now().astimezone()
     run_id = args.run_id or now_id(generated_at)
@@ -6810,6 +6838,16 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
     odds_capture_refresh_report = (
         load_json(output_dir / "odds_capture_refresh_report.json")
         or load_json(output_dir / "refresh_prejump_report.json")
+    )
+    current_race_index_publish = publish_current_race_index_after_refresh(
+        state_path=getattr(args, "current_race_index_state_path", None),
+        evidence_root=evidence_root,
+        output_dir=output_dir,
+        run_id=collector_run_id or run_id,
+    )
+    write_json(
+        output_dir / "current_race_index_publish.json",
+        current_race_index_publish,
     )
     if args.enable_autonomous_odds_capture:
         capture_current_time = (
@@ -8317,6 +8355,7 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
             "inserted_live_odds_rows"
         ),
         "manual_prediction_collector_request": manual_request_status,
+        "current_race_index_publish": current_race_index_publish,
         "prediction_sample_odds_coverage_status": daily_status.get(
             "prediction_sample_odds_coverage_status"
         ),
@@ -8488,6 +8527,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--run-id")
     parser.add_argument("--evidence-root", type=Path, default=DEFAULT_EVIDENCE_ROOT)
     parser.add_argument("--collector-lock-path", type=Path)
+    parser.add_argument("--current-race-index-state-path", type=Path)
     parser.add_argument("--output-dir", type=Path)
     parser.add_argument("--current-time")
     parser.add_argument("--db", type=Path, default=ROOT / "greyhound_racing_data.db")

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -1186,6 +1186,7 @@ def test_odds_capture_only_autopilot_command_is_narrow_and_append_only():
         odds_capture_max_minutes=60.0,
         odds_capture_refresh_limit=8,
         timeout_seconds=600,
+        state_path=Path("/runtime/odds_capture_state.json"),
     )
 
     assert "scripts/shadow_autopilot_v1.py" in command[1]
@@ -1202,6 +1203,9 @@ def test_odds_capture_only_autopilot_command_is_narrow_and_append_only():
     assert "--require-safe-refresh-metadata" in command
     assert command[command.index("--collector-lock-path") + 1] == (
         "/runtime/shared.lock"
+    )
+    assert command[command.index("--current-race-index-state-path") + 1] == (
+        "/runtime/odds_capture_state.json"
     )
     assert "--enable-autonomous-result-capture" not in command
 

--- a/tests/test_shadow_autopilot_v1.py
+++ b/tests/test_shadow_autopilot_v1.py
@@ -50,6 +50,47 @@ def test_autopilot_accepts_step_timeout_seconds():
     assert args.step_timeout_seconds == 12
 
 
+def test_autopilot_accepts_current_race_index_state_path():
+    args = autopilot.parse_args(
+        ["--current-race-index-state-path", "/runtime/odds_capture_state.json"]
+    )
+
+    assert args.current_race_index_state_path == Path(
+        "/runtime/odds_capture_state.json"
+    )
+
+
+def test_current_race_index_is_published_from_completed_refresh(
+    tmp_path, monkeypatch
+):
+    evidence_root = tmp_path / "evidence"
+    output_dir = evidence_root / "run"
+    state_path = evidence_root / "runtime/odds_capture_state.json"
+    source_path = output_dir / "odds_capture_refresh_report.json"
+    observed = {}
+
+    def fake_publish(**kwargs):
+        observed.update(kwargs)
+        return {"status": "PUBLISHED", "race_count": 1}
+
+    monkeypatch.setattr(autopilot, "publish_current_race_index", fake_publish)
+
+    result = autopilot.publish_current_race_index_after_refresh(
+        state_path=state_path,
+        evidence_root=evidence_root,
+        output_dir=output_dir,
+        run_id="scheduled-run",
+    )
+
+    assert result == {"status": "PUBLISHED", "race_count": 1}
+    assert observed == {
+        "state_path": state_path,
+        "evidence_root": evidence_root,
+        "source_refresh_report_path": source_path,
+        "run_id": "scheduled-run",
+    }
+
+
 def test_step_command_records_timeout_and_logs_output(tmp_path, monkeypatch):
     def fake_run(command, cwd, text, capture_output, check, timeout):
         assert timeout == 3


### PR DESCRIPTION
## Summary
- publish the sealed bounded current-race index immediately after scheduled refresh
- preserve the slower multi-race odds-capture batch and parent replay publication
- prevent batch timeouts from leaving manual discovery on a stale index

## Validation
- 5 focused index/command tests passed
- fatal Ruff passed
- py_compile passed
- git diff --check passed

No acquisition, model, cadence, persistence, EV or betting changes.