### PR TITLE
Accept sealed collector receipt source

### DIFF
--- a/scripts/predict_market_form_residual.py
+++ b/scripts/predict_market_form_residual.py
@@ -125,6 +125,8 @@ CAPTURE_REPORT_SCHEMAS = {
     "autonomous_live_odds_capture_report_v1",
     # Current capture reports overlay this summary after the report header.
     "autonomous_live_odds_capture_t2_miss_cause_summary_v1",
+    # Scheduled collector receipts wrap one hash-bound canonical capture attempt.
+    "collector_exact_capture_source_v1",
 }
 CAPTURE_ATTEMPT_SCHEMA = "autonomous_live_odds_capture_attempt_v1"
 CAPTURE_VALIDATION_SCHEMA = "autonomous_live_odds_capture_validation_v1"

--- a/tests/test_predict_market_form_residual.py
+++ b/tests/test_predict_market_form_residual.py
@@ -455,6 +455,28 @@ def test_scores_hash_bound_exact_race_page_grade(tmp_path):
     assert prediction["persisted"] is False
 
 
+def test_scores_collector_exact_receipt_source_wrapper(tmp_path):
+    paths = _write_fixture(tmp_path)
+    capture = _json(paths["capture"])
+    _write_json(
+        paths["capture"],
+        {
+            "schema_version": "collector_exact_capture_source_v1",
+            "collector_run_id": "scheduled-run",
+            "generated_at": "2026-07-16T18:51:00+10:00",
+            "race_id": RACE_ID,
+            "source_race_id": RACE_ID,
+            "attempts": capture["attempts"],
+        },
+    )
+
+    prediction = _score_paths(paths)
+
+    assert prediction["status"] == "MANUAL_PREJUMP_FROZEN_RESIDUAL_PREDICTION"
+    assert prediction["persisted"] is False
+    assert prediction["outcomes_present"] is False
+
+
 def test_rejects_exact_race_page_grade_bound_to_other_race(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- admit the canonical scheduled collector receipt wrapper to the existing read-only capture validator
- retain single-attempt, runner, timing, source, schema and outcome-exclusion gates

## Validation
- 4 focused scorer/discovery tests passed
- fatal Ruff passed
- py_compile passed
- git diff --check passed

No acquisition, model, persistence, EV or betting changes.