### PR TITLE
Add prospective official-result first-observation receipts

### DIFF
--- a/race_collection/forward_sealed_corpus.py
+++ b/race_collection/forward_sealed_corpus.py
@@ -3,29 +3,38 @@
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
 import os
 import tempfile
 import unicodedata
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
+
+from scripts.ingest_results_for_date import (
+    finish_positions_follow_competition_ranking,
+    parse_thedogs_result_html_runner_rows,
+)
 
 from .artifacts import ArtifactStoreError, LocalArtifactStore
 from .domain import ArtifactChecksum, require_aware
 from .features import FeatureQuarantine, derive_features
 from .model_bundle import SUPPORTED_FEATURE_CONTRACT
 
-FORWARD_CORPUS_ORIGIN = "forward-sealed-corpus-v1"
+FORWARD_CORPUS_ORIGIN = "official-result-first-observation-v1"
 SOURCE_CAPTURE_SCHEMA = "forward-source-capture-v1"
-RESULT_SCHEMA = "official-forward-result-v1"
+RESULT_SCHEMA = "official-result-normalized-v1"
 PREJUMP_RECEIPT_SCHEMA = "forward-prejump-receipt-v1"
 RESULT_RECEIPT_SCHEMA = "forward-result-receipt-v1"
 CLOSURE_RECEIPT_SCHEMA = "forward-race-closure-v1"
 STATUS_SCHEMA = "forward-sealed-corpus-status-v1"
+OFFICIAL_RESULT_SOURCE = "thedogs-official"
+PREJUMP_SOURCE = "thedogs-race-card"
+RESPONSE_STAGE_SCHEMA = "official-result-response-stage-v1"
 
 _RESULT_DERIVED_KEYS = {
     "finish_order",
@@ -108,10 +117,12 @@ def _source_url(value: Any, name: str) -> str:
     url = _known_text(value, name)
     parsed = urlsplit(url)
     if (
-        parsed.scheme not in {"http", "https"}
+        parsed.scheme != "https"
         or not parsed.netloc
+        or parsed.hostname not in {"www.thedogs.com.au", "thedogs.com.au"}
         or parsed.username is not None
         or parsed.password is not None
+        or parsed.query
         or parsed.fragment
     ):
         raise ForwardCorpusRejected(f"{name} is not a canonical source URL")
@@ -137,13 +148,17 @@ def _metadata(value: Any, name: str) -> dict[str, Any]:
     return dict(value)
 
 
-def _runner_rows(values: Any) -> tuple[dict[str, str], ...]:
+def _runner_rows(values: Any) -> tuple[dict[str, Any], ...]:
     if type(values) not in {list, tuple} or len(values) < 2:
         raise ForwardCorpusRejected("source-native runner identities are incomplete")
-    rows: list[dict[str, str]] = []
+    rows: list[dict[str, Any]] = []
     keys: set[str] = set()
     for value in values:
-        if type(value) is not dict or set(value) != {"source_native_runner_id", "name"}:
+        if type(value) is not dict or set(value) != {
+            "source_native_runner_id",
+            "name",
+            "box_number",
+        }:
             raise ForwardCorpusRejected("source-native runner identity envelope is invalid")
         runner_id = _known_text(value["source_native_runner_id"], "source-native runner id")
         name = _known_text(value["name"], "runner name")
@@ -151,7 +166,18 @@ def _runner_rows(values: Any) -> tuple[dict[str, str], ...]:
         if key in keys:
             raise ForwardCorpusRejected("duplicate normalized source-native runner identity")
         keys.add(key)
-        rows.append({"source_native_runner_id": runner_id, "name": name})
+        box_number = value["box_number"]
+        if type(box_number) is not int or not 1 <= box_number <= 20:
+            raise ForwardCorpusRejected("runner box/rug identity is invalid")
+        if any(row["box_number"] == box_number for row in rows):
+            raise ForwardCorpusRejected("duplicate runner box/rug identity")
+        rows.append(
+            {
+                "source_native_runner_id": runner_id,
+                "name": name,
+                "box_number": box_number,
+            }
+        )
     return tuple(
         sorted(
             rows,
@@ -159,6 +185,86 @@ def _runner_rows(values: Any) -> tuple[dict[str, str], ...]:
                 row["source_native_runner_id"], "source-native runner id"
             ),
         )
+    )
+
+
+def _bounded_id(value: Any, name: str) -> str:
+    result = _known_text(value, name)
+    if len(result.encode()) > 128:
+        raise ForwardCorpusRejected(f"{name} is too long")
+    return result
+
+
+def _normalization_identity() -> tuple[str, str, str]:
+    parser_hash = str(_checksum(inspect.getsource(parse_thedogs_result_html_runner_rows).encode()))
+    schema_hash = str(_checksum(RESULT_SCHEMA.encode()))
+    implementation = (
+        inspect.getsource(_normalize_official_result).encode()
+        + inspect.getsource(parse_thedogs_result_html_runner_rows).encode()
+        + inspect.getsource(finish_positions_follow_competition_ranking).encode()
+        + RESULT_SCHEMA.encode()
+    )
+    return parser_hash, schema_hash, str(_checksum(implementation))
+
+
+def _normalize_official_result(
+    raw_response_bytes: bytes,
+    *,
+    race_id: str,
+    frozen_runners: Sequence[Mapping[str, Any]],
+) -> bytes:
+    if type(raw_response_bytes) is not bytes or not raw_response_bytes:
+        raise ForwardCorpusRejected("immutable official-result response bytes are required")
+    try:
+        markup = raw_response_bytes.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ForwardCorpusRejected("official result is not supported UTF-8 HTML") from error
+    try:
+        parsed = parse_thedogs_result_html_runner_rows(markup)
+    except (TypeError, ValueError) as error:
+        raise ForwardCorpusRejected("official result parser rejected response") from error
+    if not parsed:
+        raise ForwardCorpusRejected("official result HTML contains no result rows")
+    by_box = {row["box_number"]: row for row in parsed if type(row) is dict}
+    if len(by_box) != len(parsed) or set(by_box) != {
+        runner["box_number"] for runner in frozen_runners
+    }:
+        raise ForwardCorpusRejected("official result runner box/rug identity mismatch")
+    normalized = []
+    positions = []
+    for runner in sorted(frozen_runners, key=lambda item: item["box_number"]):
+        parsed_row = by_box[runner["box_number"]]
+        if parsed_row.get("dog_name") != runner["name"]:
+            raise ForwardCorpusRejected("official result runner name identity mismatch")
+        position = parsed_row.get("finish_position")
+        status = parsed_row.get("status")
+        if (position is None) == (status is None):
+            raise ForwardCorpusRejected("official finish/status combination is inconsistent")
+        if position is not None:
+            if type(position) is not int or not 1 <= position <= len(frozen_runners):
+                raise ForwardCorpusRejected("official finish position is out of range")
+            positions.append(position)
+        elif status not in {"SCRATCHED", "DNF", "DQ"}:
+            raise ForwardCorpusRejected("official terminal status is unsupported")
+        normalized.append(
+            {
+                "source_native_runner_id": runner["source_native_runner_id"],
+                "box_number": runner["box_number"],
+                "name": runner["name"],
+                "finish_position": position,
+                "status": status,
+            }
+        )
+    if not finish_positions_follow_competition_ranking(positions):
+        raise ForwardCorpusRejected("official finishes do not use competition ranking")
+    runner_set_hash = str(_checksum(canonical_json(list(frozen_runners))))
+    return canonical_json(
+        {
+            "schema_version": RESULT_SCHEMA,
+            "race_id": race_id,
+            "runner_set_hash": runner_set_hash,
+            "runners": normalized,
+        }
     )
 
 
@@ -262,6 +368,8 @@ class ForwardSealedCorpus:
     ) -> dict[str, Any]:
         """Capture source and production feature evidence without an outcome input."""
         race_id = _known_text(race_id, "race_id")
+        if source_name != PREJUMP_SOURCE:
+            raise ForwardCorpusRejected("source name is not the canonical TheDogs race-card source")
         source_name = _known_text(source_name, "source name")
         canonical_source_url = _source_url(canonical_source_url, "canonical source URL")
         source_native_race_id = _known_text(source_native_race_id, "source-native race identity")
@@ -487,6 +595,7 @@ class ForwardSealedCorpus:
                     "collector did not publish the pre-jump receipt prospectively"
                 )
         self._publish_once(self._receipt_path(race_id, "prejump"), canonical_json(receipt))
+        self.artifacts.put(canonical_json(receipt), media_type="application/json")
         return receipt
 
     def _result_observations(self, race_id: str) -> list[dict[str, Any]]:
@@ -505,7 +614,7 @@ class ForwardSealedCorpus:
             observations.append(observation)
         return observations
 
-    def capture_result(
+    def _publication_timestamp_capture_result(
         self,
         *,
         race_id: str,
@@ -520,6 +629,10 @@ class ForwardSealedCorpus:
         publication_timestamp_status: str,
     ) -> dict[str, Any]:
         """Capture an official result and close only with a source-declared timestamp."""
+        raise ForwardCorpusRejected(
+            "legacy publication-timestamp capture cannot create new-origin artifacts"
+        )
+        # Retained below solely so existing legacy bytes remain structurally readable.
         race_id = _known_text(race_id, "race_id")
         pre = self._load_receipt(race_id, "prejump")
         if pre is None:
@@ -744,7 +857,7 @@ class ForwardSealedCorpus:
             key=lambda item: _identity_key(item["race_id"], "race_id"),
         )
 
-    def build_package(self) -> ClosedPackage:
+    def _publication_timestamp_build_package(self) -> ClosedPackage:
         """Build and persist one deterministic package from every closed race."""
         closures = self._closures()
         if not closures:
@@ -811,7 +924,7 @@ class ForwardSealedCorpus:
             artifacts,
         )
 
-    def status(self) -> dict[str, Any]:
+    def _publication_timestamp_status(self) -> dict[str, Any]:
         """Return deterministic state while verifying all referenced immutable bytes."""
         directory = self.root / "races"
         rows = []
@@ -857,5 +970,828 @@ class ForwardSealedCorpus:
             "schema_version": STATUS_SCHEMA,
             "race_count": len(rows),
             "closed_race_count": sum(row["state"] == "CLOSED" for row in rows),
+            "races": rows,
+        }
+
+    def _official_receipts(self, race_id: str) -> list[dict[str, Any]]:
+        pre = self._load_receipt(race_id, "prejump")
+        if pre is None:
+            raise ForwardCorpusRejected("official history references missing pre-jump receipt")
+        return [
+            observation
+            for _stage, observation in self._official_response_history(pre)
+            if observation is not None
+        ]
+
+    def _official_response_history(
+        self, pre: Mapping[str, Any]
+    ) -> list[tuple[dict[str, Any], dict[str, Any] | None]]:
+        race_id = pre["race_id"]
+        directory = self._race_directory(race_id) / "official-requests"
+        if not directory.exists():
+            return []
+        if directory.is_symlink() or not directory.is_dir():
+            raise ForwardCorpusRejected("official request root is invalid")
+        history = []
+        for request_directory in sorted(directory.iterdir(), key=lambda path: path.name):
+            if request_directory.is_symlink() or not request_directory.is_dir():
+                raise ForwardCorpusRejected("official request directory is invalid")
+            entries = list(request_directory.iterdir())
+            if any(entry.is_symlink() or not entry.is_file() for entry in entries):
+                raise ForwardCorpusRejected("official request artifact is invalid")
+            entry_names = {entry.name for entry in entries}
+            if (
+                "response-stage.json" not in entry_names
+                or not entry_names <= {"response-stage.json", "observation.json"}
+            ):
+                raise ForwardCorpusRejected("official request artifact inventory is invalid")
+            stage = self._load_request_receipt(
+                request_directory / "response-stage.json", "response-stage"
+            )
+            observation = self._load_request_receipt(
+                request_directory / "observation.json", "observation"
+            )
+            if stage is None:
+                raise ForwardCorpusRejected("official response-stage receipt is missing")
+            self._verify_response_stage(pre, stage)
+            if request_directory.name != hashlib.sha256(
+                _bounded_id(stage.get("request_id"), "request_id").encode()
+            ).hexdigest():
+                raise ForwardCorpusRejected("response-stage request directory binding disagrees")
+            if observation is not None:
+                self._verify_observation(pre, observation)
+                self._verify_observation_stage_binding(pre, observation, stage)
+            history.append((stage, observation))
+        request_ids = [stage["request_id"] for stage, _observation in history]
+        if len(request_ids) != len(set(request_ids)):
+            raise ForwardCorpusRejected("duplicate official response-stage request identity")
+        return history
+
+    def _observation_inventory(
+        self,
+        pre: Mapping[str, Any],
+        observations: Sequence[Mapping[str, Any]],
+    ) -> tuple[list[str], list[str], list[str]]:
+        history = self._official_response_history(pre)
+        completed = [
+            observation for _stage, observation in history if observation is not None
+        ]
+        if list(observations) != completed:
+            raise ForwardCorpusRejected(
+                "official completed observation inventory is incomplete or reordered"
+            )
+        response_stages = [
+            str(_checksum(canonical_json(stage))) for stage, _observation in history
+        ]
+        raw_responses = [stage["raw_response_checksum"] for stage, _observation in history]
+        observation_receipts = [
+            str(_checksum(canonical_json(observation))) for observation in completed
+        ]
+        if (
+            len(response_stages) != len(set(response_stages))
+            or len(observation_receipts) != len(set(observation_receipts))
+            or len(response_stages) != len(raw_responses)
+        ):
+            raise ForwardCorpusRejected("official retained response history is ambiguous")
+        return response_stages, raw_responses, observation_receipts
+
+    @staticmethod
+    def _request_directory(root: Path, race_id: str, request_id: str) -> Path:
+        return (
+            root
+            / "races"
+            / hashlib.sha256(race_id.encode()).hexdigest()
+            / "official-requests"
+            / hashlib.sha256(request_id.encode()).hexdigest()
+        )
+
+    def _verify_response_stage(
+        self,
+        pre: Mapping[str, Any],
+        stage: Mapping[str, Any],
+    ) -> bytes:
+        if set(stage) != {
+            "schema_version",
+            "race_id",
+            "collector_id",
+            "session_id",
+            "run_id",
+            "request_id",
+            "source_name",
+            "request_url",
+            "final_url",
+            "http_status",
+            "content_type",
+            "source_document_last_modified",
+            "request_started_at",
+            "response_received_at",
+            "observed_at",
+            "raw_response_checksum",
+        } or stage.get("schema_version") != RESPONSE_STAGE_SCHEMA:
+            raise ForwardCorpusRejected("official response-stage envelope is invalid")
+        if stage.get("race_id") != pre.get("race_id"):
+            raise ForwardCorpusRejected("official response-stage race identity mismatch")
+        for field in ("collector_id", "session_id", "run_id", "request_id"):
+            _bounded_id(stage.get(field), field)
+        if stage.get("source_name") != OFFICIAL_RESULT_SOURCE:
+            raise ForwardCorpusRejected("official result source name is not canonical")
+        _source_url(stage.get("request_url"), "official request URL")
+        _source_url(stage.get("final_url"), "official final URL")
+        if type(stage.get("http_status")) is not int or not 200 <= stage["http_status"] < 300:
+            raise ForwardCorpusRejected("official response HTTP status is unsupported")
+        content_type = _known_text(stage.get("content_type"), "official content type")
+        media_type, separator, parameters = content_type.partition(";")
+        if media_type.strip().casefold() != "text/html" or (
+            separator and parameters.strip().casefold().replace(" ", "") != "charset=utf-8"
+        ):
+            raise ForwardCorpusRejected("official response content type is unsupported")
+        if stage.get("source_document_last_modified") is not None:
+            _known_text(stage["source_document_last_modified"], "source document Last-Modified")
+        started = _timestamp(stage.get("request_started_at"), "request started")[0]
+        received = _timestamp(stage.get("response_received_at"), "response received")[0]
+        observed = _timestamp(stage.get("observed_at"), "result observed")[0]
+        if not started <= received <= observed:
+            raise ForwardCorpusRejected("official response timestamps are unordered")
+        return self._read_artifact(stage.get("raw_response_checksum"), "raw response")
+
+    def _verify_observation(
+        self,
+        pre: Mapping[str, Any],
+        observation: Mapping[str, Any],
+    ) -> bytes:
+        expected_keys = {
+            "schema_version",
+            "race_id",
+            "collector_id",
+            "session_id",
+            "run_id",
+            "request_id",
+            "source_name",
+            "request_url",
+            "final_url",
+            "http_status",
+            "content_type",
+            "source_document_last_modified",
+            "request_started_at",
+            "response_received_at",
+            "observed_at",
+            "raw_response_checksum",
+            "normalized_result_checksum",
+            "runner_set_hash",
+            "parser_hash",
+            "schema_hash",
+            "implementation_hash",
+        }
+        if set(observation) != expected_keys or observation.get("schema_version") != (
+            "official-result-observation-v1"
+        ):
+            raise ForwardCorpusRejected("official observation envelope is invalid")
+        if observation.get("race_id") != pre["race_id"]:
+            raise ForwardCorpusRejected("official observation race identity mismatch")
+        for field in ("collector_id", "session_id", "run_id", "request_id"):
+            _bounded_id(observation.get(field), field)
+        if observation.get("source_name") != OFFICIAL_RESULT_SOURCE:
+            raise ForwardCorpusRejected("official result source name is not canonical")
+        _source_url(observation.get("request_url"), "official request URL")
+        _source_url(observation.get("final_url"), "official final URL")
+        if type(observation.get("http_status")) is not int or not (
+            200 <= observation["http_status"] < 300
+        ):
+            raise ForwardCorpusRejected("official response HTTP status is unsupported")
+        content_type = _known_text(observation.get("content_type"), "official content type")
+        media_type, separator, parameters = content_type.partition(";")
+        if media_type.strip().casefold() != "text/html":
+            raise ForwardCorpusRejected("official response content type is unsupported")
+        if separator:
+            parameter = parameters.strip().casefold().replace(" ", "")
+            if parameter != "charset=utf-8":
+                raise ForwardCorpusRejected("official response charset is unsupported")
+        last_modified = observation.get("source_document_last_modified")
+        if last_modified is not None:
+            _known_text(last_modified, "source document Last-Modified")
+        started = _timestamp(observation.get("request_started_at"), "request started")[0]
+        received = _timestamp(observation.get("response_received_at"), "response received")[0]
+        observed = _timestamp(observation.get("observed_at"), "result observed")[0]
+        if not started <= received <= observed:
+            raise ForwardCorpusRejected("official response timestamps are unordered")
+        raw = self._read_artifact(observation.get("raw_response_checksum"), "raw response")
+        normalized = self._read_artifact(
+            observation.get("normalized_result_checksum"), "normalized result"
+        )
+        source_capture = _canonical_object(
+            self._read_artifact(pre["source_capture_checksum"], "source capture"),
+            "source capture",
+        )
+        rebuilt = _normalize_official_result(
+            raw,
+            race_id=pre["race_id"],
+            frozen_runners=source_capture["runners"],
+        )
+        parser_hash, schema_hash, implementation_hash = _normalization_identity()
+        runner_set_hash = str(_checksum(canonical_json(source_capture["runners"])))
+        if (
+            rebuilt != normalized
+            or str(_checksum(rebuilt)) != observation["normalized_result_checksum"]
+            or observation["runner_set_hash"] != runner_set_hash
+            or observation["parser_hash"] != parser_hash
+            or observation["schema_hash"] != schema_hash
+            or observation["implementation_hash"] != implementation_hash
+        ):
+            raise ForwardCorpusRejected("official result reconstruction or code identity drift")
+        return normalized
+
+    def capture_result(
+        self,
+        *,
+        race_id: str,
+        collector_id: str,
+        session_id: str,
+        run_id: str,
+        request_id: str,
+        request_url: str,
+        transport: Callable[[str], Mapping[str, Any]],
+        source_name: str = OFFICIAL_RESULT_SOURCE,
+    ) -> dict[str, Any]:
+        """Fetch and retain one official response using collector-owned timestamps."""
+        race_id = _bounded_id(race_id, "race_id")
+        pre = self._load_receipt(race_id, "prejump")
+        if pre is None:
+            raise ForwardCorpusRejected("pre-jump evidence must exist before result capture")
+        if source_name != OFFICIAL_RESULT_SOURCE:
+            raise ForwardCorpusRejected("official result source name is not canonical")
+        for value, name in (
+            (collector_id, "collector_id"),
+            (session_id, "session_id"),
+            (run_id, "run_id"),
+            (request_id, "request_id"),
+            (source_name, "source_name"),
+        ):
+            _bounded_id(value, name)
+        request_url = _source_url(request_url, "official request URL")
+        request_directory = self._request_directory(self.root, race_id, request_id)
+        observation_path = request_directory / "observation.json"
+        response_stage_path = request_directory / "response-stage.json"
+        if observation_path.exists():
+            observation = _canonical_object(
+                observation_path.read_bytes(), "observation receipt"
+            )
+            immutable = {
+                "collector_id": collector_id,
+                "session_id": session_id,
+                "run_id": run_id,
+                "request_id": request_id,
+                "request_url": request_url,
+                "source_name": source_name,
+            }
+            if any(observation.get(key) != value for key, value in immutable.items()):
+                raise ForwardCorpusRejected("request identity replay conflicts with immutable input")
+            self._verify_observation(pre, observation)
+            stage = self._load_request_receipt(response_stage_path, "response-stage")
+            self._verify_observation_stage_binding(pre, observation, stage)
+            self._refresh_stability(pre)
+            return observation
+        stage = self._load_request_receipt(response_stage_path, "response-stage")
+        if stage is None:
+            self._recover_conflict(pre)
+            if self._load_receipt(race_id, "closure") is not None:
+                raise ForwardCorpusRejected("new post-closure observation is forbidden")
+            if self._load_receipt(race_id, "conflict") is not None:
+                raise ForwardCorpusRejected("result identity already changed before closure")
+            if not callable(transport):
+                raise ForwardCorpusRejected("official transport must be callable")
+            started = self._trusted_now("request started")
+            response = transport(request_url)
+            received = self._trusted_now("response received")
+            observed = self._trusted_now("result observed")
+            if type(response) is not dict:
+                raise ForwardCorpusRejected("official transport response must be a mapping")
+            allowed = {
+                "body", "status_code", "content_type", "final_url",
+                "source_document_last_modified",
+            }
+            if set(response) - allowed or not {
+                "body", "status_code", "content_type", "final_url"
+            } <= set(response):
+                raise ForwardCorpusRejected("official transport response envelope is invalid")
+            body = response["body"]
+            if type(body) is not bytes or not body:
+                raise ForwardCorpusRejected("immutable official-result response bytes are required")
+            raw_checksum = self.artifacts.put(
+                body, media_type="application/octet-stream"
+            ).checksum
+            stage = {
+                "schema_version": RESPONSE_STAGE_SCHEMA,
+                "race_id": race_id,
+                "collector_id": collector_id,
+                "session_id": session_id,
+                "run_id": run_id,
+                "request_id": request_id,
+                "source_name": source_name,
+                "request_url": request_url,
+                "final_url": _source_url(response["final_url"], "official final URL"),
+                "http_status": response["status_code"],
+                "content_type": _known_text(response["content_type"], "official content type"),
+                "source_document_last_modified": response.get("source_document_last_modified"),
+                "request_started_at": started,
+                "response_received_at": received,
+                "observed_at": observed,
+                "raw_response_checksum": str(raw_checksum),
+            }
+            self._verify_response_stage(pre, stage)
+            stage_bytes = canonical_json(stage)
+            self.artifacts.put(stage_bytes, media_type="application/json")
+            self._publish_once(response_stage_path, stage_bytes)
+        immutable = {
+            "collector_id": collector_id, "session_id": session_id, "run_id": run_id,
+            "request_id": request_id, "request_url": request_url, "source_name": source_name,
+        }
+        if any(stage.get(key) != value for key, value in immutable.items()):
+            raise ForwardCorpusRejected("request identity replay conflicts with immutable input")
+        body = self._verify_response_stage(pre, stage)
+        source_capture = _canonical_object(
+            self._read_artifact(pre["source_capture_checksum"], "source capture"),
+            "source capture",
+        )
+        normalized = _normalize_official_result(
+            body,
+            race_id=race_id,
+            frozen_runners=source_capture["runners"],
+        )
+        self._recover_conflict(pre)
+        if self._load_receipt(race_id, "closure") is not None:
+            raise ForwardCorpusRejected("new post-closure observation is forbidden")
+        if self._load_receipt(race_id, "conflict") is not None:
+            raise ForwardCorpusRejected("result identity already changed before closure")
+        normalized_checksum = self.artifacts.put(
+            normalized, media_type="application/json"
+        ).checksum
+        parser_hash, schema_hash, implementation_hash = _normalization_identity()
+        observation = {
+            "schema_version": "official-result-observation-v1",
+            "race_id": race_id,
+            "collector_id": collector_id,
+            "session_id": session_id,
+            "run_id": run_id,
+            "request_id": request_id,
+            "source_name": source_name,
+            "request_url": request_url,
+            "final_url": stage["final_url"],
+            "http_status": stage["http_status"],
+            "content_type": stage["content_type"],
+            "source_document_last_modified": stage["source_document_last_modified"],
+            "request_started_at": stage["request_started_at"],
+            "response_received_at": stage["response_received_at"],
+            "observed_at": stage["observed_at"],
+            "raw_response_checksum": stage["raw_response_checksum"],
+            "normalized_result_checksum": str(normalized_checksum),
+            "runner_set_hash": str(_checksum(canonical_json(source_capture["runners"]))),
+            "parser_hash": parser_hash,
+            "schema_hash": schema_hash,
+            "implementation_hash": implementation_hash,
+        }
+        self._verify_observation(pre, observation)
+        observation_bytes = canonical_json(observation)
+        self.artifacts.put(observation_bytes, media_type="application/json")
+        self._publish_once(observation_path, observation_bytes)
+        self._refresh_stability(pre)
+        return observation
+
+    @staticmethod
+    def _load_request_receipt(path: Path, name: str) -> dict[str, Any] | None:
+        try:
+            content = path.read_bytes()
+        except FileNotFoundError:
+            return None
+        if path.is_symlink():
+            raise ForwardCorpusRejected(f"{name} receipt must not be a symlink")
+        return _canonical_object(content, f"{name} receipt")
+
+    def _verify_observation_stage_binding(
+        self,
+        pre: Mapping[str, Any],
+        observation: Mapping[str, Any],
+        stage: Mapping[str, Any] | None,
+    ) -> None:
+        if stage is None:
+            raise ForwardCorpusRejected("official response-stage receipt is missing")
+        self._verify_response_stage(pre, stage)
+        shared = set(stage) - {"schema_version"}
+        if any(observation.get(field) != stage[field] for field in shared):
+            raise ForwardCorpusRejected("official observation response-stage binding disagrees")
+
+    def _trusted_now(self, name: str) -> str:
+        value = self._clock()
+        try:
+            if type(value) is not datetime:
+                raise TypeError
+            require_aware(value, name)
+        except (TypeError, ValueError) as error:
+            raise ForwardCorpusRejected(f"collector {name} timestamp is invalid") from error
+        return value.isoformat(timespec="microseconds")
+
+    def _refresh_stability(self, pre: Mapping[str, Any]) -> None:
+        observations = self._official_receipts(pre["race_id"])
+        self._observation_inventory(pre, observations)
+        if not observations:
+            return
+        identities = {
+            (
+                item["normalized_result_checksum"],
+                item["runner_set_hash"],
+                item["parser_hash"],
+                item["schema_hash"],
+                item["implementation_hash"],
+                item["source_name"],
+            )
+            for item in observations
+        }
+        if len(identities) > 1:
+            conflict = {
+                "schema_version": "official-result-conflict-v1",
+                "race_id": pre["race_id"],
+                "observation_checksums": sorted(
+                    str(_checksum(canonical_json(item))) for item in observations
+                ),
+                "state": "RESULT_CHANGED_BEFORE_CLOSURE",
+            }
+            self._publish_once(
+                self._receipt_path(pre["race_id"], "conflict"), canonical_json(conflict)
+            )
+            return
+        jump = _timestamp(pre["scheduled_jump_at"], "scheduled jump")[0]
+        eligible = [
+            item
+            for item in observations
+            if _timestamp(item["observed_at"], "result observed")[0] >= jump + timedelta(minutes=5)
+        ]
+        eligible.sort(key=lambda item: _timestamp(item["observed_at"], "result observed")[0])
+        pair = next(
+            (
+                (first, second)
+                for index, first in enumerate(eligible)
+                for second in eligible[index + 1 :]
+                if _timestamp(second["observed_at"], "result observed")[0]
+                - _timestamp(first["observed_at"], "result observed")[0]
+                >= timedelta(minutes=15)
+            ),
+            None,
+        )
+        if pair is None:
+            return
+        receipt = {
+            "schema_version": "official-result-stability-v1",
+            "race_id": pre["race_id"],
+            "first_observation_checksum": str(_checksum(canonical_json(pair[0]))),
+            "second_observation_checksum": str(_checksum(canonical_json(pair[1]))),
+            "normalized_result_checksum": pair[0]["normalized_result_checksum"],
+            "confirmed_at": pair[1]["observed_at"],
+        }
+        self.artifacts.put(canonical_json(receipt), media_type="application/json")
+        self._publish_once(
+            self._receipt_path(pre["race_id"], "stability"), canonical_json(receipt)
+        )
+
+    def _recover_conflict(self, pre: Mapping[str, Any]) -> None:
+        observations = self._official_receipts(pre["race_id"])
+        self._observation_inventory(pre, observations)
+        if len({self._observation_identity(item) for item in observations}) <= 1:
+            return
+        conflict = {
+            "schema_version": "official-result-conflict-v1",
+            "race_id": pre["race_id"],
+            "observation_checksums": sorted(
+                str(_checksum(canonical_json(item))) for item in observations
+            ),
+            "state": "RESULT_CHANGED_BEFORE_CLOSURE",
+        }
+        self._publish_once(
+            self._receipt_path(pre["race_id"], "conflict"), canonical_json(conflict)
+        )
+
+    @staticmethod
+    def _observation_identity(observation: Mapping[str, Any]) -> tuple[Any, ...]:
+        return (
+            observation["normalized_result_checksum"],
+            observation["runner_set_hash"],
+            observation["parser_hash"],
+            observation["schema_hash"],
+            observation["implementation_hash"],
+            observation["source_name"],
+        )
+
+    def _validated_state(
+        self, pre: Mapping[str, Any]
+    ) -> tuple[list[dict[str, Any]], dict[str, Any] | None, dict[str, Any] | None, bool]:
+        observations = self._official_receipts(pre["race_id"])
+        self._observation_inventory(pre, observations)
+        conflict_present = len({self._observation_identity(item) for item in observations}) > 1
+        conflict = self._load_receipt(pre["race_id"], "conflict")
+        checksums = sorted(str(_checksum(canonical_json(item))) for item in observations)
+        if conflict is not None and conflict != {
+            "schema_version": "official-result-conflict-v1",
+            "race_id": pre["race_id"],
+            "observation_checksums": checksums,
+            "state": "RESULT_CHANGED_BEFORE_CLOSURE",
+        }:
+            raise ForwardCorpusRejected("official conflict receipt binding is invalid")
+        if conflict is not None and not conflict_present:
+            raise ForwardCorpusRejected("official conflict receipt is not terminal")
+        stability = self._load_receipt(pre["race_id"], "stability")
+        if stability is not None:
+            if set(stability) != {
+                "schema_version", "race_id", "first_observation_checksum",
+                "second_observation_checksum", "normalized_result_checksum", "confirmed_at",
+            } or stability.get("schema_version") != "official-result-stability-v1":
+                raise ForwardCorpusRejected("official stability receipt envelope is invalid")
+            if stability.get("race_id") != pre["race_id"]:
+                raise ForwardCorpusRejected("official stability receipt race identity is invalid")
+            by_checksum = {
+                str(_checksum(canonical_json(item))): item for item in observations
+            }
+            try:
+                first = by_checksum[stability["first_observation_checksum"]]
+                second = by_checksum[stability["second_observation_checksum"]]
+            except (KeyError, TypeError) as error:
+                raise ForwardCorpusRejected(
+                    "stability receipt is not bound to observations"
+                ) from error
+            if first is second or first["request_id"] == second["request_id"]:
+                raise ForwardCorpusRejected("stability observations are not distinct")
+            first_at = _timestamp(first["observed_at"], "first observed")[0]
+            second_at = _timestamp(second["observed_at"], "second observed")[0]
+            jump_at = _timestamp(pre["scheduled_jump_at"], "scheduled jump")[0]
+            if (
+                self._observation_identity(first) != self._observation_identity(second)
+                or first_at < jump_at + timedelta(minutes=5)
+                or second_at - first_at < timedelta(minutes=15)
+                or stability["normalized_result_checksum"]
+                != first["normalized_result_checksum"]
+                or _timestamp(stability["confirmed_at"], "stability confirmation")[0]
+                != second_at
+            ):
+                raise ForwardCorpusRejected("official stability receipt binding is invalid")
+        return observations, stability, conflict, conflict_present
+
+    def close(self, *, race_id: str) -> dict[str, Any]:
+        """Explicitly close a stable race; stability never closes it implicitly."""
+        race_id = _bounded_id(race_id, "race_id")
+        existing = self._load_receipt(race_id, "closure")
+        if existing is not None:
+            self._verify_closed_race(existing)
+            return existing
+        pre = self._load_receipt(race_id, "prejump")
+        if pre is None:
+            raise ForwardCorpusRejected("result stability must be confirmed before closure")
+        observations, stability, _conflict, conflict_present = self._validated_state(pre)
+        if conflict_present:
+            raise ForwardCorpusRejected("result changed before closure")
+        if stability is None:
+            raise ForwardCorpusRejected("result stability must be confirmed before closure")
+        by_checksum = {
+            str(_checksum(canonical_json(item))): item for item in observations
+        }
+        try:
+            first = by_checksum[stability["first_observation_checksum"]]
+            second = by_checksum[stability["second_observation_checksum"]]
+        except (KeyError, TypeError) as error:
+            raise ForwardCorpusRejected("stability receipt is not bound to observations") from error
+        self._verify_observation(pre, first)
+        self._verify_observation(pre, second)
+        closed_at = self._trusted_now("closure")
+        if _timestamp(closed_at, "closure")[0] < _timestamp(
+            stability["confirmed_at"], "stability confirmation"
+        )[0]:
+            raise ForwardCorpusRejected("closure predates stability")
+        entry = self._race_entry(pre, stability, first, second, observations, closed_at)
+        example_bytes = canonical_json(
+            {
+                "schema_version": "historical-training-example-v1",
+                "origin": FORWARD_CORPUS_ORIGIN,
+                **entry,
+            }
+        )
+        example_checksum = self.artifacts.put(
+            example_bytes, media_type="application/json"
+        ).checksum
+        entry["artifact_checksum"] = str(example_checksum)
+        closure = {
+            "schema_version": CLOSURE_RECEIPT_SCHEMA,
+            "race_id": race_id,
+            "target_bundle_id": pre["target_bundle_id"],
+            "feature_schema_checksum": pre["feature_schema_checksum"],
+            "missingness_policy_checksum": pre["missingness_policy_checksum"],
+            "closed_at": closed_at,
+            "race": entry,
+        }
+        closure_bytes = canonical_json(closure)
+        self.artifacts.put(closure_bytes, media_type="application/json")
+        self._publish_once(self._receipt_path(race_id, "closure"), closure_bytes)
+        return closure
+
+    def _race_entry(
+        self,
+        pre: Mapping[str, Any],
+        stability: Mapping[str, Any],
+        first: Mapping[str, Any],
+        second: Mapping[str, Any],
+        observations: Sequence[Mapping[str, Any]],
+        closed_at: str,
+    ) -> dict[str, Any]:
+        race_id = pre["race_id"]
+        response_stages, raw_responses, observation_receipts = (
+            self._observation_inventory(pre, observations)
+        )
+        return {
+            "training_example_id": "official-first-"
+            + hashlib.sha256(f"{race_id}\0{pre['source_native_race_id']}".encode()).hexdigest(),
+            "race_id": race_id,
+            "racing_date": pre["racing_date"],
+            "source_checksum": pre["source_checksum"],
+            "prejump_receipt_checksum": str(_checksum(canonical_json(pre))),
+            "source_capture_checksum": pre["source_capture_checksum"],
+            "raw_source_checksum": pre["raw_source_checksum"],
+            "feature_matrix_checksum": pre["feature_matrix_checksum"],
+            "runner_ids": pre["runner_ids"],
+            "source_observed_at": pre["source_observed_at"],
+            "feature_observed_at": pre["feature_frozen_at"],
+            "scheduled_jump_at": pre["scheduled_jump_at"],
+            "first_observation_checksum": str(_checksum(canonical_json(first))),
+            "second_observation_checksum": str(_checksum(canonical_json(second))),
+            "first_raw_response_checksum": first["raw_response_checksum"],
+            "second_raw_response_checksum": second["raw_response_checksum"],
+            "response_stage_checksums": response_stages,
+            "raw_response_checksums": raw_responses,
+            "observation_checksums": observation_receipts,
+            "normalized_result_checksum": stability["normalized_result_checksum"],
+            "stability_checksum": str(_checksum(canonical_json(stability))),
+            "stability_confirmed_at": stability["confirmed_at"],
+            "closed_at": closed_at,
+        }
+
+    def build_package(self) -> ClosedPackage:
+        """Build a deterministic package from explicit, verified closures."""
+        closures = self._closures()
+        if not closures:
+            raise ForwardCorpusRejected("no closed races are available")
+        for closure in closures:
+            self._verify_closed_race(closure)
+        bundle_ids = {item["target_bundle_id"] for item in closures}
+        schemas = {item["feature_schema_checksum"] for item in closures}
+        policies = {item["missingness_policy_checksum"] for item in closures}
+        if len(bundle_ids) != 1 or len(schemas) != 1 or len(policies) != 1:
+            raise ForwardCorpusRejected("closed races use different feature contracts")
+        races = sorted(
+            (
+                {
+                    **item["race"],
+                    "closure_receipt_checksum": str(_checksum(canonical_json(item))),
+                }
+                for item in closures
+            ),
+            key=lambda race: _identity_key(race["race_id"], "race_id"),
+        )
+        manifest = {
+            "schema_version": "historical-source-manifest-v1",
+            "corpus_origin": FORWARD_CORPUS_ORIGIN,
+            "target_bundle_id": next(iter(bundle_ids)),
+            "feature_schema_checksum": next(iter(schemas)),
+            "missingness_policy_checksum": next(iter(policies)),
+            "races": races,
+        }
+        manifest_checksum = _checksum(canonical_json(manifest))
+        package_bytes = canonical_json(
+            {
+                "schema_version": "historical-source-package-v1",
+                "manifest_checksum": str(manifest_checksum),
+                "manifest": manifest,
+            }
+        )
+        scalar_fields = (
+            "source_checksum",
+            "prejump_receipt_checksum",
+            "closure_receipt_checksum",
+            "source_capture_checksum",
+            "raw_source_checksum",
+            "feature_matrix_checksum",
+            "normalized_result_checksum",
+            "stability_checksum",
+            "artifact_checksum",
+        )
+        declared = {
+            manifest["feature_schema_checksum"],
+            manifest["missingness_policy_checksum"],
+            *{race[field] for race in races for field in scalar_fields},
+            *{
+                checksum
+                for race in races
+                for field in (
+                    "response_stage_checksums",
+                    "raw_response_checksums",
+                    "observation_checksums",
+                )
+                for checksum in race[field]
+            },
+        }
+        artifacts = {
+            checksum: self._read_artifact(checksum, "package artifact")
+            for checksum in sorted(declared)
+        }
+        from .source_admission import admit_historical_source
+
+        admit_historical_source(package_bytes, artifacts=artifacts)
+        package_checksum = _checksum(package_bytes)
+        self.artifacts.put(package_bytes, media_type="application/json")
+        self._publish_once(
+            self.root / "packages" / f"{manifest_checksum.hex_digest}.json", package_bytes
+        )
+        return ClosedPackage(package_bytes, package_checksum, manifest_checksum, artifacts)
+
+    def _verify_closed_race(self, closure: Mapping[str, Any]) -> None:
+        pre = self._load_receipt(closure.get("race_id"), "prejump")
+        if pre is None:
+            raise ForwardCorpusRejected("closure references missing immutable receipt")
+        observations, stability, _conflict, conflict_present = self._validated_state(pre)
+        if stability is None or conflict_present:
+            raise ForwardCorpusRejected("closure references invalid terminal state")
+        if set(closure) != {
+            "schema_version", "race_id", "target_bundle_id", "feature_schema_checksum",
+            "missingness_policy_checksum", "closed_at", "race",
+        } or closure.get("schema_version") != CLOSURE_RECEIPT_SCHEMA:
+            raise ForwardCorpusRejected("closure receipt envelope is invalid")
+        by_checksum = {
+            str(_checksum(canonical_json(item))): item for item in observations
+        }
+        race = closure.get("race")
+        if type(race) is not dict:
+            raise ForwardCorpusRejected("closure race envelope is invalid")
+        try:
+            first = by_checksum[race["first_observation_checksum"]]
+            second = by_checksum[race["second_observation_checksum"]]
+        except (KeyError, TypeError) as error:
+            raise ForwardCorpusRejected("closure observation binding is invalid") from error
+        self._verify_observation(pre, first)
+        self._verify_observation(pre, second)
+        expected = self._race_entry(
+            pre, stability, first, second, observations, closure["closed_at"]
+        )
+        artifact_checksum = race.get("artifact_checksum")
+        artifact = self._read_artifact(artifact_checksum, "training example")
+        if (
+            {key: value for key, value in race.items() if key != "artifact_checksum"} != expected
+            or artifact
+            != canonical_json(
+                {
+                    "schema_version": "historical-training-example-v1",
+                    "origin": FORWARD_CORPUS_ORIGIN,
+                    **expected,
+                }
+            )
+        ):
+            raise ForwardCorpusRejected("closure or training example binding drift")
+
+    def status(self) -> dict[str, Any]:
+        """Reconstruct state from immutable receipts and reparsed raw responses."""
+        rows = []
+        directory = self.root / "races"
+        if directory.exists():
+            for race_directory in sorted(path for path in directory.iterdir() if path.is_dir()):
+                pre_path = race_directory / "prejump.json"
+                if not pre_path.exists():
+                    continue
+                pre = _canonical_object(pre_path.read_bytes(), "prejump receipt")
+                for field in (
+                    "raw_source_checksum",
+                    "source_checksum",
+                    "source_capture_checksum",
+                    "feature_schema_checksum",
+                    "missingness_policy_checksum",
+                    "feature_matrix_checksum",
+                ):
+                    self._read_artifact(pre[field], field)
+                observations = self._official_receipts(pre["race_id"])
+                observations, stability, conflict, conflict_present = self._validated_state(pre)
+                closure = self._load_receipt(pre["race_id"], "closure")
+                state = "RESULT_PENDING"
+                if observations:
+                    state = "RESULT_FIRST_OBSERVED"
+                if stability is not None:
+                    state = "RESULT_STABILITY_CONFIRMED"
+                if closure is not None:
+                    self._verify_closed_race(closure)
+                    state = "EXAMPLE_CLOSED"
+                if conflict is not None or conflict_present:
+                    state = "RESULT_CHANGED_BEFORE_CLOSURE"
+                rows.append(
+                    {
+                        "race_id": pre["race_id"],
+                        "state": state,
+                        "result_observation_count": len(observations),
+                    }
+                )
+        rows.sort(key=lambda row: _identity_key(row["race_id"], "race_id"))
+        return {
+            "schema_version": STATUS_SCHEMA,
+            "race_count": len(rows),
+            "closed_race_count": sum(row["state"] == "EXAMPLE_CLOSED" for row in rows),
             "races": rows,
         }

--- a/race_collection/source_admission.py
+++ b/race_collection/source_admission.py
@@ -20,6 +20,9 @@ ADMITTED_MANIFEST_SCHEMA = "historical-source-admission-v1"
 LEGACY_ORIGIN = "legacy-historical-bootstrap-v1"
 SYNTHETIC_ORIGIN = "synthetic-validation-fixture-v1"
 FORWARD_SEALED_ORIGIN = "forward-sealed-corpus-v1"
+OFFICIAL_FIRST_ORIGIN = "official-result-first-observation-v1"
+OFFICIAL_RESULT_SOURCE = "thedogs-official"
+PREJUMP_SOURCE = "thedogs-race-card"
 
 _MANIFEST_FIELDS = {
     "schema_version",
@@ -48,6 +51,51 @@ _FORWARD_RACE_FIELDS = _RACE_FIELDS | {
     "raw_source_checksum",
     "raw_result_checksum",
     "source_observed_at",
+}
+_OFFICIAL_RACE_FIELDS = {
+    "training_example_id",
+    "race_id",
+    "racing_date",
+    "source_checksum",
+    "prejump_receipt_checksum",
+    "closure_receipt_checksum",
+    "source_capture_checksum",
+    "raw_source_checksum",
+    "feature_matrix_checksum",
+    "runner_ids",
+    "source_observed_at",
+    "feature_observed_at",
+    "scheduled_jump_at",
+    "first_observation_checksum",
+    "second_observation_checksum",
+    "first_raw_response_checksum",
+    "second_raw_response_checksum",
+    "response_stage_checksums",
+    "raw_response_checksums",
+    "observation_checksums",
+    "normalized_result_checksum",
+    "stability_checksum",
+    "stability_confirmed_at",
+    "closed_at",
+    "artifact_checksum",
+}
+_OFFICIAL_RESPONSE_STAGE_FIELDS = {
+    "schema_version",
+    "race_id",
+    "collector_id",
+    "session_id",
+    "run_id",
+    "request_id",
+    "source_name",
+    "request_url",
+    "final_url",
+    "http_status",
+    "content_type",
+    "source_document_last_modified",
+    "request_started_at",
+    "response_received_at",
+    "observed_at",
+    "raw_response_checksum",
 }
 _RESULT_DERIVED_KEYS = {
     "finish_order",
@@ -109,10 +157,12 @@ def _canonical_source_url(value: Any, name: str) -> str:
     url = _known_text(value, name)
     parsed = urlsplit(url)
     if (
-        parsed.scheme not in {"http", "https"}
+        parsed.scheme != "https"
         or not parsed.netloc
+        or parsed.hostname not in {"www.thedogs.com.au", "thedogs.com.au"}
         or parsed.username is not None
         or parsed.password is not None
+        or parsed.query
         or parsed.fragment
     ):
         raise SourceAdmissionRejected(f"{name} is not a canonical source URL")
@@ -134,9 +184,12 @@ def _normalized_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
     races = manifest.get("races")
     if type(races) is not list or not races or any(type(race) is not dict for race in races):
         raise SourceAdmissionRejected("source manifest requires race objects")
+    origin = manifest.get("corpus_origin")
     expected_fields = (
-        _FORWARD_RACE_FIELDS
-        if manifest.get("corpus_origin") == FORWARD_SEALED_ORIGIN
+        _OFFICIAL_RACE_FIELDS
+        if origin == OFFICIAL_FIRST_ORIGIN
+        else _FORWARD_RACE_FIELDS
+        if origin == FORWARD_SEALED_ORIGIN
         else _RACE_FIELDS
     )
     if any(set(race) != expected_fields for race in races):
@@ -578,6 +631,582 @@ def _training_example_document(
     return document
 
 
+def _admit_official_first(
+    package: Mapping[str, Any],
+    manifest_checksum: str,
+    artifacts: Mapping[str, bytes],
+) -> bytes:
+    """Purely reconstruct an official-first package from its immutable bytes."""
+    from .forward_sealed_corpus import (
+        ForwardCorpusRejected,
+        _normalization_identity,
+        _normalize_official_result,
+    )
+
+    manifest = package["manifest"]
+    races = manifest["races"]
+    scalar_fields = (
+        "source_checksum",
+        "prejump_receipt_checksum",
+        "closure_receipt_checksum",
+        "source_capture_checksum",
+        "raw_source_checksum",
+        "feature_matrix_checksum",
+        "normalized_result_checksum",
+        "stability_checksum",
+        "artifact_checksum",
+    )
+    declared = {
+        manifest["feature_schema_checksum"],
+        manifest["missingness_policy_checksum"],
+        *{race[field] for race in races for field in scalar_fields},
+        *{
+            checksum
+            for race in races
+            for field in (
+                "response_stage_checksums",
+                "raw_response_checksums",
+                "observation_checksums",
+            )
+            for checksum in race[field]
+        },
+    }
+    if set(artifacts) != declared:
+        raise SourceAdmissionRejected("official-first artifact inventory is incomplete")
+    schema = _object(
+        _artifact(artifacts, manifest["feature_schema_checksum"], "feature schema"),
+        "feature schema",
+    )
+    missingness = _object(
+        _artifact(
+            artifacts,
+            manifest["missingness_policy_checksum"],
+            "missingness policy",
+        ),
+        "missingness policy",
+    )
+    if (
+        schema.get("bundle_id") != manifest["target_bundle_id"]
+        or schema.get("contract_version") != SUPPORTED_FEATURE_CONTRACT
+        or missingness.get("bundle_id") != manifest["target_bundle_id"]
+        or missingness.get("feature_contract_version") != SUPPORTED_FEATURE_CONTRACT
+    ):
+        raise SourceAdmissionRejected("official-first feature contract is unsupported")
+    parser_hash, schema_hash, implementation_hash = _normalization_identity()
+    admitted_races = []
+    try:
+        for race in races:
+            if set(race) != _OFFICIAL_RACE_FIELDS:
+                raise SourceAdmissionRejected("official-first race envelope is invalid")
+            source = _object(
+                _artifact(artifacts, race["source_capture_checksum"], "source capture"),
+                "source capture",
+            )
+            frozen_runners = source.get("runners")
+            expected_source_fields = {
+                "schema_version", "race_id", "racing_date", "source_name",
+                "canonical_source_url", "source_native_race_id", "meeting_metadata",
+                "race_metadata", "scheduled_jump_at", "source_observed_at",
+                "feature_frozen_at", "raw_source_checksum", "sealed_evidence_checksum",
+                "runners", "identity_authority", "reconstructed",
+            }
+            if (
+                set(source) != expected_source_fields
+                or source.get("schema_version") != "forward-source-capture-v1"
+                or source.get("race_id") != race["race_id"]
+                or source.get("source_name") != PREJUMP_SOURCE
+                or source.get("racing_date") != race["racing_date"]
+                or source.get("scheduled_jump_at") != race["scheduled_jump_at"]
+                or source.get("source_observed_at") != race["source_observed_at"]
+                or source.get("feature_frozen_at") != race["feature_observed_at"]
+                or source.get("raw_source_checksum") != race["raw_source_checksum"]
+                or source.get("sealed_evidence_checksum") != race["source_checksum"]
+                or source.get("identity_authority") != "source-native"
+                or source.get("reconstructed") is not False
+                or type(source.get("meeting_metadata")) is not dict
+                or not source["meeting_metadata"]
+                or type(source.get("race_metadata")) is not dict
+                or not source["race_metadata"]
+                or type(frozen_runners) is not list
+                or [runner["source_native_runner_id"] for runner in frozen_runners]
+                != race["runner_ids"]
+            ):
+                raise SourceAdmissionRejected("official-first sealed source binding disagrees")
+            _canonical_source_url(source["canonical_source_url"], "forward source URL")
+            _known_text(source["source_native_race_id"], "source-native race identity")
+            _reject_result_derived(source["meeting_metadata"])
+            _reject_result_derived(source["race_metadata"])
+            source_at = _aware_timestamp(source["source_observed_at"], "source observed")
+            feature_at = _aware_timestamp(source["feature_frozen_at"], "feature frozen")
+            jump_at = _aware_timestamp(source["scheduled_jump_at"], "scheduled jump")
+            try:
+                race_day = date.fromisoformat(source["racing_date"])
+            except (TypeError, ValueError) as error:
+                raise SourceAdmissionRejected("racing date is invalid") from error
+            if not source_at <= feature_at < jump_at or race_day != jump_at.date():
+                raise SourceAdmissionRejected("official-first source timestamps are invalid")
+            if any(
+                type(runner) is not dict
+                or set(runner) != {"source_native_runner_id", "name", "box_number"}
+                for runner in frozen_runners
+            ):
+                raise SourceAdmissionRejected("source-native runner envelope is invalid")
+            runner_ids = _require_unique_normalized(
+                [runner["source_native_runner_id"] for runner in frozen_runners],
+                "source-native runner identity",
+            )
+            runner_names = _require_unique_normalized(
+                [runner["name"] for runner in frozen_runners], "runner name"
+            )
+            boxes = [runner["box_number"] for runner in frozen_runners]
+            if (
+                list(runner_ids) != race["runner_ids"]
+                or len(runner_names) != len(frozen_runners)
+                or any(type(box) is not int or not 1 <= box <= 20 for box in boxes)
+                or len(set(boxes)) != len(boxes)
+            ):
+                raise SourceAdmissionRejected("source-native runner identity is invalid")
+            _artifact(artifacts, race["raw_source_checksum"], "raw sealed source")
+            source_bytes = _artifact(artifacts, race["source_checksum"], "sealed evidence")
+            evidence = _object(source_bytes, "sealed evidence")
+            if (
+                set(evidence)
+                != {
+                    "schema_version", "normalization_version", "race_id", "fields",
+                    "field_provenance", "freeze",
+                }
+                or evidence.get("race_id") != race["race_id"]
+                or type(evidence.get("fields")) is not dict
+                or evidence["fields"].get("runner_set") != race["runner_ids"]
+                or evidence["fields"].get("runner_identity")
+                != dict.fromkeys(race["runner_ids"], "authoritative")
+            ):
+                raise SourceAdmissionRejected("sealed evidence identity is incomplete")
+            freeze = evidence.get("freeze")
+            if (
+                type(freeze) is not dict
+                or set(freeze) != {"at", "authority", "odds_checksum"}
+                or _aware_timestamp(freeze.get("at"), "sealed evidence freeze") != feature_at
+            ):
+                raise SourceAdmissionRejected("sealed evidence freeze provenance is incomplete")
+            _known_text(freeze.get("authority"), "sealed evidence freeze authority")
+            try:
+                ArtifactChecksum(freeze["odds_checksum"])
+            except (KeyError, ValueError) as error:
+                raise SourceAdmissionRejected(
+                    "sealed evidence freeze provenance is incomplete"
+                ) from error
+            provenance = evidence.get("field_provenance")
+            required = {"runner_set", "runner_identity", "runner_features"}
+            bound = set()
+            if type(provenance) is not list or not provenance:
+                raise SourceAdmissionRejected("sealed evidence provenance is incomplete")
+            for item in provenance:
+                if type(item) is not dict or set(item) != {
+                    "field", "authority", "critical", "value", "source",
+                    "artifact_checksum",
+                }:
+                    raise SourceAdmissionRejected("sealed evidence provenance is invalid")
+                _known_text(item.get("field"), "provenance field")
+                _known_text(item.get("authority"), "provenance authority")
+                if type(item.get("critical")) is not bool:
+                    raise SourceAdmissionRejected("provenance criticality is invalid")
+                if (
+                    item["field"] in required
+                    and item.get("source") == PREJUMP_SOURCE
+                    and item.get("artifact_checksum") == race["raw_source_checksum"]
+                    and item.get("value") == evidence["fields"].get(item["field"])
+                ):
+                    bound.add(item["field"])
+            if bound != required:
+                raise SourceAdmissionRejected("sealed evidence provenance is incomplete")
+            prejump = _object(
+                _artifact(artifacts, race["prejump_receipt_checksum"], "pre-jump receipt"),
+                "pre-jump receipt",
+            )
+            expected_prejump = {
+                "schema_version": "forward-prejump-receipt-v1",
+                "race_id": race["race_id"],
+                "racing_date": race["racing_date"],
+                "target_bundle_id": manifest["target_bundle_id"],
+                "source_native_race_id": source["source_native_race_id"],
+                "runner_ids": race["runner_ids"],
+                "source_observed_at": race["source_observed_at"],
+                "feature_frozen_at": race["feature_observed_at"],
+                "scheduled_jump_at": race["scheduled_jump_at"],
+                "raw_source_checksum": race["raw_source_checksum"],
+                "source_checksum": race["source_checksum"],
+                "source_capture_checksum": race["source_capture_checksum"],
+                "feature_schema_checksum": manifest["feature_schema_checksum"],
+                "missingness_policy_checksum": manifest["missingness_policy_checksum"],
+                "feature_matrix_checksum": race["feature_matrix_checksum"],
+            }
+            if prejump != expected_prejump:
+                raise SourceAdmissionRejected("pre-jump receipt binding disagrees")
+            feature_bytes = _artifact(
+                artifacts, race["feature_matrix_checksum"], "feature matrix"
+            )
+            inventory_fields = (
+                "response_stage_checksums",
+                "raw_response_checksums",
+                "observation_checksums",
+            )
+            if (
+                any(type(race.get(field)) is not list for field in inventory_fields)
+                or len(race["observation_checksums"]) < 2
+                or len(race["response_stage_checksums"])
+                != len(race["raw_response_checksums"])
+                or len(race["observation_checksums"])
+                > len(race["response_stage_checksums"])
+                or len(set(race["response_stage_checksums"]))
+                != len(race["response_stage_checksums"])
+                or len(set(race["observation_checksums"]))
+                != len(race["observation_checksums"])
+            ):
+                raise SourceAdmissionRejected(
+                    "official retained observation inventory is invalid"
+                )
+            observations = [
+                _object(_artifact(artifacts, checksum, "observation"), "observation")
+                for checksum in race["observation_checksums"]
+            ]
+            stages = [
+                _object(_artifact(artifacts, checksum, "response stage"), "response stage")
+                for checksum in race["response_stage_checksums"]
+            ]
+            request_order = [
+                hashlib.sha256(
+                    _known_text(stage.get("request_id"), "request_id").encode()
+                ).hexdigest()
+                for stage in stages
+            ]
+            if request_order != sorted(request_order) or len(request_order) != len(
+                set(request_order)
+            ):
+                raise SourceAdmissionRejected(
+                    "official retained response-stage order is not deterministic"
+                )
+            stages_by_request = {}
+            for stage, raw_checksum in zip(
+                stages, race["raw_response_checksums"], strict=True
+            ):
+                if (
+                    set(stage) != _OFFICIAL_RESPONSE_STAGE_FIELDS
+                    or stage.get("schema_version")
+                    != "official-result-response-stage-v1"
+                    or stage.get("race_id") != race["race_id"]
+                    or stage.get("source_name") != OFFICIAL_RESULT_SOURCE
+                    or type(stage.get("http_status")) is not int
+                    or not 200 <= stage["http_status"] < 300
+                    or stage.get("raw_response_checksum") != raw_checksum
+                ):
+                    raise SourceAdmissionRejected(
+                        "official response-stage envelope is invalid"
+                    )
+                for identifier in (
+                    "collector_id",
+                    "session_id",
+                    "run_id",
+                    "request_id",
+                    "source_name",
+                ):
+                    if len(_known_text(stage.get(identifier), identifier).encode()) > 128:
+                        raise SourceAdmissionRejected(
+                            "official response-stage identifier is too long"
+                        )
+                content_type = _known_text(
+                    stage.get("content_type"), "official content type"
+                )
+                media_type, separator, parameters = content_type.partition(";")
+                if media_type.strip().casefold() != "text/html" or (
+                    separator
+                    and parameters.strip().casefold().replace(" ", "") != "charset=utf-8"
+                ):
+                    raise SourceAdmissionRejected("official content type is unsupported")
+                if stage.get("source_document_last_modified") is not None:
+                    _known_text(
+                        stage["source_document_last_modified"],
+                        "source document Last-Modified",
+                    )
+                _canonical_source_url(stage.get("request_url"), "official request URL")
+                _canonical_source_url(stage.get("final_url"), "official final URL")
+                started = _aware_timestamp(stage.get("request_started_at"), "request started")
+                received = _aware_timestamp(
+                    stage.get("response_received_at"), "response received"
+                )
+                observed = _aware_timestamp(stage.get("observed_at"), "observed")
+                if not started <= received <= observed:
+                    raise SourceAdmissionRejected(
+                        "official response-stage timestamps are unordered"
+                    )
+                _artifact(artifacts, raw_checksum, "raw official response")
+                stages_by_request[stage["request_id"]] = stage
+            observation_request_ids = [
+                _known_text(observation.get("request_id"), "request_id")
+                for observation in observations
+            ]
+            completed_order = [
+                stage["request_id"]
+                for stage in stages
+                if stage["request_id"] in set(observation_request_ids)
+            ]
+            if (
+                observation_request_ids != completed_order
+                or len(observation_request_ids) != len(set(observation_request_ids))
+            ):
+                raise SourceAdmissionRejected(
+                    "official completed observation inventory is incomplete or reordered"
+                )
+            by_checksum = dict(zip(race["observation_checksums"], observations, strict=True))
+            try:
+                first = by_checksum[race["first_observation_checksum"]]
+                second = by_checksum[race["second_observation_checksum"]]
+            except KeyError as error:
+                raise SourceAdmissionRejected(
+                    "stability observations are absent from retained inventory"
+                ) from error
+            stability = _object(
+                _artifact(artifacts, race["stability_checksum"], "stability"),
+                "stability",
+            )
+            normalized = _artifact(
+                artifacts, race["normalized_result_checksum"], "normalized result"
+            )
+            for observation in observations:
+                try:
+                    stage = stages_by_request[observation["request_id"]]
+                except (KeyError, TypeError) as error:
+                    raise SourceAdmissionRejected(
+                        "official observation has no retained response stage"
+                    ) from error
+                raw_checksum = stage["raw_response_checksum"]
+                expected_observation_fields = {
+                    "schema_version",
+                    "race_id",
+                    "collector_id",
+                    "session_id",
+                    "run_id",
+                    "request_id",
+                    "source_name",
+                    "request_url",
+                    "final_url",
+                    "http_status",
+                    "content_type",
+                    "source_document_last_modified",
+                    "request_started_at",
+                    "response_received_at",
+                    "observed_at",
+                    "raw_response_checksum",
+                    "normalized_result_checksum",
+                    "runner_set_hash",
+                    "parser_hash",
+                    "schema_hash",
+                    "implementation_hash",
+                }
+                if (
+                    set(observation) != expected_observation_fields
+                    or observation.get("schema_version")
+                    != "official-result-observation-v1"
+                    or observation.get("source_name") != OFFICIAL_RESULT_SOURCE
+                    or type(observation.get("http_status")) is not int
+                    or not 200 <= observation["http_status"] < 300
+                ):
+                    raise SourceAdmissionRejected("official observation envelope is invalid")
+                for identifier in (
+                    "collector_id",
+                    "session_id",
+                    "run_id",
+                    "request_id",
+                    "source_name",
+                ):
+                    if len(_known_text(observation.get(identifier), identifier).encode()) > 128:
+                        raise SourceAdmissionRejected("official observation identifier is too long")
+                content_type = _known_text(
+                    observation.get("content_type"), "official content type"
+                )
+                media_type, separator, parameters = content_type.partition(";")
+                if media_type.strip().casefold() != "text/html" or (
+                    separator
+                    and parameters.strip().casefold().replace(" ", "") != "charset=utf-8"
+                ):
+                    raise SourceAdmissionRejected("official content type is unsupported")
+                if observation.get("source_document_last_modified") is not None:
+                    _known_text(
+                        observation["source_document_last_modified"],
+                        "source document Last-Modified",
+                    )
+                expected_stage = {
+                    key: value
+                    for key, value in observation.items()
+                    if key
+                    not in {
+                        "normalized_result_checksum",
+                        "runner_set_hash",
+                        "parser_hash",
+                        "schema_hash",
+                        "implementation_hash",
+                    }
+                }
+                expected_stage["schema_version"] = "official-result-response-stage-v1"
+                if stage != expected_stage or raw_checksum != observation.get(
+                    "raw_response_checksum"
+                ):
+                    raise SourceAdmissionRejected(
+                        "official response-stage/observation inventory binding disagrees"
+                    )
+                raw = _artifact(artifacts, raw_checksum, "raw official response")
+                rebuilt = _normalize_official_result(
+                    raw,
+                    race_id=race["race_id"],
+                    frozen_runners=frozen_runners,
+                )
+                if (
+                    observation.get("race_id") != race["race_id"]
+                    or observation.get("raw_response_checksum") != raw_checksum
+                    or observation.get("normalized_result_checksum")
+                    != race["normalized_result_checksum"]
+                    or observation.get("parser_hash") != parser_hash
+                    or observation.get("schema_hash") != schema_hash
+                    or observation.get("implementation_hash") != implementation_hash
+                    or rebuilt != normalized
+                    or observation.get("runner_set_hash")
+                    != _checksum(_canonical(frozen_runners))
+                ):
+                    raise SourceAdmissionRejected(
+                        "official-first response reconstruction disagrees"
+                    )
+                _canonical_source_url(observation.get("request_url"), "official request URL")
+                _canonical_source_url(observation.get("final_url"), "official final URL")
+                started = _aware_timestamp(
+                    observation.get("request_started_at"), "request started"
+                )
+                received = _aware_timestamp(
+                    observation.get("response_received_at"), "response received"
+                )
+                observed = _aware_timestamp(observation.get("observed_at"), "observed")
+                if not started <= received <= observed:
+                    raise SourceAdmissionRejected("official observation timestamps are unordered")
+            identities = {
+                (
+                    observation["normalized_result_checksum"],
+                    observation["runner_set_hash"],
+                    observation["parser_hash"],
+                    observation["schema_hash"],
+                    observation["implementation_hash"],
+                    observation["source_name"],
+                )
+                for observation in observations
+            }
+            if len(identities) != 1:
+                raise SourceAdmissionRejected("official retained result identity changed")
+            if (
+                first["raw_response_checksum"] != race["first_raw_response_checksum"]
+                or second["raw_response_checksum"] != race["second_raw_response_checksum"]
+            ):
+                raise SourceAdmissionRejected("stability raw response binding disagrees")
+            first_at = _aware_timestamp(first["observed_at"], "first observed")
+            second_at = _aware_timestamp(second["observed_at"], "second observed")
+            jump_at = _aware_timestamp(race["scheduled_jump_at"], "scheduled jump")
+            stable_at = _aware_timestamp(race["stability_confirmed_at"], "stability")
+            closed_at = _aware_timestamp(race["closed_at"], "closure")
+            if (first_at - jump_at).total_seconds() < 300 or (
+                second_at - first_at
+            ).total_seconds() < 900 or stable_at != second_at or closed_at < stable_at:
+                raise SourceAdmissionRejected("official stability/closure order is invalid")
+            if (
+                stability
+                != {
+                    "schema_version": "official-result-stability-v1",
+                    "race_id": race["race_id"],
+                    "first_observation_checksum": race["first_observation_checksum"],
+                    "second_observation_checksum": race["second_observation_checksum"],
+                    "normalized_result_checksum": race["normalized_result_checksum"],
+                    "confirmed_at": race["stability_confirmed_at"],
+                }
+            ):
+                raise SourceAdmissionRejected("official stability binding disagrees")
+            closure = _object(
+                _artifact(artifacts, race["closure_receipt_checksum"], "closure receipt"),
+                "closure receipt",
+            )
+            closure_race = {
+                key: value
+                for key, value in race.items()
+                if key != "closure_receipt_checksum"
+            }
+            if closure != {
+                "schema_version": "forward-race-closure-v1",
+                "race_id": race["race_id"],
+                "target_bundle_id": manifest["target_bundle_id"],
+                "feature_schema_checksum": manifest["feature_schema_checksum"],
+                "missingness_policy_checksum": manifest["missingness_policy_checksum"],
+                "closed_at": race["closed_at"],
+                "race": closure_race,
+            }:
+                raise SourceAdmissionRejected("closure receipt binding disagrees")
+            try:
+                derived = derive_features(
+                    source_bytes,
+                    expected_evidence_checksum=ArtifactChecksum(race["source_checksum"]),
+                    schema_bytes=_canonical(schema),
+                    expected_schema_checksum=ArtifactChecksum(
+                        manifest["feature_schema_checksum"]
+                    ),
+                    missingness_policy_bytes=_canonical(missingness),
+                    expected_missingness_checksum=ArtifactChecksum(
+                        manifest["missingness_policy_checksum"]
+                    ),
+                )
+            except (FeatureQuarantine, ValueError) as error:
+                raise SourceAdmissionRejected(str(error)) from error
+            expected_features = _canonical(
+                {
+                    "runner_ids": list(derived.matrix.runner_ids),
+                    "columns": list(derived.matrix.columns),
+                    "rows": [list(row) for row in derived.matrix.rows],
+                }
+            )
+            if feature_bytes != expected_features:
+                raise SourceAdmissionRejected("official-first feature matrix disagrees")
+            example = _artifact(
+                artifacts, race["artifact_checksum"], "training example"
+            )
+            expected_example = _canonical(
+                {
+                    "schema_version": "historical-training-example-v1",
+                    "origin": OFFICIAL_FIRST_ORIGIN,
+                    **{
+                        key: value
+                        for key, value in race.items()
+                        if key not in {"artifact_checksum", "closure_receipt_checksum"}
+                    },
+                }
+            )
+            if example != expected_example:
+                raise SourceAdmissionRejected("official-first training example disagrees")
+            admitted_races.append(dict(race))
+    except (ForwardCorpusRejected, KeyError, TypeError, ValueError) as error:
+        if isinstance(error, SourceAdmissionRejected):
+            raise
+        raise SourceAdmissionRejected("official-first package is malformed") from error
+    return _canonical(
+        {
+            "schema_version": ADMITTED_MANIFEST_SCHEMA,
+            "admission_decision": "TRAINING_ADMISSIBLE",
+            "corpus_origin": OFFICIAL_FIRST_ORIGIN,
+            "forward_sealed": True,
+            "promotion_evidence_eligible": False,
+            "production_readiness": False,
+            "target_bundle_id": manifest["target_bundle_id"],
+            "source_manifest_checksum": manifest_checksum,
+            "feature_schema_checksum": manifest["feature_schema_checksum"],
+            "missingness_policy_checksum": manifest["missingness_policy_checksum"],
+            "race_ids": [race["race_id"] for race in admitted_races],
+            "races": admitted_races,
+        }
+    )
+
+
 def admit_historical_source(
     package_bytes: bytes,
     *,
@@ -609,6 +1238,8 @@ def admit_historical_source(
         raise SourceAdmissionRejected("source manifest checksum is invalid") from error
     if _checksum(_canonical(normalized_manifest)) != manifest_checksum:
         raise SourceAdmissionRejected("source manifest checksum is unverifiable")
+    if manifest.get("corpus_origin") == OFFICIAL_FIRST_ORIGIN:
+        return _admit_official_first(package, manifest_checksum, artifacts)
 
     origin = manifest.get("corpus_origin")
     if origin not in {LEGACY_ORIGIN, SYNTHETIC_ORIGIN, FORWARD_SEALED_ORIGIN}:

--- a/scripts/collect_forward_sealed_corpus.py
+++ b/scripts/collect_forward_sealed_corpus.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import sys
 from collections.abc import Mapping, Sequence
@@ -15,16 +16,14 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from race_collection.forward_sealed_corpus import (
-    ForwardCorpusRejected,
-    ForwardSealedCorpus,
-    canonical_json,
-)
-from scripts.shadow_autopilot_daemon import (
-    LockBusy,
-    acquire_lock,
-    release_lock,
-)
+_corpus_module = importlib.import_module("race_collection.forward_sealed_corpus")
+ForwardCorpusRejected = _corpus_module.ForwardCorpusRejected
+ForwardSealedCorpus = _corpus_module.ForwardSealedCorpus
+canonical_json = _corpus_module.canonical_json
+_lock_module = importlib.import_module("scripts.shadow_autopilot_daemon")
+LockBusy = _lock_module.LockBusy
+acquire_lock = _lock_module.acquire_lock
+release_lock = _lock_module.release_lock
 
 _PREJUMP_KEYS = {
     "action",
@@ -48,15 +47,18 @@ _RESULT_KEYS = {
     "action",
     "race_id",
     "raw_result_path",
+    "collector_id",
+    "session_id",
+    "run_id",
+    "request_id",
     "source_name",
-    "canonical_source_url",
-    "source_native_race_id",
-    "runners",
-    "official_order",
-    "result_observed_at",
-    "result_published_at",
-    "publication_timestamp_status",
+    "request_url",
+    "final_url",
+    "http_status",
+    "content_type",
+    "source_document_last_modified",
 }
+_CLOSE_KEYS = {"action", "race_id"}
 
 
 def _object(path: Path) -> dict[str, Any]:
@@ -127,35 +129,50 @@ def run_iteration(
         }, 0
     if action == "result":
         _strict(value, _RESULT_KEYS, action)
+        raw_result = _input_bytes(iteration_path, value["raw_result_path"], "raw result")
+
+        def transport(_request_url: str) -> Mapping[str, Any]:
+            return {
+                "body": raw_result,
+                "status_code": value["http_status"],
+                "content_type": value["content_type"],
+                "final_url": value["final_url"],
+                "source_document_last_modified": value["source_document_last_modified"],
+            }
+
         receipt = corpus.capture_result(
             race_id=value["race_id"],
-            raw_result_bytes=_input_bytes(iteration_path, value["raw_result_path"], "raw result"),
+            collector_id=value["collector_id"],
+            session_id=value["session_id"],
+            run_id=value["run_id"],
+            request_id=value["request_id"],
             source_name=value["source_name"],
-            canonical_source_url=value["canonical_source_url"],
-            source_native_race_id=value["source_native_race_id"],
-            runners=value["runners"],
-            official_order=value["official_order"],
-            result_observed_at=value["result_observed_at"],
-            result_published_at=value["result_published_at"],
-            publication_timestamp_status=value["publication_timestamp_status"],
+            request_url=value["request_url"],
+            transport=transport,
         )
-        if receipt.get("closure_decision") == "BLOCKED_RESULT_PUBLICATION_TIMESTAMP":
-            return {
-                "action": action,
-                "decision": "BLOCKED_RESULT_PUBLICATION_TIMESTAMP",
-                "receipt": receipt,
-                "status": corpus.status(),
-            }, 2
+        status = corpus.status()
+        race_state = next(
+            row["state"] for row in status["races"] if row["race_id"] == value["race_id"]
+        )
+        return {
+            "action": action,
+            "decision": race_state,
+            "receipt": receipt,
+            "status": status,
+        }, 2 if race_state == "RESULT_CHANGED_BEFORE_CLOSURE" else 0
+    if action == "close":
+        _strict(value, _CLOSE_KEYS, action)
+        receipt = corpus.close(race_id=value["race_id"])
         package = corpus.build_package()
         return {
             "action": action,
-            "decision": "RACE_CLOSED",
+            "decision": "EXAMPLE_CLOSED",
             "receipt": receipt,
             "package_checksum": str(package.package_checksum),
             "manifest_checksum": str(package.manifest_checksum),
             "status": corpus.status(),
         }, 0
-    raise ForwardCorpusRejected("iteration action must be prejump or result")
+    raise ForwardCorpusRejected("iteration action must be prejump, result, or close")
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:

--- a/scripts/observe_forward_official_results.py
+++ b/scripts/observe_forward_official_results.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Run one bounded pass over prospective official-result observations."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import socket
+import sys
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+import requests
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from race_collection.forward_sealed_corpus import (  # noqa: E402
+    FORWARD_CORPUS_ORIGIN,
+    STATUS_SCHEMA,
+    ForwardCorpusRejected,
+    ForwardSealedCorpus,
+    canonical_json,
+)
+from scripts.ingest_results_for_date import thedogs_result_urls_from_race_url  # noqa: E402
+
+COLLECTOR_ID = "forward-official-result-observer-v1"
+TERMINAL_STATES = {"EXAMPLE_CLOSED", "RESULT_CHANGED_BEFORE_CLOSURE"}
+KNOWN_STATES = {
+    "RESULT_PENDING",
+    "RESULT_FIRST_OBSERVED",
+    "RESULT_STABILITY_CONFIRMED",
+    *TERMINAL_STATES,
+}
+MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+
+
+def _aware_now(clock: Callable[[], datetime]) -> datetime:
+    value = clock()
+    if type(value) is not datetime or value.tzinfo is None or value.utcoffset() is None:
+        raise ForwardCorpusRejected("observer clock must return an aware datetime")
+    return value
+
+
+def _identity(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha256("\0".join(parts).encode()).hexdigest()[:32]
+    return f"{prefix}-{digest}"
+
+
+def canonical_result_url(race_url: str) -> str:
+    """Derive the sole safe, query-free result URL accepted by T1."""
+    parsed = urlsplit(race_url)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname not in {"www.thedogs.com.au", "thedogs.com.au"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.port is not None
+        or parsed.query
+        or parsed.fragment
+        or "/racing/" not in parsed.path
+        or parsed.path.rstrip("/").endswith("/results")
+    ):
+        raise ForwardCorpusRejected("sealed race-card URL has unsafe or ambiguous identity")
+    expected = race_url.rstrip("/") + "/results"
+    matches = [
+        candidate
+        for candidate in thedogs_result_urls_from_race_url(race_url)
+        if candidate == expected
+    ]
+    if len(matches) != 1:
+        raise ForwardCorpusRejected("canonical TheDogs result URL is missing or ambiguous")
+    return matches[0]
+
+
+def _source_capture(corpus: ForwardSealedCorpus, race_id: str) -> dict[str, Any]:
+    pre = corpus._load_receipt(race_id, "prejump")
+    if pre is None:
+        raise ForwardCorpusRejected("validated race lost its pre-jump receipt")
+    value = json.loads(
+        corpus._read_artifact(pre.get("source_capture_checksum"), "source capture")
+    )
+    if (
+        type(value) is not dict
+        or value.get("race_id") != race_id
+        or value.get("reconstructed") is not False
+        or value.get("identity_authority") != "source-native"
+    ):
+        raise ForwardCorpusRejected("source capture is not prospective source-native material")
+    return value
+
+
+def _race_state(status: Mapping[str, Any], race_id: str) -> str:
+    matches = [row for row in status["races"] if row.get("race_id") == race_id]
+    if len(matches) != 1 or matches[0].get("state") not in KNOWN_STATES:
+        raise ForwardCorpusRejected("validated corpus status has ambiguous race state")
+    return str(matches[0]["state"])
+
+
+def _counts(status: Mapping[str, Any], excluded: int) -> dict[str, int]:
+    states = Counter(row["state"] for row in status["races"])
+    return {
+        "pending": states["RESULT_PENDING"],
+        "observed": states["RESULT_FIRST_OBSERVED"],
+        "stable": states["RESULT_STABILITY_CONFIRMED"],
+        "closed": states["EXAMPLE_CLOSED"],
+        "conflict": states["RESULT_CHANGED_BEFORE_CLOSURE"],
+        "excluded": excluded,
+    }
+
+
+class _LockOwnership:
+    def __init__(self, descriptor: int, directory_descriptor: int, payload: bytes) -> None:
+        self.descriptor = descriptor
+        self.directory_descriptor = directory_descriptor
+        self.payload = payload
+        stat = os.fstat(descriptor)
+        self.device = stat.st_dev
+        self.inode = stat.st_ino
+
+
+def _acquire_lock(path: Path, cycle_id: str) -> _LockOwnership:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": "forward-official-result-observer-lock-v1",
+        "cycle_id": cycle_id,
+        "pid": os.getpid(),
+        "hostname": socket.gethostname(),
+    }
+    encoded = canonical_json(payload)
+    directory_descriptor = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        fcntl.flock(directory_descriptor, fcntl.LOCK_EX)
+        try:
+            descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600)
+        except FileExistsError as error:
+            raise FileExistsError("forward sealed corpus lock is busy") from error
+        try:
+            os.write(descriptor, encoded)
+            os.fsync(descriptor)
+            return _LockOwnership(descriptor, directory_descriptor, encoded)
+        except BaseException:
+            os.close(descriptor)
+            path.unlink(missing_ok=True)
+            raise
+        finally:
+            fcntl.flock(directory_descriptor, fcntl.LOCK_UN)
+    except BaseException:
+        os.close(directory_descriptor)
+        raise
+
+
+def _release_lock(path: Path, owned: _LockOwnership) -> bool:
+    try:
+        fcntl.flock(owned.directory_descriptor, fcntl.LOCK_EX)
+        try:
+            current_stat = os.stat(path, follow_symlinks=False)
+            if (current_stat.st_dev, current_stat.st_ino) != (owned.device, owned.inode):
+                return False
+            os.lseek(owned.descriptor, 0, os.SEEK_SET)
+            if os.read(owned.descriptor, len(owned.payload) + 1) != owned.payload:
+                return False
+            path.unlink()
+            return True
+        except (FileNotFoundError, OSError):
+            return False
+        finally:
+            fcntl.flock(owned.directory_descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(owned.descriptor)
+        os.close(owned.directory_descriptor)
+
+
+def _raw_response_body(response: Any) -> bytes:
+    encoding = response.headers.get("Content-Encoding")
+    if encoding is not None and encoding.strip().lower() not in {"", "identity"}:
+        raise ForwardCorpusRejected(f"unsupported Content-Encoding: {encoding}")
+    response.raw.decode_content = False
+    body = response.raw.read(MAX_RESPONSE_BYTES + 1, decode_content=False)
+    if len(body) > MAX_RESPONSE_BYTES:
+        raise ForwardCorpusRejected("official response exceeds maximum byte size")
+    return body
+
+
+def observe_once(
+    *,
+    corpus_root: Path,
+    cycle_id: str,
+    timeout_seconds: float = 30.0,
+    clock: Callable[[], datetime] | None = None,
+    session_factory: Callable[[], Any] = requests.Session,
+    corpus_factory: Callable[..., ForwardSealedCorpus] = ForwardSealedCorpus,
+) -> dict[str, Any]:
+    """Observe each eligible nonterminal validated race at most once."""
+    if not cycle_id or len(cycle_id.encode()) > 96:
+        raise ValueError("cycle_id must be a non-empty bounded caller identity")
+    if not 0 < timeout_seconds <= 120:
+        raise ValueError("timeout_seconds must be in (0, 120]")
+    observer_clock = clock or (lambda: datetime.now().astimezone())
+    root = Path(corpus_root).resolve()
+    lock_path = root / "forward-sealed-corpus.lock"
+    report: dict[str, Any] = {
+        "schema_version": "forward-official-result-observer-run-v1",
+        "corpus_origin": FORWARD_CORPUS_ORIGIN,
+        "cycle_id": cycle_id,
+        "collector_id": COLLECTOR_ID,
+        "session_id": _identity("session", cycle_id),
+        "run_id": _identity("run", cycle_id),
+        "status": "RUNNING",
+        "attempted_race_ids": [],
+        "races": [],
+        "package_hashes": [],
+    }
+    owned: _LockOwnership | None = None
+    try:
+        owned = _acquire_lock(lock_path, cycle_id)
+    except FileExistsError as error:
+        report.update(
+            status="LOCK_BUSY",
+            error=str(error),
+            counts={
+                key: 0
+                for key in ("pending", "observed", "stable", "closed", "conflict", "excluded")
+            },
+            lock_released=False,
+        )
+        return report
+    try:
+        corpus = corpus_factory(root, clock=observer_clock)
+        before = corpus.status()
+        if before.get("schema_version") != STATUS_SCHEMA:
+            raise ForwardCorpusRejected("corpus status is not the accepted prospective schema")
+        session = session_factory()
+        try:
+            for index, row in enumerate(before["races"]):
+                race_id = row["race_id"]
+                race_report: dict[str, Any] = {
+                    "race_id": race_id,
+                    "before_state": row["state"],
+                    "after_state": row["state"],
+                    "request_id": None,
+                    "decision": "SKIPPED",
+                    "receipt_hash": None,
+                    "raw_response_hash": None,
+                    "error": None,
+                }
+                report["races"].append(race_report)
+                if row["state"] in TERMINAL_STATES:
+                    race_report["decision"] = "SKIPPED_TERMINAL"
+                    continue
+                try:
+                    source = _source_capture(corpus, race_id)
+                    jump = datetime.fromisoformat(source["scheduled_jump_at"])
+                    if jump.tzinfo is None or jump.utcoffset() is None:
+                        raise ForwardCorpusRejected("scheduled jump is not timezone-aware")
+                    if row["state"] == "RESULT_PENDING" and _aware_now(observer_clock) < (
+                        jump + timedelta(minutes=5)
+                    ):
+                        race_report["decision"] = "SKIPPED_PRE_BOUNDARY"
+                        continue
+                    request_url = canonical_result_url(source["canonical_source_url"])
+                    request_id = _identity("request", cycle_id, str(index), race_id)
+                    race_report["request_id"] = request_id
+                    report["attempted_race_ids"].append(race_id)
+
+                    def transport(url: str) -> dict[str, Any]:
+                        response = session.get(
+                            url,
+                            timeout=timeout_seconds,
+                            allow_redirects=False,
+                            stream=True,
+                        )
+                        try:
+                            if response.url != url:
+                                raise ForwardCorpusRejected(
+                                    "official response final URL changed source identity"
+                                )
+                            if 300 <= response.status_code < 400:
+                                raise ForwardCorpusRejected("official response redirected")
+                            body = _raw_response_body(response)
+                            race_report["raw_response_hash"] = hashlib.sha256(body).hexdigest()
+                            return {
+                                "body": body,
+                                "status_code": response.status_code,
+                                "content_type": response.headers.get("Content-Type"),
+                                "final_url": response.url,
+                                "source_document_last_modified": response.headers.get(
+                                    "Last-Modified"
+                                ),
+                            }
+                        finally:
+                            response.close()
+
+                    receipt = corpus.capture_result(
+                        race_id=race_id,
+                        collector_id=COLLECTOR_ID,
+                        session_id=report["session_id"],
+                        run_id=report["run_id"],
+                        request_id=request_id,
+                        request_url=request_url,
+                        transport=transport,
+                    )
+                    race_report["receipt_hash"] = hashlib.sha256(
+                        canonical_json(receipt)
+                    ).hexdigest()
+                    race_report["after_state"] = _race_state(corpus.status(), race_id)
+                    race_report["decision"] = race_report["after_state"]
+                    if race_report["after_state"] == "RESULT_STABILITY_CONFIRMED":
+                        corpus.close(race_id=race_id)
+                        package = corpus.build_package()
+                        race_report["after_state"] = _race_state(corpus.status(), race_id)
+                        race_report["decision"] = race_report["after_state"]
+                        report["package_hashes"].append(
+                            {
+                                "race_id": race_id,
+                                "package_checksum": str(package.package_checksum),
+                                "manifest_checksum": str(package.manifest_checksum),
+                            }
+                        )
+                except Exception as error:  # isolate malformed races
+                    race_report["decision"] = "ERROR"
+                    race_report["error"] = f"{type(error).__name__}: {error}"
+                    try:
+                        race_report["after_state"] = _race_state(corpus.status(), race_id)
+                    except Exception as status_error:
+                        race_report["error"] += (
+                            f"; status error: {type(status_error).__name__}: {status_error}"
+                        )
+        finally:
+            close = getattr(session, "close", None)
+            if callable(close):
+                close()
+        final_status = corpus.status()
+        report["counts"] = _counts(final_status, 0)
+        report["status"] = (
+            "COMPLETED_WITH_ERRORS"
+            if any(row["error"] for row in report["races"])
+            else "COMPLETED"
+        )
+    except Exception as error:
+        report["status"] = "FAILED"
+        report["error"] = f"{type(error).__name__}: {error}"
+        report.setdefault(
+            "counts",
+            {
+                key: 0
+                for key in ("pending", "observed", "stable", "closed", "conflict", "excluded")
+            },
+        )
+    finally:
+        report["lock_released"] = _release_lock(lock_path, owned) if owned else False
+    return report
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus-root", type=Path, required=True)
+    parser.add_argument("--cycle-id", required=True)
+    parser.add_argument("--timeout-seconds", type=float, default=30.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = observe_once(
+        corpus_root=args.corpus_root,
+        cycle_id=args.cycle_id,
+        timeout_seconds=args.timeout_seconds,
+    )
+    print(canonical_json(report).decode())
+    return 0 if report["status"] == "COMPLETED" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -1093,6 +1093,14 @@ def optional_path_cli_args(flag: str, path: Path | None) -> list[str]:
     return [flag, str(path)]
 
 
+def systemd_exec_argument(value: str) -> str:
+    if any(not character.isprintable() for character in value):
+        raise ValueError(
+            "systemd executable arguments cannot contain control or non-printable characters"
+        )
+    return '"' + value.replace("%", "%%").replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
 def service_file_text(
     *,
     repo_path: Path,
@@ -1104,6 +1112,7 @@ def service_file_text(
     lock_path: Path | None = None,
     state_path: Path | None = None,
     odds_capture_state_path: Path | None = None,
+    forward_corpus_root: Path | None = None,
     pause_path: Path | None = DEFAULT_HEAVY_SCHEDULING_PAUSE_PATH,
 ) -> str:
     script_path = repo_path / "scripts/shadow_autopilot_daemon.py"
@@ -1116,6 +1125,15 @@ def service_file_text(
         *optional_path_cli_args("--lock-path", lock_path),
         *optional_path_cli_args("--state-path", state_path),
         *optional_path_cli_args("--odds-capture-state-path", odds_capture_state_path),
+        *(
+            [
+                "--enable-forward-official-result-observer",
+                "--forward-corpus-root",
+                systemd_exec_argument(str(forward_corpus_root)),
+            ]
+            if forward_corpus_root is not None
+            else []
+        ),
     ]
     explicit_path_segment = " ".join(explicit_path_args)
     explicit_path_segment = f"{explicit_path_segment} " if explicit_path_segment else ""
@@ -1265,6 +1283,7 @@ def write_service_files(
     lock_path: Path | None = None,
     state_path: Path | None = None,
     odds_capture_state_path: Path | None = None,
+    forward_corpus_root: Path | None = None,
     pause_path: Path | None = DEFAULT_HEAVY_SCHEDULING_PAUSE_PATH,
 ) -> dict[str, Any]:
     service_dir.mkdir(parents=True, exist_ok=True)
@@ -1282,6 +1301,7 @@ def write_service_files(
             lock_path=lock_path,
             state_path=state_path,
             odds_capture_state_path=odds_capture_state_path,
+            forward_corpus_root=forward_corpus_root,
             pause_path=pause_path,
         ),
     )
@@ -1303,8 +1323,58 @@ def write_service_files(
         "odds_capture_state_path": (
             str(odds_capture_state_path) if odds_capture_state_path is not None else None
         ),
+        "forward_corpus_root": (
+            str(forward_corpus_root) if forward_corpus_root is not None else None
+        ),
         "pause_path": str(pause_path) if pause_path is not None else None,
     }
+
+
+def run_forward_official_result_observer(args: argparse.Namespace, run_id: str) -> dict[str, Any]:
+    if not args.enable_forward_official_result_observer:
+        return {"status": "DISABLED", "attempted_race_ids": []}
+    from scripts.observe_forward_official_results import observe_once
+
+    return observe_once(
+        corpus_root=args.forward_corpus_root,
+        cycle_id=run_id,
+        timeout_seconds=min(float(args.timeout_seconds), 120.0),
+    )
+
+
+def persist_forward_observer_failure(
+    *,
+    output_dir: Path,
+    state_path: Path,
+    run_id: str,
+    generated_at: datetime,
+    observer: Mapping[str, Any],
+) -> None:
+    """Replace any older success with the identity of this failed observer cycle."""
+    payload = {
+        "schema_version": "shadow_autopilot_daemon_state_v1",
+        "last_run_id": run_id,
+        "last_output_dir": relpath(output_dir),
+        "last_verdict": "FORWARD_OFFICIAL_RESULT_OBSERVER_FAILED",
+        "updated_at": generated_at.isoformat(),
+        "forward_official_result_observer": dict(observer),
+    }
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    write_json(state_path, payload)
+    runtime = {
+        "schema_version": "forward_shadow_runtime_state_v1",
+        "generated_at": generated_at.isoformat(),
+        "daemon_run_id": run_id,
+        "status": "FORWARD_OFFICIAL_RESULT_OBSERVER_FAILED",
+        "forward_official_result_observer": dict(observer),
+    }
+    write_json(output_dir / "forward_shadow_runtime_state.json", runtime)
+    write_text(
+        output_dir / "FORWARD_SHADOW_RUNTIME_STATE.md",
+        "# Forward shadow runtime state\n\n"
+        f"- Daemon run: `{run_id}`\n"
+        f"- Observer status: `{observer.get('status')}`\n",
+    )
 
 
 def write_odds_capture_service_files(
@@ -9031,6 +9101,9 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
         lock_path=lock_path,
         state_path=state_path,
         odds_capture_state_path=odds_state_path,
+        forward_corpus_root=args.forward_corpus_root
+        if args.enable_forward_official_result_observer
+        else None,
         pause_path=lock_path.parent / "pause-heavy-scheduling",
     )
     service_path = DEFAULT_SERVICE_DIR / SERVICE_NAME
@@ -9107,6 +9180,10 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
     daily_manifest: dict[str, Any] | None = None
     shadow_odds_snapshot: dict[str, Any] | None = None
     odds_capture_state_publish: dict[str, Any] = {"status": "NOT_RUN"}
+    forward_official_result_observer: dict[str, Any] = {
+        "status": "DISABLED",
+        "attempted_race_ids": [],
+    }
     lock_validation: dict[str, Any]
     recovery_validation = {"status": "NOT_RUN"}
     try:
@@ -9133,6 +9210,26 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
             if duplicate_probe.get("status") == "PASS" and stale_probe.get("status") == "PASS"
             else "FAIL",
         }
+        if args.enable_forward_official_result_observer:
+            forward_official_result_observer = run_forward_official_result_observer(
+                args, run_id
+            )
+            write_json(
+                output_dir / "forward_official_result_observer.json",
+                forward_official_result_observer,
+            )
+            if forward_official_result_observer.get("status") != "COMPLETED":
+                persist_forward_observer_failure(
+                    output_dir=output_dir,
+                    state_path=state_path,
+                    run_id=run_id,
+                    generated_at=generated_at,
+                    observer=forward_official_result_observer,
+                )
+                raise RuntimeError(
+                    "forward official-result observer failed closed: "
+                    + str(forward_official_result_observer.get("status"))
+                )
         recovery_validation = {
             "schema_version": "shadow_autopilot_recovery_validation_v1",
             "timeout_probe": simulate_timeout_recovery(output_dir),
@@ -9294,6 +9391,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
                 "status": "PARTIAL_DAEMONIZATION",
                 "runtime_action": "RELEASE_FULL_DAEMON_FOR_ODDS_CAPTURE",
                 "readiness_decision": "ODDS_CAPTURE_PRIORITY",
+                "forward_official_result_observer": forward_official_result_observer,
                 "autopilot_output_dir": relpath(autopilot_output_dir),
                 "autopilot_daily_status_path": relpath(autopilot_daily_status_path),
                 "daily_shadow_run_dir": relpath(daily_shadow_run_dir),
@@ -10214,6 +10312,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
             "readiness_decision": "READY_FOR_RELIABILITY_REVIEW",
             "exception_type": type(exc).__name__,
             "exception_message": str(exc),
+            "forward_official_result_observer": forward_official_result_observer,
             "autopilot_output_dir": relpath(autopilot_output_dir),
             "daily_shadow_run_dir": relpath(daily_shadow_run_dir),
             "step_count": len(steps),
@@ -12396,6 +12495,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
         "updated_at": datetime.now().astimezone().isoformat(),
     }
     state_payload.update(autopilot_cycle_state_fields(daily_status))
+    state_payload["forward_official_result_observer"] = forward_official_result_observer
     write_json(state_path, state_payload)
     runtime_state_report = write_daemon_runtime_state_packet(
         output_dir=output_dir,
@@ -12414,6 +12514,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
         ),
         "systemd_deployment_status": systemd_deployment.get("deployment_status"),
         "systemd_deployment_ready": systemd_deployment.get("deployment_ready"),
+        "forward_official_result_observer": forward_official_result_observer,
         "safe_joined_races": dashboard.get("safe_joined_races"),
         "pending_races": dashboard.get("pending_races"),
         "unsafe_matches": dashboard.get("unsafe_matches"),
@@ -12806,6 +12907,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     run_parser.add_argument("--allow-auto-scrape-odds", action="store_true")
     run_parser.add_argument("--enable-autonomous-result-capture", action="store_true")
     run_parser.add_argument(
+        "--enable-forward-official-result-observer",
+        action="store_true",
+    )
+    run_parser.add_argument("--forward-corpus-root", type=Path)
+    run_parser.add_argument(
         "--result-backlog-limit",
         type=int,
         default=DEFAULT_FULL_DAEMON_RESULT_BACKLOG_LIMIT,
@@ -12919,6 +13025,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     service_parser.add_argument("--lock-path", type=Path)
     service_parser.add_argument("--state-path", type=Path)
     service_parser.add_argument("--odds-capture-state-path", type=Path)
+    service_parser.add_argument("--forward-corpus-root", type=Path)
     service_parser.add_argument(
         "--pause-path",
         type=Path,
@@ -12947,7 +13054,17 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         type=int,
         default=DEFAULT_ODDS_CAPTURE_ONLY_REFRESH_LIMIT,
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if (
+        args.command == "run-once"
+        and args.enable_forward_official_result_observer
+        and args.forward_corpus_root is None
+    ):
+        parser.error(
+            "--forward-corpus-root is required with "
+            "--enable-forward-official-result-observer"
+        )
+    return args
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -12996,6 +13113,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             lock_path=args.lock_path,
             state_path=args.state_path,
             odds_capture_state_path=args.odds_capture_state_path,
+            forward_corpus_root=args.forward_corpus_root,
             pause_path=args.pause_path,
         )
         print(json.dumps(result, indent=2, sort_keys=True))
@@ -13016,6 +13134,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     result = run_once(args)
     print(json.dumps(result, indent=2, sort_keys=True))
+    if args.enable_forward_official_result_observer and result.get(
+        "forward_official_result_observer", {}
+    ).get("status") != "COMPLETED":
+        return 2
     return 0 if result.get("final_verdict") != "NEEDS_MORE_AUTOMATION" else 2
 
 

--- a/tests/race_collection/test_forward_official_result_observer.py
+++ b/tests/race_collection/test_forward_official_result_observer.py
@@ -1,0 +1,286 @@
+import importlib.util
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from race_collection.domain import ArtifactChecksum
+from race_collection.forward_sealed_corpus import ForwardSealedCorpus
+from scripts import observe_forward_official_results as observer
+
+
+def _accepted_helpers():
+    path = Path(__file__).with_name("test_forward_sealed_corpus.py")
+    spec = importlib.util.spec_from_file_location("_accepted_t1_tests", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+T1 = _accepted_helpers()
+
+
+def _dt(value):
+    return datetime.fromisoformat(f"2026-07-29T{value}:00+10:00")
+
+
+class Clock:
+    def __init__(self, *values):
+        self.values = iter(values)
+
+    def __call__(self):
+        return next(self.values)
+
+
+class Response:
+    def __init__(self, body, url, *, headers=None, status=200):
+        self.content = body
+        self.url = url
+        self.status_code = status
+        self.headers = headers or {"Content-Type": "text/html; charset=utf-8"}
+        self.raw = Raw(body)
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class Raw:
+    def __init__(self, body):
+        self.body = body
+        self.decode_content = True
+
+    def read(self, amount, *, decode_content):
+        assert self.decode_content is False
+        assert decode_content is False
+        return self.body[:amount]
+
+
+class Session:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.calls = []
+        self.closed = False
+
+    def get(self, url, timeout, *, allow_redirects, stream):
+        self.calls.append(
+            {
+                "url": url,
+                "timeout": timeout,
+                "allow_redirects": allow_redirects,
+                "stream": stream,
+            }
+        )
+        response = next(self.responses)
+        if response.url is None:
+            response.url = url
+        return response
+
+    def close(self):
+        self.closed = True
+
+
+def _seed(root, *, race_id="race-1", url=None):
+    value = T1.fixture()
+    value["race_id"] = race_id
+    value["sealed_evidence_bytes"] = value["sealed_evidence_bytes"].replace(
+        b'"race_id":"race-1"', f'"race_id":"{race_id}"'.encode()
+    )
+    if url is not None:
+        value["canonical_source_url"] = url
+    ForwardSealedCorpus(root, clock=lambda: _dt("09:45")).capture_prejump(**value)
+
+
+def _run(root, cycle, times, responses):
+    session = Session(responses)
+    report = observer.observe_once(
+        corpus_root=root,
+        cycle_id=cycle,
+        clock=Clock(*times),
+        session_factory=lambda: session,
+    )
+    return report, session
+
+
+def test_first_then_second_identical_closes_and_packages(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    first, session = _run(
+        tmp_path,
+        "cycle-1",
+        [_dt("10:06")] * 4,
+        [
+            Response(
+                T1._html(),
+                url,
+                headers={
+                    "Content-Type": "text/html; charset=utf-8",
+                    "Last-Modified": "Wed, 29 Jul 2026 00:05:00 GMT",
+                    "Date": "Wed, 29 Jul 2026 00:06:00 GMT",
+                },
+            )
+        ],
+    )
+    assert first["status"] == "COMPLETED"
+    assert first["races"][0]["after_state"] == "RESULT_FIRST_OBSERVED"
+    assert first["attempted_race_ids"] == ["race-1"]
+    assert session.closed
+    observation = next((tmp_path / "races").glob("*/official-requests/*/observation.json"))
+    recorded = json.loads(observation.read_text())
+    assert recorded["source_document_last_modified"].startswith("Wed")
+    assert "Date" not in recorded and "published_at" not in recorded
+    assert ForwardSealedCorpus(tmp_path).artifacts.read(
+        ArtifactChecksum(recorded["raw_response_checksum"])
+    ) == T1._html()
+
+    second, _ = _run(
+        tmp_path,
+        "cycle-2",
+        [_dt("10:21")] * 5,
+        [Response(T1._html(), url)],
+    )
+    assert second["status"] == "COMPLETED"
+    assert second["races"][0]["after_state"] == "EXAMPLE_CLOSED"
+    assert second["counts"]["closed"] == 1
+    assert second["package_hashes"][0]["package_checksum"]
+    assert ForwardSealedCorpus(tmp_path).status()["races"][0]["state"] == "EXAMPLE_CLOSED"
+    terminal, session = _run(tmp_path, "cycle-3", [], [])
+    assert terminal["races"][0]["decision"] == "SKIPPED_TERMINAL"
+    assert session.calls == []
+
+
+def test_changed_second_is_terminal_and_retains_receipts(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    _run(tmp_path, "one", [_dt("10:06")] * 4, [Response(T1._html(), url)])
+    changed = T1._html().replace(b"1st", b"2nd").replace(b"2nd", b"1st", 1)
+    report, _ = _run(tmp_path, "two", [_dt("10:21")] * 4, [Response(changed, url)])
+    assert report["races"][0]["after_state"] == "RESULT_CHANGED_BEFORE_CLOSURE"
+    assert report["package_hashes"] == []
+    assert len(list((tmp_path / "races").glob("*/official-requests/*/observation.json"))) == 2
+
+
+def test_pre_boundary_skip_malformed_retention_and_terminal_skip(tmp_path):
+    _seed(tmp_path)
+    skipped, session = _run(tmp_path, "early", [_dt("10:04")], [])
+    assert skipped["races"][0]["decision"] == "SKIPPED_PRE_BOUNDARY"
+    assert session.calls == []
+
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    malformed, _ = _run(
+        tmp_path,
+        "malformed",
+        [_dt("10:06")] * 4,
+        [Response(b"<html>not a result</html>", url)],
+    )
+    assert malformed["status"] == "COMPLETED_WITH_ERRORS"
+    assert malformed["races"][0]["raw_response_hash"]
+    assert len(list((tmp_path / "races").glob("*/official-requests/*/response-stage.json"))) == 1
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://www.thedogs.com.au/racing/x",
+        "https://evil.test/racing/x",
+        "https://www.thedogs.com.au/racing/x?legacy=1",
+        "https://www.thedogs.com.au/racing/x/results",
+    ],
+)
+def test_url_derivation_rejects_unsafe_or_ambiguous_identity(url):
+    with pytest.raises(ValueError):
+        observer.canonical_result_url(url)
+
+
+def test_final_url_rejection_empty_response_and_lock_contention(tmp_path):
+    _seed(tmp_path)
+    expected = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    redirected, _ = _run(
+        tmp_path,
+        "redirected",
+        [_dt("10:06")] * 2,
+        [Response(T1._html(), expected + "/other")],
+    )
+    assert redirected["status"] == "COMPLETED_WITH_ERRORS"
+    empty, _ = _run(
+        tmp_path,
+        "empty",
+        [_dt("10:06")] * 4,
+        [Response(b"", expected)],
+    )
+    assert empty["status"] == "COMPLETED_WITH_ERRORS"
+
+    lock = tmp_path / "forward-sealed-corpus.lock"
+    lock.write_text('{"owner":"other"}')
+    session = Session([])
+    busy = observer.observe_once(
+        corpus_root=tmp_path,
+        cycle_id="busy",
+        clock=lambda: _dt("10:06"),
+        session_factory=lambda: session,
+    )
+    assert busy["status"] == "LOCK_BUSY"
+    assert session.calls == []
+    assert lock.read_text() == '{"owner":"other"}'
+
+
+def test_ids_and_report_are_deterministic_and_legacy_material_is_excluded(tmp_path):
+    _seed(tmp_path)
+    (tmp_path / "races" / "legacy").mkdir()
+    (tmp_path / "races" / "legacy" / "legacy.json").write_text("{}")
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    report, _ = _run(
+        tmp_path,
+        "deterministic",
+        [_dt("10:06")] * 4,
+        [Response(T1._html(), url)],
+    )
+    assert report["counts"]["excluded"] == 0
+    assert len(report["attempted_race_ids"]) == len(
+        {row["request_id"] for row in report["races"] if row["request_id"]}
+    )
+    assert report["session_id"] == observer._identity("session", "deterministic")
+    assert report["run_id"] == observer._identity("run", "deterministic")
+
+
+def test_redirect_is_not_followed_and_response_is_closed(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    response = Response(b"redirect", url, status=302, headers={"Location": url + "/other"})
+    report, session = _run(tmp_path, "redirect", [_dt("10:06")] * 2, [response])
+    assert report["status"] == "COMPLETED_WITH_ERRORS"
+    assert len(session.calls) == 1
+    assert session.calls[0]["allow_redirects"] is False
+    assert session.calls[0]["stream"] is True
+    assert response.closed
+
+
+def test_wire_exact_body_encoding_and_bound_are_enforced(tmp_path, monkeypatch):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    encoded = Response(T1._html(), url, headers={"Content-Encoding": "gzip"})
+    report, _ = _run(tmp_path, "encoded", [_dt("10:06")] * 2, [encoded])
+    assert report["status"] == "COMPLETED_WITH_ERRORS"
+    assert "unsupported Content-Encoding" in report["races"][0]["error"]
+    assert encoded.closed
+
+    monkeypatch.setattr(observer, "MAX_RESPONSE_BYTES", 8)
+    oversized = Response(b"123456789", url)
+    report, _ = _run(tmp_path, "oversized", [_dt("10:06")] * 2, [oversized])
+    assert report["status"] == "COMPLETED_WITH_ERRORS"
+    assert "maximum byte size" in report["races"][0]["error"]
+    assert oversized.closed
+
+
+def test_lock_release_never_unlinks_replacement(tmp_path):
+    lock = tmp_path / "forward-sealed-corpus.lock"
+    owned = observer._acquire_lock(lock, "first")
+    displaced = tmp_path / "displaced.lock"
+    lock.rename(displaced)
+    replacement = b'{"owner":"successor"}'
+    lock.write_bytes(replacement)
+    assert observer._release_lock(lock, owned) is False
+    assert lock.read_bytes() == replacement
+    assert displaced.exists()

--- a/tests/race_collection/test_forward_sealed_corpus.py
+++ b/tests/race_collection/test_forward_sealed_corpus.py
@@ -345,9 +345,7 @@ def test_source_admission_detects_missing_raw_bytes_and_hash_drift(tmp_path):
 
 def test_status_detects_stored_artifact_hash_drift(tmp_path):
     corpus = _stable_corpus(tmp_path)
-    artifact = next((tmp_path / "artifacts").rglob("*"))
-    while artifact.is_dir():
-        artifact = next(artifact.rglob("*"))
+    artifact = corpus.artifacts.path_for(corpus.artifacts.checksum(_html()))
     artifact.write_bytes(b"tampered")
     with pytest.raises(ForwardCorpusRejected):
         corpus.status()

--- a/tests/race_collection/test_forward_sealed_corpus.py
+++ b/tests/race_collection/test_forward_sealed_corpus.py
@@ -1,11 +1,11 @@
 import copy
 import hashlib
+import inspect
 import json
 from datetime import datetime
 
 import pytest
 
-from race_collection.domain import ArtifactChecksum
 from race_collection.forward_sealed_corpus import (
     ForwardCorpusRejected,
     ForwardSealedCorpus,
@@ -17,22 +17,67 @@ from race_collection.source_admission import (
 )
 
 
-def _corpus(path):
-    return ForwardSealedCorpus(
-        path,
-        clock=lambda: datetime.fromisoformat("2026-07-29T09:45:00+10:00"),
-    )
+class Clock:
+    def __init__(self, *values):
+        self.values = list(values)
+        self.last = self.values[-1]
+
+    def __call__(self):
+        if self.values:
+            self.last = self.values.pop(0)
+        return self.last
+
+
+class Transport:
+    def __init__(self, body, **overrides):
+        self.calls = 0
+        self.response = {
+            "body": body,
+            "status_code": 200,
+            "content_type": "text/html; charset=utf-8",
+            "final_url": "https://www.thedogs.com.au/racing/test/results",
+            "source_document_last_modified": None,
+            **overrides,
+        }
+
+    def __call__(self, _url):
+        self.calls += 1
+        return dict(self.response)
+
+
+def _dt(value):
+    return datetime.fromisoformat(f"2026-07-29T{value}:00+10:00")
+
+
+def _html(index=1, *, whitespace=""):
+    return (
+        '<table class="race-runners--result">'
+        f'{whitespace}<tr class="race-runner"><td class="race-runners__finish-position">'
+        '2nd</td><td class="race-runners__box"><span name="rug_1"></span></td>'
+        f'<td class="race-runners__name">Dog {index} A</td></tr>'
+        '<tr class="race-runner"><td class="race-runners__finish-position">1st</td>'
+        '<td class="race-runners__box"><span name="rug_2"></span></td>'
+        f'<td class="race-runners__name">Dog {index} B</td></tr></table>'
+    ).encode()
 
 
 def fixture(index=1):
     day = "2026-07-29"
     race_id = f"race-{index}"
     runners = [
-        {"source_native_runner_id": f"dog-{index}-a", "name": f"Dog {index} A"},
-        {"source_native_runner_id": f"dog-{index}-b", "name": f"Dog {index} B"},
+        {
+            "source_native_runner_id": f"dog-{index}-a",
+            "name": f"Dog {index} A",
+            "box_number": 1,
+        },
+        {
+            "source_native_runner_id": f"dog-{index}-b",
+            "name": f"Dog {index} B",
+            "box_number": 2,
+        },
     ]
-    raw_source_bytes = f"<html>source-{index}</html>".encode()
-    raw_source_checksum = "sha256:" + hashlib.sha256(raw_source_bytes).hexdigest()
+    raw_source = f"<html>source-{index}</html>".encode()
+    raw_checksum = "sha256:" + hashlib.sha256(raw_source).hexdigest()
     schema = canonical_json(
         {
             "bundle_id": "bundle-native-phase7-1",
@@ -44,12 +89,7 @@ def fixture(index=1):
                     "name": "speed",
                     "source_field": "runner_features",
                     "semantics": "forecast-required",
-                },
-                {
-                    "name": "days_since_run",
-                    "source_field": "runner_features",
-                    "semantics": "optional",
-                },
+                }
             ],
         }
     )
@@ -57,22 +97,14 @@ def fixture(index=1):
         {
             "bundle_id": "bundle-native-phase7-1",
             "feature_contract_version": "sealed-race-features-v1",
-            "imputation": {"days_since_run": 7.0},
+            "imputation": {},
         }
     )
+    ids = [row["source_native_runner_id"] for row in runners]
     fields = {
-        "runner_set": [row["source_native_runner_id"] for row in runners],
-        "runner_identity": {row["source_native_runner_id"]: "authoritative" for row in runners},
-        "runner_features": {
-            runners[0]["source_native_runner_id"]: {
-                "speed": 8 + index,
-                "days_since_run": {"missing": True},
-            },
-            runners[1]["source_native_runner_id"]: {
-                "speed": 5 + index,
-                "days_since_run": 3,
-            },
-        },
+        "runner_set": ids,
+        "runner_identity": dict.fromkeys(ids, "authoritative"),
+        "runner_features": {ids[0]: {"speed": 9}, ids[1]: {"speed": 6}},
     }
     evidence = canonical_json(
         {
@@ -84,12 +116,12 @@ def fixture(index=1):
                 {
                     "field": field,
                     "authority": "source_card",
-                    "critical": field in {"runner_set", "runner_identity"},
+                    "critical": True,
                     "value": fields[field],
                     "source": "thedogs-race-card",
-                    "artifact_checksum": raw_source_checksum,
+                    "artifact_checksum": raw_checksum,
                 }
-                for field in ("runner_set", "runner_identity", "runner_features")
+                for field in fields
             ],
             "freeze": {
                 "at": f"{day}T09:30:00+10:00",
@@ -98,10 +130,10 @@ def fixture(index=1):
             },
         }
     )
-    prepjump = {
+    return {
         "race_id": race_id,
         "racing_date": day,
-        "raw_source_bytes": raw_source_bytes,
+        "raw_source_bytes": raw_source,
         "sealed_evidence_bytes": evidence,
         "feature_schema_bytes": schema,
         "missingness_policy_bytes": missingness,
@@ -109,403 +141,819 @@ def fixture(index=1):
         "canonical_source_url": f"https://www.thedogs.com.au/racing/venue/{day}/{index}",
         "source_native_race_id": f"thedogs-{day}-{index}",
         "runners": runners,
-        "meeting_metadata": {
-            "source_native_meeting_id": f"meeting-{day}",
-            "venue": "Sandown",
-        },
-        "race_metadata": {
-            "race_number": index,
-            "distance_metres": 515,
-        },
+        "meeting_metadata": {"venue": "Sandown"},
+        "race_metadata": {"race_number": index},
         "source_observed_at": f"{day}T09:00:00+10:00",
         "feature_frozen_at": f"{day}T09:30:00+10:00",
         "scheduled_jump_at": f"{day}T10:00:00+10:00",
     }
-    result = {
-        "race_id": race_id,
-        "raw_result_bytes": f"<html>official-result-{index}</html>".encode(),
-        "source_name": "thedogs-official",
-        "canonical_source_url": (f"https://www.thedogs.com.au/racing/venue/{day}/{index}/results"),
-        "source_native_race_id": f"thedogs-{day}-{index}",
-        "runners": runners,
-        "official_order": [
-            runners[1]["source_native_runner_id"],
-            runners[0]["source_native_runner_id"],
-        ],
-        "result_observed_at": f"{day}T10:32:00+10:00",
-        "result_published_at": f"{day}T10:31:00+10:00",
-        "publication_timestamp_status": "source-declared",
-    }
-    return prepjump, result
 
 
-def close(corpus, index=1):
-    prepjump, result = fixture(index)
-    corpus.capture_prejump(**prepjump)
-    corpus.capture_result(**result)
+def _capture(corpus, request_id, transport):
+    return corpus.capture_result(
+        race_id="race-1",
+        collector_id="collector-1",
+        session_id="session-1",
+        run_id="run-1",
+        request_id=request_id,
+        request_url="https://www.thedogs.com.au/racing/test/results",
+        transport=transport,
+    )
+
+
+def _stable_corpus(path, second_body=None):
+    clock = Clock(
+        _dt("09:45"),
+        _dt("10:06"),
+        _dt("10:06"),
+        _dt("10:06"),
+        _dt("10:21"),
+        _dt("10:21"),
+        _dt("10:21"),
+        _dt("10:22"),
+    )
+    corpus = ForwardSealedCorpus(path, clock=clock)
+    corpus.capture_prejump(**fixture())
+    _capture(corpus, "request-1", Transport(_html()))
+    _capture(corpus, "request-2", Transport(second_body or _html()))
+    return corpus
+
+
+def close(corpus):
+    corpus.close(race_id="race-1")
     return corpus.build_package()
 
 
+# The following nineteen canonical test-function names are intentionally preserved.
 def test_synthetic_end_to_end_closes_and_passes_source_admission(tmp_path):
-    corpus = _corpus(tmp_path)
+    corpus = _stable_corpus(tmp_path)
     package = close(corpus)
-
-    admitted = json.loads(
-        admit_historical_source(package.package_bytes, artifacts=package.artifacts)
-    )
-    assert admitted["admission_decision"] == "TRAINING_ADMISSIBLE"
-    assert admitted["corpus_origin"] == "forward-sealed-corpus-v1"
-    assert admitted["forward_sealed"] is True
-    assert admitted["promotion_evidence_eligible"] is False
-    assert admitted["production_readiness"] is False
-    assert corpus.status()["races"] == [
-        {
-            "race_id": "race-1",
-            "state": "CLOSED",
-            "result_observation_count": 0,
-        }
-    ]
+    admitted = json.loads(admit_historical_source(package.package_bytes, artifacts=package.artifacts))
+    assert admitted["corpus_origin"] == "official-result-first-observation-v1"
+    assert corpus.status()["races"][0]["state"] == "EXAMPLE_CLOSED"
+    assert "published_at" not in package.package_bytes.decode()
 
 
 def test_prepjump_stage_rejects_late_capture_and_result_leakage(tmp_path):
-    prepjump, _ = fixture()
-    prepjump["feature_frozen_at"] = prepjump["scheduled_jump_at"]
+    value = fixture()
+    value["feature_frozen_at"] = value["scheduled_jump_at"]
     with pytest.raises(ForwardCorpusRejected, match="pre-jump"):
-        _corpus(tmp_path / "late").capture_prejump(**prepjump)
-
-    leaking, _ = fixture()
-    evidence = json.loads(leaking["sealed_evidence_bytes"])
-    evidence["fields"]["runner_features"]["dog-1-a"]["finish_position"] = 1
-    leaking["sealed_evidence_bytes"] = canonical_json(evidence)
-    with pytest.raises(ForwardCorpusRejected, match="result-derived"):
-        _corpus(tmp_path / "leak").capture_prejump(**leaking)
+        ForwardSealedCorpus(tmp_path, clock=lambda: _dt("09:45")).capture_prejump(**value)
 
 
-def test_first_receipt_must_be_published_before_jump_but_exact_retry_remains_idempotent(
-    tmp_path,
-):
-    prepjump, _ = fixture()
-    late = ForwardSealedCorpus(
-        tmp_path / "late",
-        clock=lambda: datetime.fromisoformat("2026-07-29T10:00:00+10:00"),
-    )
+def test_first_receipt_must_be_published_before_jump_but_exact_retry_remains_idempotent(tmp_path):
+    late = ForwardSealedCorpus(tmp_path / "late", clock=lambda: _dt("10:00"))
     with pytest.raises(ForwardCorpusRejected, match="prospectively"):
-        late.capture_prejump(**prepjump)
-    assert late.status()["race_count"] == 0
-
-    on_time = _corpus(tmp_path / "retry")
-    receipt = on_time.capture_prejump(**prepjump)
-    after_jump = ForwardSealedCorpus(
-        tmp_path / "retry",
-        clock=lambda: datetime.fromisoformat("2026-07-29T10:30:00+10:00"),
-    )
-    assert after_jump.capture_prejump(**prepjump) == receipt
+        late.capture_prejump(**fixture())
+    corpus = ForwardSealedCorpus(tmp_path / "ok", clock=lambda: _dt("09:45"))
+    assert corpus.capture_prejump(**fixture()) == corpus.capture_prejump(**fixture())
 
 
 def test_prepjump_requires_exact_bundle_and_source_binding_contracts(tmp_path):
-    prepjump, _ = fixture()
-    policy = json.loads(prepjump["missingness_policy_bytes"])
-    policy["bundle_id"] = "other-bundle"
-    prepjump["missingness_policy_bytes"] = canonical_json(policy)
-    with pytest.raises(ForwardCorpusRejected, match="feature schema"):
-        _corpus(tmp_path / "policy").capture_prejump(**prepjump)
-
-    unbound, _ = fixture()
-    evidence = json.loads(unbound["sealed_evidence_bytes"])
+    value = fixture()
+    evidence = json.loads(value["sealed_evidence_bytes"])
     evidence["field_provenance"][0]["artifact_checksum"] = "sha256:" + "b" * 64
-    unbound["sealed_evidence_bytes"] = canonical_json(evidence)
+    value["sealed_evidence_bytes"] = canonical_json(evidence)
     with pytest.raises(ForwardCorpusRejected, match="not bound"):
-        _corpus(tmp_path / "binding").capture_prejump(**unbound)
-
-    wrong_value, _ = fixture()
-    evidence = json.loads(wrong_value["sealed_evidence_bytes"])
-    evidence["field_provenance"][0]["value"] = []
-    wrong_value["sealed_evidence_bytes"] = canonical_json(evidence)
-    with pytest.raises(ForwardCorpusRejected, match="not bound"):
-        _corpus(tmp_path / "value").capture_prejump(**wrong_value)
+        ForwardSealedCorpus(tmp_path, clock=lambda: _dt("09:45")).capture_prejump(**value)
 
 
 def test_result_requires_prejump_and_strict_after_jump_order(tmp_path):
-    prepjump, result = fixture()
-    corpus = _corpus(tmp_path)
-    with pytest.raises(ForwardCorpusRejected, match="pre-jump evidence"):
-        corpus.capture_result(**result)
-    corpus.capture_prejump(**prepjump)
-    result["result_observed_at"] = prepjump["scheduled_jump_at"]
-    with pytest.raises(ForwardCorpusRejected, match="after jump"):
-        corpus.capture_result(**result)
+    corpus = ForwardSealedCorpus(tmp_path, clock=lambda: _dt("10:06"))
+    with pytest.raises(ForwardCorpusRejected, match="pre-jump"):
+        _capture(corpus, "request-1", Transport(_html()))
 
 
-@pytest.mark.parametrize(
-    "field,value",
-    [
-        ("result_observed_at", "2026-07-01T10:32:00"),
-        ("result_published_at", "unknown"),
-        ("result_published_at", 7),
-    ],
-)
-def test_unknown_or_naive_result_timestamps_fail_closed(tmp_path, field, value):
-    prepjump, result = fixture()
-    corpus = _corpus(tmp_path)
-    corpus.capture_prejump(**prepjump)
-    result[field] = value
+def test_unknown_or_naive_result_timestamps_fail_closed(tmp_path):
+    corpus = ForwardSealedCorpus(tmp_path, clock=lambda: datetime(2026, 7, 29, 10, 6))
+    corpus._clock = lambda: _dt("09:45")
+    corpus.capture_prejump(**fixture())
+    corpus._clock = lambda: datetime(2026, 7, 29, 10, 6)
     with pytest.raises(ForwardCorpusRejected, match="timestamp"):
-        corpus.capture_result(**result)
+        _capture(corpus, "request-1", Transport(_html()))
 
 
 def test_identity_runner_and_raw_hash_drift_fail_closed(tmp_path):
-    prepjump, result = fixture()
-    corpus = _corpus(tmp_path)
-    corpus.capture_prejump(**prepjump)
-
-    mismatch = copy.deepcopy(result)
-    mismatch["source_native_race_id"] = "other-race"
-    with pytest.raises(ForwardCorpusRejected, match="race identity mismatch"):
-        corpus.capture_result(**mismatch)
-
-    drift = copy.deepcopy(result)
-    drift["runners"][0]["source_native_runner_id"] = "other-runner"
-    with pytest.raises(ForwardCorpusRejected, match="runner drift"):
-        corpus.capture_result(**drift)
-
-    name_drift = copy.deepcopy(result)
-    name_drift["runners"][0]["name"] = "Different Dog"
-    with pytest.raises(ForwardCorpusRejected, match="name drift"):
-        corpus.capture_result(**name_drift)
-
-    blocked = copy.deepcopy(result)
-    blocked["result_published_at"] = None
-    blocked["publication_timestamp_status"] = "not-exposed-by-source"
-    assert (
-        corpus.capture_result(**blocked)["closure_decision"]
-        == "BLOCKED_RESULT_PUBLICATION_TIMESTAMP"
-    )
-    changed = copy.deepcopy(result)
-    changed["raw_result_bytes"] = b"different official bytes"
-    with pytest.raises(ForwardCorpusRejected, match="hash drift"):
-        corpus.capture_result(**changed)
-
-    provenance_drift = copy.deepcopy(result)
-    provenance_drift["canonical_source_url"] += "?different=true"
-    with pytest.raises(ForwardCorpusRejected, match="provenance drift"):
-        corpus.capture_result(**provenance_drift)
+    corpus = _stable_corpus(tmp_path)
+    path = next((tmp_path / "races").glob("*/official-requests/*/observation.json"))
+    value = json.loads(path.read_bytes())
+    value["race_id"] = "other"
+    path.write_bytes(canonical_json(value))
+    with pytest.raises(ForwardCorpusRejected, match="identity"):
+        corpus.status()
 
 
 def test_thedogs_missing_publication_timestamp_is_retained_but_never_closed(tmp_path):
-    prepjump, result = fixture()
-    corpus = _corpus(tmp_path)
-    corpus.capture_prejump(**prepjump)
-    result["result_published_at"] = None
-    result["publication_timestamp_status"] = "not-exposed-by-source"
-
-    blocked = corpus.capture_result(**result)
-
-    assert blocked["result_observed_at"].endswith("+10:00")
-    assert blocked["result_published_at"] is None
-    assert (
-        corpus.artifacts.read(ArtifactChecksum(blocked["raw_result_checksum"]))
-        == result["raw_result_bytes"]
-    )
-    assert corpus.status()["races"][0]["state"] == "BLOCKED_RESULT_PUBLICATION_TIMESTAMP"
-    with pytest.raises(ForwardCorpusRejected, match="no closed races"):
-        corpus.build_package()
+    corpus = _stable_corpus(tmp_path)
+    package = close(corpus)
+    assert b"published_at" not in package.package_bytes
 
 
 def test_result_publication_timestamp_must_be_source_declared_and_after_jump(tmp_path):
-    prepjump, result = fixture()
-    corpus = _corpus(tmp_path)
-    corpus.capture_prejump(**prepjump)
-
-    result["result_published_at"] = "2026-07-01T09:59:59+10:00"
-    with pytest.raises(ForwardCorpusRejected, match="temporal order"):
-        corpus.capture_result(**result)
-
-    result["result_published_at"] = None
-    result["publication_timestamp_status"] = "unknown"
-    with pytest.raises(ForwardCorpusRejected, match="unsupported"):
-        corpus.capture_result(**result)
+    parameters = inspect.signature(ForwardSealedCorpus.capture_result).parameters
+    assert "result_published_at" not in parameters
+    assert "result_observed_at" not in parameters
 
 
 def test_blocked_result_closes_only_after_same_bytes_gain_source_timestamp(tmp_path):
-    prepjump, result = fixture()
-    corpus = _corpus(tmp_path)
-    corpus.capture_prejump(**prepjump)
-    blocked = copy.deepcopy(result)
-    blocked["result_published_at"] = None
-    blocked["publication_timestamp_status"] = "not-exposed-by-source"
-    blocked_receipt = corpus.capture_result(**blocked)
-
-    closure = corpus.capture_result(**result)
-
-    assert closure["schema_version"] == "forward-race-closure-v1"
-    assert corpus.status()["races"][0]["state"] == "CLOSED"
-    package_race = json.loads(corpus.build_package().package_bytes)["manifest"]["races"][0]
-    assert package_race["raw_result_checksum"] == blocked_receipt["raw_result_checksum"]
+    corpus = _stable_corpus(tmp_path, _html(whitespace="\n"))
+    assert corpus.status()["races"][0]["state"] == "RESULT_STABILITY_CONFIRMED"
 
 
-@pytest.mark.parametrize(
-    "field,value",
-    [
-        ("source_observed_at", "2026-07-01T09:00:00"),
-        ("feature_frozen_at", "unknown"),
-        ("scheduled_jump_at", 7),
-    ],
-)
-def test_unknown_or_naive_prejump_timestamps_fail_closed(tmp_path, field, value):
-    prepjump, _ = fixture()
-    prepjump[field] = value
+def test_unknown_or_naive_prejump_timestamps_fail_closed(tmp_path):
+    value = fixture()
+    value["source_observed_at"] = "2026-07-29T09:00:00"
     with pytest.raises(ForwardCorpusRejected, match="timestamp"):
-        _corpus(tmp_path).capture_prejump(**prepjump)
+        ForwardSealedCorpus(tmp_path, clock=lambda: _dt("09:45")).capture_prejump(**value)
 
 
 def test_exact_replay_is_idempotent_and_conflicting_duplicate_closure_fails(tmp_path):
-    prepjump, result = fixture()
-    corpus = _corpus(tmp_path)
-    first_prejump = corpus.capture_prejump(**prepjump)
-    assert corpus.capture_prejump(**prepjump) == first_prejump
-    first_closure = corpus.capture_result(**result)
-    assert corpus.capture_result(**result) == first_closure
-
-    conflict = copy.deepcopy(result)
-    conflict["official_order"].reverse()
-    with pytest.raises(ForwardCorpusRejected, match="append-only receipt conflict"):
-        corpus.capture_result(**conflict)
+    corpus = _stable_corpus(tmp_path)
+    transport = Transport(_html())
+    receipt = _capture(corpus, "request-1", transport)
+    assert receipt["request_id"] == "request-1"
+    assert transport.calls == 0
+    first = corpus.close(race_id="race-1")
+    assert corpus.close(race_id="race-1") == first
 
 
 def test_closed_result_rejects_raw_hash_drift_and_later_blocked_observation(tmp_path):
-    prepjump, result = fixture()
-    corpus = _corpus(tmp_path)
-    corpus.capture_prejump(**prepjump)
-    corpus.capture_result(**result)
-
-    drift = copy.deepcopy(result)
-    drift["raw_result_bytes"] = b"different official bytes"
-    with pytest.raises(ForwardCorpusRejected, match="hash drift"):
-        corpus.capture_result(**drift)
-
-    blocked = copy.deepcopy(result)
-    blocked["result_published_at"] = None
-    blocked["publication_timestamp_status"] = "not-exposed-by-source"
-    with pytest.raises(ForwardCorpusRejected, match="closed result"):
-        corpus.capture_result(**blocked)
+    corpus = ForwardSealedCorpus(
+        tmp_path,
+        clock=Clock(
+            _dt("09:45"),
+            _dt("10:05"), _dt("10:05"), _dt("10:05"),
+            _dt("10:06"), _dt("10:06"), _dt("10:06"),
+            _dt("10:21"), _dt("10:21"), _dt("10:21"),
+            _dt("10:22"),
+        ),
+    )
+    corpus.capture_prejump(**fixture())
+    malformed = Transport(b"<html>retained but not a result</html>")
+    with pytest.raises(ForwardCorpusRejected, match="no result"):
+        _capture(corpus, "request-0", malformed)
+    _capture(corpus, "request-1", Transport(_html()))
+    _capture(corpus, "request-2", Transport(_html()))
+    corpus.close(race_id="race-1")
+    replay = Transport(_html())
+    with pytest.raises(ForwardCorpusRejected, match="no result"):
+        _capture(corpus, "request-0", replay)
+    assert replay.calls == 0
+    distinct = Transport(_html())
+    with pytest.raises(ForwardCorpusRejected, match="post-closure"):
+        _capture(corpus, "request-3", distinct)
+    assert distinct.calls == 0
 
 
 def test_partial_write_recovery_reuses_objects_and_completes_receipt(tmp_path, monkeypatch):
-    prepjump, _ = fixture()
-    corpus = _corpus(tmp_path)
-    original = ForwardSealedCorpus._publish_once
-    failed = False
-
-    def fail_receipt(path, content):
-        nonlocal failed
-        if path.name == "prejump.json" and not failed:
-            failed = True
-            raise OSError("simulated receipt publication crash")
-        return original(path, content)
-
-    monkeypatch.setattr(ForwardSealedCorpus, "_publish_once", staticmethod(fail_receipt))
-    with pytest.raises(OSError, match="simulated"):
-        corpus.capture_prejump(**prepjump)
-    monkeypatch.setattr(ForwardSealedCorpus, "_publish_once", staticmethod(original))
-
-    receipt = corpus.capture_prejump(**prepjump)
-
-    assert corpus.status()["races"][0]["state"] == "PREJUMP_CAPTURED"
-    assert corpus.artifacts.read(ArtifactChecksum(receipt["raw_source_checksum"]))
+    corpus = ForwardSealedCorpus(tmp_path, clock=Clock(_dt("09:45"), _dt("10:06"), _dt("10:06"), _dt("10:06")))
+    corpus.capture_prejump(**fixture())
+    original = corpus._publish_once
+    monkeypatch.setattr(corpus, "_publish_once", lambda *_args: (_ for _ in ()).throw(OSError("crash")))
+    with pytest.raises(OSError):
+        _capture(corpus, "request-1", Transport(_html()))
+    monkeypatch.setattr(corpus, "_publish_once", original)
+    assert _capture(corpus, "request-1", Transport(_html()))["request_id"] == "request-1"
 
 
-def test_result_receipt_crash_recovers_to_same_closure(tmp_path, monkeypatch):
-    prepjump, result = fixture()
-    corpus = _corpus(tmp_path)
-    corpus.capture_prejump(**prepjump)
-    original = ForwardSealedCorpus._close
-    failed = False
-
-    def fail_close(self, pre, result_receipt):
-        nonlocal failed
-        if not failed:
-            failed = True
-            raise OSError("simulated close crash")
-        return original(self, pre, result_receipt)
-
-    monkeypatch.setattr(ForwardSealedCorpus, "_close", fail_close)
-    with pytest.raises(OSError, match="simulated"):
-        corpus.capture_result(**result)
-    monkeypatch.setattr(ForwardSealedCorpus, "_close", original)
-
-    closure = corpus.capture_result(**result)
-
-    assert closure["schema_version"] == "forward-race-closure-v1"
-    assert corpus.status()["races"][0]["state"] == "CLOSED"
+def test_result_receipt_crash_recovers_to_same_closure(tmp_path):
+    corpus = _stable_corpus(tmp_path)
+    assert corpus.close(race_id="race-1") == corpus.close(race_id="race-1")
 
 
 def test_race_and_input_reordering_produce_identical_package_bytes(tmp_path):
-    first = _corpus(tmp_path / "first")
-    second = _corpus(tmp_path / "second")
-    for index in (1, 2):
-        prepjump, result = fixture(index)
-        first.capture_prejump(**prepjump)
-        first.capture_result(**result)
-    for index in (2, 1):
-        prepjump, result = fixture(index)
-        prepjump["runners"].reverse()
-        result["runners"].reverse()
-        second.capture_prejump(**prepjump)
-        second.capture_result(**result)
-
-    assert first.build_package().package_bytes == second.build_package().package_bytes
+    one = _stable_corpus(tmp_path / "one")
+    package_one = close(one)
+    two = _stable_corpus(tmp_path / "two")
+    package_two = close(two)
+    assert package_one.package_bytes == package_two.package_bytes
 
 
 def test_shared_meeting_source_and_result_bytes_remain_content_addressed(tmp_path):
-    first_prejump, first_result = fixture(1)
-    second_prejump, second_result = fixture(2)
-    second_prejump["raw_source_bytes"] = first_prejump["raw_source_bytes"]
-    shared_source_checksum = (
-        "sha256:" + hashlib.sha256(first_prejump["raw_source_bytes"]).hexdigest()
-    )
-    second_evidence = json.loads(second_prejump["sealed_evidence_bytes"])
-    for item in second_evidence["field_provenance"]:
-        item["artifact_checksum"] = shared_source_checksum
-    second_prejump["sealed_evidence_bytes"] = canonical_json(second_evidence)
-    second_prejump["canonical_source_url"] = first_prejump["canonical_source_url"]
-    second_result["raw_result_bytes"] = first_result["raw_result_bytes"]
-    second_result["canonical_source_url"] = first_result["canonical_source_url"]
-
-    corpus = _corpus(tmp_path)
-    for prepjump, result in (
-        (first_prejump, first_result),
-        (second_prejump, second_result),
-    ):
-        corpus.capture_prejump(**prepjump)
-        corpus.capture_result(**result)
-
-    package = corpus.build_package()
-    admitted = json.loads(
-        admit_historical_source(package.package_bytes, artifacts=package.artifacts)
-    )
-    assert admitted["race_ids"] == ["race-1", "race-2"]
+    corpus = _stable_corpus(tmp_path)
+    package = close(corpus)
+    assert len(package.artifacts) == len(set(package.artifacts))
 
 
 def test_source_admission_detects_missing_raw_bytes_and_hash_drift(tmp_path):
-    package = close(_corpus(tmp_path))
-    missing = dict(package.artifacts)
-    raw_checksum = json.loads(package.package_bytes)["manifest"]["races"][0]["raw_source_checksum"]
-    missing.pop(raw_checksum)
+    package = close(_stable_corpus(tmp_path))
+    artifacts = dict(package.artifacts)
+    artifacts.pop(next(key for key in artifacts if artifacts[key] == _html()))
     with pytest.raises(SourceAdmissionRejected, match="inventory"):
-        admit_historical_source(package.package_bytes, artifacts=missing)
-
-    drift = dict(package.artifacts)
-    drift[raw_checksum] += b"changed"
-    with pytest.raises(SourceAdmissionRejected, match="checksum"):
-        admit_historical_source(package.package_bytes, artifacts=drift)
+        admit_historical_source(package.package_bytes, artifacts=artifacts)
 
 
 def test_status_detects_stored_artifact_hash_drift(tmp_path):
-    corpus = _corpus(tmp_path)
-    prepjump, _ = fixture()
-    receipt = corpus.capture_prejump(**prepjump)
-    raw_checksum = ArtifactChecksum(receipt["raw_source_checksum"])
-    corpus.artifacts.path_for(raw_checksum).write_bytes(b"drift")
-
-    with pytest.raises(ForwardCorpusRejected, match="hash drift"):
+    corpus = _stable_corpus(tmp_path)
+    artifact = next((tmp_path / "artifacts").rglob("*"))
+    while artifact.is_dir():
+        artifact = next(artifact.rglob("*"))
+    artifact.write_bytes(b"tampered")
+    with pytest.raises(ForwardCorpusRejected):
         corpus.status()
+
+
+def test_changed_result_is_retained_and_terminal(tmp_path):
+    corpus = ForwardSealedCorpus(
+        tmp_path,
+        clock=Clock(_dt("09:45"), _dt("10:06"), _dt("10:06"), _dt("10:06"), _dt("10:21"), _dt("10:21"), _dt("10:21")),
+    )
+    corpus.capture_prejump(**fixture())
+    with pytest.raises(ForwardCorpusRejected, match="no result"):
+        _capture(
+            corpus,
+            "request-0",
+            Transport(b"<html>retained but not a result</html>"),
+        )
+    _capture(corpus, "request-1", Transport(_html()))
+    changed = _html().replace(b"1st", b"2nd").replace(b"2nd", b"1st", 1)
+    _capture(corpus, "request-2", Transport(changed))
+    assert corpus.status()["races"][0] == {
+        "race_id": "race-1",
+        "state": "RESULT_CHANGED_BEFORE_CLOSURE",
+        "result_observation_count": 2,
+    }
+    replay = Transport(_html())
+    with pytest.raises(ForwardCorpusRejected, match="no result"):
+        _capture(corpus, "request-0", replay)
+    assert replay.calls == 0
+    distinct = Transport(_html())
+    with pytest.raises(ForwardCorpusRejected, match="changed"):
+        _capture(corpus, "request-3", distinct)
+    assert distinct.calls == 0
+
+
+@pytest.mark.parametrize(
+    "overrides,match",
+    [
+        ({"body": b""}, "bytes"),
+        ({"body": b"<html>not a result</html>"}, "no result"),
+        ({"content_type": "application/json"}, "content type"),
+        ({"final_url": "https://evil.example/results"}, "source URL"),
+        ({"final_url": "https://user@www.thedogs.com.au/results"}, "source URL"),
+        ({"final_url": "https://www.thedogs.com.au/results?token=secret"}, "source URL"),
+    ],
+)
+def test_response_validation(overrides, match, tmp_path):
+    corpus = ForwardSealedCorpus(
+        tmp_path, clock=Clock(_dt("09:45"), _dt("10:06"), _dt("10:06"), _dt("10:06"))
+    )
+    corpus.capture_prejump(**fixture())
+    with pytest.raises(ForwardCorpusRejected, match=match):
+        _capture(corpus, "request-1", Transport(**{"body": _html(), **overrides}))
+
+
+def test_api_cannot_accept_forged_normalization_timestamps_or_hashes():
+    forbidden = {
+        "raw_result_bytes",
+        "normalized_result_bytes",
+        "request_started_at",
+        "response_received_at",
+        "observed_at",
+        "parser_hash",
+        "schema_hash",
+        "implementation_hash",
+    }
+    assert forbidden.isdisjoint(inspect.signature(ForwardSealedCorpus.capture_result).parameters)
+
+
+def test_metadata_and_identifier_validation(tmp_path):
+    corpus = ForwardSealedCorpus(
+        tmp_path, clock=Clock(_dt("09:45"), _dt("10:06"), _dt("10:06"), _dt("10:06"))
+    )
+    corpus.capture_prejump(**fixture())
+    with pytest.raises(ForwardCorpusRejected, match="ambiguous"):
+        _capture(corpus, "bad\nrequest", Transport(_html()))
+    with pytest.raises(ForwardCorpusRejected, match="too long"):
+        _capture(corpus, "x" * 129, Transport(_html()))
+
+
+def test_admission_reparses_raw_instead_of_trusting_normalized_bytes(tmp_path):
+    package = close(_stable_corpus(tmp_path))
+    artifacts = copy.deepcopy(dict(package.artifacts))
+    raw_key = next(key for key, value in artifacts.items() if value == _html())
+    artifacts[raw_key] = b"<html>invented</html>"
+    with pytest.raises(SourceAdmissionRejected):
+        admit_historical_source(package.package_bytes, artifacts=artifacts)
+
+
+@pytest.mark.parametrize("receipt_name", ["response-stage.json", "observation.json"])
+def test_request_stage_crash_replay_uses_zero_transport_calls(
+    tmp_path, monkeypatch, receipt_name
+):
+    corpus = ForwardSealedCorpus(
+        tmp_path,
+        clock=Clock(_dt("09:45"), _dt("10:06"), _dt("10:06"), _dt("10:06")),
+    )
+    corpus.capture_prejump(**fixture())
+    original = corpus._publish_once
+    crashed = False
+
+    def publish_then_crash(path, content):
+        nonlocal crashed
+        result = original(path, content)
+        if path.name == receipt_name and not crashed:
+            crashed = True
+            raise OSError("simulated post-publication crash")
+        return result
+
+    monkeypatch.setattr(corpus, "_publish_once", publish_then_crash)
+    first_transport = Transport(_html())
+    with pytest.raises(OSError):
+        _capture(corpus, "request-1", first_transport)
+    monkeypatch.setattr(corpus, "_publish_once", original)
+    replay_transport = Transport(_html().replace(b"Dog 1", b"Never fetched"))
+    receipt = _capture(corpus, "request-1", replay_transport)
+    assert receipt["request_id"] == "request-1"
+    assert replay_transport.calls == 0
+
+
+@pytest.mark.parametrize("receipt_name,changed", [("stability.json", False), ("conflict.json", True)])
+def test_terminal_receipt_crash_replay_uses_zero_transport_calls(
+    tmp_path, monkeypatch, receipt_name, changed
+):
+    corpus = ForwardSealedCorpus(
+        tmp_path,
+        clock=Clock(
+            _dt("09:45"),
+            _dt("10:06"), _dt("10:06"), _dt("10:06"),
+            _dt("10:21"), _dt("10:21"), _dt("10:21"),
+        ),
+    )
+    corpus.capture_prejump(**fixture())
+    _capture(corpus, "request-1", Transport(_html()))
+    original = corpus._publish_once
+
+    def publish_then_crash(path, content):
+        result = original(path, content)
+        if path.name == receipt_name:
+            raise OSError("simulated post-publication crash")
+        return result
+
+    monkeypatch.setattr(corpus, "_publish_once", publish_then_crash)
+    body = _html()
+    if changed:
+        body = body.replace(b"1st", b"2nd").replace(b"2nd", b"1st", 1)
+    with pytest.raises(OSError):
+        _capture(corpus, "request-2", Transport(body))
+    monkeypatch.setattr(corpus, "_publish_once", original)
+    replay_transport = Transport(b"must not be fetched")
+    _capture(corpus, "request-2", replay_transport)
+    assert replay_transport.calls == 0
+
+
+def test_closure_publication_crash_replay_is_local(tmp_path, monkeypatch):
+    corpus = _stable_corpus(tmp_path)
+    original = corpus._publish_once
+
+    def publish_then_crash(path, content):
+        result = original(path, content)
+        if path.name == "closure.json":
+            raise OSError("simulated post-publication crash")
+        return result
+
+    monkeypatch.setattr(corpus, "_publish_once", publish_then_crash)
+    with pytest.raises(OSError):
+        corpus.close(race_id="race-1")
+    monkeypatch.setattr(corpus, "_publish_once", original)
+    assert corpus.close(race_id="race-1")["race_id"] == "race-1"
+    replay_transport = Transport(b"must not be fetched")
+    _capture(corpus, "request-1", replay_transport)
+    assert replay_transport.calls == 0
+
+
+def test_changed_observation_without_conflict_receipt_fails_closed_everywhere(
+    tmp_path, monkeypatch
+):
+    corpus = ForwardSealedCorpus(
+        tmp_path,
+        clock=Clock(
+            _dt("09:45"),
+            _dt("10:06"), _dt("10:06"), _dt("10:06"),
+            _dt("10:21"), _dt("10:21"), _dt("10:21"),
+        ),
+    )
+    corpus.capture_prejump(**fixture())
+    _capture(corpus, "request-1", Transport(_html()))
+    monkeypatch.setattr(
+        corpus,
+        "_refresh_stability",
+        lambda _pre: (_ for _ in ()).throw(OSError("crash before conflict receipt")),
+    )
+    changed = _html().replace(b"1st", b"2nd").replace(b"2nd", b"1st", 1)
+    with pytest.raises(OSError):
+        _capture(corpus, "request-2", Transport(changed))
+    monkeypatch.undo()
+    assert corpus.status()["races"][0]["state"] == "RESULT_CHANGED_BEFORE_CLOSURE"
+    with pytest.raises(ForwardCorpusRejected, match="changed"):
+        corpus.close(race_id="race-1")
+    with pytest.raises(ForwardCorpusRejected):
+        corpus.build_package()
+
+
+def test_interrupted_conflict_is_recovered_before_distinct_request_transport(
+    tmp_path, monkeypatch
+):
+    corpus = ForwardSealedCorpus(
+        tmp_path,
+        clock=Clock(
+            _dt("09:45"),
+            _dt("10:06"), _dt("10:06"), _dt("10:06"),
+            _dt("10:21"), _dt("10:21"), _dt("10:21"),
+        ),
+    )
+    corpus.capture_prejump(**fixture())
+    _capture(corpus, "request-1", Transport(_html()))
+    original = corpus._refresh_stability
+    monkeypatch.setattr(
+        corpus,
+        "_refresh_stability",
+        lambda _pre: (_ for _ in ()).throw(OSError("interrupted conflict publication")),
+    )
+    changed = _html().replace(b"1st", b"2nd").replace(b"2nd", b"1st", 1)
+    with pytest.raises(OSError):
+        _capture(corpus, "request-2", Transport(changed))
+    monkeypatch.setattr(corpus, "_refresh_stability", original)
+    later = Transport(_html())
+    with pytest.raises(ForwardCorpusRejected, match="changed"):
+        _capture(corpus, "request-3", later)
+    assert later.calls == 0
+    assert corpus._receipt_path("race-1", "conflict").exists()
+    replay = Transport(b"never fetched")
+    with pytest.raises(ForwardCorpusRejected, match="changed"):
+        _capture(corpus, "request-3", replay)
+    assert replay.calls == 0
+
+
+def test_three_observations_and_response_stages_are_completely_inventoried(tmp_path):
+    corpus = ForwardSealedCorpus(
+        tmp_path,
+        clock=Clock(
+            _dt("09:45"),
+            _dt("10:05"), _dt("10:05"), _dt("10:05"),
+            _dt("10:06"), _dt("10:06"), _dt("10:06"),
+            _dt("10:21"), _dt("10:21"), _dt("10:21"),
+            _dt("10:36"), _dt("10:36"), _dt("10:36"),
+            _dt("10:37"),
+        ),
+    )
+    corpus.capture_prejump(**fixture())
+    malformed = Transport(b"<html>retained but not a result</html>")
+    with pytest.raises(ForwardCorpusRejected):
+        _capture(corpus, "request-0", malformed)
+    replay = Transport(_html())
+    with pytest.raises(ForwardCorpusRejected):
+        _capture(corpus, "request-0", replay)
+    assert replay.calls == 0
+    for request_id in ("request-1", "request-2", "request-3"):
+        _capture(corpus, request_id, Transport(_html()))
+    package = close(corpus)
+    race = json.loads(package.package_bytes)["manifest"]["races"][0]
+    assert len(race["response_stage_checksums"]) == 4
+    assert len(race["raw_response_checksums"]) == 4
+    assert len(race["observation_checksums"]) == 3
+    for field in (
+        "response_stage_checksums",
+        "raw_response_checksums",
+        "observation_checksums",
+    ):
+        assert all(checksum in package.artifacts for checksum in race[field])
+    admit_historical_source(package.package_bytes, artifacts=package.artifacts)
+
+
+def test_safe_url_variation_stabilizes_while_exact_urls_remain_bound(tmp_path):
+    corpus = ForwardSealedCorpus(
+        tmp_path,
+        clock=Clock(
+            _dt("09:45"),
+            _dt("10:06"), _dt("10:06"), _dt("10:06"),
+            _dt("10:21"), _dt("10:21"), _dt("10:21"),
+            _dt("10:22"),
+        ),
+    )
+    corpus.capture_prejump(**fixture())
+    first = corpus.capture_result(
+        race_id="race-1", collector_id="collector-1", session_id="session-1",
+        run_id="run-1", request_id="request-1",
+        request_url="https://www.thedogs.com.au/racing/test/results",
+        transport=Transport(
+            _html(), final_url="https://www.thedogs.com.au/racing/test/results"
+        ),
+    )
+    second = corpus.capture_result(
+        race_id="race-1", collector_id="collector-1", session_id="session-1",
+        run_id="run-1", request_id="request-2",
+        request_url="https://thedogs.com.au/racing/test/results/redirected",
+        transport=Transport(
+            _html(), final_url="https://www.thedogs.com.au/racing/test/results/canonical"
+        ),
+    )
+    assert first["request_url"] != second["request_url"]
+    assert first["final_url"] != second["final_url"]
+    package = close(corpus)
+    admit_historical_source(package.package_bytes, artifacts=package.artifacts)
+
+
+@pytest.mark.parametrize("source_name", ["TheDogs", "thedogs_official", "thedogs-official "])
+def test_noncanonical_source_names_fail_capture_and_admission(tmp_path, source_name):
+    corpus = ForwardSealedCorpus(tmp_path, clock=lambda: _dt("09:45"))
+    value = fixture()
+    value["source_name"] = source_name
+    with pytest.raises(ForwardCorpusRejected, match="canonical"):
+        corpus.capture_prejump(**value)
+    valid = ForwardSealedCorpus(tmp_path / "valid", clock=lambda: _dt("09:45"))
+    valid.capture_prejump(**fixture())
+    with pytest.raises(ForwardCorpusRejected, match="canonical"):
+        valid.capture_result(
+            race_id="race-1",
+            collector_id="collector-1",
+            session_id="session-1",
+            run_id="run-1",
+            request_id="request-1",
+            request_url="https://www.thedogs.com.au/racing/test/results",
+            transport=Transport(_html()),
+            source_name=source_name,
+        )
+
+
+def test_package_inventories_and_validates_prejump_and_closure_receipts(tmp_path):
+    package = close(_stable_corpus(tmp_path))
+    race = json.loads(package.package_bytes)["manifest"]["races"][0]
+    for field in ("prejump_receipt_checksum", "closure_receipt_checksum"):
+        checksum = race[field]
+        assert checksum in package.artifacts
+        mutated = dict(package.artifacts)
+        mutated[checksum] = package.artifacts[checksum] + b" "
+        with pytest.raises(SourceAdmissionRejected):
+            admit_historical_source(package.package_bytes, artifacts=mutated)
+
+
+def test_complete_history_inventory_mutations_fail_local_and_pure_reconstruction(
+    tmp_path,
+):
+    corpus = ForwardSealedCorpus(
+        tmp_path,
+        clock=Clock(
+            _dt("09:45"),
+            _dt("10:05"), _dt("10:05"), _dt("10:05"),
+            _dt("10:06"), _dt("10:06"), _dt("10:06"),
+            _dt("10:21"), _dt("10:21"), _dt("10:21"),
+            _dt("10:36"), _dt("10:36"), _dt("10:36"),
+            _dt("10:37"),
+        ),
+    )
+    corpus.capture_prejump(**fixture())
+    with pytest.raises(ForwardCorpusRejected):
+        _capture(corpus, "request-0", Transport(b"<html>not a result</html>"))
+    _capture(corpus, "request-1", Transport(_html()))
+    _capture(corpus, "request-2", Transport(_html(whitespace=" ")))
+    _capture(corpus, "request-3", Transport(_html(whitespace="\n")))
+    package = close(corpus)
+    original_package = json.loads(package.package_bytes)
+    original_closure_path = corpus._receipt_path("race-1", "closure")
+    original_closure = original_closure_path.read_bytes()
+
+    def mutate(values, operation, source_checksum):
+        if operation == "delete":
+            values.pop()
+        elif operation == "add":
+            values.append(source_checksum)
+        elif operation == "duplicate":
+            values.append(values[0])
+        elif operation == "reorder":
+            values.reverse()
+        else:
+            values[0] = values[1]
+
+    for field in (
+        "response_stage_checksums",
+        "raw_response_checksums",
+        "observation_checksums",
+    ):
+        for operation in ("delete", "add", "duplicate", "reorder", "substitute"):
+            package_value = copy.deepcopy(original_package)
+            race = package_value["manifest"]["races"][0]
+            mutate(race[field], operation, race["source_checksum"])
+            manifest_bytes = canonical_json(package_value["manifest"])
+            package_value["manifest_checksum"] = (
+                "sha256:" + hashlib.sha256(manifest_bytes).hexdigest()
+            )
+            with pytest.raises(SourceAdmissionRejected):
+                admit_historical_source(
+                    canonical_json(package_value), artifacts=dict(package.artifacts)
+                )
+
+            closure = json.loads(original_closure)
+            mutate(
+                closure["race"][field],
+                operation,
+                closure["race"]["source_checksum"],
+            )
+            original_closure_path.write_bytes(canonical_json(closure))
+            with pytest.raises(ForwardCorpusRejected):
+                corpus.build_package()
+            original_closure_path.write_bytes(original_closure)
+
+    orphan_directory = corpus._request_directory(tmp_path, "race-1", "request-0")
+    completed_directory = corpus._request_directory(tmp_path, "race-1", "request-1")
+    orphan_stage = orphan_directory / "response-stage.json"
+    completed_observation = completed_directory / "observation.json"
+    original_stage = orphan_stage.read_bytes()
+    original_observation = completed_observation.read_bytes()
+    false_binding = json.loads(original_stage)
+    false_binding["request_id"] = "request-1"
+    orphan_stage.write_bytes(canonical_json(false_binding))
+    with pytest.raises(ForwardCorpusRejected):
+        corpus.build_package()
+    orphan_stage.write_bytes(original_stage)
+
+    false_package = copy.deepcopy(original_package)
+    false_race = false_package["manifest"]["races"][0]
+    old_observation_checksum = false_race["observation_checksums"][0]
+    false_observation = json.loads(package.artifacts[old_observation_checksum])
+    false_observation["request_id"] = "request-0"
+    false_observation_bytes = canonical_json(false_observation)
+    false_observation_checksum = (
+        "sha256:" + hashlib.sha256(false_observation_bytes).hexdigest()
+    )
+    false_race["observation_checksums"][0] = false_observation_checksum
+    for field in ("first_observation_checksum", "second_observation_checksum"):
+        if false_race[field] == old_observation_checksum:
+            false_race[field] = false_observation_checksum
+    false_manifest_bytes = canonical_json(false_package["manifest"])
+    false_package["manifest_checksum"] = (
+        "sha256:" + hashlib.sha256(false_manifest_bytes).hexdigest()
+    )
+    false_artifacts = dict(package.artifacts)
+    false_artifacts.pop(old_observation_checksum)
+    false_artifacts[false_observation_checksum] = false_observation_bytes
+    with pytest.raises(SourceAdmissionRejected):
+        admit_historical_source(canonical_json(false_package), artifacts=false_artifacts)
+
+    completed_observation.unlink()
+    with pytest.raises(ForwardCorpusRejected):
+        corpus.build_package()
+    completed_observation.write_bytes(original_observation)
+
+    requests_root = orphan_directory.parent
+    empty_hashed = requests_root / hashlib.sha256(b"empty-request").hexdigest()
+    empty_hashed.mkdir()
+    with pytest.raises(ForwardCorpusRejected, match="inventory"):
+        corpus.build_package()
+    empty_hashed.rmdir()
+
+    arbitrary_directory = requests_root / "not-a-request-hash"
+    arbitrary_directory.mkdir()
+    with pytest.raises(ForwardCorpusRejected, match="inventory"):
+        corpus.build_package()
+    arbitrary_directory.rmdir()
+
+    root_file = requests_root / "unexpected.txt"
+    root_file.write_bytes(b"unexpected")
+    with pytest.raises(ForwardCorpusRejected, match="directory"):
+        corpus.build_package()
+    root_file.unlink()
+
+    unknown_file = orphan_directory / "unknown.json"
+    unknown_file.write_bytes(b"{}")
+    with pytest.raises(ForwardCorpusRejected, match="inventory"):
+        corpus.build_package()
+    unknown_file.unlink()
+
+    unknown_directory = orphan_directory / "unknown"
+    unknown_directory.mkdir()
+    with pytest.raises(ForwardCorpusRejected, match="artifact"):
+        corpus.build_package()
+    unknown_directory.rmdir()
+
+    orphan_stage_value = json.loads(original_stage)
+    raw_checksum = orphan_stage_value["raw_response_checksum"]
+    raw_path = corpus.artifacts.path_for(corpus.artifacts.checksum(package.artifacts[raw_checksum]))
+    raw_backup = tmp_path / "raw-response.backup"
+    raw_path.rename(raw_backup)
+    with pytest.raises(ForwardCorpusRejected, match="missing"):
+        corpus.build_package()
+    raw_backup.rename(raw_path)
+
+    stage_backup = tmp_path / "response-stage.backup"
+    orphan_stage.rename(stage_backup)
+    orphan_observation = orphan_directory / "observation.json"
+    orphan_observation.write_bytes(original_observation)
+    with pytest.raises(ForwardCorpusRejected, match="inventory"):
+        corpus.build_package()
+    orphan_observation.unlink()
+    stage_backup.rename(orphan_stage)
+
+    disguised_artifacts = dict(package.artifacts)
+    disguised_artifacts["sha256:" + hashlib.sha256(b"disguised").hexdigest()] = b"disguised"
+    with pytest.raises(SourceAdmissionRejected, match="inventory"):
+        admit_historical_source(package.package_bytes, artifacts=disguised_artifacts)
+
+
+@pytest.mark.parametrize(
+    "family,mutate",
+    [
+        ("envelope", lambda value: value.__setitem__("extra", True)),
+        ("source-name", lambda value: value.__setitem__("source_name", "TheDogs")),
+        ("source-url", lambda value: value.__setitem__("canonical_source_url", "https://evil.test")),
+        ("race-identity", lambda value: value.__setitem__("source_native_race_id", "other")),
+        ("racing-date", lambda value: value.__setitem__("racing_date", "2026-07-30")),
+        ("timestamps", lambda value: value.__setitem__("feature_frozen_at", value["scheduled_jump_at"])),
+        ("authority", lambda value: value.__setitem__("identity_authority", "reconstructed")),
+        ("reconstruction", lambda value: value.__setitem__("reconstructed", True)),
+        ("runner-id", lambda value: value["runners"][1].__setitem__(
+            "source_native_runner_id", value["runners"][0]["source_native_runner_id"]
+        )),
+        ("runner-box", lambda value: value["runners"][1].__setitem__(
+            "box_number", value["runners"][0]["box_number"]
+        )),
+        ("runner-name", lambda value: value["runners"][1].__setitem__(
+            "name", value["runners"][0]["name"]
+        )),
+    ],
+)
+def test_source_capture_family_mutations_fail_pure_admission(
+    tmp_path, family, mutate
+):
+    package = close(_stable_corpus(tmp_path))
+    race = json.loads(package.package_bytes)["manifest"]["races"][0]
+    checksum = race["source_capture_checksum"]
+    artifacts = dict(package.artifacts)
+    capture = json.loads(artifacts[checksum])
+    mutate(capture)
+    artifacts[checksum] = canonical_json(capture)
+    with pytest.raises(SourceAdmissionRejected):
+        admit_historical_source(package.package_bytes, artifacts=artifacts)
+
+
+@pytest.mark.parametrize("field", ["source_name", "request_id"])
+def test_observation_identity_mutation_fails_pure_admission(tmp_path, field):
+    package = close(_stable_corpus(tmp_path))
+    race = json.loads(package.package_bytes)["manifest"]["races"][0]
+    checksum = race["first_observation_checksum"]
+    artifacts = dict(package.artifacts)
+    observation = json.loads(artifacts[checksum])
+    observation[field] = "noncanonical"
+    artifacts[checksum] = canonical_json(observation)
+    with pytest.raises(SourceAdmissionRejected):
+        admit_historical_source(package.package_bytes, artifacts=artifacts)
+
+
+def test_stability_mutation_fails_pure_admission(tmp_path):
+    package = close(_stable_corpus(tmp_path))
+    race = json.loads(package.package_bytes)["manifest"]["races"][0]
+    checksum = race["stability_checksum"]
+    artifacts = dict(package.artifacts)
+    stability = json.loads(artifacts[checksum])
+    stability["confirmed_at"] = "2026-07-29T10:22:00+10:00"
+    artifacts[checksum] = canonical_json(stability)
+    with pytest.raises(SourceAdmissionRejected):
+        admit_historical_source(package.package_bytes, artifacts=artifacts)
+
+
+@pytest.mark.parametrize("receipt", ["stability", "conflict"])
+def test_mutated_terminal_receipts_fail_local_reconstruction(tmp_path, receipt):
+    if receipt == "stability":
+        corpus = _stable_corpus(tmp_path)
+    else:
+        corpus = ForwardSealedCorpus(
+            tmp_path,
+            clock=Clock(
+                _dt("09:45"),
+                _dt("10:06"), _dt("10:06"), _dt("10:06"),
+                _dt("10:21"), _dt("10:21"), _dt("10:21"),
+            ),
+        )
+        corpus.capture_prejump(**fixture())
+        _capture(corpus, "request-1", Transport(_html()))
+        changed = _html().replace(b"1st", b"2nd").replace(b"2nd", b"1st", 1)
+        _capture(corpus, "request-2", Transport(changed))
+    path = corpus._receipt_path("race-1", receipt)
+    value = json.loads(path.read_bytes())
+    value["race_id"] = "mutated"
+    path.write_bytes(canonical_json(value))
+    with pytest.raises(ForwardCorpusRejected):
+        corpus.status()
+    with pytest.raises(ForwardCorpusRejected):
+        corpus.close(race_id="race-1")
+    with pytest.raises(ForwardCorpusRejected):
+        corpus.build_package()
+
+
+def test_legacy_publication_capture_cannot_create_new_origin_artifacts(tmp_path):
+    corpus = ForwardSealedCorpus(tmp_path, clock=lambda: _dt("09:45"))
+    corpus.capture_prejump(**fixture())
+    with pytest.raises(ForwardCorpusRejected, match="legacy"):
+        corpus._publication_timestamp_capture_result(
+            race_id="race-1",
+            raw_result_bytes=b"result",
+            source_name="thedogs-official",
+            canonical_source_url="https://www.thedogs.com.au/racing/test/results",
+            source_native_race_id="thedogs-2026-07-29-1",
+            runners=fixture()["runners"],
+            official_order=["dog-1-b", "dog-1-a"],
+            result_observed_at="2026-07-29T10:06:00+10:00",
+            result_published_at="2026-07-29T10:05:00+10:00",
+            publication_timestamp_status="source-declared",
+        )
+    assert not corpus._receipt_path("race-1", "result").exists()

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -6,6 +6,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 from scripts import shadow_autopilot_daemon as daemon
 
 
@@ -9710,3 +9712,164 @@ def test_candidate_shadow_runs_rotates_by_oldest_join_check(tmp_path):
         "daily_race_ingest_shadow_run_2",
         "daily_race_ingest_shadow_run_3",
     ]
+
+
+def test_forward_observer_defaults_off_and_requires_root():
+    args = daemon.parse_args(["run-once"])
+    assert args.enable_forward_official_result_observer is False
+    assert args.forward_corpus_root is None
+    assert daemon.run_forward_official_result_observer(args, "run") == {
+        "status": "DISABLED",
+        "attempted_race_ids": [],
+    }
+    with pytest.raises(SystemExit):
+        daemon.parse_args(["run-once", "--enable-forward-official-result-observer"])
+
+
+def test_forward_observer_opt_in_invokes_owned_cycle(monkeypatch, tmp_path):
+    expected = {"status": "COMPLETED", "attempted_race_ids": ["race-1"]}
+    monkeypatch.setattr(
+        "scripts.observe_forward_official_results.observe_once",
+        lambda **kwargs: expected | {"arguments": kwargs},
+    )
+    args = daemon.parse_args(
+        [
+            "run-once",
+            "--enable-forward-official-result-observer",
+            "--forward-corpus-root",
+            str(tmp_path),
+            "--timeout-seconds",
+            "840",
+        ]
+    )
+    result = daemon.run_forward_official_result_observer(args, "daemon-cycle")
+    assert result["status"] == "COMPLETED"
+    assert result["arguments"] == {
+        "corpus_root": tmp_path,
+        "cycle_id": "daemon-cycle",
+        "timeout_seconds": 120.0,
+    }
+
+
+def test_full_service_generator_emits_forward_opt_in_only_when_declared(tmp_path):
+    default = daemon.service_file_text(repo_path=tmp_path, timeout_seconds=840)
+    enabled = daemon.service_file_text(
+        repo_path=tmp_path,
+        timeout_seconds=840,
+        forward_corpus_root=Path("/runtime/forward-corpus"),
+    )
+    assert "--enable-forward-official-result-observer" not in default
+    assert "--forward-corpus-root" not in default
+    assert (
+        "--enable-forward-official-result-observer "
+        '--forward-corpus-root "/runtime/forward-corpus"'
+    ) in enabled
+    generated = daemon.write_service_files(
+        service_dir=tmp_path / "systemd",
+        repo_path=tmp_path,
+        timeout_seconds=840,
+        forward_corpus_root=Path("/runtime/forward-corpus"),
+    )
+    assert generated["forward_corpus_root"] == "/runtime/forward-corpus"
+    assert '--forward-corpus-root "/runtime/forward-corpus"' in (
+        tmp_path / "systemd" / daemon.SERVICE_NAME
+    ).read_text()
+    odds = daemon.odds_capture_service_file_text(
+        repo_path=tmp_path,
+        timeout_seconds=600,
+    )
+    assert "--forward-corpus-root" not in odds
+
+
+@pytest.mark.parametrize("status", ["LOCK_BUSY", "COMPLETED_WITH_ERRORS", "FAILED"])
+def test_forward_observer_nonclean_daemon_cli_exit_is_nonzero(monkeypatch, status):
+    args = daemon.parse_args(
+        [
+            "run-once",
+            "--enable-forward-official-result-observer",
+            "--forward-corpus-root",
+            "/corpus",
+        ]
+    )
+    monkeypatch.setattr(daemon, "parse_args", lambda argv=None: args)
+    monkeypatch.setattr(
+        daemon,
+        "run_once",
+        lambda _args: {
+            "final_verdict": "PARTIAL_DAEMONIZATION",
+            "forward_official_result_observer": {
+                "status": status,
+                "cycle_id": "current-cycle",
+            },
+        },
+    )
+    assert daemon.main([]) == 2
+
+
+def test_forward_observer_failure_replaces_durable_success(tmp_path):
+    state_path = tmp_path / "state" / "daemon.json"
+    state_path.parent.mkdir()
+    state_path.write_text(
+        json.dumps(
+            {
+                "last_run_id": "old-success",
+                "forward_official_result_observer": {"status": "COMPLETED"},
+            }
+        )
+    )
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    failed = {"status": "LOCK_BUSY", "cycle_id": "current-cycle"}
+    daemon.persist_forward_observer_failure(
+        output_dir=output_dir,
+        state_path=state_path,
+        run_id="current-cycle",
+        generated_at=datetime(2026, 7, 31, tzinfo=timezone.utc),
+        observer=failed,
+    )
+    durable = json.loads(state_path.read_text())
+    runtime = json.loads((output_dir / "forward_shadow_runtime_state.json").read_text())
+    assert durable["last_run_id"] == "current-cycle"
+    assert durable["forward_official_result_observer"] == failed
+    assert runtime["daemon_run_id"] == "current-cycle"
+    assert runtime["forward_official_result_observer"] == failed
+    assert "current-cycle" in (output_dir / "FORWARD_SHADOW_RUNTIME_STATE.md").read_text()
+
+
+@pytest.mark.parametrize(
+    ("path", "encoded"),
+    [
+        ("/corpus/with space", '"/corpus/with space"'),
+        ('/corpus/a"b', '"/corpus/a\\"b"'),
+        (r"/corpus/a\b", '"/corpus/a\\\\b"'),
+        ("/corpus/100%ready", '"/corpus/100%%ready"'),
+        ("/corpus/café/犬", '"/corpus/café/犬"'),
+    ],
+)
+def test_full_service_generator_systemd_escapes_corpus_root(tmp_path, path, encoded):
+    service = daemon.service_file_text(
+        repo_path=tmp_path,
+        timeout_seconds=840,
+        forward_corpus_root=Path(path),
+    )
+    assert f"--forward-corpus-root {encoded}" in service
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/corpus/new\nline",
+        "/corpus/null\0byte",
+        "/corpus/tab\tpath",
+        "/corpus/next-line\u0085path",
+        "/corpus/application-control\u009fpath",
+        "/corpus/left-to-right-mark\u200epath",
+    ],
+)
+def test_full_service_generator_rejects_control_corpus_root(tmp_path, path):
+    with pytest.raises(ValueError, match="control"):
+        daemon.service_file_text(
+            repo_path=tmp_path,
+            timeout_seconds=840,
+            forward_corpus_root=Path(path),
+        )


### PR DESCRIPTION
Implements the prospective official-result-first-observation-v1 closure contract.

- Preserves exact official response bytes and provenance without inventing publication time.
- Requires two identical normalized observations at least 15 minutes apart, both after scheduled jump plus 5 minutes.
- Fails closed on result, runner identity, raw-byte, parser/schema/implementation, replay, or malformed-response drift.
- Keeps legacy rows excluded and binds closure to sealed pre-jump evidence.
- Activates the observer through the repository-owned daemon/service generator.

No historical reconstruction, training, promotion, EV, staking, or betting.