### PR TITLE
Send established TheDogs headers from result observer

### DIFF
--- a/scripts/observe_forward_official_results.py
+++ b/scripts/observe_forward_official_results.py
@@ -30,7 +30,10 @@ from race_collection.forward_sealed_corpus import (  # noqa: E402
     ForwardSealedCorpus,
     canonical_json,
 )
-from scripts.ingest_results_for_date import thedogs_result_urls_from_race_url  # noqa: E402
+from scripts.ingest_results_for_date import (  # noqa: E402
+    THEDOGS_PUBLIC_HEADERS,
+    thedogs_result_urls_from_race_url,
+)
 
 COLLECTOR_ID = "forward-official-result-observer-v1"
 TERMINAL_STATES = {"EXAMPLE_CLOSED", "RESULT_CHANGED_BEFORE_CLOSURE"}
@@ -274,6 +277,7 @@ def observe_once(
                     def transport(url: str) -> dict[str, Any]:
                         response = session.get(
                             url,
+                            headers=dict(THEDOGS_PUBLIC_HEADERS),
                             timeout=timeout_seconds,
                             allow_redirects=False,
                             stream=True,

--- a/tests/race_collection/test_forward_official_result_observer.py
+++ b/tests/race_collection/test_forward_official_result_observer.py
@@ -64,10 +64,11 @@ class Session:
         self.calls = []
         self.closed = False
 
-    def get(self, url, timeout, *, allow_redirects, stream):
+    def get(self, url, headers, timeout, *, allow_redirects, stream):
         self.calls.append(
             {
                 "url": url,
+                "headers": headers,
                 "timeout": timeout,
                 "allow_redirects": allow_redirects,
                 "stream": stream,
@@ -252,6 +253,8 @@ def test_redirect_is_not_followed_and_response_is_closed(tmp_path):
     report, session = _run(tmp_path, "redirect", [_dt("10:06")] * 2, [response])
     assert report["status"] == "COMPLETED_WITH_ERRORS"
     assert len(session.calls) == 1
+    assert session.calls[0]["headers"] == observer.THEDOGS_PUBLIC_HEADERS
+    assert session.calls[0]["headers"] is not observer.THEDOGS_PUBLIC_HEADERS
     assert session.calls[0]["allow_redirects"] is False
     assert session.calls[0]["stream"] is True
     assert response.closed

--- a/tests/race_collection/test_phase7_operational.py
+++ b/tests/race_collection/test_phase7_operational.py
@@ -4750,7 +4750,7 @@ class Phase7OperationalTests(unittest.TestCase):
         fixture = Phase7OperationalTests(methodName="runTest")
         fixture.store = store
         fixture.artifacts = artifacts
-        fixture.authority = OperationalAuthority(store, artifacts)
+        fixture.authority = OperationalAuthority(store, artifacts, clock=lambda: NOW)
         boundary = fixture.establish_cutover(50000, 400, date(2026, 8, 1))
         predecessor = boundary
         probation_days = []


### PR DESCRIPTION
## Summary
- reuse the repository's established TheDogs public request headers for prospective official-result observations
- pass an independent header dictionary without changing URL, redirect, streaming, timeout, raw-byte, receipt, or state-machine semantics
- add a focused regression assertion for exact header equality and independent identity

## Runtime evidence
The first natural prospective observer cycle failed closed on an exact retained 118-byte HTTP 403 response (SHA-256 `58bf2215b395dcac74c009aa98701854e43cbe54a1cd3a95fee6a647ca9910d4`). The existing TheDogs ingestion path already declares the required public headers; this change applies that established contract to the observer.

## Validation
- focused observer tests: 12 passed
- Ruff: passed
- py_compile: passed
- git diff --check: passed
- independent exact-diff review: ACCEPT, no findings

The repository classifier selects `full_forecasting`; protected PR checks remain the broader release gate. This PR does not itself prove a successful live endpoint response or natural-cycle closure.