### PR TITLE
Request identity encoding for official result receipts

### DIFF
--- a/scripts/observe_forward_official_results.py
+++ b/scripts/observe_forward_official_results.py
@@ -44,6 +44,10 @@ KNOWN_STATES = {
     *TERMINAL_STATES,
 }
 MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+OFFICIAL_RESULT_REQUEST_HEADERS = {
+    **THEDOGS_PUBLIC_HEADERS,
+    "Accept-Encoding": "identity",
+}
 
 
 def _aware_now(clock: Callable[[], datetime]) -> datetime:
@@ -277,7 +281,7 @@ def observe_once(
                     def transport(url: str) -> dict[str, Any]:
                         response = session.get(
                             url,
-                            headers=dict(THEDOGS_PUBLIC_HEADERS),
+                            headers=dict(OFFICIAL_RESULT_REQUEST_HEADERS),
                             timeout=timeout_seconds,
                             allow_redirects=False,
                             stream=True,

--- a/tests/race_collection/test_forward_official_result_observer.py
+++ b/tests/race_collection/test_forward_official_result_observer.py
@@ -253,8 +253,11 @@ def test_redirect_is_not_followed_and_response_is_closed(tmp_path):
     report, session = _run(tmp_path, "redirect", [_dt("10:06")] * 2, [response])
     assert report["status"] == "COMPLETED_WITH_ERRORS"
     assert len(session.calls) == 1
-    assert session.calls[0]["headers"] == observer.THEDOGS_PUBLIC_HEADERS
-    assert session.calls[0]["headers"] is not observer.THEDOGS_PUBLIC_HEADERS
+    assert session.calls[0]["headers"] == {
+        **observer.THEDOGS_PUBLIC_HEADERS,
+        "Accept-Encoding": "identity",
+    }
+    assert session.calls[0]["headers"] is not observer.OFFICIAL_RESULT_REQUEST_HEADERS
     assert session.calls[0]["allow_redirects"] is False
     assert session.calls[0]["stream"] is True
     assert response.closed


### PR DESCRIPTION
## Summary
- preserve established TheDogs public headers
- request identity content encoding so retained official response bytes remain exact and directly parseable
- keep fail-closed rejection if the server returns any non-identity encoding

## Natural evidence
The merged header correction reached TheDogs, but the first natural cycle returned `Content-Encoding: gzip`. The observer rejected it before parsing and left the race `RESULT_PENDING`; no receipt or raw body was admitted.

## Validation
- 12 focused observer tests passed
- Ruff passed
- py_compile passed
- git diff --check passed
- independent exact-diff review: ACCEPT, no findings
- reviewed diff: `0cb935bd80fe7b469eb4925a4b9030cbfad4e2e1397a2702bbe0ad937eea3ae2`

No historical reconstruction, training, promotion, EV, staking, betting, lock manipulation, or odds-service change.