### PR TITLE
Use canonical non-trial official result URL

### DIFF
--- a/race_collection/forward_sealed_corpus.py
+++ b/race_collection/forward_sealed_corpus.py
@@ -113,7 +113,12 @@ def _timestamp(value: Any, name: str) -> tuple[datetime, str]:
     return parsed, parsed.isoformat(timespec="microseconds")
 
 
-def _source_url(value: Any, name: str) -> str:
+def _source_url(
+    value: Any,
+    name: str,
+    *,
+    allow_official_result_query: bool = False,
+) -> str:
     url = _known_text(value, name)
     parsed = urlsplit(url)
     if (
@@ -122,7 +127,14 @@ def _source_url(value: Any, name: str) -> str:
         or parsed.hostname not in {"www.thedogs.com.au", "thedogs.com.au"}
         or parsed.username is not None
         or parsed.password is not None
-        or parsed.query
+        or (
+            parsed.query
+            and not (
+                allow_official_result_query
+                and parsed.query == "trial=false"
+                and parsed.path.endswith("/results")
+            )
+        )
         or parsed.fragment
     ):
         raise ForwardCorpusRejected(f"{name} is not a canonical source URL")
@@ -1095,8 +1107,16 @@ class ForwardSealedCorpus:
             _bounded_id(stage.get(field), field)
         if stage.get("source_name") != OFFICIAL_RESULT_SOURCE:
             raise ForwardCorpusRejected("official result source name is not canonical")
-        _source_url(stage.get("request_url"), "official request URL")
-        _source_url(stage.get("final_url"), "official final URL")
+        _source_url(
+            stage.get("request_url"),
+            "official request URL",
+            allow_official_result_query=True,
+        )
+        _source_url(
+            stage.get("final_url"),
+            "official final URL",
+            allow_official_result_query=True,
+        )
         if type(stage.get("http_status")) is not int or not 200 <= stage["http_status"] < 300:
             raise ForwardCorpusRejected("official response HTTP status is unsupported")
         content_type = _known_text(stage.get("content_type"), "official content type")
@@ -1152,8 +1172,16 @@ class ForwardSealedCorpus:
             _bounded_id(observation.get(field), field)
         if observation.get("source_name") != OFFICIAL_RESULT_SOURCE:
             raise ForwardCorpusRejected("official result source name is not canonical")
-        _source_url(observation.get("request_url"), "official request URL")
-        _source_url(observation.get("final_url"), "official final URL")
+        _source_url(
+            observation.get("request_url"),
+            "official request URL",
+            allow_official_result_query=True,
+        )
+        _source_url(
+            observation.get("final_url"),
+            "official final URL",
+            allow_official_result_query=True,
+        )
         if type(observation.get("http_status")) is not int or not (
             200 <= observation["http_status"] < 300
         ):
@@ -1227,7 +1255,11 @@ class ForwardSealedCorpus:
             (source_name, "source_name"),
         ):
             _bounded_id(value, name)
-        request_url = _source_url(request_url, "official request URL")
+        request_url = _source_url(
+            request_url,
+            "official request URL",
+            allow_official_result_query=True,
+        )
         request_directory = self._request_directory(self.root, race_id, request_id)
         observation_path = request_directory / "observation.json"
         response_stage_path = request_directory / "response-stage.json"
@@ -1288,7 +1320,11 @@ class ForwardSealedCorpus:
                 "request_id": request_id,
                 "source_name": source_name,
                 "request_url": request_url,
-                "final_url": _source_url(response["final_url"], "official final URL"),
+                "final_url": _source_url(
+                    response["final_url"],
+                    "official final URL",
+                    allow_official_result_query=True,
+                ),
                 "http_status": response["status_code"],
                 "content_type": _known_text(response["content_type"], "official content type"),
                 "source_document_last_modified": response.get("source_document_last_modified"),

--- a/race_collection/source_admission.py
+++ b/race_collection/source_admission.py
@@ -153,7 +153,12 @@ def _identity_key(value: Any, name: str) -> str:
     return normalized
 
 
-def _canonical_source_url(value: Any, name: str) -> str:
+def _canonical_source_url(
+    value: Any,
+    name: str,
+    *,
+    allow_official_result_query: bool = False,
+) -> str:
     url = _known_text(value, name)
     parsed = urlsplit(url)
     if (
@@ -162,7 +167,14 @@ def _canonical_source_url(value: Any, name: str) -> str:
         or parsed.hostname not in {"www.thedogs.com.au", "thedogs.com.au"}
         or parsed.username is not None
         or parsed.password is not None
-        or parsed.query
+        or (
+            parsed.query
+            and not (
+                allow_official_result_query
+                and parsed.query == "trial=false"
+                and parsed.path.endswith("/results")
+            )
+        )
         or parsed.fragment
     ):
         raise SourceAdmissionRejected(f"{name} is not a canonical source URL")
@@ -928,8 +940,16 @@ def _admit_official_first(
                         stage["source_document_last_modified"],
                         "source document Last-Modified",
                     )
-                _canonical_source_url(stage.get("request_url"), "official request URL")
-                _canonical_source_url(stage.get("final_url"), "official final URL")
+                _canonical_source_url(
+                    stage.get("request_url"),
+                    "official request URL",
+                    allow_official_result_query=True,
+                )
+                _canonical_source_url(
+                    stage.get("final_url"),
+                    "official final URL",
+                    allow_official_result_query=True,
+                )
                 started = _aware_timestamp(stage.get("request_started_at"), "request started")
                 received = _aware_timestamp(
                     stage.get("response_received_at"), "response received"
@@ -1075,8 +1095,16 @@ def _admit_official_first(
                     raise SourceAdmissionRejected(
                         "official-first response reconstruction disagrees"
                     )
-                _canonical_source_url(observation.get("request_url"), "official request URL")
-                _canonical_source_url(observation.get("final_url"), "official final URL")
+                _canonical_source_url(
+                    observation.get("request_url"),
+                    "official request URL",
+                    allow_official_result_query=True,
+                )
+                _canonical_source_url(
+                    observation.get("final_url"),
+                    "official final URL",
+                    allow_official_result_query=True,
+                )
                 started = _aware_timestamp(
                     observation.get("request_started_at"), "request started"
                 )

--- a/scripts/observe_forward_official_results.py
+++ b/scripts/observe_forward_official_results.py
@@ -63,7 +63,7 @@ def _identity(prefix: str, *parts: str) -> str:
 
 
 def canonical_result_url(race_url: str) -> str:
-    """Derive the sole safe, query-free result URL accepted by T1."""
+    """Derive the sole safe non-trial official-result URL accepted by T1."""
     parsed = urlsplit(race_url)
     if (
         parsed.scheme != "https"
@@ -77,7 +77,7 @@ def canonical_result_url(race_url: str) -> str:
         or parsed.path.rstrip("/").endswith("/results")
     ):
         raise ForwardCorpusRejected("sealed race-card URL has unsafe or ambiguous identity")
-    expected = race_url.rstrip("/") + "/results"
+    expected = race_url.rstrip("/") + "/results?trial=false"
     matches = [
         candidate
         for candidate in thedogs_result_urls_from_race_url(race_url)

--- a/tests/race_collection/test_forward_official_result_observer.py
+++ b/tests/race_collection/test_forward_official_result_observer.py
@@ -107,7 +107,7 @@ def _run(root, cycle, times, responses):
 
 def test_first_then_second_identical_closes_and_packages(tmp_path):
     _seed(tmp_path)
-    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
     first, session = _run(
         tmp_path,
         "cycle-1",
@@ -154,7 +154,7 @@ def test_first_then_second_identical_closes_and_packages(tmp_path):
 
 def test_changed_second_is_terminal_and_retains_receipts(tmp_path):
     _seed(tmp_path)
-    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
     _run(tmp_path, "one", [_dt("10:06")] * 4, [Response(T1._html(), url)])
     changed = T1._html().replace(b"1st", b"2nd").replace(b"2nd", b"1st", 1)
     report, _ = _run(tmp_path, "two", [_dt("10:21")] * 4, [Response(changed, url)])
@@ -169,7 +169,7 @@ def test_pre_boundary_skip_malformed_retention_and_terminal_skip(tmp_path):
     assert skipped["races"][0]["decision"] == "SKIPPED_PRE_BOUNDARY"
     assert session.calls == []
 
-    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
     malformed, _ = _run(
         tmp_path,
         "malformed",
@@ -195,9 +195,16 @@ def test_url_derivation_rejects_unsafe_or_ambiguous_identity(url):
         observer.canonical_result_url(url)
 
 
+def test_url_derivation_uses_established_non_trial_result_route():
+    race_url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name"
+    assert observer.canonical_result_url(race_url) == race_url + "/results?trial=false"
+
+
 def test_final_url_rejection_empty_response_and_lock_contention(tmp_path):
     _seed(tmp_path)
-    expected = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    expected = (
+        "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
+    )
     redirected, _ = _run(
         tmp_path,
         "redirected",
@@ -231,7 +238,7 @@ def test_ids_and_report_are_deterministic_and_legacy_material_is_excluded(tmp_pa
     _seed(tmp_path)
     (tmp_path / "races" / "legacy").mkdir()
     (tmp_path / "races" / "legacy" / "legacy.json").write_text("{}")
-    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
     report, _ = _run(
         tmp_path,
         "deterministic",
@@ -248,7 +255,7 @@ def test_ids_and_report_are_deterministic_and_legacy_material_is_excluded(tmp_pa
 
 def test_redirect_is_not_followed_and_response_is_closed(tmp_path):
     _seed(tmp_path)
-    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
     response = Response(b"redirect", url, status=302, headers={"Location": url + "/other"})
     report, session = _run(tmp_path, "redirect", [_dt("10:06")] * 2, [response])
     assert report["status"] == "COMPLETED_WITH_ERRORS"
@@ -265,7 +272,7 @@ def test_redirect_is_not_followed_and_response_is_closed(tmp_path):
 
 def test_wire_exact_body_encoding_and_bound_are_enforced(tmp_path, monkeypatch):
     _seed(tmp_path)
-    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results"
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
     encoded = Response(T1._html(), url, headers={"Content-Encoding": "gzip"})
     report, _ = _run(tmp_path, "encoded", [_dt("10:06")] * 2, [encoded])
     assert report["status"] == "COMPLETED_WITH_ERRORS"

--- a/tests/race_collection/test_forward_sealed_corpus.py
+++ b/tests/race_collection/test_forward_sealed_corpus.py
@@ -6,6 +6,8 @@ from datetime import datetime
 
 import pytest
 
+from race_collection import forward_sealed_corpus as corpus_module
+from race_collection import source_admission as admission_module
 from race_collection.forward_sealed_corpus import (
     ForwardCorpusRejected,
     ForwardSealedCorpus,
@@ -15,6 +17,55 @@ from race_collection.source_admission import (
     SourceAdmissionRejected,
     admit_historical_source,
 )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.thedogs.com.au/racing/test/results?trial=true",
+        "https://www.thedogs.com.au/racing/test/results?trial=false&other=1",
+        "https://www.thedogs.com.au/racing/test/results?trial%3Dfalse",
+        "https://www.thedogs.com.au/racing/test/results?trial=false%26other=1",
+        "https://www.thedogs.com.au/racing/test?trial=false",
+    ],
+)
+def test_official_result_query_exception_rejects_every_other_query(url):
+    with pytest.raises(ForwardCorpusRejected):
+        corpus_module._source_url(
+            url,
+            "official request URL",
+            allow_official_result_query=True,
+        )
+    with pytest.raises(SourceAdmissionRejected):
+        admission_module._canonical_source_url(
+            url,
+            "official request URL",
+            allow_official_result_query=True,
+        )
+
+
+def test_official_result_query_exception_is_not_a_generic_source_exception():
+    url = "https://www.thedogs.com.au/racing/test/results?trial=false"
+    assert (
+        corpus_module._source_url(
+            url,
+            "official request URL",
+            allow_official_result_query=True,
+        )
+        == url
+    )
+    assert (
+        admission_module._canonical_source_url(
+            url,
+            "official request URL",
+            allow_official_result_query=True,
+        )
+        == url
+    )
+    with pytest.raises(ForwardCorpusRejected):
+        corpus_module._source_url(url, "canonical source URL")
+    with pytest.raises(SourceAdmissionRejected):
+        admission_module._canonical_source_url(url, "forward source URL")
 
 
 class Clock:


### PR DESCRIPTION
## Summary
- derive the same exact TheDogs result URL the repository resolver ranks first: `/results?trial=false`
- allow only literal `trial=false` on paths ending in `/results`, and only for official-result request/final URL validation
- keep every other query form and all generic source queries rejected

## Natural evidence
The query-free identity-encoded cycle retained a 17,378-byte TheDogs not-found page at SHA-256 `41fc76ab33e184a6e904984d5f237f7a14dfcabb5f44aedffffe8b880cb31649`, admitted no observation, and remained `RESULT_PENDING`.

## Validation
- 89 focused observer/core/admission tests passed
- Ruff passed
- py_compile passed
- git diff --check passed
- fresh independent exact-diff review: ACCEPT, no findings
- reviewed diff: `c3d4d61cc72bdb7e711ccb2997e605de7e89c71e7eccd8750fe93bed7bebd978`

No historical reconstruction, training, promotion, EV, staking, betting, lock manipulation, or odds-service change.