### PR TITLE
Use established TheDogs public race result route

### DIFF
--- a/race_collection/forward_sealed_corpus.py
+++ b/race_collection/forward_sealed_corpus.py
@@ -113,6 +113,20 @@ def _timestamp(value: Any, name: str) -> tuple[datetime, str]:
     return parsed, parsed.isoformat(timespec="microseconds")
 
 
+def _official_result_query_path(path: str) -> bool:
+    if path.endswith("/results"):
+        return True
+    parts = path.split("/")
+    if len(parts) != 6 or parts[1] != "racing" or not all(parts[2:]):
+        return False
+    try:
+        date.fromisoformat(parts[3])
+        race_number = int(parts[4])
+    except ValueError:
+        return False
+    return race_number > 0
+
+
 def _source_url(
     value: Any,
     name: str,
@@ -132,7 +146,7 @@ def _source_url(
             and not (
                 allow_official_result_query
                 and parsed.query == "trial=false"
-                and parsed.path.endswith("/results")
+                and _official_result_query_path(parsed.path)
             )
         )
         or parsed.fragment

--- a/race_collection/source_admission.py
+++ b/race_collection/source_admission.py
@@ -153,6 +153,20 @@ def _identity_key(value: Any, name: str) -> str:
     return normalized
 
 
+def _official_result_query_path(path: str) -> bool:
+    if path.endswith("/results"):
+        return True
+    parts = path.split("/")
+    if len(parts) != 6 or parts[1] != "racing" or not all(parts[2:]):
+        return False
+    try:
+        date.fromisoformat(parts[3])
+        race_number = int(parts[4])
+    except ValueError:
+        return False
+    return race_number > 0
+
+
 def _canonical_source_url(
     value: Any,
     name: str,
@@ -172,7 +186,7 @@ def _canonical_source_url(
             and not (
                 allow_official_result_query
                 and parsed.query == "trial=false"
-                and parsed.path.endswith("/results")
+                and _official_result_query_path(parsed.path)
             )
         )
         or parsed.fragment

--- a/scripts/observe_forward_official_results.py
+++ b/scripts/observe_forward_official_results.py
@@ -63,7 +63,7 @@ def _identity(prefix: str, *parts: str) -> str:
 
 
 def canonical_result_url(race_url: str) -> str:
-    """Derive the sole safe non-trial official-result URL accepted by T1."""
+    """Derive the sealed non-trial race URL used by the installed resolver."""
     parsed = urlsplit(race_url)
     if (
         parsed.scheme != "https"
@@ -77,7 +77,7 @@ def canonical_result_url(race_url: str) -> str:
         or parsed.path.rstrip("/").endswith("/results")
     ):
         raise ForwardCorpusRejected("sealed race-card URL has unsafe or ambiguous identity")
-    expected = race_url.rstrip("/") + "/results?trial=false"
+    expected = race_url.rstrip("/") + "?trial=false"
     matches = [
         candidate
         for candidate in thedogs_result_urls_from_race_url(race_url)

--- a/tests/race_collection/test_forward_official_result_observer.py
+++ b/tests/race_collection/test_forward_official_result_observer.py
@@ -89,8 +89,9 @@ def _seed(root, *, race_id="race-1", url=None):
     value["sealed_evidence_bytes"] = value["sealed_evidence_bytes"].replace(
         b'"race_id":"race-1"', f'"race_id":"{race_id}"'.encode()
     )
-    if url is not None:
-        value["canonical_source_url"] = url
+    value["canonical_source_url"] = url or (
+        "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name"
+    )
     ForwardSealedCorpus(root, clock=lambda: _dt("09:45")).capture_prejump(**value)
 
 
@@ -107,7 +108,9 @@ def _run(root, cycle, times, responses):
 
 def test_first_then_second_identical_closes_and_packages(tmp_path):
     _seed(tmp_path)
-    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
+    url = (
+        "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    )
     first, session = _run(
         tmp_path,
         "cycle-1",
@@ -154,7 +157,9 @@ def test_first_then_second_identical_closes_and_packages(tmp_path):
 
 def test_changed_second_is_terminal_and_retains_receipts(tmp_path):
     _seed(tmp_path)
-    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
+    url = (
+        "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    )
     _run(tmp_path, "one", [_dt("10:06")] * 4, [Response(T1._html(), url)])
     changed = T1._html().replace(b"1st", b"2nd").replace(b"2nd", b"1st", 1)
     report, _ = _run(tmp_path, "two", [_dt("10:21")] * 4, [Response(changed, url)])
@@ -169,7 +174,9 @@ def test_pre_boundary_skip_malformed_retention_and_terminal_skip(tmp_path):
     assert skipped["races"][0]["decision"] == "SKIPPED_PRE_BOUNDARY"
     assert session.calls == []
 
-    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
+    url = (
+        "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    )
     malformed, _ = _run(
         tmp_path,
         "malformed",
@@ -197,13 +204,13 @@ def test_url_derivation_rejects_unsafe_or_ambiguous_identity(url):
 
 def test_url_derivation_uses_established_non_trial_result_route():
     race_url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name"
-    assert observer.canonical_result_url(race_url) == race_url + "/results?trial=false"
+    assert observer.canonical_result_url(race_url) == race_url + "?trial=false"
 
 
 def test_final_url_rejection_empty_response_and_lock_contention(tmp_path):
     _seed(tmp_path)
     expected = (
-        "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
+        "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
     )
     redirected, _ = _run(
         tmp_path,
@@ -238,7 +245,9 @@ def test_ids_and_report_are_deterministic_and_legacy_material_is_excluded(tmp_pa
     _seed(tmp_path)
     (tmp_path / "races" / "legacy").mkdir()
     (tmp_path / "races" / "legacy" / "legacy.json").write_text("{}")
-    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
+    url = (
+        "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    )
     report, _ = _run(
         tmp_path,
         "deterministic",
@@ -255,7 +264,9 @@ def test_ids_and_report_are_deterministic_and_legacy_material_is_excluded(tmp_pa
 
 def test_redirect_is_not_followed_and_response_is_closed(tmp_path):
     _seed(tmp_path)
-    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
+    url = (
+        "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    )
     response = Response(b"redirect", url, status=302, headers={"Location": url + "/other"})
     report, session = _run(tmp_path, "redirect", [_dt("10:06")] * 2, [response])
     assert report["status"] == "COMPLETED_WITH_ERRORS"
@@ -272,7 +283,9 @@ def test_redirect_is_not_followed_and_response_is_closed(tmp_path):
 
 def test_wire_exact_body_encoding_and_bound_are_enforced(tmp_path, monkeypatch):
     _seed(tmp_path)
-    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/results?trial=false"
+    url = (
+        "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    )
     encoded = Response(T1._html(), url, headers={"Content-Encoding": "gzip"})
     report, _ = _run(tmp_path, "encoded", [_dt("10:06")] * 2, [encoded])
     assert report["status"] == "COMPLETED_WITH_ERRORS"

--- a/tests/race_collection/test_forward_sealed_corpus.py
+++ b/tests/race_collection/test_forward_sealed_corpus.py
@@ -27,6 +27,9 @@ from race_collection.source_admission import (
         "https://www.thedogs.com.au/racing/test/results?trial%3Dfalse",
         "https://www.thedogs.com.au/racing/test/results?trial=false%26other=1",
         "https://www.thedogs.com.au/racing/test?trial=false",
+        "https://www.thedogs.com.au/racing/venue/not-a-date/1/race?trial=false",
+        "https://www.thedogs.com.au/racing/venue/2026-07-29/not-a-race/race?trial=false",
+        "https://www.thedogs.com.au/racing/venue/2026-07-29/0/race?trial=false",
     ],
 )
 def test_official_result_query_exception_rejects_every_other_query(url):
@@ -46,6 +49,30 @@ def test_official_result_query_exception_rejects_every_other_query(url):
 
 def test_official_result_query_exception_is_not_a_generic_source_exception():
     url = "https://www.thedogs.com.au/racing/test/results?trial=false"
+    assert (
+        corpus_module._source_url(
+            url,
+            "official request URL",
+            allow_official_result_query=True,
+        )
+        == url
+    )
+    assert (
+        admission_module._canonical_source_url(
+            url,
+            "official request URL",
+            allow_official_result_query=True,
+        )
+        == url
+    )
+    with pytest.raises(ForwardCorpusRejected):
+        corpus_module._source_url(url, "canonical source URL")
+    with pytest.raises(SourceAdmissionRejected):
+        admission_module._canonical_source_url(url, "forward source URL")
+
+
+def test_official_result_query_exception_accepts_exact_sealed_race_route_only():
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
     assert (
         corpus_module._source_url(
             url,


### PR DESCRIPTION
## Summary
- derive the prospective observer URL from the installed resolver public race-page candidate (`?trial=false`)
- admit that literal query only for a structurally valid TheDogs race route under the existing official-result opt-in
- preserve exact final-URL equality, one request per natural cycle, raw-byte receipts, and generic query rejection

## Runtime evidence
- merged `/results?trial=false` lane returned a retained 17,378-byte 404 page, SHA-256 `63b334ea6595827bcfabdcc7081818965f149bc275597dce8767465f2bcb75f3`
- the installed result resolver already includes the sealed race URL plus `?trial=false`, and repository tests establish it as a public official-result route

## Validation
- 93 focused observer/corpus/source-admission tests passed
- focused Ruff passed
- `py_compile` and `git diff --check` passed
- independent exact-diff review: ACCEPT, no findings
- exact reviewed binary diff SHA-256: `4567adb2c81b842088ce801b4c9b9d5c787601cce0851a6b7477ff5a3ebdfda2`

No historical reconstruction, training, promotion, EV, staking, betting, canonical DB writes, or odds-service changes.