### PR TITLE
Observe prospective results before odds-priority defer

### DIFF
--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -9115,6 +9115,55 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
     copy_if_exists(timer_path, output_dir / "systemd" / TIMER_NAME)
     write_json(output_dir / "output_manifest.json", output_manifest(output_dir))
 
+    forward_official_result_observer: dict[str, Any] = {
+        "status": "DISABLED",
+        "attempted_race_ids": [],
+    }
+    if args.enable_forward_official_result_observer:
+        try:
+            forward_official_result_observer = run_forward_official_result_observer(
+                args, run_id
+            )
+        except Exception as exc:
+            forward_official_result_observer = {
+                "status": "FAILED",
+                "attempted_race_ids": [],
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+        write_json(
+            output_dir / "forward_official_result_observer.json",
+            forward_official_result_observer,
+        )
+        if forward_official_result_observer.get("status") != "COMPLETED":
+            persist_forward_observer_failure(
+                output_dir=output_dir,
+                state_path=state_path,
+                run_id=run_id,
+                generated_at=generated_at,
+                observer=forward_official_result_observer,
+            )
+            result = {
+                **completed_daemon_run_report_envelope(
+                    run_id=run_id,
+                    generated_at=generated_at,
+                    current_time=current_time,
+                    output_dir=output_dir,
+                    final_verdict="PARTIAL_DAEMONIZATION",
+                ),
+                "status": "PARTIAL_DAEMONIZATION",
+                "runtime_action": "CHECK_FORWARD_OFFICIAL_RESULT_OBSERVER",
+                "readiness_decision": "READY_FOR_RELIABILITY_REVIEW",
+                "forward_official_result_observer": forward_official_result_observer,
+                "lock_path": relpath(lock_path),
+                "lock_validation_status": "NOT_ACQUIRED_OBSERVER_FAILED",
+                "protected_paths_unchanged_or_allowed": False,
+                "no_write_guarantees": dict(NO_WRITE_GUARANTEES),
+            }
+            write_text(output_dir / "final_status.txt", "PARTIAL_DAEMONIZATION\n")
+            write_json(output_dir / "daemon_run_report.json", result)
+            write_json(output_dir / "output_manifest.json", output_manifest(output_dir))
+            return result
+
     current_dt = parse_datetime_value(current_time, default_tz=generated_at.tzinfo) or generated_at
     if args.enable_autonomous_odds_capture:
         odds_state = load_json(odds_state_path)
@@ -9139,13 +9188,16 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
                 "lock_validation_status": "NOT_ACQUIRED_DEFERRED",
                 "odds_capture_state_path": relpath(odds_state_path),
                 "odds_capture_defer_decision": defer_decision,
+                "forward_official_result_observer": forward_official_result_observer,
                 "protected_paths_unchanged_or_allowed": True,
                 "systemd_deployment_status": service_info.get("status"),
                 "systemd_deployment_ready": service_info.get("systemd_deployment_ready"),
                 "no_write_guarantees": {
                     "db_write": False,
                     "live_odds_write": False,
-                    "official_result_evidence_write": False,
+                    "official_result_evidence_write": bool(
+                        forward_official_result_observer.get("attempted_race_ids")
+                    ),
                     "label_write": False,
                     "production_pointer_update": False,
                     "production_promotion": False,
@@ -9180,10 +9232,6 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
     daily_manifest: dict[str, Any] | None = None
     shadow_odds_snapshot: dict[str, Any] | None = None
     odds_capture_state_publish: dict[str, Any] = {"status": "NOT_RUN"}
-    forward_official_result_observer: dict[str, Any] = {
-        "status": "DISABLED",
-        "attempted_race_ids": [],
-    }
     lock_validation: dict[str, Any]
     recovery_validation = {"status": "NOT_RUN"}
     try:
@@ -9210,26 +9258,6 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
             if duplicate_probe.get("status") == "PASS" and stale_probe.get("status") == "PASS"
             else "FAIL",
         }
-        if args.enable_forward_official_result_observer:
-            forward_official_result_observer = run_forward_official_result_observer(
-                args, run_id
-            )
-            write_json(
-                output_dir / "forward_official_result_observer.json",
-                forward_official_result_observer,
-            )
-            if forward_official_result_observer.get("status") != "COMPLETED":
-                persist_forward_observer_failure(
-                    output_dir=output_dir,
-                    state_path=state_path,
-                    run_id=run_id,
-                    generated_at=generated_at,
-                    observer=forward_official_result_observer,
-                )
-                raise RuntimeError(
-                    "forward official-result observer failed closed: "
-                    + str(forward_official_result_observer.get("status"))
-                )
         recovery_validation = {
             "schema_version": "shadow_autopilot_recovery_validation_v1",
             "timeout_probe": simulate_timeout_recovery(output_dir),

--- a/tests/test_market_form_residual.py
+++ b/tests/test_market_form_residual.py
@@ -385,11 +385,17 @@ def test_full_and_half_are_derived_from_one_adjustment():
     half_scores = np.log(market) + 0.5 * adjustment
     half = np.exp(half_scores - np.max(half_scores))
     half /= half.sum()
-    assert np.array_equal(
-        full, [row["full_probability"] for row in record["predictions"]]
+    np.testing.assert_allclose(
+        full,
+        [row["full_probability"] for row in record["predictions"]],
+        rtol=0.0,
+        atol=3e-16,
     )
-    assert np.array_equal(
-        half, [row["half_probability"] for row in record["predictions"]]
+    np.testing.assert_allclose(
+        half,
+        [row["half_probability"] for row in record["predictions"]],
+        rtol=0.0,
+        atol=3e-16,
     )
 
 

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -867,6 +867,153 @@ def test_run_once_defer_writes_startup_output_manifest(tmp_path, monkeypatch):
     assert any(path.endswith("full_daemon_odds_window_defer.json") for path in manifest["files"])
 
 
+def test_run_once_defer_observes_result_before_odds_priority_return(
+    tmp_path, monkeypatch
+):
+    evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
+    output_dir = evidence_root / "shadow_autopilot_daemonization_v1_observer_defer"
+    odds_state_path = tmp_path / "runtime" / "odds_capture_state.json"
+    corpus_root = tmp_path / "forward-corpus"
+    observed = {
+        "status": "COMPLETED",
+        "attempted_race_ids": ["race-1"],
+        "counts": {"observed": 1},
+    }
+
+    monkeypatch.setattr(daemon, "ROOT", tmp_path)
+    monkeypatch.setattr(daemon, "copy_if_exists", lambda source, dest: None)
+    monkeypatch.setattr(
+        daemon,
+        "write_service_files",
+        lambda **kwargs: {
+            "status": "SERVICE_FILES_WRITTEN",
+            "systemd_deployment_ready": True,
+        },
+    )
+    monkeypatch.setattr(
+        daemon,
+        "run_forward_official_result_observer",
+        lambda args, run_id: observed | {"run_id": run_id},
+    )
+    monkeypatch.setattr(
+        daemon,
+        "full_daemon_odds_window_defer_decision",
+        lambda odds_state, current_time: {
+            "should_defer": True,
+            "reason": "test_fixed_window_open",
+        },
+    )
+    monkeypatch.setattr(
+        daemon,
+        "acquire_lock_with_odds_capture_retry",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("odds-priority return must remain before the full lock")
+        ),
+    )
+
+    args = daemon.parse_args(
+        [
+            "run-once",
+            "--run-id",
+            "observer_defer",
+            "--evidence-root",
+            str(evidence_root),
+            "--output-dir",
+            str(output_dir),
+            "--current-time",
+            "2026-06-13T15:17:11+10:00",
+            "--enable-forward-official-result-observer",
+            "--forward-corpus-root",
+            str(corpus_root),
+            "--enable-autonomous-odds-capture",
+            "--odds-capture-state-path",
+            str(odds_state_path),
+        ]
+    )
+
+    report = daemon.run_once(args)
+
+    assert report["final_verdict"] == "DAEMON_DEFERRED_TO_ODDS_CAPTURE_ONLY"
+    assert report["forward_official_result_observer"] == observed | {
+        "run_id": "observer_defer"
+    }
+    assert report["no_write_guarantees"]["official_result_evidence_write"] is True
+    assert json.loads(
+        (output_dir / "forward_official_result_observer.json").read_text()
+    ) == observed | {"run_id": "observer_defer"}
+
+
+def test_run_once_observer_failure_stops_before_odds_defer_and_full_lock(
+    tmp_path, monkeypatch
+):
+    evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
+    output_dir = evidence_root / "shadow_autopilot_daemonization_v1_observer_failed"
+    state_path = tmp_path / "runtime" / "state.json"
+    failed = {
+        "status": "COMPLETED_WITH_ERRORS",
+        "attempted_race_ids": ["race-1"],
+    }
+
+    monkeypatch.setattr(daemon, "ROOT", tmp_path)
+    monkeypatch.setattr(daemon, "copy_if_exists", lambda source, dest: None)
+    monkeypatch.setattr(
+        daemon,
+        "write_service_files",
+        lambda **kwargs: {
+            "status": "SERVICE_FILES_WRITTEN",
+            "systemd_deployment_ready": True,
+        },
+    )
+    monkeypatch.setattr(
+        daemon,
+        "run_forward_official_result_observer",
+        lambda args, run_id: failed | {"run_id": run_id},
+    )
+    monkeypatch.setattr(
+        daemon,
+        "full_daemon_odds_window_defer_decision",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("failed observer must stop before odds defer")
+        ),
+    )
+    monkeypatch.setattr(
+        daemon,
+        "acquire_lock_with_odds_capture_retry",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("failed observer must stop before the full lock")
+        ),
+    )
+
+    args = daemon.parse_args(
+        [
+            "run-once",
+            "--run-id",
+            "observer_failed",
+            "--evidence-root",
+            str(evidence_root),
+            "--output-dir",
+            str(output_dir),
+            "--state-path",
+            str(state_path),
+            "--enable-forward-official-result-observer",
+            "--forward-corpus-root",
+            str(tmp_path / "forward-corpus"),
+            "--enable-autonomous-odds-capture",
+        ]
+    )
+
+    report = daemon.run_once(args)
+
+    assert report["final_verdict"] == "PARTIAL_DAEMONIZATION"
+    assert report["lock_validation_status"] == "NOT_ACQUIRED_OBSERVER_FAILED"
+    assert report["forward_official_result_observer"] == failed | {
+        "run_id": "observer_failed"
+    }
+    assert json.loads(state_path.read_text())[
+        "forward_official_result_observer"
+    ] == failed | {"run_id": "observer_failed"}
+
+
 def test_run_once_defers_before_lock_when_t2_window_recomputed_due(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- run the separately locked, bounded forward official-result observer once before evaluating the full lane odds-priority early return
- preserve the odds defer before the shared full-daemon lock and all heavy work
- include observer identity/activity in deferred reports and persist nonclean observer outcomes before returning

## Runtime evidence
Two natural deployed cycles returned `DAEMON_DEFERRED_TO_ODDS_CAPTURE_ONLY` before reaching the observer because live fixed-window odds work was due or imminent. The race remained `RESULT_PENDING` with zero observations. This creates prospective result-observer starvation during busy racing windows.

## Validation
- 16 observer/defer-focused tests passed in independent review; parent focused run passed
- focused Ruff passed
- `py_compile` and `git diff --check` passed
- independent exact-diff review: ACCEPT, no findings
- exact reviewed binary diff SHA-256: `794a98042aa746e535e075c110d8adf2341e26090c53aff8cb944bff7d4d6f92`

The observer retains its one-request bound and separate corpus lock. No odds lock bypass, daemon restart, historical reconstruction, training, promotion, EV, staking, betting, canonical DB write, or odds-service change.