### PR TITLE
Accept TheDogs NBT result badge identity

### DIFF
--- a/race_collection/forward_sealed_corpus.py
+++ b/race_collection/forward_sealed_corpus.py
@@ -260,7 +260,10 @@ def _normalize_official_result(
     positions = []
     for runner in sorted(frozen_runners, key=lambda item: item["box_number"]):
         parsed_row = by_box[runner["box_number"]]
-        if parsed_row.get("dog_name") != runner["name"]:
+        official_name = parsed_row.get("dog_name")
+        if type(official_name) is str and official_name.endswith(" NBT"):
+            official_name = official_name[:-4]
+        if official_name != runner["name"]:
             raise ForwardCorpusRejected("official result runner name identity mismatch")
         position = parsed_row.get("finish_position")
         status = parsed_row.get("status")

--- a/tests/race_collection/test_forward_sealed_corpus.py
+++ b/tests/race_collection/test_forward_sealed_corpus.py
@@ -302,6 +302,35 @@ def test_result_requires_prejump_and_strict_after_jump_order(tmp_path):
         _capture(corpus, "request-1", Transport(_html()))
 
 
+def test_result_strips_only_established_terminal_nbt_non_name_badge(tmp_path):
+    corpus = ForwardSealedCorpus(
+        tmp_path / "accepted",
+        clock=Clock(_dt("09:45"), _dt("10:06"), _dt("10:06"), _dt("10:06")),
+    )
+    corpus.capture_prejump(**fixture())
+    receipt = _capture(
+        corpus,
+        "request-1",
+        Transport(_html().replace(b"Dog 1 B", b"Dog 1 B NBT")),
+    )
+    normalized = json.loads(
+        corpus._read_artifact(receipt["normalized_result_checksum"], "normalized result")
+    )
+    assert normalized["runners"][1]["name"] == "Dog 1 B"
+
+    rejected = ForwardSealedCorpus(
+        tmp_path / "rejected",
+        clock=Clock(_dt("09:45"), _dt("10:06"), _dt("10:06"), _dt("10:06")),
+    )
+    rejected.capture_prejump(**fixture())
+    with pytest.raises(ForwardCorpusRejected, match="name identity mismatch"):
+        _capture(
+            rejected,
+            "request-1",
+            Transport(_html().replace(b"Dog 1 B", b"Dog 1 B NBTX")),
+        )
+
+
 def test_unknown_or_naive_result_timestamps_fail_closed(tmp_path):
     corpus = ForwardSealedCorpus(tmp_path, clock=lambda: datetime(2026, 7, 29, 10, 6))
     corpus._clock = lambda: _dt("09:45")


### PR DESCRIPTION
Prospective correction for official-result-first-observation-v1 after natural runtime evidence. TheDogs appends the established non-name NBT badge to some official result display names. Strip only exact terminal ' NBT', then continue requiring exact frozen name and box identity. Existing response stages remain immutable; no historical reconstruction or training.\n\nValidation: 84 focused corpus/observer tests; authentic retained response normalization; Ruff; py_compile; git diff --check.