### PR TITLE
Read official receipts from exact race path

### DIFF
--- a/race_collection/forward_sealed_corpus.py
+++ b/race_collection/forward_sealed_corpus.py
@@ -1012,11 +1012,15 @@ class ForwardSealedCorpus:
             if observation is not None
         ]
 
+    @staticmethod
+    def _official_request_root(root: Path, race_id: str) -> Path:
+        return root / "races" / hashlib.sha256(race_id.encode()).hexdigest() / "official-requests"
+
     def _official_response_history(
         self, pre: Mapping[str, Any]
     ) -> list[tuple[dict[str, Any], dict[str, Any] | None]]:
         race_id = pre["race_id"]
-        directory = self._race_directory(race_id) / "official-requests"
+        directory = self._official_request_root(self.root, race_id)
         if not directory.exists():
             return []
         if directory.is_symlink() or not directory.is_dir():
@@ -1087,10 +1091,7 @@ class ForwardSealedCorpus:
     @staticmethod
     def _request_directory(root: Path, race_id: str, request_id: str) -> Path:
         return (
-            root
-            / "races"
-            / hashlib.sha256(race_id.encode()).hexdigest()
-            / "official-requests"
+            ForwardSealedCorpus._official_request_root(root, race_id)
             / hashlib.sha256(request_id.encode()).hexdigest()
         )
 

--- a/tests/race_collection/test_forward_sealed_corpus.py
+++ b/tests/race_collection/test_forward_sealed_corpus.py
@@ -331,6 +331,40 @@ def test_result_strips_only_established_terminal_nbt_non_name_badge(tmp_path):
         )
 
 
+def test_result_history_uses_exact_race_id_request_root(tmp_path):
+    race_id = "Race 1 - SAN - 2026-07-29"
+    value = fixture()
+    evidence = json.loads(value["sealed_evidence_bytes"])
+    evidence["race_id"] = race_id
+    value["race_id"] = race_id
+    value["sealed_evidence_bytes"] = canonical_json(evidence)
+    corpus = ForwardSealedCorpus(
+        tmp_path,
+        clock=Clock(_dt("09:45"), _dt("10:06"), _dt("10:06"), _dt("10:06")),
+    )
+    corpus.capture_prejump(**value)
+    corpus.capture_result(
+        race_id=race_id,
+        collector_id="collector-1",
+        session_id="session-1",
+        run_id="run-1",
+        request_id="request-1",
+        request_url="https://www.thedogs.com.au/racing/test/results",
+        transport=Transport(_html()),
+    )
+
+    assert corpus._official_request_root(tmp_path, race_id) != (
+        corpus._race_directory(race_id) / "official-requests"
+    )
+    assert corpus.status()["races"] == [
+        {
+            "race_id": race_id,
+            "state": "RESULT_FIRST_OBSERVED",
+            "result_observation_count": 1,
+        }
+    ]
+
+
 def test_unknown_or_naive_result_timestamps_fail_closed(tmp_path):
     corpus = ForwardSealedCorpus(tmp_path, clock=lambda: datetime(2026, 7, 29, 10, 6))
     corpus._clock = lambda: _dt("09:45")


### PR DESCRIPTION
Prospective runtime correction for official-result-first-observation-v1. Official request receipts are stored under the exact race-ID hash, while pre-jump receipts use the normalized identity hash. Make history reconstruction read the existing exact request root so all retained stages/observations are included without moving or rewriting bytes.\n\nValidation: live retained history reconstructs RESULT_FIRST_OBSERVED; 85 focused corpus/observer tests; Ruff; py_compile; git diff --check.