### PR TITLE
Preserve official-result observer evidence compatibility

### DIFF
--- a/race_collection/forward_sealed_corpus.py
+++ b/race_collection/forward_sealed_corpus.py
@@ -35,6 +35,38 @@ STATUS_SCHEMA = "forward-sealed-corpus-status-v1"
 OFFICIAL_RESULT_SOURCE = "thedogs-official"
 PREJUMP_SOURCE = "thedogs-race-card"
 RESPONSE_STAGE_SCHEMA = "official-result-response-stage-v1"
+OBSERVATION_SCHEMA_V1 = "official-result-observation-v1"
+OBSERVATION_SCHEMA_V2 = "official-result-observation-v2"
+PARENT_NORMALIZATION_VERSION = "official-result-normalization-exact-v1"
+CURRENT_NORMALIZATION_VERSION = "official-result-normalization-terminal-nbt-v2"
+PARENT_IMPLEMENTATION_HASH = (
+    "sha256:9f05e9b29d90ec274d7d1c8c5c992dcbf41f38d61258f9f836ec935062829819"
+)
+
+_OBSERVATION_FIELDS_V1 = {
+    "schema_version",
+    "race_id",
+    "collector_id",
+    "session_id",
+    "run_id",
+    "request_id",
+    "source_name",
+    "request_url",
+    "final_url",
+    "http_status",
+    "content_type",
+    "source_document_last_modified",
+    "request_started_at",
+    "response_received_at",
+    "observed_at",
+    "raw_response_checksum",
+    "normalized_result_checksum",
+    "runner_set_hash",
+    "parser_hash",
+    "schema_hash",
+    "implementation_hash",
+}
+_OBSERVATION_FIELDS_V2 = _OBSERVATION_FIELDS_V1 | {"normalization_version"}
 
 _RESULT_DERIVED_KEYS = {
     "finish_order",
@@ -221,9 +253,15 @@ def _bounded_id(value: Any, name: str) -> str:
     return result
 
 
-def _normalization_identity() -> tuple[str, str, str]:
+def _normalization_identity(
+    normalization_version: str = CURRENT_NORMALIZATION_VERSION,
+) -> tuple[str, str, str]:
     parser_hash = str(_checksum(inspect.getsource(parse_thedogs_result_html_runner_rows).encode()))
     schema_hash = str(_checksum(RESULT_SCHEMA.encode()))
+    if normalization_version == PARENT_NORMALIZATION_VERSION:
+        return parser_hash, schema_hash, PARENT_IMPLEMENTATION_HASH
+    if normalization_version != CURRENT_NORMALIZATION_VERSION:
+        raise ForwardCorpusRejected("official result normalization version is unsupported")
     implementation = (
         inspect.getsource(_normalize_official_result).encode()
         + inspect.getsource(parse_thedogs_result_html_runner_rows).encode()
@@ -231,6 +269,111 @@ def _normalization_identity() -> tuple[str, str, str]:
         + RESULT_SCHEMA.encode()
     )
     return parser_hash, schema_hash, str(_checksum(implementation))
+
+
+def _normalization_version_from_observation(observation: Mapping[str, Any]) -> str:
+    schema_version = observation.get("schema_version")
+    if schema_version == OBSERVATION_SCHEMA_V1 and set(observation) == (
+        _OBSERVATION_FIELDS_V1
+    ):
+        implementation_hash = observation.get("implementation_hash")
+        if implementation_hash == PARENT_IMPLEMENTATION_HASH:
+            return PARENT_NORMALIZATION_VERSION
+        if implementation_hash == _normalization_identity()[2]:
+            return CURRENT_NORMALIZATION_VERSION
+    elif (
+        schema_version == OBSERVATION_SCHEMA_V2
+        and set(observation) == _OBSERVATION_FIELDS_V2
+        and observation.get("normalization_version") == CURRENT_NORMALIZATION_VERSION
+    ):
+        return CURRENT_NORMALIZATION_VERSION
+    raise ForwardCorpusRejected("official observation envelope or normalization is invalid")
+
+
+def _normalize_official_result_parent_v1(
+    raw_response_bytes: bytes,
+    *,
+    race_id: str,
+    frozen_runners: Sequence[Mapping[str, Any]],
+) -> bytes:
+    """Reconstruct immutable observations emitted before terminal NBT handling."""
+    if type(raw_response_bytes) is not bytes or not raw_response_bytes:
+        raise ForwardCorpusRejected("immutable official-result response bytes are required")
+    try:
+        markup = raw_response_bytes.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ForwardCorpusRejected("official result is not supported UTF-8 HTML") from error
+    try:
+        parsed = parse_thedogs_result_html_runner_rows(markup)
+    except (TypeError, ValueError) as error:
+        raise ForwardCorpusRejected("official result parser rejected response") from error
+    if not parsed:
+        raise ForwardCorpusRejected("official result HTML contains no result rows")
+    by_box = {row["box_number"]: row for row in parsed if type(row) is dict}
+    if len(by_box) != len(parsed) or set(by_box) != {
+        runner["box_number"] for runner in frozen_runners
+    }:
+        raise ForwardCorpusRejected("official result runner box/rug identity mismatch")
+    normalized = []
+    positions = []
+    for runner in sorted(frozen_runners, key=lambda item: item["box_number"]):
+        parsed_row = by_box[runner["box_number"]]
+        if parsed_row.get("dog_name") != runner["name"]:
+            raise ForwardCorpusRejected("official result runner name identity mismatch")
+        position = parsed_row.get("finish_position")
+        status = parsed_row.get("status")
+        if (position is None) == (status is None):
+            raise ForwardCorpusRejected("official finish/status combination is inconsistent")
+        if position is not None:
+            if type(position) is not int or not 1 <= position <= len(frozen_runners):
+                raise ForwardCorpusRejected("official finish position is out of range")
+            positions.append(position)
+        elif status not in {"SCRATCHED", "DNF", "DQ"}:
+            raise ForwardCorpusRejected("official terminal status is unsupported")
+        normalized.append(
+            {
+                "source_native_runner_id": runner["source_native_runner_id"],
+                "box_number": runner["box_number"],
+                "name": runner["name"],
+                "finish_position": position,
+                "status": status,
+            }
+        )
+    if not finish_positions_follow_competition_ranking(positions):
+        raise ForwardCorpusRejected("official finishes do not use competition ranking")
+    runner_set_hash = str(_checksum(canonical_json(list(frozen_runners))))
+    return canonical_json(
+        {
+            "schema_version": RESULT_SCHEMA,
+            "race_id": race_id,
+            "runner_set_hash": runner_set_hash,
+            "runners": normalized,
+        }
+    )
+
+
+def _normalize_official_result_for_version(
+    raw_response_bytes: bytes,
+    *,
+    race_id: str,
+    frozen_runners: Sequence[Mapping[str, Any]],
+    normalization_version: str,
+) -> bytes:
+    normalizer = (
+        _normalize_official_result_parent_v1
+        if normalization_version == PARENT_NORMALIZATION_VERSION
+        else _normalize_official_result
+    )
+    if normalization_version not in {
+        PARENT_NORMALIZATION_VERSION,
+        CURRENT_NORMALIZATION_VERSION,
+    }:
+        raise ForwardCorpusRejected("official result normalization version is unsupported")
+    return normalizer(
+        raw_response_bytes,
+        race_id=race_id,
+        frozen_runners=frozen_runners,
+    )
 
 
 def _normalize_official_result(
@@ -1157,33 +1300,7 @@ class ForwardSealedCorpus:
         pre: Mapping[str, Any],
         observation: Mapping[str, Any],
     ) -> bytes:
-        expected_keys = {
-            "schema_version",
-            "race_id",
-            "collector_id",
-            "session_id",
-            "run_id",
-            "request_id",
-            "source_name",
-            "request_url",
-            "final_url",
-            "http_status",
-            "content_type",
-            "source_document_last_modified",
-            "request_started_at",
-            "response_received_at",
-            "observed_at",
-            "raw_response_checksum",
-            "normalized_result_checksum",
-            "runner_set_hash",
-            "parser_hash",
-            "schema_hash",
-            "implementation_hash",
-        }
-        if set(observation) != expected_keys or observation.get("schema_version") != (
-            "official-result-observation-v1"
-        ):
-            raise ForwardCorpusRejected("official observation envelope is invalid")
+        normalization_version = _normalization_version_from_observation(observation)
         if observation.get("race_id") != pre["race_id"]:
             raise ForwardCorpusRejected("official observation race identity mismatch")
         for field in ("collector_id", "session_id", "run_id", "request_id"):
@@ -1228,12 +1345,15 @@ class ForwardSealedCorpus:
             self._read_artifact(pre["source_capture_checksum"], "source capture"),
             "source capture",
         )
-        rebuilt = _normalize_official_result(
+        rebuilt = _normalize_official_result_for_version(
             raw,
             race_id=pre["race_id"],
             frozen_runners=source_capture["runners"],
+            normalization_version=normalization_version,
         )
-        parser_hash, schema_hash, implementation_hash = _normalization_identity()
+        parser_hash, schema_hash, implementation_hash = _normalization_identity(
+            normalization_version
+        )
         runner_set_hash = str(_checksum(canonical_json(source_capture["runners"])))
         if (
             rebuilt != normalized
@@ -1381,7 +1501,8 @@ class ForwardSealedCorpus:
         ).checksum
         parser_hash, schema_hash, implementation_hash = _normalization_identity()
         observation = {
-            "schema_version": "official-result-observation-v1",
+            "schema_version": OBSERVATION_SCHEMA_V2,
+            "normalization_version": CURRENT_NORMALIZATION_VERSION,
             "race_id": race_id,
             "collector_id": collector_id,
             "session_id": session_id,
@@ -1448,17 +1569,7 @@ class ForwardSealedCorpus:
         self._observation_inventory(pre, observations)
         if not observations:
             return
-        identities = {
-            (
-                item["normalized_result_checksum"],
-                item["runner_set_hash"],
-                item["parser_hash"],
-                item["schema_hash"],
-                item["implementation_hash"],
-                item["source_name"],
-            )
-            for item in observations
-        }
+        identities = {self._observation_identity(item) for item in observations}
         if len(identities) > 1:
             conflict = {
                 "schema_version": "official-result-conflict-v1",
@@ -1527,9 +1638,6 @@ class ForwardSealedCorpus:
         return (
             observation["normalized_result_checksum"],
             observation["runner_set_hash"],
-            observation["parser_hash"],
-            observation["schema_hash"],
-            observation["implementation_hash"],
             observation["source_name"],
         )
 

--- a/race_collection/source_admission.py
+++ b/race_collection/source_admission.py
@@ -666,7 +666,8 @@ def _admit_official_first(
     from .forward_sealed_corpus import (
         ForwardCorpusRejected,
         _normalization_identity,
-        _normalize_official_result,
+        _normalization_version_from_observation,
+        _normalize_official_result_for_version,
     )
 
     manifest = package["manifest"]
@@ -718,7 +719,6 @@ def _admit_official_first(
         or missingness.get("feature_contract_version") != SUPPORTED_FEATURE_CONTRACT
     ):
         raise SourceAdmissionRejected("official-first feature contract is unsupported")
-    parser_hash, schema_hash, implementation_hash = _normalization_identity()
     admitted_races = []
     try:
         for race in races:
@@ -1014,34 +1014,11 @@ def _admit_official_first(
                         "official observation has no retained response stage"
                     ) from error
                 raw_checksum = stage["raw_response_checksum"]
-                expected_observation_fields = {
-                    "schema_version",
-                    "race_id",
-                    "collector_id",
-                    "session_id",
-                    "run_id",
-                    "request_id",
-                    "source_name",
-                    "request_url",
-                    "final_url",
-                    "http_status",
-                    "content_type",
-                    "source_document_last_modified",
-                    "request_started_at",
-                    "response_received_at",
-                    "observed_at",
-                    "raw_response_checksum",
-                    "normalized_result_checksum",
-                    "runner_set_hash",
-                    "parser_hash",
-                    "schema_hash",
-                    "implementation_hash",
-                }
+                normalization_version = _normalization_version_from_observation(
+                    observation
+                )
                 if (
-                    set(observation) != expected_observation_fields
-                    or observation.get("schema_version")
-                    != "official-result-observation-v1"
-                    or observation.get("source_name") != OFFICIAL_RESULT_SOURCE
+                    observation.get("source_name") != OFFICIAL_RESULT_SOURCE
                     or type(observation.get("http_status")) is not int
                     or not 200 <= observation["http_status"] < 300
                 ):
@@ -1079,6 +1056,7 @@ def _admit_official_first(
                         "parser_hash",
                         "schema_hash",
                         "implementation_hash",
+                        "normalization_version",
                     }
                 }
                 expected_stage["schema_version"] = "official-result-response-stage-v1"
@@ -1089,10 +1067,14 @@ def _admit_official_first(
                         "official response-stage/observation inventory binding disagrees"
                     )
                 raw = _artifact(artifacts, raw_checksum, "raw official response")
-                rebuilt = _normalize_official_result(
+                rebuilt = _normalize_official_result_for_version(
                     raw,
                     race_id=race["race_id"],
                     frozen_runners=frozen_runners,
+                    normalization_version=normalization_version,
+                )
+                parser_hash, schema_hash, implementation_hash = _normalization_identity(
+                    normalization_version
                 )
                 if (
                     observation.get("race_id") != race["race_id"]
@@ -1132,9 +1114,6 @@ def _admit_official_first(
                 (
                     observation["normalized_result_checksum"],
                     observation["runner_set_hash"],
-                    observation["parser_hash"],
-                    observation["schema_hash"],
-                    observation["implementation_hash"],
                     observation["source_name"],
                 )
                 for observation in observations

--- a/race_collection/synchronous_manual_capture.py
+++ b/race_collection/synchronous_manual_capture.py
@@ -193,6 +193,8 @@ def acquire_collector_lock_no_steal(
     *,
     run_id: str,
     output_dir: Path,
+    phase: str = "manual_capture_one",
+    acquisition_policy: str = "collector_capture_one_no_steal_v1",
 ) -> OwnedCollectorLock:
     lock_path = lock_path.absolute()
     if (
@@ -208,8 +210,8 @@ def acquire_collector_lock_no_steal(
         "hostname": socket.gethostname(),
         "started_at": datetime.now().astimezone().isoformat(),
         "output_dir": str(output_dir.resolve()),
-        "phase": "manual_capture_one",
-        "acquisition_policy": "collector_capture_one_no_steal_v1",
+        "phase": phase,
+        "acquisition_policy": acquisition_policy,
     }
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
     flags |= getattr(os, "O_NOFOLLOW", 0)

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -36,6 +36,11 @@ ROOT_STR = str(ROOT)
 sys.path = [path for path in sys.path if path != ROOT_STR]
 sys.path.insert(0, ROOT_STR)
 
+from race_collection.synchronous_manual_capture import (  # noqa: E402
+    CollectorBusy,
+    acquire_collector_lock_no_steal,
+    release_owned_collector_lock,
+)
 from scripts import shadow_autopilot_v1 as autopilot  # noqa: E402
 from scripts.forward_shadow_runtime_state import (  # noqa: E402
     build_runtime_state as build_forward_shadow_runtime_state,
@@ -128,6 +133,10 @@ class LockBusy(RuntimeError):
     def __init__(self, payload: Mapping[str, Any]):
         super().__init__("shadow_autopilot_daemon_lock_busy")
         self.payload = dict(payload)
+
+
+def wall_clock_now() -> datetime:
+    return datetime.now().astimezone()
 
 
 def now_id(now: datetime | None = None) -> str:
@@ -9063,7 +9072,7 @@ def build_final_summary(
 
 
 def run_once(args: argparse.Namespace) -> dict[str, Any]:
-    generated_at = datetime.now().astimezone()
+    generated_at = wall_clock_now()
     run_id = args.run_id or now_id(generated_at)
     evidence_root = args.evidence_root
     output_dir = assert_output_dir_safe(
@@ -9091,45 +9100,125 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
         ),
     )
 
-    service_info = write_service_files(
-        repo_path=ROOT,
-        timeout_seconds=args.timeout_seconds,
-        python_path=Path(sys.executable),
-        evidence_root=evidence_root,
-        shadow_model=args.shadow_model,
-        db_path=args.db,
-        lock_path=lock_path,
-        state_path=state_path,
-        odds_capture_state_path=odds_state_path,
-        forward_corpus_root=args.forward_corpus_root
-        if args.enable_forward_official_result_observer
-        else None,
-        pause_path=lock_path.parent / "pause-heavy-scheduling",
-    )
-    service_path = DEFAULT_SERVICE_DIR / SERVICE_NAME
-    timer_path = DEFAULT_SERVICE_DIR / TIMER_NAME
-    write_text(output_dir / "daemon_design.md", daemon_design_markdown())
-    write_json(output_dir / "lifecycle_diagram.json", lifecycle_diagram())
-    write_text(output_dir / "service_install.md", install_markdown(service_info))
-    copy_if_exists(service_path, output_dir / "systemd" / SERVICE_NAME)
-    copy_if_exists(timer_path, output_dir / "systemd" / TIMER_NAME)
-    write_json(output_dir / "output_manifest.json", output_manifest(output_dir))
-
     forward_official_result_observer: dict[str, Any] = {
         "status": "DISABLED",
         "attempted_race_ids": [],
     }
+    observer_shared_lock = None
     if args.enable_forward_official_result_observer:
         try:
-            forward_official_result_observer = run_forward_official_result_observer(
-                args, run_id
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            observer_shared_lock = acquire_collector_lock_no_steal(
+                lock_path,
+                run_id=run_id,
+                output_dir=output_dir,
+                phase="forward_official_result_observer",
+                acquisition_policy="forward_official_result_observer_no_steal_v1",
             )
-        except Exception as exc:
+        except CollectorBusy as exc:
             forward_official_result_observer = {
-                "status": "FAILED",
+                "status": "SHARED_LOCK_BUSY",
                 "attempted_race_ids": [],
-                "error": f"{type(exc).__name__}: {exc}",
+                "shared_lock": dict(exc.evidence),
             }
+            result = {
+                **completed_daemon_run_report_envelope(
+                    run_id=run_id,
+                    generated_at=generated_at,
+                    current_time=current_time,
+                    output_dir=output_dir,
+                    final_verdict="PARTIAL_DAEMONIZATION",
+                ),
+                "status": "SKIPPED_LOCK_HELD",
+                "runtime_action": "DEFER_FORWARD_OBSERVER_SHARED_LOCK_HELD",
+                "readiness_decision": "WAIT_FOR_CANONICAL_SHARED_LOCK",
+                "forward_official_result_observer": forward_official_result_observer,
+                "lock_path": relpath(lock_path),
+                "lock_validation_status": "OBSERVER_NOT_ACQUIRED_SHARED_LOCK_HELD",
+                "lock_owner_phase": exc.evidence.get("lock_owner_phase"),
+                "lock_owner_run_id": exc.evidence.get("lock_owner_run_id"),
+                "lock_owner_pid": exc.evidence.get("lock_owner_pid"),
+                "lock_owner_hostname": exc.evidence.get("lock_owner_hostname"),
+                "lock_owner_started_at": exc.evidence.get("lock_owner_started_at"),
+                "lock_owner_output_dir": exc.evidence.get("lock_owner_output_dir"),
+                "protected_paths_unchanged_or_allowed": True,
+                "no_write_guarantees": dict(NO_WRITE_GUARANTEES),
+            }
+            write_json(
+                output_dir / "forward_official_result_observer.json",
+                forward_official_result_observer,
+            )
+            write_text(output_dir / "final_status.txt", "PARTIAL_DAEMONIZATION\n")
+            write_json(output_dir / "daemon_run_report.json", result)
+            write_json(output_dir / "output_manifest.json", output_manifest(output_dir))
+            return result
+
+    try:
+        service_info = write_service_files(
+            repo_path=ROOT,
+            timeout_seconds=args.timeout_seconds,
+            python_path=Path(sys.executable),
+            evidence_root=evidence_root,
+            shadow_model=args.shadow_model,
+            db_path=args.db,
+            lock_path=lock_path,
+            state_path=state_path,
+            odds_capture_state_path=odds_state_path,
+            forward_corpus_root=args.forward_corpus_root
+            if args.enable_forward_official_result_observer
+            else None,
+            pause_path=lock_path.parent / "pause-heavy-scheduling",
+        )
+        service_path = DEFAULT_SERVICE_DIR / SERVICE_NAME
+        timer_path = DEFAULT_SERVICE_DIR / TIMER_NAME
+        write_text(output_dir / "daemon_design.md", daemon_design_markdown())
+        write_json(output_dir / "lifecycle_diagram.json", lifecycle_diagram())
+        write_text(output_dir / "service_install.md", install_markdown(service_info))
+        copy_if_exists(service_path, output_dir / "systemd" / SERVICE_NAME)
+        copy_if_exists(timer_path, output_dir / "systemd" / TIMER_NAME)
+        write_json(output_dir / "output_manifest.json", output_manifest(output_dir))
+
+        if args.enable_forward_official_result_observer:
+            try:
+                forward_official_result_observer = run_forward_official_result_observer(
+                    args, run_id
+                )
+            except Exception as exc:
+                forward_official_result_observer = {
+                    "status": "FAILED",
+                    "attempted_race_ids": [],
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+    finally:
+        if observer_shared_lock is not None:
+            try:
+                release_owned_collector_lock(observer_shared_lock)
+                observer_lock_release = {
+                    "released": True,
+                    "reason": "released_by_observer_owner",
+                }
+            except Exception as exc:
+                observer_lock_release = {
+                    "released": False,
+                    "reason": "observer_lock_release_failed",
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+                forward_official_result_observer = {
+                    **forward_official_result_observer,
+                    "status": "FAILED",
+                    "error": observer_lock_release["error"],
+                }
+            forward_official_result_observer = {
+                **forward_official_result_observer,
+                "shared_lock": {
+                    "lock_path": relpath(lock_path),
+                    "phase": "forward_official_result_observer",
+                    "acquisition_policy": "forward_official_result_observer_no_steal_v1",
+                    "release": observer_lock_release,
+                },
+            }
+
+    if args.enable_forward_official_result_observer:
         write_json(
             output_dir / "forward_official_result_observer.json",
             forward_official_result_observer,
@@ -9155,7 +9244,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
                 "readiness_decision": "READY_FOR_RELIABILITY_REVIEW",
                 "forward_official_result_observer": forward_official_result_observer,
                 "lock_path": relpath(lock_path),
-                "lock_validation_status": "NOT_ACQUIRED_OBSERVER_FAILED",
+                "lock_validation_status": "OBSERVER_LOCK_RELEASED_AFTER_FAILURE",
                 "protected_paths_unchanged_or_allowed": False,
                 "no_write_guarantees": dict(NO_WRITE_GUARANTEES),
             }
@@ -9163,6 +9252,9 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
             write_json(output_dir / "daemon_run_report.json", result)
             write_json(output_dir / "output_manifest.json", output_manifest(output_dir))
             return result
+
+        if args.current_time is None:
+            current_time = wall_clock_now().isoformat()
 
     current_dt = parse_datetime_value(current_time, default_tz=generated_at.tzinfo) or generated_at
     if args.enable_autonomous_odds_capture:

--- a/tests/race_collection/test_forward_sealed_corpus.py
+++ b/tests/race_collection/test_forward_sealed_corpus.py
@@ -317,18 +317,76 @@ def test_result_strips_only_established_terminal_nbt_non_name_badge(tmp_path):
         corpus._read_artifact(receipt["normalized_result_checksum"], "normalized result")
     )
     assert normalized["runners"][1]["name"] == "Dog 1 B"
-
-    rejected = ForwardSealedCorpus(
-        tmp_path / "rejected",
-        clock=Clock(_dt("09:45"), _dt("10:06"), _dt("10:06"), _dt("10:06")),
+    assert receipt["schema_version"] == corpus_module.OBSERVATION_SCHEMA_V2
+    assert (
+        receipt["normalization_version"]
+        == corpus_module.CURRENT_NORMALIZATION_VERSION
     )
-    rejected.capture_prejump(**fixture())
-    with pytest.raises(ForwardCorpusRejected, match="name identity mismatch"):
-        _capture(
-            rejected,
-            "request-1",
-            Transport(_html().replace(b"Dog 1 B", b"Dog 1 B NBTX")),
+    assert corpus.artifacts.read(
+        corpus.artifacts.checksum(_html().replace(b"Dog 1 B", b"Dog 1 B NBT"))
+    ) == _html().replace(b"Dog 1 B", b"Dog 1 B NBT")
+
+    for index, near_match in enumerate(
+        (b"Dog 1 B NBTX", b"Dog NBT 1 B", b"Dog 1 B NBT (R)"),
+        start=1,
+    ):
+        rejected = ForwardSealedCorpus(
+            tmp_path / f"rejected-{index}",
+            clock=Clock(_dt("09:45"), _dt("10:06"), _dt("10:06"), _dt("10:06")),
         )
+        rejected.capture_prejump(**fixture())
+        with pytest.raises(ForwardCorpusRejected, match="name identity mismatch"):
+            _capture(
+                rejected,
+                "request-1",
+                Transport(_html().replace(b"Dog 1 B", near_match)),
+            )
+
+
+def test_parent_observation_verifies_closes_and_is_admissible_after_upgrade(tmp_path):
+    corpus = ForwardSealedCorpus(
+        tmp_path,
+        clock=Clock(
+            _dt("09:45"),
+            _dt("10:06"),
+            _dt("10:06"),
+            _dt("10:06"),
+            _dt("10:21"),
+            _dt("10:21"),
+            _dt("10:21"),
+            _dt("10:22"),
+        ),
+    )
+    corpus.capture_prejump(**fixture())
+    _capture(corpus, "request-1", Transport(_html()))
+    first_path = corpus._request_directory(tmp_path, "race-1", "request-1") / (
+        "observation.json"
+    )
+    parent = json.loads(first_path.read_bytes())
+    raw_checksum = parent["raw_response_checksum"]
+    normalized_checksum = parent["normalized_result_checksum"]
+    parent.pop("normalization_version")
+    parent["schema_version"] = corpus_module.OBSERVATION_SCHEMA_V1
+    parent["implementation_hash"] = corpus_module.PARENT_IMPLEMENTATION_HASH
+    parent_bytes = canonical_json(parent)
+    first_path.write_bytes(parent_bytes)
+    corpus.artifacts.put(parent_bytes, media_type="application/json")
+
+    assert corpus.status()["races"][0]["state"] == "RESULT_FIRST_OBSERVED"
+    second = _capture(corpus, "request-2", Transport(_html()))
+    assert second["normalization_version"] == corpus_module.CURRENT_NORMALIZATION_VERSION
+    assert second["raw_response_checksum"] == raw_checksum
+    assert second["normalized_result_checksum"] == normalized_checksum
+    assert corpus.status()["races"][0]["state"] == "RESULT_STABILITY_CONFIRMED"
+
+    package = close(corpus)
+    admitted = json.loads(
+        admit_historical_source(package.package_bytes, artifacts=package.artifacts)
+    )
+    assert admitted["admission_decision"] == "TRAINING_ADMISSIBLE"
+    assert corpus.artifacts.read(
+        corpus.artifacts.checksum(_html())
+    ) == _html()
 
 
 def test_result_history_uses_exact_race_id_request_root(tmp_path):
@@ -552,6 +610,7 @@ def test_api_cannot_accept_forged_normalization_timestamps_or_hashes():
         "parser_hash",
         "schema_hash",
         "implementation_hash",
+        "normalization_version",
     }
     assert forbidden.isdisjoint(inspect.signature(ForwardSealedCorpus.capture_result).parameters)
 

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -873,12 +873,14 @@ def test_run_once_defer_observes_result_before_odds_priority_return(
     evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
     output_dir = evidence_root / "shadow_autopilot_daemonization_v1_observer_defer"
     odds_state_path = tmp_path / "runtime" / "odds_capture_state.json"
+    lock_path = tmp_path / "runtime" / "shadow_autopilot.lock"
     corpus_root = tmp_path / "forward-corpus"
     observed = {
         "status": "COMPLETED",
         "attempted_race_ids": ["race-1"],
         "counts": {"observed": 1},
     }
+    defer_times = []
 
     monkeypatch.setattr(daemon, "ROOT", tmp_path)
     monkeypatch.setattr(daemon, "copy_if_exists", lambda source, dest: None)
@@ -898,10 +900,10 @@ def test_run_once_defer_observes_result_before_odds_priority_return(
     monkeypatch.setattr(
         daemon,
         "full_daemon_odds_window_defer_decision",
-        lambda odds_state, current_time: {
-            "should_defer": True,
-            "reason": "test_fixed_window_open",
-        },
+        lambda odds_state, current_time: (
+            defer_times.append(current_time)
+            or {"should_defer": True, "reason": "test_fixed_window_open"}
+        ),
     )
     monkeypatch.setattr(
         daemon,
@@ -922,6 +924,8 @@ def test_run_once_defer_observes_result_before_odds_priority_return(
             str(output_dir),
             "--current-time",
             "2026-06-13T15:17:11+10:00",
+            "--lock-path",
+            str(lock_path),
             "--enable-forward-official-result-observer",
             "--forward-corpus-root",
             str(corpus_root),
@@ -934,13 +938,23 @@ def test_run_once_defer_observes_result_before_odds_priority_return(
     report = daemon.run_once(args)
 
     assert report["final_verdict"] == "DAEMON_DEFERRED_TO_ODDS_CAPTURE_ONLY"
+    assert defer_times == [datetime.fromisoformat("2026-06-13T15:17:11+10:00")]
     assert report["forward_official_result_observer"] == observed | {
-        "run_id": "observer_defer"
+        "run_id": "observer_defer",
+        "shared_lock": {
+            "lock_path": daemon.relpath(lock_path),
+            "phase": "forward_official_result_observer",
+            "acquisition_policy": "forward_official_result_observer_no_steal_v1",
+            "release": {
+                "released": True,
+                "reason": "released_by_observer_owner",
+            },
+        },
     }
     assert report["no_write_guarantees"]["official_result_evidence_write"] is True
     assert json.loads(
         (output_dir / "forward_official_result_observer.json").read_text()
-    ) == observed | {"run_id": "observer_defer"}
+    ) == report["forward_official_result_observer"]
 
 
 def test_run_once_observer_failure_stops_before_odds_defer_and_full_lock(
@@ -949,6 +963,7 @@ def test_run_once_observer_failure_stops_before_odds_defer_and_full_lock(
     evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
     output_dir = evidence_root / "shadow_autopilot_daemonization_v1_observer_failed"
     state_path = tmp_path / "runtime" / "state.json"
+    lock_path = tmp_path / "runtime" / "shadow_autopilot.lock"
     failed = {
         "status": "COMPLETED_WITH_ERRORS",
         "attempted_race_ids": ["race-1"],
@@ -995,6 +1010,8 @@ def test_run_once_observer_failure_stops_before_odds_defer_and_full_lock(
             str(output_dir),
             "--state-path",
             str(state_path),
+            "--lock-path",
+            str(lock_path),
             "--enable-forward-official-result-observer",
             "--forward-corpus-root",
             str(tmp_path / "forward-corpus"),
@@ -1005,13 +1022,163 @@ def test_run_once_observer_failure_stops_before_odds_defer_and_full_lock(
     report = daemon.run_once(args)
 
     assert report["final_verdict"] == "PARTIAL_DAEMONIZATION"
-    assert report["lock_validation_status"] == "NOT_ACQUIRED_OBSERVER_FAILED"
+    assert report["lock_validation_status"] == "OBSERVER_LOCK_RELEASED_AFTER_FAILURE"
     assert report["forward_official_result_observer"] == failed | {
-        "run_id": "observer_failed"
+        "run_id": "observer_failed",
+        "shared_lock": {
+            "lock_path": daemon.relpath(lock_path),
+            "phase": "forward_official_result_observer",
+            "acquisition_policy": "forward_official_result_observer_no_steal_v1",
+            "release": {
+                "released": True,
+                "reason": "released_by_observer_owner",
+            },
+        },
     }
     assert json.loads(state_path.read_text())[
         "forward_official_result_observer"
-    ] == failed | {"run_id": "observer_failed"}
+    ] == report["forward_official_result_observer"]
+
+
+def test_live_shared_lock_defers_before_observer_service_or_corpus_mutation(
+    tmp_path, monkeypatch
+):
+    evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
+    output_dir = evidence_root / "shadow_autopilot_daemonization_v1_lock_busy"
+    lock_path = tmp_path / "runtime" / "shadow_autopilot.lock"
+    corpus_root = tmp_path / "forward-corpus"
+    lock_path.parent.mkdir(parents=True)
+    corpus_root.mkdir()
+    sentinel = corpus_root / "immutable.json"
+    sentinel.write_bytes(b'{"immutable":true}\n')
+    lock_bytes = json.dumps(
+        {
+            "schema_version": "shadow_autopilot_daemon_lock_v1",
+            "run_id": "active_odds_capture",
+            "pid": os.getpid(),
+            "hostname": "test-host",
+            "started_at": "2026-06-13T15:16:00+10:00",
+            "output_dir": "/runtime/active-odds",
+            "phase": "odds_capture",
+        },
+        sort_keys=True,
+    ).encode()
+    lock_path.write_bytes(lock_bytes)
+
+    monkeypatch.setattr(daemon, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        daemon,
+        "write_service_files",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("live shared owner must prevent service mutation")
+        ),
+    )
+    monkeypatch.setattr(
+        daemon,
+        "run_forward_official_result_observer",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("live shared owner must prevent observer I/O")
+        ),
+    )
+    args = daemon.parse_args(
+        [
+            "run-once",
+            "--run-id",
+            "lock-busy",
+            "--evidence-root",
+            str(evidence_root),
+            "--output-dir",
+            str(output_dir),
+            "--lock-path",
+            str(lock_path),
+            "--enable-forward-official-result-observer",
+            "--forward-corpus-root",
+            str(corpus_root),
+        ]
+    )
+
+    report = daemon.run_once(args)
+
+    assert report["status"] == "SKIPPED_LOCK_HELD"
+    assert report["runtime_action"] == "DEFER_FORWARD_OBSERVER_SHARED_LOCK_HELD"
+    assert report["lock_owner_phase"] == "odds_capture"
+    assert report["lock_owner_pid"] == os.getpid()
+    assert report["forward_official_result_observer"]["attempted_race_ids"] == []
+    assert lock_path.read_bytes() == lock_bytes
+    assert list(corpus_root.iterdir()) == [sentinel]
+    assert sentinel.read_bytes() == b'{"immutable":true}\n'
+
+
+def test_observer_completion_refreshes_wall_time_before_odds_defer(
+    tmp_path, monkeypatch
+):
+    evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
+    output_dir = evidence_root / "shadow_autopilot_daemonization_v1_time_crossing"
+    lock_path = tmp_path / "runtime" / "shadow_autopilot.lock"
+    odds_state_path = tmp_path / "runtime" / "odds_capture_state.json"
+    before = datetime.fromisoformat("2026-06-13T15:09:59+10:00")
+    after = datetime.fromisoformat("2026-06-13T15:10:01+10:00")
+    wall_times = iter((before, after))
+
+    monkeypatch.setattr(daemon, "ROOT", tmp_path)
+    monkeypatch.setattr(daemon, "wall_clock_now", lambda: next(wall_times))
+    monkeypatch.setattr(daemon, "copy_if_exists", lambda source, dest: None)
+    monkeypatch.setattr(
+        daemon,
+        "write_service_files",
+        lambda **kwargs: {
+            "status": "SERVICE_FILES_WRITTEN",
+            "systemd_deployment_ready": True,
+        },
+    )
+    monkeypatch.setattr(
+        daemon,
+        "run_forward_official_result_observer",
+        lambda args, run_id: {"status": "COMPLETED", "attempted_race_ids": []},
+    )
+
+    def decide(_odds_state, current_time):
+        assert current_time == after
+        return {"should_defer": True, "reason": "crossed_into_defer_horizon"}
+
+    monkeypatch.setattr(daemon, "full_daemon_odds_window_defer_decision", decide)
+    monkeypatch.setattr(
+        daemon,
+        "acquire_lock_with_odds_capture_retry",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("refreshed defer must remain before the full lock")
+        ),
+    )
+    args = daemon.parse_args(
+        [
+            "run-once",
+            "--run-id",
+            "time-crossing",
+            "--evidence-root",
+            str(evidence_root),
+            "--output-dir",
+            str(output_dir),
+            "--lock-path",
+            str(lock_path),
+            "--enable-forward-official-result-observer",
+            "--forward-corpus-root",
+            str(tmp_path / "forward-corpus"),
+            "--enable-autonomous-odds-capture",
+            "--odds-capture-state-path",
+            str(odds_state_path),
+        ]
+    )
+
+    report = daemon.run_once(args)
+
+    assert report["final_verdict"] == "DAEMON_DEFERRED_TO_ODDS_CAPTURE_ONLY"
+    assert report["odds_capture_defer_decision"]["reason"] == (
+        "crossed_into_defer_horizon"
+    )
+    assert report["forward_official_result_observer"]["shared_lock"]["release"][
+        "released"
+    ] is True
+    assert not lock_path.exists()
 
 
 def test_run_once_defers_before_lock_when_t2_window_recomputed_due(
@@ -9899,10 +10066,12 @@ def test_forward_observer_opt_in_invokes_owned_cycle(monkeypatch, tmp_path):
 
 
 def test_full_service_generator_emits_forward_opt_in_only_when_declared(tmp_path):
+    lock_path = Path("/runtime/shared-shadow-autopilot.lock")
     default = daemon.service_file_text(repo_path=tmp_path, timeout_seconds=840)
     enabled = daemon.service_file_text(
         repo_path=tmp_path,
         timeout_seconds=840,
+        lock_path=lock_path,
         forward_corpus_root=Path("/runtime/forward-corpus"),
     )
     assert "--enable-forward-official-result-observer" not in default
@@ -9911,13 +10080,16 @@ def test_full_service_generator_emits_forward_opt_in_only_when_declared(tmp_path
         "--enable-forward-official-result-observer "
         '--forward-corpus-root "/runtime/forward-corpus"'
     ) in enabled
+    assert "--lock-path /runtime/shared-shadow-autopilot.lock" in enabled
     generated = daemon.write_service_files(
         service_dir=tmp_path / "systemd",
         repo_path=tmp_path,
         timeout_seconds=840,
+        lock_path=lock_path,
         forward_corpus_root=Path("/runtime/forward-corpus"),
     )
     assert generated["forward_corpus_root"] == "/runtime/forward-corpus"
+    assert generated["lock_path"] == "/runtime/shared-shadow-autopilot.lock"
     assert '--forward-corpus-root "/runtime/forward-corpus"' in (
         tmp_path / "systemd" / daemon.SERVICE_NAME
     ).read_text()


### PR DESCRIPTION
## What changed

- Version official-result observation receipts explicitly for new captures while retaining verification of historical parent and terminal-NBT receipts.
- Dispatch verification and source admission through the normalization identity stored in each receipt, without changing raw or normalized artifact hashes.
- Treat matching semantic result evidence as stable across normalization implementation versions after each observation independently re-verifies.
- Coordinate the prospective observer with the canonical no-steal collector lock and preserve owner/phase evidence when it is busy.
- Refresh wall-clock time after observer completion before the odds-window defer decision, while preserving explicit deterministic `--current-time` input.

## Why

The terminal-NBT normalization repair changed the implementation hash used to verify earlier prospective observations. Those immutable receipts could no longer be reconstructed even when their raw and normalized evidence remained valid. The observer also needed to honor the same lock authority as odds capture and recompute timing after observer work.

## Validation

- `python -m pytest -q --noconftest tests/race_collection` — 609 passed in 3967.29s
- focused observer/corpus/lock tests — 116 passed
- `python -m py_compile` on the four changed production modules
- Ruff fatal-rule gate (`E9,F63,F7,F82`) on all six changed paths
- `git diff --check`
- independent exact-diff review: 0 critical findings, 0 unresolved warnings

No service deployment, daemon restart, canary, live observer run, database mutation, model action, EV output, or betting action was performed.