### PR TITLE
Canonicalize full-daemon timer recurrence

### DIFF
--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -1194,6 +1194,7 @@ def timer_file_text() -> str:
             "Description=Run greyhound shadow autopilot every 15 minutes",
             "",
             "[Timer]",
+            f"OnActiveSec={DEFAULT_TIMER_FREQUENCY}",
             f"OnUnitInactiveSec={DEFAULT_TIMER_ON_UNIT_INACTIVE_SEC}",
             f"AccuracySec={DEFAULT_TIMER_ACCURACY}",
             "Persistent=true",

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -4644,6 +4644,7 @@ def test_service_and_timer_define_15_minute_oneshot_cycle():
     assert "TimeoutStartSec=3360" in service
     assert "GREYHOUND_ALLOW_TGR=0" in service
     assert "/home/l4nd0/.local/bin" in service
+    assert "OnActiveSec=15min" in timer
     assert "OnUnitInactiveSec=15min" in timer
     assert "OnCalendar" not in timer
     assert "AccuracySec=30s" in timer


### PR DESCRIPTION
## What changed

- Add `OnActiveSec=15min` to the generated full-daemon timer.
- Retain `OnUnitInactiveSec=15min` so normal cycles continue to recur fifteen minutes after completion.
- Assert both activation-relative and completion-relative recurrence in the focused daemon timer test.

## Why

After a user-systemd restart, `OnUnitInactiveSec` has no service-deactivation baseline. The enabled timer can therefore remain at infinity until the service has completed once. `OnActiveSec` supplies the missing post-activation baseline without changing normal completion-relative cadence.

## Validation

- Focused timer test: 1 passed.
- Fatal Ruff gate (`E9,F63,F7,F82`): passed.
- `py_compile`: passed.
- `git diff --check`: passed.
- Generated timer SHA-256: `8cbf2c51c7f11f029c2b9b3cf6bf221df38039c68a95a39816ea9704e6caecaf`, matching the live-only repair evidence.
- Independent exact-diff review: 0 critical findings, 0 warnings, 0 suggestions.

No deployment, installed-unit write, timer action, runtime/data/model mutation, prediction, training, promotion, EV, staking, or betting action was performed.
