### PR TITLE
Accept canonical absolute odds refresh authority

### DIFF
--- a/src/operator_ui/deployment.py
+++ b/src/operator_ui/deployment.py
@@ -287,11 +287,16 @@ def _live_authority(path: Path) -> dict[str, Any]:
             refresh_root = refresh_path.parent
         else:
             relative = Path(output_dir) / "odds_capture_refresh_report.json"
-            if relative.is_absolute() or ".." in relative.parts or len(relative.parts) < 2:
+            if ".." in relative.parts or len(relative.parts) < 2:
                 raise ValueError
-            refresh_root = refresh_path.parents[len(relative.parts) - 1]
-            if refresh_path.relative_to(refresh_root) != relative:
-                raise ValueError
+            if relative.is_absolute():
+                refresh_root = Path(output_dir)
+                if refresh_path != relative:
+                    raise ValueError
+            else:
+                refresh_root = refresh_path.parents[len(relative.parts) - 1]
+                if refresh_path.relative_to(refresh_root) != relative:
+                    raise ValueError
         _safe_existing(refresh_root, directory=True)
     except (KeyError, TypeError, ValueError, OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
         raise DeploymentRejected("odds refresh authority is contradictory") from error

--- a/tests/operator_ui/test_deployment_generator.py
+++ b/tests/operator_ui/test_deployment_generator.py
@@ -547,6 +547,41 @@ def test_enabled_generator_derives_refresh_root_without_rereading_odds_report(tm
     assert reads == 1
 
 
+def test_enabled_generator_accepts_exact_absolute_odds_output_dir(tmp_path, monkeypatch):
+    values = deployment_inputs(tmp_path); git_identity(monkeypatch)
+    authority = json.loads(values["live_authority"].read_text())
+    odds_report = Path(authority["sources"]["odds_report"])
+    refresh = Path(authority["sources"]["odds_refresh"])
+    odds_report.write_text(json.dumps({
+        "schema_version": "shadow_autopilot_odds_capture_only_daemon_report_v1",
+        "autopilot_output_dir": str(refresh.parent),
+    }))
+
+    generate_package(**values, enabled=True)
+
+    binding = json.loads(
+        (values["source_root"] / "var/operator_ui/generated/repository-v1.binding.json").read_text()
+    )
+    assert Path(binding["live_evidence"]["sources"]["odds_refresh"]["allowlisted_root"]) == refresh.parent
+
+
+def test_enabled_generator_rejects_mismatched_absolute_odds_output_dir_without_output(
+    tmp_path, monkeypatch
+):
+    values = deployment_inputs(tmp_path); git_identity(monkeypatch)
+    authority = json.loads(values["live_authority"].read_text())
+    odds_report = Path(authority["sources"]["odds_report"])
+    odds_report.write_text(json.dumps({
+        "schema_version": "shadow_autopilot_odds_capture_only_daemon_report_v1",
+        "autopilot_output_dir": str(tmp_path / "different-reports"),
+    }))
+
+    with pytest.raises(DeploymentRejected, match="odds refresh authority is contradictory"):
+        generate_package(**values, enabled=True)
+
+    assert all(not target.exists() for target in generated_targets(values))
+
+
 def test_enabled_generator_binds_waiting_cycle_without_refresh_output(tmp_path, monkeypatch):
     values = deployment_inputs(tmp_path); git_identity(monkeypatch)
     authority = json.loads(values["live_authority"].read_text())


### PR DESCRIPTION
## What changed

The Operator UI deployment generator now accepts the canonical odds daemon contract when `autopilot_output_dir` is absolute, but only when the selected refresh report is exactly `<autopilot_output_dir>/odds_capture_refresh_report.json`.

The existing relative and no-refresh paths remain unchanged. Existing path traversal, directory, permission, and symlink safety checks remain in force.

## Why

The live odds daemon emits an absolute `autopilot_output_dir`. The prior generator rejected every absolute value, preventing repository-owned deployment from binding otherwise canonical live evidence.

## Validation

- Independent Codex X review: ACCEPT
- Reviewed diff: `b29a5e269040860f6c09719d9fc08f1a442b8d43c47439841b865fc9af9cd30f`
- Focused absolute authority tests: 2 passed
- Deployment generator suite excluding four root-copying startup fixtures: 108 passed, 4 deselected
- `git diff --check`: passed

Commit: `334b581203c3bdafca028f73fd543e57cba384f9`
Tree: `8efb852228ac2981e3153511e959f7cba4be6e95`