### PR TITLE
Bound full collector evidence reads

### DIFF
--- a/src/operator_ui/bootstrap.py
+++ b/src/operator_ui/bootstrap.py
@@ -44,6 +44,8 @@ _DEPLOYMENT_KEYS={"source_commit","source_tree","ui_version","profile_id"}
 _PROFILE_DEPLOYMENT_KEYS={"ui_version","profile_id"}
 _ARTIFACT_KEYS={"prediction_script","prediction_config","model_artifact","model_manifest","model_schema"}
 _MAX_CONTROL_BYTES=256*1024
+_MAX_FULL_SOURCE_BYTES=512*1024
+_FULL_SOURCE_KEYS={"full_state","full_report"}
 _DIGEST_ONLY_RAW_KEYS={"corpus_inventory_csv","corpus_inventory_jsonl"}
 _HEX40_RE=re.compile(r"^[0-9a-f]{40}$")
 _HEX64_RE=re.compile(r"^[0-9a-f]{64}$")
@@ -113,6 +115,11 @@ def _retained_read(path:Path,*,maximum:int=_MAX_CONTROL_BYTES)->bytes:
         return b"".join(chunks)
     finally:
         for item in reversed(opened):os.close(item)
+
+
+def _retained_source_read(path:Path,key:str)->bytes:
+    maximum=_MAX_FULL_SOURCE_BYTES if key in _FULL_SOURCE_KEYS else _MAX_CONTROL_BYTES
+    return _retained_read(path,maximum=maximum)
 
 
 def _regular(path: Path) -> None:
@@ -206,7 +213,7 @@ def _configured_live(layout:Mapping[str,Any])->LiveEvidenceAdapters:
     sources={}
     for key,policy in policies.items():
         path,digest,sealed_root=entry("sources",key)
-        try:payload=json.loads(_retained_read(path))
+        try:payload=json.loads(_retained_source_read(path,key))
         except (UnicodeDecodeError,json.JSONDecodeError) as exc:raise RuntimeError("generated live evidence source invalid") from exc
         if type(payload) is not dict:raise RuntimeError("generated live evidence source invalid")
         schema=payload.get("schema_version")

--- a/tests/operator_ui/test_live_adapters.py
+++ b/tests/operator_ui/test_live_adapters.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 from werkzeug.security import generate_password_hash
 
 import src.operator_ui.live_adapters as live_module
+import src.operator_ui.bootstrap as bootstrap_module
 from race_collection.synchronous_manual_capture import VerifiedCurrentRaceIndex
 from race_collection.synchronous_manual_capture import CaptureOneRejected
 from src.predictor.on_demand import (
@@ -51,6 +52,30 @@ NOW = datetime(2026, 7, 31, 2, tzinfo=timezone.utc)
 
 def canonical(value):
     return json.dumps(value, allow_nan=False, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+
+
+@pytest.mark.parametrize("source_key", ["full_state", "full_report"])
+def test_full_sources_have_hard_512_kib_retained_read_ceiling(tmp_path, source_key):
+    path = tmp_path / f"{source_key}.json"
+    at_limit = b"{}" + b" " * (512 * 1024 - 2)
+    path.write_bytes(at_limit)
+    assert bootstrap_module._retained_source_read(path, source_key) == at_limit
+
+    path.write_bytes(at_limit + b" ")
+    with pytest.raises(RuntimeError, match="fixed R3 runtime oversized"):
+        bootstrap_module._retained_source_read(path, source_key)
+
+
+@pytest.mark.parametrize("source_key", ["odds_state", "model_catalog"])
+def test_non_full_sources_retain_default_256_kib_ceiling(tmp_path, source_key):
+    path = tmp_path / f"{source_key}.json"
+    at_limit = b"{}" + b" " * (256 * 1024 - 2)
+    path.write_bytes(at_limit)
+    assert bootstrap_module._retained_source_read(path, source_key) == at_limit
+
+    path.write_bytes(at_limit + b" ")
+    with pytest.raises(RuntimeError, match="fixed R3 runtime oversized"):
+        bootstrap_module._retained_source_read(path, source_key)
 
 
 def actual_payloads(at=NOW - timedelta(seconds=30)):


### PR DESCRIPTION
## What changed

- Keep the default retained-read ceiling at 256 KiB.
- Permit only the canonical `full_state` and `full_report` sources to use a hard 512 KiB ceiling.
- Add exact-limit and one-byte-over boundary tests for the two privileged sources and representative default sources.

## Why

Current canonical full-collector state and report files are approximately 340 KiB and 332 KiB. The merged Operator UI deployment correctly failed closed because both exceeded the prior global 256 KiB ceiling.

## Safety

The change preserves no-follow descriptor traversal, component and final identity rechecks, expected SHA-256 binding, JSON parsing, provenance, and all other source ceilings. It adds no dependency and does not change collector, prediction, training, promotion, betting, or runtime authority.

## Validation

- Independent Codex X review: ACCEPT
- Four focused ceiling boundary cases: passed
- Python compilation: passed
- `git diff --check`: passed

Reviewed binary diff SHA-256: `4e03f7fb3091167d0e81cf8fac12dca1a27b121badf3acc3f1c8f97021e5c655`