### PR TITLE
GHU-036 C20: bind runtime disclosures to exact request evidence

### DIFF
--- a/src/operator_ui/api.py
+++ b/src/operator_ui/api.py
@@ -549,6 +549,29 @@ def _collector_lane(value: Any, *, request_now: datetime) -> dict[str, Any]:
 
 
 def _corpus_report(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("corpus report is invalid")
+    status = _text(value.get("status"))
+    if status == "UNAVAILABLE":
+        raw = _exact(
+            value,
+            frozenset(
+                {
+                    "report_id",
+                    "chain_hashes",
+                    "generated_at",
+                    "status",
+                    "admission_gap",
+                }
+            ),
+        )
+        return {
+            "chain_hashes": _named_hashes(raw["chain_hashes"]),
+            "generated_at": _utc(raw["generated_at"], field="generated_at")[0],
+            "report_id": _id(raw["report_id"]),
+            "status": status,
+            "admission_gap": _text(raw["admission_gap"]),
+        }
     raw = _exact(
         value,
         frozenset(

--- a/src/operator_ui/foundation.py
+++ b/src/operator_ui/foundation.py
@@ -842,7 +842,7 @@ class OperatorEvidenceReader:
         return envelope
 
     def read_payload(
-        self, source_key: str
+        self, source_key: str, *, server_observed_at: datetime | None = None
     ) -> tuple[EvidenceEnvelope, Mapping[str, Any] | None]:
         """Observe one configured source and return verified JSON when usable.
 
@@ -855,7 +855,7 @@ class OperatorEvidenceReader:
         except (KeyError, TypeError) as exc:
             raise KeyError("unknown evidence source key") from exc
 
-        observed = self._clock()
+        observed = self._clock() if server_observed_at is None else server_observed_at
         observed_text = _utc_text(observed)
         try:
             raw = _read_regular_file(
@@ -992,14 +992,16 @@ class OperatorEvidenceReader:
         self._check_envelope_size(envelope, config.max_envelope_bytes)
         return envelope, MappingProxyType(payload)
 
-    def read_raw(self, source_key: str) -> tuple[EvidenceEnvelope, bytes | None]:
+    def read_raw(
+        self, source_key: str, *, server_observed_at: datetime | None = None
+    ) -> tuple[EvidenceEnvelope, bytes | None]:
         """Read one configured regular file without interpreting its bytes."""
         try:
             config = self._raw_sources[source_key]
             binding = self._raw_bindings[source_key]
         except (KeyError, TypeError) as exc:
             raise KeyError("unknown raw evidence source key") from exc
-        observed = self._clock()
+        observed = self._clock() if server_observed_at is None else server_observed_at
         observed_text = _utc_text(observed)
         try:
             if config.digest_only:
@@ -1029,15 +1031,20 @@ class OperatorEvidenceReader:
         self._check_envelope_size(envelope, config.max_envelope_bytes)
         return envelope, raw
 
-    def read_raw_authenticated(self, source_key: str) -> tuple[EvidenceEnvelope, bytes | None, int | None]:
+    def read_raw_authenticated(
+        self, source_key: str, *, server_observed_at: datetime | None = None
+    ) -> tuple[EvidenceEnvelope, bytes | None, int | None]:
         """Return authenticated bytes when retained, plus the verified byte count."""
-        envelope, raw = self.read_raw(source_key)
+        envelope, raw = self.read_raw(
+            source_key, server_observed_at=server_observed_at
+        )
         if envelope.content_sha256 is None: return envelope, raw, None
         config = self._raw_sources[source_key]
         return envelope, raw, config.expected_bytes if config.digest_only and envelope.status != EvidenceStatus.DIVERGENT.value else len(raw) if raw is not None else None
 
     def read_verified_payload(
-        self, source_key: str, expected_source_locator: str
+        self, source_key: str, expected_source_locator: str, *,
+        server_observed_at: datetime | None = None,
     ) -> tuple[EvidenceEnvelope, Mapping[str, Any] | None]:
         """Read a fixed server source only when its public locator is expected.
 
@@ -1069,7 +1076,9 @@ class OperatorEvidenceReader:
             raise _PathChanged("configured source is outside its fixed root") from exc
         if configured_relative != expected_source_locator:
             raise _PathChanged("configured source locator does not match producer identity")
-        return self.read_payload(source_key)
+        return self.read_payload(
+            source_key, server_observed_at=server_observed_at
+        )
 
     @staticmethod
     def _check_envelope_size(

--- a/src/operator_ui/live_adapters.py
+++ b/src/operator_ui/live_adapters.py
@@ -1651,7 +1651,7 @@ class LiveEvidenceAdapters:
         # scanned prediction/result artifacts or the DB, publication/closure
         # evidence, or a hash-bound backlog report.  Consequently neither a
         # population identity nor producer counts may be disclosed as usable.
-        return APIObservation(_status(envelope, "UNAVAILABLE/DATA_MISSING"), {
+        return APIObservation(_status(envelope, "AVAILABLE/FRESH"), {
             "reports": [{
                 "report_id": hashlib.sha256((envelope.content_sha256 or "").encode()).hexdigest(),
                 "status": "UNAVAILABLE",

--- a/src/operator_ui/live_adapters.py
+++ b/src/operator_ui/live_adapters.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from race_collection.synchronous_manual_capture import (
     CURRENT_RACE_INDEX_SCHEMA,
+    MAX_CURRENT_INDEX_BYTES,
     CaptureOneRejected,
     VerifiedCurrentRaceIndex,
     bounded_current_race_index,
@@ -32,7 +33,13 @@ from src.predictor.on_demand import (
 )
 
 from .api import APIObservation
-from .foundation import EvidenceEnvelope, OperatorEvidenceReader, _new_envelope
+from .foundation import (
+    EvidenceEnvelope,
+    OperatorEvidenceReader,
+    _bind_path,
+    _digest_regular_file,
+    _new_envelope,
+)
 
 _DURATION = re.compile(
     r"^(?P<n>[+-]?(?:[0-9]+(?:\.[0-9]+)?|inf(?:inity)?|nan))\s*"
@@ -647,6 +654,8 @@ def _inventory_semantics(report: Mapping[str, Any]) -> tuple[dict[str, int], dic
 
 
 def _status(envelope: EvidenceEnvelope, status: str, *, policy: str | None = None) -> EvidenceEnvelope:
+    if status == "INVALID/INTEGRITY_FAILED":
+        envelope = _invalid(envelope)
     values = envelope.to_dict()
     values["status"] = status
     if policy is not None:
@@ -975,7 +984,17 @@ class LiveEvidenceAdapters:
             return envelope, races
         except CaptureOneRejected as exc:
             status, availability = self._collector_failure(exc.code)
-            return self._verified_envelope(now=now, policy="P-UPCOMING-300-PREJUMP", identity=CURRENT_RACE_INDEX_SCHEMA, locator="operator_ui.current_race_index", status=status, availability=availability), []
+            content_sha256 = None
+            if status == "INVALID/INTEGRITY_FAILED":
+                try:
+                    content_sha256, _ = _digest_regular_file(
+                        _bind_path(source.index_path, source.evidence_root),
+                        MAX_CURRENT_INDEX_BYTES,
+                    )
+                    availability = "present"
+                except (FileNotFoundError, PermissionError, OSError, ValueError):
+                    pass
+            return self._verified_envelope(now=now, policy="P-UPCOMING-300-PREJUMP", identity=CURRENT_RACE_INDEX_SCHEMA, locator="operator_ui.current_race_index", status=status, availability=availability, content_sha256=content_sha256), []
         except FileNotFoundError:
             return self._verified_envelope(now=now, policy="P-UPCOMING-300-PREJUMP", identity=CURRENT_RACE_INDEX_SCHEMA, locator="operator_ui.current_race_index", status="UNAVAILABLE/DATA_MISSING"), []
         except PermissionError:
@@ -1082,20 +1101,26 @@ class LiveEvidenceAdapters:
             invalid = self._verified_envelope(now=now, policy="P-IMMUTABLE-HISTORICAL", identity="on_demand_race_prediction_v2", locator="operator_ui.prediction_bundle", status="INVALID/INTEGRITY_FAILED")
             return APIObservation(invalid, {})
 
-    def _read(self, key: str) -> tuple[EvidenceEnvelope, Mapping[str, Any] | None]:
-        return self._reader.read_payload(key)
+    def _read(
+        self, key: str, now: datetime
+    ) -> tuple[EvidenceEnvelope, Mapping[str, Any] | None]:
+        return self._reader.read_payload(key, server_observed_at=now)
 
-    def _raw(self, key: str) -> tuple[EvidenceEnvelope, bytes | None]:
-        return self._reader.read_raw(key)
+    def _raw(
+        self, key: str, now: datetime
+    ) -> tuple[EvidenceEnvelope, bytes | None]:
+        return self._reader.read_raw(key, server_observed_at=now)
 
-    def _authenticated_raw(self, key: str) -> tuple[EvidenceEnvelope, bytes | None, int | None]:
-        return self._reader.read_raw_authenticated(key)
+    def _authenticated_raw(
+        self, key: str, now: datetime
+    ) -> tuple[EvidenceEnvelope, bytes | None, int | None]:
+        return self._reader.read_raw_authenticated(key, server_observed_at=now)
 
     def _lane(self, *, lane: str, now: datetime) -> tuple[EvidenceEnvelope, dict[str, Any]]:
         odds = lane == "ODDS_ONLY"
         state_key, report_key = (("odds_state", "odds_report") if odds else ("full_state", "full_report"))
-        state_env, state = self._read(state_key)
-        report_env, report = self._read(report_key)
+        state_env, state = self._read(state_key, now)
+        report_env, report = self._read(report_key, now)
         if state is None or report is None:
             failed = state_env if state is None else report_env
             outer = _missing_or_invalid(failed)
@@ -1272,7 +1297,7 @@ class LiveEvidenceAdapters:
             expected_locator = f"{autopilot_dir}/odds_capture_refresh_report.json"
             try:
                 refresh_env, raw_refresh = self._reader.read_verified_payload(
-                    "odds_refresh", expected_locator
+                    "odds_refresh", expected_locator, server_observed_at=now
                 )
             except (KeyError, ValueError):
                 return _status(report_env, "DIVERGENT"), _lane_data(lane, "DIVERGENT", run_id=run_id)
@@ -1342,7 +1367,7 @@ class LiveEvidenceAdapters:
         return APIObservation(_status(full_env, worst, policy="P-COLLECTOR-AGGREGATE"), {"lanes": [full, odds]})
 
     def system(self, now: datetime) -> APIObservation:
-        envelope, payload = self._read("deployment_manifest")
+        envelope, payload = self._read("deployment_manifest", now)
         if payload is None:
             return APIObservation(_status(envelope, _missing_or_invalid(envelope)), {})
         manifest_fields = frozenset({
@@ -1536,8 +1561,8 @@ class LiveEvidenceAdapters:
         }]})
 
     def corpus(self, now: datetime) -> APIObservation:
-        envelope, report = self._read("corpus_report")
-        manifest_env, manifest = self._read("corpus_manifest")
+        envelope, report = self._read("corpus_report", now)
+        manifest_env, manifest = self._read("corpus_manifest", now)
         if report is None or manifest is None:
             failed = envelope if report is None else manifest_env
             return APIObservation(_status(failed, _missing_or_invalid(failed)), {})
@@ -1588,7 +1613,7 @@ class LiveEvidenceAdapters:
                 if not isinstance(item, Mapping) or set(item) != {"bytes", "sha256"} or type(item["bytes"]) is not int or item["bytes"] < 0:
                     raise ValueError("inventory manifest entry is invalid")
                 declared = _sha(item.get("sha256"))
-                raw_env, raw, byte_count = self._authenticated_raw(key)
+                raw_env, raw, byte_count = self._authenticated_raw(key, now)
                 if raw is None and key not in {"corpus_inventory_csv", "corpus_inventory_jsonl"}:
                     return APIObservation(_status(raw_env, _missing_or_invalid(raw_env)), {})
                 if raw_env.status == "DIVERGENT":
@@ -1640,7 +1665,7 @@ class LiveEvidenceAdapters:
         })
 
     def models(self, now: datetime) -> APIObservation:
-        envelope, catalog = self._read("model_catalog")
+        envelope, catalog = self._read("model_catalog", now)
         if catalog is None:
             return APIObservation(_status(envelope, _missing_or_invalid(envelope)), {})
         expected = (
@@ -1671,12 +1696,12 @@ class LiveEvidenceAdapters:
                     raise ValueError("resolved model identity is invalid")
                 if identity.get("requested") != selector or identity.get("resolved") != resolved or identity.get("alias_resolved") is not True:
                     raise ValueError("resolved model identity is divergent")
-                config_env, config_raw = self._raw(f"{prefix}_config")
-                schema_env, schema_raw = self._raw(f"{prefix}_schema")
+                config_env, config_raw = self._raw(f"{prefix}_config", now)
+                schema_env, schema_raw = self._raw(f"{prefix}_schema", now)
                 raw_observations = [(config_env, config_raw), (schema_env, schema_raw)]
                 if resolved == "market_form_residual_v1":
-                    model_env, model_raw = self._raw(f"{prefix}_artifact")
-                    manifest_env, manifest_raw = self._raw(f"{prefix}_manifest")
+                    model_env, model_raw = self._raw(f"{prefix}_artifact", now)
+                    manifest_env, manifest_raw = self._raw(f"{prefix}_manifest", now)
                     raw_observations.extend([(model_env, model_raw), (manifest_env, manifest_raw)])
                 else:
                     model_env = manifest_env = None

--- a/tests/operator_ui/test_live_adapters.py
+++ b/tests/operator_ui/test_live_adapters.py
@@ -704,7 +704,7 @@ def test_calendar_rejects_arbitrary_prefix_but_accepts_complete_date_token():
 
 def test_real_corpus_catalog_and_deployment_shapes(tmp_path):
     live = make_live(tmp_path)
-    assert live.corpus(NOW).evidence.status == "UNAVAILABLE/DATA_MISSING"
+    assert live.corpus(NOW).evidence.status == "AVAILABLE/FRESH"
     models = live.models(NOW).data["models"]
     assert [(item["model_id"], item["role"]) for item in models] == [
         ("market_form_residual_v1", "LATEST_RESEARCH"),
@@ -726,7 +726,7 @@ def test_corpus_uses_report_time_and_exposes_admission_gap(tmp_path):
     values = actual_payloads(NOW - timedelta(seconds=86400))
     result = make_live(tmp_path, values).corpus(NOW)
     report = result.data["reports"][0]
-    assert result.evidence.status == "UNAVAILABLE/DATA_MISSING"
+    assert result.evidence.status == "AVAILABLE/FRESH"
     assert report["status"] == "UNAVAILABLE"
     assert "population_id" not in report
     assert "population_count" not in report
@@ -758,7 +758,7 @@ def test_corpus_inventory_is_digest_only_but_final_status_retains_bytes(tmp_path
     def capture(key, **kwargs):
         result = original(key, **kwargs); observed[key] = result; return result
     monkeypatch.setattr(live._reader, "read_raw_authenticated", capture)
-    assert live.corpus(NOW).evidence.status == "UNAVAILABLE/DATA_MISSING"
+    assert live.corpus(NOW).evidence.status == "AVAILABLE/FRESH"
     csv_manifest = values["corpus_manifest"]["files"]["packet/race_evidence_inventory.csv"]
     assert observed["corpus_inventory_csv"][0].content_sha256 == hashlib.sha256(
         b"race_id\n1\n"
@@ -860,7 +860,7 @@ def test_corpus_accepts_genuine_relative_and_absolute_producer_locators_without_
     values["corpus_report"]["db_summary"]["db_status"]["db_path"] = f"{prefix}/greyhound.sqlite"
     values["corpus_manifest"]["output_dir"] = output
     result = make_live(tmp_path, values).corpus(NOW)
-    assert result.evidence.status == "UNAVAILABLE/DATA_MISSING"
+    assert result.evidence.status == "AVAILABLE/FRESH"
     rendered = json.dumps(result.data)
     assert prefix not in rendered
     assert "population_count" not in rendered

--- a/tests/operator_ui/test_live_adapters.py
+++ b/tests/operator_ui/test_live_adapters.py
@@ -176,6 +176,7 @@ def make_live(
     raw_overrides=None,
     upcoming_races=None,
     prediction_bundles=None,
+    reader_clock=None,
 ):
     values = values or actual_payloads()
     unit_bytes = {
@@ -279,7 +280,9 @@ def make_live(
                 authority_observed_at=(now.isoformat() if key == "model_catalog" else None),
             ),
         )
-    reader = OperatorEvidenceReader(sources, raw_sources=raw_sources, clock=lambda: now)
+    reader = OperatorEvidenceReader(
+        sources, raw_sources=raw_sources, clock=reader_clock or (lambda: now)
+    )
     units = InstalledUnits(
         **unit_bytes, observed_at=units_observed_at or now, working_directory="/srv/app",
         full_unit_name="shadow-autopilot.service",
@@ -345,6 +348,56 @@ def test_realistic_producer_payloads_are_bound_at_authenticated_collector_endpoi
     payload = response.get_json()
     assert payload["classification"] == "AVAILABLE/FRESH"
     assert [lane["run_id"] for lane in payload["data"]["lanes"]] == ["full-1", "odds-9"]
+
+
+def test_live_endpoints_use_exact_nonfrozen_request_clock(tmp_path, monkeypatch):
+    base = datetime.now(timezone.utc)
+    view = VerifiedCurrentRaceIndex(
+        "collector_current_race_index_v2", "run-live", base.isoformat(),
+        "1" * 64, b"packet", (), "refresh.json", "2" * 64,
+        "3" * 64, "4" * 64, "5" * 64,
+    )
+    monkeypatch.setattr(
+        live_module, "bounded_current_race_index", lambda **kwargs: view
+    )
+    live = make_live(
+        tmp_path / "live",
+        actual_payloads(base - timedelta(seconds=30)),
+        now=base,
+        units_observed_at=base,
+        reader_clock=lambda: datetime.now(timezone.utc),
+        upcoming_races=UpcomingRaceSource(tmp_path / "live/index.json", tmp_path / "live"),
+    )
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True, OPERATOR_UI_CONNECTED_MODE=True, OPERATOR_UI_LEVEL=2,
+        OPERATOR_UI_SECRET_KEY="endpoint-secret-" + "x" * 40,
+        OPERATOR_UI_USERNAME="operator",
+        OPERATOR_UI_PASSWORD_HASH=generate_password_hash("correct horse"),
+        OPERATOR_UI_AUDIT_DB_PATH=str(tmp_path / "audit.sqlite3"),
+        DATABASE_PATH=str(tmp_path / "canonical.sqlite3"),
+        OPERATOR_UI_DEPLOYED_COMMIT="b" * 40,
+        OPERATOR_UI_DEPLOYED_TREE="c" * 40,
+        OPERATOR_UI_DEPLOYED_VERSION="operator-ui-v1",
+        OPERATOR_UI_CLOCK=lambda: datetime.now(timezone.utc),
+    )
+    install_connected_mode(app); assert install_level_1_api(app)
+    app.config[CONFIG_KEY] = live
+    assert bind_configured_live_evidence(app)
+    client = app.test_client()
+    token = client.get("/operator-ui/login").get_json()["csrf_token"]
+    assert client.post("/operator-ui/login", data={"username":"operator","password":"correct horse","csrf_token":token}).status_code == 200
+
+    for route in (
+        "/operator-ui/api/v1/races/upcoming",
+        "/operator-ui/api/v1/collector",
+        "/operator-ui/api/v1/corpus",
+        "/operator-ui/api/v1/models",
+        "/operator-ui/api/v1/system",
+    ):
+        response = client.get(route)
+        assert response.status_code == 200
+        assert response.get_json()["classification"] != "NON_OPERATIONAL/PROVIDER_ERROR"
 
 
 def test_complete_calendar_and_nondefault_values(tmp_path):
@@ -702,8 +755,8 @@ def test_corpus_inventory_is_digest_only_but_final_status_retains_bytes(tmp_path
     live = make_live(tmp_path, values)
     observed = {}
     original = live._reader.read_raw_authenticated
-    def capture(key):
-        result = original(key); observed[key] = result; return result
+    def capture(key, **kwargs):
+        result = original(key, **kwargs); observed[key] = result; return result
     monkeypatch.setattr(live._reader, "read_raw_authenticated", capture)
     assert live.corpus(NOW).evidence.status == "UNAVAILABLE/DATA_MISSING"
     csv_manifest = values["corpus_manifest"]["files"]["packet/race_evidence_inventory.csv"]
@@ -1377,6 +1430,57 @@ def test_real_collector_rejection_codes_map_truthfully(tmp_path, monkeypatch, co
     result = make_live(tmp_path, upcoming_races=UpcomingRaceSource(tmp_path / "index", tmp_path)).upcoming(NOW)
     assert (result.evidence.status, result.evidence.availability, result.evidence.schema_integrity) == (status, availability, integrity)
     assert "no operational claim" in result.evidence.supported_claim
+
+
+def test_invalid_present_current_index_retains_exact_bounded_content_hash(tmp_path):
+    index = tmp_path / "index.json"
+    raw = b'{"schema_version":"collector_current_race_index_v2","broken":true}'
+    index.write_bytes(raw)
+    result = make_live(
+        tmp_path,
+        upcoming_races=UpcomingRaceSource(index, tmp_path),
+    ).upcoming(NOW)
+
+    assert result.evidence.status == "INVALID/INTEGRITY_FAILED"
+    assert result.evidence.availability == "present"
+    assert result.evidence.schema_integrity == "failed"
+    assert result.evidence.content_sha256 == hashlib.sha256(raw).hexdigest()
+    assert result.data == {}
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True, OPERATOR_UI_CONNECTED_MODE=True, OPERATOR_UI_LEVEL=2,
+        OPERATOR_UI_SECRET_KEY="endpoint-secret-" + "x" * 40,
+        OPERATOR_UI_USERNAME="operator",
+        OPERATOR_UI_PASSWORD_HASH=generate_password_hash("correct horse"),
+        OPERATOR_UI_AUDIT_DB_PATH=str(tmp_path / "audit.sqlite3"),
+        DATABASE_PATH=str(tmp_path / "canonical.sqlite3"),
+        OPERATOR_UI_DEPLOYED_COMMIT="b" * 40,
+        OPERATOR_UI_DEPLOYED_TREE="c" * 40,
+        OPERATOR_UI_DEPLOYED_VERSION="operator-ui-v1",
+        OPERATOR_UI_CLOCK=lambda: NOW,
+    )
+    install_connected_mode(app); assert install_level_1_api(app)
+    app.config[CONFIG_KEY] = make_live(
+        tmp_path / "endpoint-live",
+        upcoming_races=UpcomingRaceSource(index, tmp_path),
+    )
+    assert bind_configured_live_evidence(app)
+    client = app.test_client()
+    token = client.get("/operator-ui/login").get_json()["csrf_token"]
+    assert client.post("/operator-ui/login", data={"username":"operator","password":"correct horse","csrf_token":token}).status_code == 200
+    response = client.get("/operator-ui/api/v1/races/upcoming")
+    assert response.status_code == 200
+    assert response.get_json()["classification"] == "INVALID/INTEGRITY_FAILED"
+
+
+def test_collector_invalid_aggregate_axes_are_coherent(tmp_path):
+    values = actual_payloads()
+    values["full_state"]["schema_version"] = "wrong"
+    live = make_live(tmp_path / "live", values)
+    aggregate = live.collector(NOW).evidence
+    assert (aggregate.status, aggregate.availability, aggregate.schema_integrity) == (
+        "INVALID/INTEGRITY_FAILED", "present", "failed"
+    )
 
 
 @pytest.mark.parametrize(("age", "status"), [(60, "AVAILABLE/FRESH"), (60.000001, "STALE")])

--- a/tests/operator_ui/test_live_adapters.py
+++ b/tests/operator_ui/test_live_adapters.py
@@ -43,7 +43,7 @@ from src.operator_ui.live_adapters import (
     InstalledUnits, LiveEvidenceAdapters, PredictionBundleSource,
     UpcomingRaceSource, _calendar_gap, _finite_metric,
 )
-from src.operator_ui.api import install_level_1_api
+from src.operator_ui.api import _corpus_report, install_level_1_api
 from src.operator_ui.bootstrap import CONFIG_KEY, bind_configured_live_evidence
 from src.operator_ui.security import install_connected_mode
 
@@ -348,6 +348,69 @@ def test_realistic_producer_payloads_are_bound_at_authenticated_collector_endpoi
     payload = response.get_json()
     assert payload["classification"] == "AVAILABLE/FRESH"
     assert [lane["run_id"] for lane in payload["data"]["lanes"]] == ["full-1", "odds-9"]
+
+
+def test_authenticated_limited_corpus_report_is_disclosed_without_population_claims(tmp_path):
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True, OPERATOR_UI_CONNECTED_MODE=True, OPERATOR_UI_LEVEL=2,
+        OPERATOR_UI_SECRET_KEY="endpoint-secret-" + "x" * 40,
+        OPERATOR_UI_USERNAME="operator",
+        OPERATOR_UI_PASSWORD_HASH=generate_password_hash("correct horse"),
+        OPERATOR_UI_AUDIT_DB_PATH=str(tmp_path / "audit.sqlite3"),
+        DATABASE_PATH=str(tmp_path / "canonical.sqlite3"),
+        OPERATOR_UI_DEPLOYED_COMMIT="b" * 40,
+        OPERATOR_UI_DEPLOYED_TREE="c" * 40,
+        OPERATOR_UI_DEPLOYED_VERSION="operator-ui-v1",
+        OPERATOR_UI_CLOCK=lambda: NOW,
+    )
+    install_connected_mode(app); assert install_level_1_api(app)
+    app.config[CONFIG_KEY] = make_live(tmp_path / "live")
+    assert bind_configured_live_evidence(app)
+    client = app.test_client()
+    token = client.get("/operator-ui/login").get_json()["csrf_token"]
+    assert client.post("/operator-ui/login", data={"username":"operator","password":"correct horse","csrf_token":token}).status_code == 200
+
+    response = client.get("/operator-ui/api/v1/corpus")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["classification"] == "AVAILABLE/FRESH"
+    report = payload["data"]["reports"][0]
+    assert report["status"] == "UNAVAILABLE"
+    assert "official-result publication/closure" in report["admission_gap"]
+    assert set(report) == {
+        "report_id", "status", "generated_at", "chain_hashes", "admission_gap",
+    }
+    assert report["chain_hashes"]
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda report: report.update(population_id="mixed-population"),
+        lambda report: report.pop("admission_gap"),
+        lambda report: report.update(unknown_claim="not-contracted"),
+        lambda report: report.update(
+            population_id="population-1",
+            population_count=1,
+            funnel_counts={"admitted": 1},
+            exclusions=[],
+        ),
+    ],
+)
+def test_limited_unavailable_corpus_report_rejects_mixed_partial_and_full_claims(mutate):
+    report = {
+        "report_id": "report-1",
+        "status": "UNAVAILABLE",
+        "generated_at": "2026-07-31T01:59:30Z",
+        "chain_hashes": {"report": "a" * 64},
+        "admission_gap": "publication/closure evidence is not hash-bound",
+    }
+    mutate(report)
+
+    with pytest.raises(ValueError):
+        _corpus_report(report)
 
 
 def test_live_endpoints_use_exact_nonfrozen_request_clock(tmp_path, monkeypatch):


### PR DESCRIPTION
Completes the bounded Operator UI runtime-disclosure correction.

- Exact reviewed head: `ccd5fd5c4a225136def70cfd04253857a1abe2d0`
- Exact tree: `c4b5fc900e1a347c6fe0c889d3b300c7df8d2922`
- Base: `e7d81beae7455a5192012b21feca1b54a2b08600`
- Binary diff SHA-256: `5d796c47035dee6d1ffe2fad99d709c2fb490ae8467a042cf2626589064cfffa`

Preserves request-time identity, bounded no-follow hashing, coherent collector axes, and strict corpus claim boundaries. Corpus evidence is authenticated and fresh; the inner unavailable report remains an exact five-field admission-gap record without population/count/closure claims.

Validation: 8 focused tests; 214/214 live-adapter tests; `git diff --check`; fresh independent exact-tree Codex X review ACCEPT (`019fcb59-e968-71f2-8608-65c0ef028b59`).