### PR TITLE
GHU-036 C23: accept canonical collector producer run IDs

### DIFF
--- a/src/operator_ui/api.py
+++ b/src/operator_ui/api.py
@@ -475,7 +475,7 @@ def _collector_lane(value: Any, *, request_now: datetime) -> dict[str, Any]:
         )
         owner = {
             "kind": _text(owner_raw["kind"]),
-            "run_id": _id(owner_raw["run_id"]),
+            "run_id": _text(owner_raw["run_id"]),
             "started_at": _utc(owner_raw["started_at"], field="lock owner started_at")[0],
         }
     capture_raw = _exact(
@@ -543,7 +543,7 @@ def _collector_lane(value: Any, *, request_now: datetime) -> dict[str, Any]:
         "reference_hashes": _named_hashes(
             raw["reference_hashes"], required=status != "DATA_MISSING"
         ),
-        "run_id": _id(raw["run_id"]),
+        "run_id": _text(raw["run_id"]),
         "state_age_seconds": state_age,
         "status": status,
     }

--- a/tests/operator_ui/test_api.py
+++ b/tests/operator_ui/test_api.py
@@ -531,6 +531,39 @@ def collector_lanes():
     return [full, odds]
 
 
+def test_collector_preserves_timezone_bearing_producer_run_ids(tmp_path):
+    lanes = collector_lanes()
+    lanes[0]["run_id"] = "20260804T100012+1000"
+    lanes[1]["run_id"] = "20260804T191454+1000_odds_capture"
+    lanes[1]["operational_context"]["lock_owner"] = {
+        "kind": "collector",
+        "run_id": "20260804T191454+1000_odds_capture",
+        "started_at": "2026-07-31T01:02:00Z",
+    }
+    app = app_for(tmp_path)
+    register_level_1_provider(
+        app,
+        "collector",
+        lambda _now: APIObservation(
+            evidence("P-COLLECTOR-AGGREGATE"), {"lanes": lanes}
+        ),
+    )
+    client = app.test_client()
+    login(client)
+
+    response = client.get(ROUTES["collector"])
+
+    assert response.status_code == 200
+    response_lanes = response.get_json()["data"]["lanes"]
+    assert [lane["run_id"] for lane in response_lanes] == [
+        "20260804T100012+1000",
+        "20260804T191454+1000_odds_capture",
+    ]
+    assert response_lanes[1]["operational_context"]["lock_owner"]["run_id"] == (
+        "20260804T191454+1000_odds_capture"
+    )
+
+
 def corpus_report():
     return {
         "report_id": "report-1",


### PR DESCRIPTION
Fresh exact-tree review: ACCEPT (Codex X session 019fcc21-7ed6-76e1-9bcb-c723ca31787c).\n\nExact candidate: ea01991c39b77c9e1cfd1bdff92a9c0bebe83229\nTree: 23861f3088c39ffc6880b3bbdbf362f4fbb4eb87\nBase: 81b72909437ec3453f619c1c16319ac002d8bdc6\n\nValidation: focused canonical producer-ID contract test passed; git diff --check passed. The change treats collector provenance run IDs as bounded printable text while retaining route identifier grammar.