### PR TITLE
fix(operator-ui): preserve untrusted collector lane evidence

### DIFF
--- a/src/operator_ui/api.py
+++ b/src/operator_ui/api.py
@@ -541,7 +541,8 @@ def _collector_lane(value: Any, *, request_now: datetime) -> dict[str, Any]:
         "operational_context": context,
         "phase": _text(raw["phase"]),
         "reference_hashes": _named_hashes(
-            raw["reference_hashes"], required=status != "DATA_MISSING"
+            raw["reference_hashes"],
+            required=status not in {"DATA_MISSING", "INTEGRITY_FAILED", "DIVERGENT"},
         ),
         "run_id": _text(raw["run_id"]),
         "state_age_seconds": state_age,

--- a/tests/operator_ui/test_api.py
+++ b/tests/operator_ui/test_api.py
@@ -668,6 +668,69 @@ def test_collector_non_healthy_discloses_bounded_lane_states(
     ]
 
 
+@pytest.mark.parametrize("lane_status", ["DIVERGENT", "INTEGRITY_FAILED"])
+def test_collector_untrusted_lane_accepts_empty_reference_hashes(
+    tmp_path, lane_status
+):
+    lanes = collector_lanes()
+    lanes[0].update(
+        status=lane_status,
+        deadline_utc=None,
+        state_age_seconds=None,
+        reference_hashes={},
+    )
+    app = app_for(tmp_path)
+    register_level_1_provider(
+        app,
+        "collector",
+        lambda _now: APIObservation(
+            evidence("P-COLLECTOR-AGGREGATE", status="DIVERGENT"),
+            {"lanes": lanes},
+        ),
+    )
+    client = app.test_client()
+    login(client)
+
+    response = client.get(ROUTES["collector"])
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["classification"] == "DIVERGENT"
+    assert payload["data"]["lanes"][0]["status"] == lane_status
+    assert payload["data"]["lanes"][0]["reference_hashes"] == {}
+
+
+@pytest.mark.parametrize(
+    "lane_status",
+    [
+        "ACTIVE",
+        "RECEIPT_READY",
+        "CAPTURE_WINDOW_CLOSED",
+        "CAPTURE_FAILED",
+        "STALE",
+    ],
+)
+def test_collector_trusted_lane_rejects_empty_reference_hashes(
+    tmp_path, lane_status
+):
+    lanes = collector_lanes()
+    lanes[0].update(status=lane_status, reference_hashes={})
+    if lane_status == "STALE":
+        lanes[0].update(deadline_utc=None, state_age_seconds=None)
+    app = app_for(tmp_path)
+    register_level_1_provider(
+        app,
+        "collector",
+        lambda _now: APIObservation(
+            evidence("P-COLLECTOR-AGGREGATE"), {"lanes": lanes}
+        ),
+    )
+    client = app.test_client()
+    login(client)
+
+    audited_provider_error(tmp_path, client.get(ROUTES["collector"]))
+
+
 @pytest.mark.parametrize(
     ("classification", "component_status"),
     [


### PR DESCRIPTION
## GHU-036 C24\n\nPreserves canonical untrusted collector-lane evidence when a DIVERGENT or INTEGRITY_FAILED lane has no usable per-lane reference hash map.\n\n- Empty hashes remain allowed for DATA_MISSING.\n- Empty hashes are allowed only for DIVERGENT and INTEGRITY_FAILED.\n- ACTIVE, RECEIPT_READY, CAPTURE_WINDOW_CLOSED, CAPTURE_FAILED, and STALE remain fail-closed and require valid non-empty named hashes.\n- Routed timezone-bearing run IDs and all research/provenance boundaries are unchanged.\n\nExact candidate:\n- commit: e7187e6bfeee6c6068907f1481f2cdd77224359c\n- tree: 9803dbf32c07960b26ebd1850d670dc2b905f6f9\n- parent: 4f71f06b63cdaca6879fcca7d6e443411694de47\n- patch SHA-256: cb62f47deb93bdb10e88fefe9410d3de2efef74917fc4a2dea8e5f13ee4b1730\n\nValidation:\n- focused parent: 7 passed, 203 deselected\n- git diff --check: passed\n- fresh independent exact-tree reviewer: ACCEPT\n- reviewer session: 019fcc41-9c0b-7343-966d-9af13941d0fb\n- reviewer standards/spec findings: none