### PR TITLE
Fix invalid collector payload suppression

### DIFF
--- a/docs/agent_tasks/operator_ui_invalid_collector_suppression_v1_20260804.md
+++ b/docs/agent_tasks/operator_ui_invalid_collector_suppression_v1_20260804.md
@@ -1,0 +1,53 @@
+---
+job_id: operator_ui_invalid_collector_suppression_v1_20260804
+lane: Operator UI
+owner: Codex
+mutation_mode: safe_extension
+approval_required: true
+approval_id: USER_PROCEED_20260804
+production_data_access: false
+timeout_seconds: 7200
+allowed_files:
+  - docs/agent_tasks/operator_ui_invalid_collector_suppression_v1_20260804.md
+  - src/operator_ui/api.py
+  - tests/operator_ui/test_api.py
+---
+
+# Operator UI invalid collector suppression repair
+
+## Objective
+
+Restore the fail-closed API contract that rejects a non-empty collector payload
+when its aggregate evidence is `INVALID/INTEGRITY_FAILED`.
+
+## Boundaries
+
+- Do not change collector, runtime, deployment, model, corpus, prediction, or
+  betting behavior.
+- Do not weaken validation or remove the existing regression test.
+- Keep the finite empty invalid response for genuinely empty provider data.
+
+## Regression adjudication
+
+- Canonical base: `38a3c992669523a0cc34d370e4039ecc658c0fdf`.
+- Old contract and permanent gate: commit `d5e1c986`,
+  `test_invalid_collector_payload_remains_suppressed`.
+- Introducing change: commit `271f0026` allowed finite invalid collector
+  resources to return `{}` even when the provider supplied non-empty data.
+- Classification: `TRUE_REGRESSION`.
+- Runtime functionality proof: not required; this is a pure read-API safety
+  repair with no live-state mutation or runtime claim.
+
+## Required validation
+
+- Run the failing regression test before and after the patch.
+- Run `tests/operator_ui/test_api.py` under an owner-controlled `TMPDIR` whose
+  ancestry is not group/world writable.
+- Run fatal Ruff, `py_compile`, and `git diff --check` for the changed Python
+  surface.
+
+## Definition of done
+
+- Non-empty invalid collector data produces the audited provider-error path.
+- Empty invalid collector data retains the finite empty response.
+- No files outside this card's allowlist change.

--- a/src/operator_ui/api.py
+++ b/src/operator_ui/api.py
@@ -1180,9 +1180,10 @@ def install_level_1_api(app: Flask) -> bool:
             elif (
                 (
                     resource in _FINITE_EMPTY_INVALID_RESOURCES
-                    or resource == "system" and not raw.data
+                    or resource == "system"
                 )
                 and classification is EvidenceStatus.INVALID_INTEGRITY_FAILED
+                and not raw.data
             ):
                 response["data"] = {}
             elif raw.data:


### PR DESCRIPTION
## What changed

Require provider data to be empty before the finite INVALID/INTEGRITY_FAILED response path may return an empty data object. Non-empty invalid collector payloads again take the audited provider-error path.

## Root cause

Commit 271f0026 broadened the finite-invalid shortcut to collector resources without retaining the prior empty-data condition, silently discarding non-empty invalid payloads.

## Impact

This restores fail-closed Operator UI read-API behavior only. It does not change collector, prediction, model, corpus, deployment, runtime, or betting behavior.

## Validation

- tests/operator_ui/test_api.py: 210 passed in 156.72s
- targeted invalid collector and invalid system projection tests: 2 passed
- fatal Ruff selection E9,F63,F7,F82: passed
- py_compile: passed
- git diff --check: passed

The full Ruff rule set still reports pre-existing style findings in the legacy files; this patch adds none.