### PR TITLE
Restore sealed scheduled-receipt prediction reuse

### DIFF
--- a/docs/agent_tasks/manual_scheduled_protocol_chain_v1_20260804.md
+++ b/docs/agent_tasks/manual_scheduled_protocol_chain_v1_20260804.md
@@ -1,0 +1,70 @@
+---
+job_id: manual_scheduled_protocol_chain_v1_20260804
+lane: Forecasting Core
+supporting_lanes:
+  - Provenance
+  - Manual Prediction
+owner: Codex
+mutation_mode: safe_extension
+approval_required: true
+approval_id: USER_PROCEED_20260804
+production_data_access: false
+timeout_seconds: 10800
+allowed_files:
+  - docs/agent_tasks/manual_scheduled_protocol_chain_v1_20260804.md
+  - race_collection/manual_prediction_collector_request.py
+  - scripts/predict_race_now.py
+  - src/predictor/on_demand.py
+  - tests/test_predict_race_now.py
+---
+
+# Scheduled receipt sealed protocol-chain repair
+
+## Objective
+
+Restore supported reuse of a current scheduled exact receipt while the canonical
+collector lock is busy, without weakening descriptor-retained provenance or the
+sealed prediction-bundle verifier.
+
+## Boundaries
+
+- Preserve the existing manual-request protocol-chain schema and validation.
+- Add a distinct, exact scheduled-receipt chain; do not fabricate a manual
+  request, claim, attempt, response, receipt, or consume lifecycle.
+- Snapshot the scheduled receipt and all referenced source members using
+  no-follow retained descriptors and verify identities again before return.
+- Do not change capture authority, browser/lock behavior, append-only writes,
+  model/features, corpus, deployment, promotion, EV, or betting behavior.
+- No live runtime claim is authorized by unit/integration validation.
+
+## Regression adjudication
+
+- Canonical base: `38a3c992669523a0cc34d370e4039ecc658c0fdf`.
+- Old fix: commit `da68ef39` and
+  `test_scheduled_exact_receipt_reuses_while_capture_authority_is_busy`.
+- Introducing change: commits `21e7b02e` through `90502a36` required every
+  selected handoff to have the manual-request protocol chain, although scheduled
+  exact receipts intentionally have their own authenticated lifecycle.
+- Classification: `TRUE_REGRESSION`.
+- Permanent gate: the existing scheduled-reuse test plus scheduled sealed-chain
+  verifier tests added by this repair.
+- Runtime functionality proof: `DATA_MISSING`; this task makes no live-runtime
+  success claim and performs no collector acquisition.
+
+## Required validation
+
+- Preserve the red result: one failure, 62 passes in `tests/test_predict_race_now.py`.
+- Run focused scheduled snapshot, scheduled reuse, and sealed verifier tests.
+- Run the complete manual prediction module and sealed-bundle verifier module.
+- Run fatal Ruff, `py_compile`, and `git diff --check` on changed Python files.
+- Run the full forecasting suite once through exact-head CI; do not repeat it
+  locally.
+
+## Definition of done
+
+- A valid current scheduled receipt produces a prediction-ready sealed bundle
+  with an independently validated scheduled protocol chain.
+- Mutation, path, hash, schema, identity, or membership mismatch still fails
+  closed.
+- Existing manual-request sealed bundles remain valid without schema changes.
+- No file outside this card's allowlist changes.

--- a/docs/agent_tasks/operator_ui_invalid_collector_suppression_v1_20260804.md
+++ b/docs/agent_tasks/operator_ui_invalid_collector_suppression_v1_20260804.md
@@ -1,0 +1,53 @@
+---
+job_id: operator_ui_invalid_collector_suppression_v1_20260804
+lane: Operator UI
+owner: Codex
+mutation_mode: safe_extension
+approval_required: true
+approval_id: USER_PROCEED_20260804
+production_data_access: false
+timeout_seconds: 7200
+allowed_files:
+  - docs/agent_tasks/operator_ui_invalid_collector_suppression_v1_20260804.md
+  - src/operator_ui/api.py
+  - tests/operator_ui/test_api.py
+---
+
+# Operator UI invalid collector suppression repair
+
+## Objective
+
+Restore the fail-closed API contract that rejects a non-empty collector payload
+when its aggregate evidence is `INVALID/INTEGRITY_FAILED`.
+
+## Boundaries
+
+- Do not change collector, runtime, deployment, model, corpus, prediction, or
+  betting behavior.
+- Do not weaken validation or remove the existing regression test.
+- Keep the finite empty invalid response for genuinely empty provider data.
+
+## Regression adjudication
+
+- Canonical base: `38a3c992669523a0cc34d370e4039ecc658c0fdf`.
+- Old contract and permanent gate: commit `d5e1c986`,
+  `test_invalid_collector_payload_remains_suppressed`.
+- Introducing change: commit `271f0026` allowed finite invalid collector
+  resources to return `{}` even when the provider supplied non-empty data.
+- Classification: `TRUE_REGRESSION`.
+- Runtime functionality proof: not required; this is a pure read-API safety
+  repair with no live-state mutation or runtime claim.
+
+## Required validation
+
+- Run the failing regression test before and after the patch.
+- Run `tests/operator_ui/test_api.py` under an owner-controlled `TMPDIR` whose
+  ancestry is not group/world writable.
+- Run fatal Ruff, `py_compile`, and `git diff --check` for the changed Python
+  surface.
+
+## Definition of done
+
+- Non-empty invalid collector data produces the audited provider-error path.
+- Empty invalid collector data retains the finite empty response.
+- No files outside this card's allowlist change.

--- a/race_collection/manual_prediction_collector_request.py
+++ b/race_collection/manual_prediction_collector_request.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import re
+import stat
 import tempfile
 import time
 import uuid
@@ -215,6 +216,7 @@ def _validate_collector_source_report(
     *,
     race_id: str,
     collector_run_id: str,
+    emitted_at: str,
     capture_attempt_sha256: str,
     append_report_sha256: str,
 ) -> None:
@@ -224,23 +226,48 @@ def _validate_collector_source_report(
         raise ProtocolRejected("RECORD_MALFORMED") from exc
     if (
         type(report) is not dict
+        or set(report)
+        != {
+            "schema_version",
+            "collector_run_id",
+            "generated_at",
+            "race_id",
+            "source_race_id",
+            "source_plan_item",
+            "source_attempt",
+            "attempts",
+        }
         or canonical_bytes(report) != raw
         or report.get("schema_version") != "collector_exact_capture_source_v1"
         or report.get("race_id") != race_id
         or report.get("collector_run_id") != collector_run_id
+        or report.get("generated_at") != emitted_at
+    ):
+        raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
+    _timestamp(report["generated_at"], "source_report.generated_at")
+    source_race_id = _known_text(
+        report.get("source_race_id"), "source_report.source_race_id"
+    )
+    source_plan = report.get("source_plan_item")
+    source_attempt = report.get("source_attempt")
+    if (
+        type(source_plan) is not dict
+        or type(source_attempt) is not dict
+        or source_plan.get("schema_version")
+        != "autonomous_live_odds_capture_plan_item_v1"
+        or source_plan.get("status") != "READY_TO_CAPTURE"
+        or source_plan.get("race_id") != source_race_id
+        or source_attempt.get("schema_version")
+        != "autonomous_live_odds_capture_attempt_v1"
+        or source_attempt.get("race_id") != source_race_id
+        or source_attempt.get("status") != "APPENDED"
     ):
         raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
     attempts = report.get("attempts")
-    matches = [
-        attempt
-        for attempt in attempts or []
-        if isinstance(attempt, Mapping)
-        and attempt.get("race_id") == race_id
-        and attempt.get("status") == "APPENDED"
-    ]
-    if len(matches) != 1:
+    adapted_attempt = {**source_attempt, "race_id": race_id}
+    if type(attempts) is not list or attempts != [adapted_attempt]:
         raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
-    attempt = matches[0]
+    attempt = attempts[0]
     append_report = attempt.get("append_report")
     if (
         sha256_bytes(canonical_bytes(attempt)) != capture_attempt_sha256
@@ -446,8 +473,18 @@ class ManualPredictionCollectorProtocol:
             flags = os.O_RDONLY | os.O_NOFOLLOW
             if directory:
                 flags |= os.O_DIRECTORY
+            elif hasattr(os, "O_NONBLOCK"):
+                flags |= os.O_NONBLOCK
             descriptor = os.open(name, flags, dir_fd=parent)
             opened.append(descriptor)
+            opened_value = os.fstat(descriptor)
+            valid_type = (
+                stat.S_ISDIR(opened_value.st_mode)
+                if directory
+                else stat.S_ISREG(opened_value.st_mode)
+            )
+            if not valid_type:
+                raise ProtocolRejected("PROTOCOL_PATH_UNSAFE")
             expected = identity(descriptor)
             if directory:
                 retained_dirs.append((parent, name, descriptor, expected))
@@ -535,6 +572,7 @@ class ManualPredictionCollectorProtocol:
             evidence_root = directory(self.root.parent)
             artifact_raws: dict[str, bytes] = {}
             artifact_paths: dict[str, Path] = {}
+            artifact_identities: dict[str, tuple[int, int]] = {}
             for label, source_key in (
                 ("report", "source_report_sha256"),
                 ("form", "source_form_sha256"),
@@ -546,16 +584,24 @@ class ManualPredictionCollectorProtocol:
                     "sha256",
                 }:
                     raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
-                relative = Path(
-                    _known_text(artifact.get("path"), f"artifacts.{label}.path")
+                relative_text = _known_text(
+                    artifact.get("path"), f"artifacts.{label}.path"
                 )
-                if relative.is_absolute() or not relative.parts:
+                relative = Path(relative_text)
+                if (
+                    len(relative_text) > 512
+                    or len(relative.parts) > _EXACT_RECEIPT_ENTRY_LIMIT
+                    or relative.is_absolute()
+                    or not relative.parts
+                ):
                     raise ProtocolRejected("PROTOCOL_PATH_UNSAFE")
                 parent = evidence_root
                 for component in relative.parts[:-1]:
                     parent = child(parent, component, directory=True)
                 descriptor = child(parent, relative.parts[-1], directory=False)
-                raw = read(descriptor, identity(descriptor))
+                descriptor_identity = identity(descriptor)
+                artifact_identities[label] = descriptor_identity[:2]
+                raw = read(descriptor, descriptor_identity)
                 expected_hash = _hash(
                     artifact.get("sha256"), f"artifacts.{label}.sha256"
                 )
@@ -568,6 +614,7 @@ class ManualPredictionCollectorProtocol:
                 artifact_paths[label] = relative
             if (
                 len(set(artifact_paths.values())) != len(artifact_paths)
+                or len(set(artifact_identities.values())) != len(artifact_identities)
                 or receipt.get("form_name") != artifact_paths["form"].name
             ):
                 raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
@@ -575,6 +622,7 @@ class ManualPredictionCollectorProtocol:
                 artifact_raws["report"],
                 race_id=race_id,
                 collector_run_id=collector_run_id,
+                emitted_at=str(receipt.get("emitted_at")),
                 capture_attempt_sha256=capture_attempt_sha,
                 append_report_sha256=str(
                     public_handoff.get("append_report_sha256")
@@ -1416,6 +1464,7 @@ class ManualPredictionCollectorProtocol:
             Path(handoff["_report_path"]).read_bytes(),
             race_id=race_id,
             collector_run_id=collector_run,
+            emitted_at=emitted_text,
             capture_attempt_sha256=capture_attempt_sha,
             append_report_sha256=public_handoff["append_report_sha256"],
         )
@@ -1584,6 +1633,7 @@ class ManualPredictionCollectorProtocol:
                 raw_artifacts["report"],
                 race_id=race_id,
                 collector_run_id=value["collector_run_id"],
+                emitted_at=value["emitted_at"],
                 capture_attempt_sha256=capture_attempt_sha,
                 append_report_sha256=handoff["append_report_sha256"],
             )

--- a/race_collection/manual_prediction_collector_request.py
+++ b/race_collection/manual_prediction_collector_request.py
@@ -419,6 +419,197 @@ class ManualPredictionCollectorProtocol:
             for descriptor in reversed(opened):
                 os.close(descriptor)
 
+    def snapshot_collector_exact_handoff(
+        self, public_handoff: Mapping[str, Any]
+    ) -> tuple[dict[str, str], dict[str, bytes], dict[str, bytes]]:
+        """Snapshot one scheduled exact receipt and all of its source members."""
+        race_id = public_handoff.get("race_id")
+        capture_attempt_sha = public_handoff.get("capture_attempt_sha256")
+        if (
+            not isinstance(race_id, str)
+            or not race_id
+            or not isinstance(capture_attempt_sha, str)
+            or _HASH_RE.fullmatch(capture_attempt_sha) is None
+        ):
+            raise ProtocolRejected("PROTOCOL_CHAIN_AMBIGUOUS")
+        opened: list[int] = []
+        retained_dirs: list[tuple[int, str, int, tuple[int, int, int, int]]] = []
+        retained_files: list[tuple[int, str, int, tuple[int, int, int, int]]] = []
+
+        def identity(descriptor: int) -> tuple[int, int, int, int]:
+            value = os.fstat(descriptor)
+            return value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns
+
+        def child(parent: int, name: str, *, directory: bool) -> int:
+            if not name or name in {".", ".."} or Path(name).name != name:
+                raise ProtocolRejected("PROTOCOL_PATH_UNSAFE")
+            flags = os.O_RDONLY | os.O_NOFOLLOW
+            if directory:
+                flags |= os.O_DIRECTORY
+            descriptor = os.open(name, flags, dir_fd=parent)
+            opened.append(descriptor)
+            expected = identity(descriptor)
+            if directory:
+                retained_dirs.append((parent, name, descriptor, expected))
+            else:
+                retained_files.append((parent, name, descriptor, expected))
+            return descriptor
+
+        def directory(path: Path) -> int:
+            descriptor = os.open("/", os.O_RDONLY | os.O_DIRECTORY)
+            opened.append(descriptor)
+            for component in path.absolute().parts[1:]:
+                descriptor = child(descriptor, component, directory=True)
+            return descriptor
+
+        def read(descriptor: int, expected: tuple[int, int, int, int]) -> bytes:
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                chunk = os.read(
+                    descriptor,
+                    min(65536, _SNAPSHOT_MEMBER_MAX_BYTES + 1 - total),
+                )
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > _SNAPSHOT_MEMBER_MAX_BYTES:
+                    raise ProtocolRejected("PROTOCOL_MEMBER_OVERSIZED")
+                chunks.append(chunk)
+            if identity(descriptor) != expected:
+                raise ProtocolRejected("PROTOCOL_MEMBER_CHANGED")
+            return b"".join(chunks)
+
+        try:
+            protocol_root = directory(self.root)
+            collector_root = child(
+                protocol_root, "collector-exact-receipts", directory=True
+            )
+            race_directory = child(
+                collector_root,
+                hashlib.sha256(race_id.encode()).hexdigest(),
+                directory=True,
+            )
+            entries = os.listdir(race_directory)
+            if len(entries) > _EXACT_RECEIPT_ENTRY_LIMIT:
+                raise ProtocolRejected("EXACT_RECEIPT_INDEX_UNBOUNDED")
+            receipt_name = f"{capture_attempt_sha}.json"
+            receipt_descriptor = child(
+                race_directory, receipt_name, directory=False
+            )
+            receipt_raw = read(receipt_descriptor, identity(receipt_descriptor))
+            try:
+                receipt = json.loads(receipt_raw)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise ProtocolRejected("PROTOCOL_MEMBER_MALFORMED") from exc
+            expected_receipt_keys = {
+                "schema_version",
+                "race_id",
+                "collector_run_id",
+                "captured_at",
+                "emitted_at",
+                "sealed_handoff",
+                "artifacts",
+                "form_name",
+            }
+            if (
+                type(receipt) is not dict
+                or set(receipt) != expected_receipt_keys
+                or canonical_bytes(receipt) != receipt_raw
+                or receipt.get("schema_version") != COLLECTOR_EXACT_RECEIPT_SCHEMA
+                or receipt.get("race_id") != race_id
+                or receipt.get("sealed_handoff") != dict(public_handoff)
+            ):
+                raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
+            collector_run_id = _known_text(
+                receipt.get("collector_run_id"), "collector_run_id"
+            )
+            artifacts = receipt.get("artifacts")
+            if type(artifacts) is not dict or set(artifacts) != {
+                "report",
+                "form",
+                "sidecar",
+            }:
+                raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
+
+            evidence_root = directory(self.root.parent)
+            artifact_raws: dict[str, bytes] = {}
+            artifact_paths: dict[str, Path] = {}
+            for label, source_key in (
+                ("report", "source_report_sha256"),
+                ("form", "source_form_sha256"),
+                ("sidecar", "source_sidecar_sha256"),
+            ):
+                artifact = artifacts[label]
+                if type(artifact) is not dict or set(artifact) != {
+                    "path",
+                    "sha256",
+                }:
+                    raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
+                relative = Path(
+                    _known_text(artifact.get("path"), f"artifacts.{label}.path")
+                )
+                if relative.is_absolute() or not relative.parts:
+                    raise ProtocolRejected("PROTOCOL_PATH_UNSAFE")
+                parent = evidence_root
+                for component in relative.parts[:-1]:
+                    parent = child(parent, component, directory=True)
+                descriptor = child(parent, relative.parts[-1], directory=False)
+                raw = read(descriptor, identity(descriptor))
+                expected_hash = _hash(
+                    artifact.get("sha256"), f"artifacts.{label}.sha256"
+                )
+                if (
+                    sha256_bytes(raw) != expected_hash
+                    or public_handoff.get(source_key) != expected_hash
+                ):
+                    raise ProtocolRejected("HASH_DRIFT", field=label)
+                artifact_raws[label] = raw
+                artifact_paths[label] = relative
+            if (
+                len(set(artifact_paths.values())) != len(artifact_paths)
+                or receipt.get("form_name") != artifact_paths["form"].name
+            ):
+                raise ProtocolRejected("EXACT_RECEIPT_MALFORMED")
+            _validate_collector_source_report(
+                artifact_raws["report"],
+                race_id=race_id,
+                collector_run_id=collector_run_id,
+                capture_attempt_sha256=capture_attempt_sha,
+                append_report_sha256=str(
+                    public_handoff.get("append_report_sha256")
+                ),
+            )
+            for parent, name, descriptor, expected in retained_files:
+                named = os.stat(name, dir_fd=parent, follow_symlinks=False)
+                if (
+                    identity(descriptor) != expected
+                    or (named.st_dev, named.st_ino) != expected[:2]
+                ):
+                    raise ProtocolRejected("PROTOCOL_MEMBER_CHANGED")
+            for parent, name, descriptor, expected in retained_dirs:
+                named = os.stat(name, dir_fd=parent, follow_symlinks=False)
+                if (
+                    identity(descriptor) != expected
+                    or (named.st_dev, named.st_ino) != expected[:2]
+                ):
+                    raise ProtocolRejected("PROTOCOL_DIRECTORY_CHANGED")
+            return (
+                {
+                    "protocol_kind": "collector_exact_capture_v1",
+                    "collector_run_id": collector_run_id,
+                    "capture_attempt_sha256": capture_attempt_sha,
+                    "collector_exact_receipt_sha256": sha256_bytes(receipt_raw),
+                },
+                {"collector_exact_receipt": receipt_raw},
+                artifact_raws,
+            )
+        except OSError as exc:
+            raise ProtocolRejected("PROTOCOL_PATH_UNSAFE") from exc
+        finally:
+            for descriptor in reversed(opened):
+                os.close(descriptor)
+
     def _safe_directory(self, path: Path) -> None:
         try:
             if self.root.is_symlink():
@@ -1410,6 +1601,7 @@ class ManualPredictionCollectorProtocol:
                         "_form_name": _known_text(
                             value["form_name"], "form_name"
                         ),
+                        "_scheduled_exact_receipt": True,
                     },
                 )
             )

--- a/scripts/predict_race_now.py
+++ b/scripts/predict_race_now.py
@@ -491,11 +491,25 @@ def _sealed_result(
     }
 
 
-def _selected_protocol_chain(protocol: ManualPredictionCollectorProtocol, handoff: Mapping[str, Any]) -> tuple[dict[str, str],dict[str,bytes]]:
+def _selected_protocol_chain(
+    protocol: ManualPredictionCollectorProtocol, handoff: Mapping[str, Any]
+) -> tuple[dict[str, str], dict[str, bytes], dict[str, Any]]:
     """Bind the already-validated exact handoff to its immutable protocol chain."""
     public={str(key):value for key,value in handoff.items() if not str(key).startswith("_")}
     try:
-        return protocol.snapshot_authenticated_handoff(public)
+        if handoff.get("_scheduled_exact_receipt") is True:
+            chain, members, artifacts = protocol.snapshot_collector_exact_handoff(
+                public
+            )
+            coherent = {
+                **handoff,
+                "_report_bytes": artifacts["report"],
+                "_form_bytes": artifacts["form"],
+                "_sidecar_bytes": artifacts["sidecar"],
+            }
+            return chain, members, coherent
+        chain, members = protocol.snapshot_authenticated_handoff(public)
+        return chain, members, dict(handoff)
     except ProtocolRejected as exc:
         raise PredictionBlocked("COLLECTOR_PROTOCOL_INVALID",reason=exc.code) from exc
 
@@ -1030,7 +1044,7 @@ def _run_prediction(
             fetch_timeout_seconds=float(args.fetch_timeout_seconds),
         )
     if handoff is not None:
-        state["protocol_chain"],protocol_members=_selected_protocol_chain(protocol,handoff)
+        state["protocol_chain"],protocol_members,handoff=_selected_protocol_chain(protocol,handoff)
         for member,raw in protocol_members.items():write_exact_bytes(bundle/"protocol"/(member+".json"),raw)
         receipt, capture_raw, form_raw, sidecar_raw = receipt_from_handoff(
             handoff,

--- a/src/operator_ui/api.py
+++ b/src/operator_ui/api.py
@@ -1180,9 +1180,10 @@ def install_level_1_api(app: Flask) -> bool:
             elif (
                 (
                     resource in _FINITE_EMPTY_INVALID_RESOURCES
-                    or resource == "system" and not raw.data
+                    or resource == "system"
                 )
                 and classification is EvidenceStatus.INVALID_INTEGRITY_FAILED
+                and not raw.data
             ):
                 response["data"] = {}
             elif raw.data:

--- a/src/predictor/on_demand.py
+++ b/src/predictor/on_demand.py
@@ -415,9 +415,50 @@ def validate_prediction_result_v2(value: Any) -> dict[str, Any]:
         raise _blocked("PREDICTION_BUNDLE_INVALID", field="result.evidence.model")
     status, stage, blocker, prediction = result["status"], result["blocker_stage"], result["blocker"], result["prediction"]
     if status == "PREDICTION_READY":
-        chain=_exact_fields(evidence["protocol_chain"],{"request_id","request_sha256","claim_sha256","attempt_sha256","response_sha256","receipt_sha256","consume_sha256","authenticated_receipt_sha256"},"result.evidence.protocol_chain")
-        if not isinstance(chain["request_id"],str) or not chain["request_id"]:raise _blocked("PREDICTION_BUNDLE_INVALID",field="result.evidence.protocol_chain.request_id")
-        for name in set(chain)-{"request_id"}:_sha(chain[name],f"result.evidence.protocol_chain.{name}")
+        chain = evidence["protocol_chain"]
+        manual_chain_keys = {
+            "request_id", "request_sha256", "claim_sha256", "attempt_sha256",
+            "response_sha256", "receipt_sha256", "consume_sha256",
+            "authenticated_receipt_sha256",
+        }
+        collector_chain_keys = {
+            "protocol_kind", "collector_run_id", "capture_attempt_sha256",
+            "collector_exact_receipt_sha256",
+        }
+        if isinstance(chain, Mapping) and set(chain) == manual_chain_keys:
+            chain = _exact_fields(
+                chain, manual_chain_keys, "result.evidence.protocol_chain"
+            )
+            if not isinstance(chain["request_id"], str) or not chain["request_id"]:
+                raise _blocked(
+                    "PREDICTION_BUNDLE_INVALID",
+                    field="result.evidence.protocol_chain.request_id",
+                )
+            for name in set(chain) - {"request_id"}:
+                _sha(chain[name], f"result.evidence.protocol_chain.{name}")
+        elif isinstance(chain, Mapping) and set(chain) == collector_chain_keys:
+            chain = _exact_fields(
+                chain, collector_chain_keys, "result.evidence.protocol_chain"
+            )
+            if (
+                chain["protocol_kind"] != "collector_exact_capture_v1"
+                or not isinstance(chain["collector_run_id"], str)
+                or not chain["collector_run_id"]
+            ):
+                raise _blocked(
+                    "PREDICTION_BUNDLE_INVALID",
+                    field="result.evidence.protocol_chain",
+                )
+            for name in (
+                "capture_attempt_sha256",
+                "collector_exact_receipt_sha256",
+            ):
+                _sha(chain[name], f"result.evidence.protocol_chain.{name}")
+        else:
+            raise _blocked(
+                "PREDICTION_BUNDLE_INVALID",
+                field="result.evidence.protocol_chain",
+            )
         cutoff=_exact_fields(evidence["authenticated_cutoff"],{"history_seal_sha256","cutoff_timestamp","source_sha256","sealed_sha256"},"result.evidence.authenticated_cutoff")
         _timestamp(cutoff["cutoff_timestamp"],"result.evidence.authenticated_cutoff.cutoff_timestamp")
         for name in ("history_seal_sha256","source_sha256","sealed_sha256"):_sha(cutoff[name],f"result.evidence.authenticated_cutoff.{name}")
@@ -507,7 +548,181 @@ def _validate_request_binding(raw: bytes, result: Mapping[str, Any]) -> dict[str
     return dict(request)
 
 
+def _validate_authenticated_cutoff(
+    contents: Mapping[str, bytes], result: Mapping[str, Any]
+) -> None:
+    required = {"features/history_seal.json", "features/sealed_history.db"}
+    if not required.issubset(contents):
+        raise _blocked("PREDICTION_BUNDLE_INVALID", reason="sealed_protocol_required")
+    cutoff = result["evidence"]["authenticated_cutoff"]
+    history_raw = contents["features/history_seal.json"]
+    history = _canonical_json(
+        history_raw, max_bytes=BUNDLE_CONTROL_MAX_BYTES, label="history_seal"
+    )
+    history_keys={"schema_version","cutoff_timestamp","source_sha256","sealed_sha256","target_race_id","cutoff_basis","safe_race_count","safe_dog_row_count","excluded_target_metadata_rows","excluded_at_or_after_cutoff_metadata_rows","excluded_ambiguous_date_metadata_rows","target_rows_materialized","at_or_after_cutoff_rows_materialized"}
+    count_keys=("safe_race_count","safe_dog_row_count","excluded_target_metadata_rows","excluded_at_or_after_cutoff_metadata_rows","excluded_ambiguous_date_metadata_rows","target_rows_materialized","at_or_after_cutoff_rows_materialized")
+    digests=(cutoff.get("history_seal_sha256"),cutoff.get("sealed_sha256"),cutoff.get("source_sha256"),history.get("sealed_sha256"),history.get("source_sha256"))
+    jump=_timestamp(result["race"]["jump_timestamp"],"race.jump_timestamp")
+    if set(history) != history_keys or history.get("schema_version") != "sealed_prediction_history_v1" or history.get("cutoff_basis") != "race_date_strictly_before_target_jump_date" or any(not isinstance(history.get(key),int) or isinstance(history.get(key),bool) or history[key] < 0 for key in count_keys) or any(not isinstance(value,str) or _SHA256_RE.fullmatch(value) is None for value in digests) or sha256_bytes(history_raw) != cutoff["history_seal_sha256"] or sha256_bytes(contents["features/sealed_history.db"]) != history.get("sealed_sha256") or history.get("sealed_sha256") != cutoff["sealed_sha256"] or history.get("source_sha256") != cutoff["source_sha256"] or _timestamp(history.get("cutoff_timestamp"),"history.cutoff_timestamp") != jump or _timestamp(cutoff.get("cutoff_timestamp"),"cutoff.cutoff_timestamp") != jump or history.get("target_rows_materialized") != 0 or history.get("at_or_after_cutoff_rows_materialized") != 0 or history.get("target_race_id") != result["race"]["race_id"]: raise _blocked("PREDICTION_BUNDLE_IDENTITY_MISMATCH", field="authenticated_cutoff")
+
+
+def _validate_collector_exact_protocol(
+    contents: Mapping[str, bytes], result: Mapping[str, Any]
+) -> None:
+    member_name = "protocol/collector_exact_receipt.json"
+    if member_name not in contents:
+        raise _blocked("PREDICTION_BUNDLE_INVALID", reason="sealed_protocol_required")
+    chain = result["evidence"]["protocol_chain"]
+    raw = contents[member_name]
+    receipt = _canonical_json(
+        raw,
+        max_bytes=BUNDLE_CONTROL_MAX_BYTES,
+        label="protocol.collector_exact_receipt",
+    )
+    receipt_keys = {
+        "schema_version", "race_id", "collector_run_id", "captured_at",
+        "emitted_at", "sealed_handoff", "artifacts", "form_name",
+    }
+    handoff_keys = {
+        "schema_version", "race_id", "race", "append_timestamp",
+        "runner_set_sha256", "source_report_sha256", "source_form_sha256",
+        "source_sidecar_sha256", "capture_attempt_sha256",
+        "append_report_sha256",
+    }
+    if (
+        set(receipt) != receipt_keys
+        or receipt.get("schema_version") != "collector-exact-capture-receipt-v1"
+        or receipt.get("race_id") != result["race"]["race_id"]
+        or receipt.get("collector_run_id") != chain["collector_run_id"]
+        or sha256_bytes(raw) != chain["collector_exact_receipt_sha256"]
+    ):
+        raise _blocked(
+            "PREDICTION_BUNDLE_IDENTITY_MISMATCH",
+            field="protocol.collector_exact_receipt",
+        )
+    handoff = receipt.get("sealed_handoff")
+    result_race = {
+        key: result["race"][key]
+        for key in (
+            "race_id", "url", "venue", "race_number", "race_date",
+            "jump_timestamp",
+        )
+    }
+    if (
+        not isinstance(handoff, Mapping)
+        or set(handoff) != handoff_keys
+        or handoff.get("schema_version") != "on_demand_verified_collector_capture_v2"
+        or handoff.get("race_id") != result["race"]["race_id"]
+        or handoff.get("race") != result_race
+        or handoff.get("runner_set_sha256")
+        != result["evidence"]["runner_set_sha256"]
+        or handoff.get("capture_attempt_sha256")
+        != chain["capture_attempt_sha256"]
+    ):
+        raise _blocked(
+            "PREDICTION_BUNDLE_IDENTITY_MISMATCH",
+            field="protocol.collector_exact_receipt.handoff",
+        )
+    captured = _timestamp(receipt.get("captured_at"), "protocol.captured_at")
+    emitted = _timestamp(receipt.get("emitted_at"), "protocol.emitted_at")
+    jump = _timestamp(result["race"]["jump_timestamp"], "race.jump_timestamp")
+    if (
+        receipt.get("captured_at") != handoff.get("append_timestamp")
+        or not captured <= emitted
+        or not captured < jump
+    ):
+        raise _blocked(
+            "PREDICTION_BUNDLE_IDENTITY_MISMATCH",
+            field="protocol.collector_exact_receipt.time",
+        )
+    artifacts = receipt.get("artifacts")
+    labels = ("report", "form", "sidecar")
+    if not isinstance(artifacts, Mapping) or set(artifacts) != set(labels):
+        raise _blocked(
+            "PREDICTION_BUNDLE_IDENTITY_MISMATCH",
+            field="protocol.collector_exact_receipt.artifacts",
+        )
+    external_paths: dict[str, str] = {}
+    for label in labels:
+        artifact = artifacts[label]
+        if not isinstance(artifact, Mapping) or set(artifact) != {"path", "sha256"}:
+            raise _blocked(
+                "PREDICTION_BUNDLE_IDENTITY_MISMATCH",
+                field="protocol.collector_exact_receipt.artifacts",
+            )
+        external_paths[label] = _relative_name(artifact.get("path"))
+        if artifact.get("sha256") != handoff.get(f"source_{label}_sha256"):
+            raise _blocked(
+                "PREDICTION_BUNDLE_IDENTITY_MISMATCH",
+                field="protocol.collector_exact_receipt.artifacts",
+            )
+    form_name = _relative_name(receipt.get("form_name"))
+    if (
+        Path(form_name).name != form_name
+        or form_name != Path(external_paths["form"]).name
+        or len(set(external_paths.values())) != len(external_paths)
+    ):
+        raise _blocked(
+            "PREDICTION_BUNDLE_IDENTITY_MISMATCH",
+            field="protocol.collector_exact_receipt.artifacts",
+        )
+    bundle_sources = {
+        "report": "source/capture.json",
+        "form": f"source/{form_name}",
+        "sidecar": f"source/{form_name}.metadata.json",
+    }
+    if not set(bundle_sources.values()).issubset(contents):
+        raise _blocked("PREDICTION_BUNDLE_INVALID", reason="sealed_protocol_required")
+    if any(
+        sha256_bytes(contents[bundle_sources[label]])
+        != artifacts[label]["sha256"]
+        for label in labels
+    ):
+        raise _blocked(
+            "PREDICTION_BUNDLE_IDENTITY_MISMATCH",
+            field="protocol.collector_exact_receipt.source",
+        )
+    source_report = _canonical_json(
+        contents[bundle_sources["report"]],
+        max_bytes=BUNDLE_CONTROL_MAX_BYTES,
+        label="source.capture",
+    )
+    attempts = source_report.get("attempts") if isinstance(source_report, Mapping) else None
+    matches = [
+        attempt
+        for attempt in attempts or []
+        if isinstance(attempt, Mapping)
+        and attempt.get("race_id") == result["race"]["race_id"]
+        and attempt.get("status") == "APPENDED"
+    ]
+    if (
+        not isinstance(source_report, Mapping)
+        or set(source_report) != {
+            "schema_version", "race_id", "collector_run_id", "attempts"
+        }
+        or source_report.get("schema_version")
+        != "collector_exact_capture_source_v1"
+        or source_report.get("race_id") != result["race"]["race_id"]
+        or source_report.get("collector_run_id") != chain["collector_run_id"]
+        or len(matches) != 1
+        or sha256_bytes(canonical_bytes(matches[0]))
+        != chain["capture_attempt_sha256"]
+        or not isinstance(matches[0].get("append_report"), Mapping)
+        or sha256_bytes(canonical_bytes(matches[0]["append_report"]))
+        != handoff.get("append_report_sha256")
+    ):
+        raise _blocked(
+            "PREDICTION_BUNDLE_IDENTITY_MISMATCH",
+            field="protocol.collector_exact_receipt.source_report",
+        )
+
+
 def _validate_sealed_protocol(contents: Mapping[str, bytes], result: Mapping[str, Any]) -> None:
+    chain = result["evidence"]["protocol_chain"]
+    if chain.get("protocol_kind") == "collector_exact_capture_v1":
+        _validate_collector_exact_protocol(contents, result)
+        _validate_authenticated_cutoff(contents, result)
+        return
     names = ("request", "claim", "attempt", "response", "receipt", "consume", "authenticated_receipt")
     required = {f"protocol/{name}.json" for name in names} | {"features/history_seal.json", "features/sealed_history.db"}
     if not required.issubset(contents): raise _blocked("PREDICTION_BUNDLE_INVALID", reason="sealed_protocol_required")
@@ -555,13 +770,7 @@ def _validate_sealed_protocol(contents: Mapping[str, bytes], result: Mapping[str
         if len(path)>512 or any(ord(character)<32 or ord(character)==127 for character in path): raise _blocked("PREDICTION_BUNDLE_IDENTITY_MISMATCH", field="protocol.authenticated_receipt.path")
         artifact_paths.append(path)
     if exact.get("receipt") != reference or len(set(artifact_paths)) != len(artifact_paths) or any(artifacts[key].get("sha256") != sealed.get(f"source_{key}_sha256") for key in artifact_labels) or exact.get("form_name") != Path(artifacts["form"]["path"]).name: raise _blocked("PREDICTION_BUNDLE_IDENTITY_MISMATCH", field="protocol.authenticated_receipt")
-    cutoff = result["evidence"]["authenticated_cutoff"]; history_raw = contents["features/history_seal.json"]
-    history = _canonical_json(history_raw, max_bytes=BUNDLE_CONTROL_MAX_BYTES, label="history_seal")
-    history_keys={"schema_version","cutoff_timestamp","source_sha256","sealed_sha256","target_race_id","cutoff_basis","safe_race_count","safe_dog_row_count","excluded_target_metadata_rows","excluded_at_or_after_cutoff_metadata_rows","excluded_ambiguous_date_metadata_rows","target_rows_materialized","at_or_after_cutoff_rows_materialized"}
-    count_keys=("safe_race_count","safe_dog_row_count","excluded_target_metadata_rows","excluded_at_or_after_cutoff_metadata_rows","excluded_ambiguous_date_metadata_rows","target_rows_materialized","at_or_after_cutoff_rows_materialized")
-    digests=(cutoff.get("history_seal_sha256"),cutoff.get("sealed_sha256"),cutoff.get("source_sha256"),history.get("sealed_sha256"),history.get("source_sha256"))
-    jump=_timestamp(result["race"]["jump_timestamp"],"race.jump_timestamp")
-    if set(history) != history_keys or history.get("schema_version") != "sealed_prediction_history_v1" or history.get("cutoff_basis") != "race_date_strictly_before_target_jump_date" or any(not isinstance(history.get(key),int) or isinstance(history.get(key),bool) or history[key] < 0 for key in count_keys) or any(not isinstance(value,str) or _SHA256_RE.fullmatch(value) is None for value in digests) or sha256_bytes(history_raw) != cutoff["history_seal_sha256"] or sha256_bytes(contents["features/sealed_history.db"]) != history.get("sealed_sha256") or history.get("sealed_sha256") != cutoff["sealed_sha256"] or history.get("source_sha256") != cutoff["source_sha256"] or _timestamp(history.get("cutoff_timestamp"),"history.cutoff_timestamp") != jump or _timestamp(cutoff.get("cutoff_timestamp"),"cutoff.cutoff_timestamp") != jump or history.get("target_rows_materialized") != 0 or history.get("at_or_after_cutoff_rows_materialized") != 0 or history.get("target_race_id") != result["race"]["race_id"]: raise _blocked("PREDICTION_BUNDLE_IDENTITY_MISMATCH", field="authenticated_cutoff")
+    _validate_authenticated_cutoff(contents, result)
 
 
 class PredictionBlocked(RuntimeError):

--- a/src/predictor/on_demand.py
+++ b/src/predictor/on_demand.py
@@ -754,8 +754,14 @@ def _validate_sealed_protocol(contents: Mapping[str, bytes], result: Mapping[str
         _validate_authenticated_cutoff(contents, result)
         return
     names = ("request", "claim", "attempt", "response", "receipt", "consume", "authenticated_receipt")
-    required = {f"protocol/{name}.json" for name in names} | {"features/history_seal.json", "features/sealed_history.db"}
-    if not required.issubset(contents): raise _blocked("PREDICTION_BUNDLE_INVALID", reason="sealed_protocol_required")
+    protocol_members = {f"protocol/{name}.json" for name in names}
+    required = protocol_members | {"features/history_seal.json", "features/sealed_history.db"}
+    if (
+        {name for name in contents if name.startswith("protocol/")}
+        != protocol_members
+        or not required.issubset(contents)
+    ):
+        raise _blocked("PREDICTION_BUNDLE_INVALID", reason="sealed_protocol_required")
     chain = result["evidence"]["protocol_chain"]
     values = {name: _canonical_json(contents[f"protocol/{name}.json"], max_bytes=BUNDLE_CONTROL_MAX_BYTES, label=f"protocol.{name}") for name in names}
     expected_keys = {

--- a/src/predictor/on_demand.py
+++ b/src/predictor/on_demand.py
@@ -570,7 +570,8 @@ def _validate_collector_exact_protocol(
     contents: Mapping[str, bytes], result: Mapping[str, Any]
 ) -> None:
     member_name = "protocol/collector_exact_receipt.json"
-    if member_name not in contents:
+    protocol_members = {name for name in contents if name.startswith("protocol/")}
+    if protocol_members != {member_name}:
         raise _blocked("PREDICTION_BUNDLE_INVALID", reason="sealed_protocol_required")
     chain = result["evidence"]["protocol_chain"]
     raw = contents[member_name]
@@ -615,7 +616,7 @@ def _validate_collector_exact_protocol(
         or handoff.get("race_id") != result["race"]["race_id"]
         or handoff.get("race") != result_race
         or handoff.get("runner_set_sha256")
-        != result["evidence"]["runner_set_sha256"]
+        != runner_set_sha256(result["prediction"]["predictions"])
         or handoff.get("capture_attempt_sha256")
         != chain["capture_attempt_sha256"]
     ):
@@ -671,7 +672,10 @@ def _validate_collector_exact_protocol(
         "form": f"source/{form_name}",
         "sidecar": f"source/{form_name}.metadata.json",
     }
-    if not set(bundle_sources.values()).issubset(contents):
+    if (
+        len(set(bundle_sources.values())) != len(bundle_sources)
+        or not set(bundle_sources.values()).issubset(contents)
+    ):
         raise _blocked("PREDICTION_BUNDLE_INVALID", reason="sealed_protocol_required")
     if any(
         sha256_bytes(contents[bundle_sources[label]])
@@ -687,28 +691,54 @@ def _validate_collector_exact_protocol(
         max_bytes=BUNDLE_CONTROL_MAX_BYTES,
         label="source.capture",
     )
-    attempts = source_report.get("attempts") if isinstance(source_report, Mapping) else None
-    matches = [
-        attempt
-        for attempt in attempts or []
-        if isinstance(attempt, Mapping)
-        and attempt.get("race_id") == result["race"]["race_id"]
-        and attempt.get("status") == "APPENDED"
-    ]
+    source_plan = (
+        source_report.get("source_plan_item")
+        if isinstance(source_report, Mapping)
+        else None
+    )
+    source_attempt = (
+        source_report.get("source_attempt")
+        if isinstance(source_report, Mapping)
+        else None
+    )
+    source_race_id = (
+        source_report.get("source_race_id")
+        if isinstance(source_report, Mapping)
+        else None
+    )
+    adapted_attempt = (
+        {**source_attempt, "race_id": result["race"]["race_id"]}
+        if isinstance(source_attempt, Mapping)
+        else None
+    )
     if (
         not isinstance(source_report, Mapping)
         or set(source_report) != {
-            "schema_version", "race_id", "collector_run_id", "attempts"
+            "schema_version", "collector_run_id", "generated_at", "race_id",
+            "source_race_id", "source_plan_item", "source_attempt", "attempts",
         }
         or source_report.get("schema_version")
         != "collector_exact_capture_source_v1"
         or source_report.get("race_id") != result["race"]["race_id"]
         or source_report.get("collector_run_id") != chain["collector_run_id"]
-        or len(matches) != 1
-        or sha256_bytes(canonical_bytes(matches[0]))
+        or source_report.get("generated_at") != receipt.get("emitted_at")
+        or not isinstance(source_race_id, str)
+        or not source_race_id
+        or not isinstance(source_plan, Mapping)
+        or source_plan.get("schema_version")
+        != "autonomous_live_odds_capture_plan_item_v1"
+        or source_plan.get("status") != "READY_TO_CAPTURE"
+        or source_plan.get("race_id") != source_race_id
+        or not isinstance(source_attempt, Mapping)
+        or source_attempt.get("schema_version")
+        != "autonomous_live_odds_capture_attempt_v1"
+        or source_attempt.get("race_id") != source_race_id
+        or source_attempt.get("status") != "APPENDED"
+        or source_report.get("attempts") != [adapted_attempt]
+        or sha256_bytes(canonical_bytes(adapted_attempt))
         != chain["capture_attempt_sha256"]
-        or not isinstance(matches[0].get("append_report"), Mapping)
-        or sha256_bytes(canonical_bytes(matches[0]["append_report"]))
+        or not isinstance(source_attempt.get("append_report"), Mapping)
+        or sha256_bytes(canonical_bytes(source_attempt["append_report"]))
         != handoff.get("append_report_sha256")
     ):
         raise _blocked(

--- a/tests/test_predict_race_now.py
+++ b/tests/test_predict_race_now.py
@@ -19,6 +19,7 @@ import scripts.predict_race_now as predict_now
 import src.predictor.on_demand as on_demand
 from race_collection.manual_prediction_collector_request import (
     ManualPredictionCollectorProtocol,
+    ProtocolRejected,
 )
 from race_collection.synchronous_manual_capture import (
     CollectorBusy as CollectorLockBusy,
@@ -883,6 +884,30 @@ def test_scheduled_exact_receipt_reuses_while_capture_authority_is_busy(
     assert result["status"] == "PREDICTION_READY"
     assert calls == {"capture": 0, "score": 1}
     assert not protocol.outstanding_request_ids()
+    assert result["evidence"]["protocol_chain"]["protocol_kind"] == (
+        "collector_exact_capture_v1"
+    )
+    index = on_demand.verify_prediction_bundle_index(tmp_path / "bundles")
+    assert len(index["entries"]) == 1
+    bundle = tmp_path / "bundles" / index["entries"][0]["directory"]
+    assert (bundle / "protocol/collector_exact_receipt.json").is_file()
+    assert not (bundle / "protocol/request.json").exists()
+    contents = {
+        path.relative_to(bundle).as_posix(): path.read_bytes()
+        for path in bundle.rglob("*")
+        if path.is_file() and path.name != "bundle_manifest.json"
+    }
+    tampered = json.loads(contents["protocol/collector_exact_receipt.json"])
+    tampered["collector_run_id"] = "substituted-run"
+    contents["protocol/collector_exact_receipt.json"] = canonical_bytes(tampered)
+    with pytest.raises(PredictionBlocked):
+        on_demand._validate_sealed_protocol(contents, result)
+    paths["form"].write_bytes(b"tampered after verified snapshot")
+    public_handoff = {
+        key: item for key, item in value.items() if not key.startswith("_")
+    }
+    with pytest.raises(ProtocolRejected):
+        protocol.snapshot_collector_exact_handoff(public_handoff)
 
 
 def test_operator_cli_emits_one_canonical_fixture_prediction(

--- a/tests/test_predict_race_now.py
+++ b/tests/test_predict_race_now.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import pytest
 
+import race_collection.manual_prediction_collector_request as collector_protocol
 import race_collection.synchronous_manual_capture as synchronous_capture
 import scripts.predict_race_now as predict_now
 import src.predictor.on_demand as on_demand
@@ -797,9 +798,14 @@ def test_fixture_e2e_reuses_receipt_seals_features_selects_model_and_bundles(
     assert json.loads((bundle / "result.json").read_bytes()) == result
 
 
-def test_scheduled_exact_receipt_reuses_while_capture_authority_is_busy(
+def scheduled_exact_receipt(
     tmp_path: Path,
-):
+) -> tuple[
+    ManualPredictionCollectorProtocol,
+    dict[str, Any],
+    dict[str, Path],
+    dict[str, Any],
+]:
     protocol_root = tmp_path / "collector-requests"
     protocol = ManualPredictionCollectorProtocol(protocol_root)
     value = handoff()
@@ -812,11 +818,30 @@ def test_scheduled_exact_receipt_reuses_while_capture_authority_is_busy(
             "inserted_rows": 2,
         },
     }
+    source_plan_item = {
+        "schema_version": "autonomous_live_odds_capture_plan_item_v1",
+        "status": "READY_TO_CAPTURE",
+        "race_id": RACE_ID,
+        "venue": "GUNN",
+        "race_number": 5,
+        "race_date": "2026-07-19",
+        "race_time": "13:00",
+        "jump_datetime": "2026-07-19T13:00:00+10:00",
+        "thedogs_source_url": race()["url"],
+        "expected_runners": [
+            {"box_number": 1, "dog_name": "Alpha", "identity": "ALPHA"},
+            {"box_number": 2, "dog_name": "Beta", "identity": "BETA"},
+        ],
+    }
     value["_report_bytes"] = canonical_bytes(
         {
             "schema_version": "collector_exact_capture_source_v1",
-            "race_id": RACE_ID,
             "collector_run_id": collector_run_id,
+            "generated_at": NOW.isoformat(),
+            "race_id": RACE_ID,
+            "source_race_id": RACE_ID,
+            "source_plan_item": source_plan_item,
+            "source_attempt": source_attempt,
             "attempts": [source_attempt],
         }
     )
@@ -862,6 +887,13 @@ def test_scheduled_exact_receipt_reuses_while_capture_authority_is_busy(
         emitted_at=NOW,
         handoff=value,
     )
+    return protocol, value, paths, source_attempt
+
+
+def test_scheduled_exact_receipt_reuses_while_capture_authority_is_busy(
+    tmp_path: Path,
+):
+    protocol, value, paths, _ = scheduled_exact_receipt(tmp_path)
 
     calls = {"capture": 0, "score": 0}
     deps = dependencies(
@@ -877,7 +909,7 @@ def test_scheduled_exact_receipt_reuses_while_capture_authority_is_busy(
 
     deps.score_residual = score
     result = run_prediction(
-        args(tmp_path, collector_request_root=protocol_root),
+        args(tmp_path, collector_request_root=protocol.root),
         deps,
     )
 
@@ -890,6 +922,10 @@ def test_scheduled_exact_receipt_reuses_while_capture_authority_is_busy(
     index = on_demand.verify_prediction_bundle_index(tmp_path / "bundles")
     assert len(index["entries"]) == 1
     bundle = tmp_path / "bundles" / index["entries"][0]["directory"]
+    verified = on_demand.verify_indexed_prediction_bundle(
+        tmp_path / "bundles", index["entries"][0]
+    )
+    assert verified.result == result
     assert (bundle / "protocol/collector_exact_receipt.json").is_file()
     assert not (bundle / "protocol/request.json").exists()
     contents = {
@@ -902,12 +938,124 @@ def test_scheduled_exact_receipt_reuses_while_capture_authority_is_busy(
     contents["protocol/collector_exact_receipt.json"] = canonical_bytes(tampered)
     with pytest.raises(PredictionBlocked):
         on_demand._validate_sealed_protocol(contents, result)
+
+    contents = {
+        path.relative_to(bundle).as_posix(): path.read_bytes()
+        for path in bundle.rglob("*")
+        if path.is_file() and path.name != "bundle_manifest.json"
+    }
+    contents["protocol/request.json"] = canonical_bytes({})
+    with pytest.raises(PredictionBlocked) as contradictory_protocol:
+        on_demand._validate_sealed_protocol(contents, result)
+    assert contradictory_protocol.value.code == "PREDICTION_BUNDLE_INVALID"
+    assert contradictory_protocol.value.details == {
+        "reason": "sealed_protocol_required"
+    }
+
+    contents.pop("protocol/request.json")
+    alias_result = json.loads(canonical_bytes(result))
+    alias_receipt = json.loads(contents["protocol/collector_exact_receipt.json"])
+    report_hash = alias_receipt["artifacts"]["report"]["sha256"]
+    alias_receipt["form_name"] = "capture.json"
+    alias_receipt["artifacts"]["form"] = {
+        "path": "capture.json",
+        "sha256": report_hash,
+    }
+    alias_receipt["sealed_handoff"]["source_form_sha256"] = report_hash
+    alias_raw = canonical_bytes(alias_receipt)
+    contents["protocol/collector_exact_receipt.json"] = alias_raw
+    alias_result["evidence"]["protocol_chain"][
+        "collector_exact_receipt_sha256"
+    ] = sha256_bytes(alias_raw)
+    with pytest.raises(PredictionBlocked) as aliased_source:
+        on_demand._validate_sealed_protocol(contents, alias_result)
+    assert aliased_source.value.code == "PREDICTION_BUNDLE_INVALID"
+    assert aliased_source.value.details == {"reason": "sealed_protocol_required"}
+
     paths["form"].write_bytes(b"tampered after verified snapshot")
     public_handoff = {
         key: item for key, item in value.items() if not key.startswith("_")
     }
     with pytest.raises(ProtocolRejected):
         protocol.snapshot_collector_exact_handoff(public_handoff)
+
+
+def test_scheduled_source_report_rejects_mismatched_source_identity(
+    tmp_path: Path,
+):
+    _, value, _, source_attempt = scheduled_exact_receipt(tmp_path)
+    report = json.loads(value["_report_bytes"])
+    report["source_race_id"] = "Race 5 - OTHER - 2026-07-19"
+
+    with pytest.raises(ProtocolRejected) as mismatch:
+        collector_protocol._validate_collector_source_report(
+            canonical_bytes(report),
+            race_id=RACE_ID,
+            collector_run_id=report["collector_run_id"],
+            emitted_at=NOW.isoformat(),
+            capture_attempt_sha256=sha256_bytes(canonical_bytes(source_attempt)),
+            append_report_sha256=sha256_bytes(
+                canonical_bytes(source_attempt["append_report"])
+            ),
+        )
+    assert mismatch.value.code == "EXACT_RECEIPT_MALFORMED"
+
+
+def test_scheduled_snapshot_rejects_fifo_without_blocking(tmp_path: Path):
+    protocol, value, paths, _ = scheduled_exact_receipt(tmp_path)
+    paths["form"].unlink()
+    os.mkfifo(paths["form"])
+    public_handoff = {
+        key: item for key, item in value.items() if not key.startswith("_")
+    }
+
+    with pytest.raises(ProtocolRejected) as fifo:
+        protocol.snapshot_collector_exact_handoff(public_handoff)
+    assert fifo.value.code == "PROTOCOL_PATH_UNSAFE"
+
+
+def test_scheduled_snapshot_rejects_hardlinked_source_members(tmp_path: Path):
+    protocol, value, paths, _ = scheduled_exact_receipt(tmp_path)
+    paths["sidecar"].unlink()
+    os.link(paths["form"], paths["sidecar"])
+    public_handoff = {
+        key: item for key, item in value.items() if not key.startswith("_")
+    }
+    public_handoff["source_sidecar_sha256"] = public_handoff[
+        "source_form_sha256"
+    ]
+    receipt_path = protocol.collector_exact_receipt_path(
+        RACE_ID, value["capture_attempt_sha256"]
+    )
+    receipt = json.loads(receipt_path.read_bytes())
+    receipt["sealed_handoff"] = public_handoff
+    receipt["artifacts"]["sidecar"]["sha256"] = public_handoff[
+        "source_sidecar_sha256"
+    ]
+    receipt_path.write_bytes(canonical_bytes(receipt))
+
+    with pytest.raises(ProtocolRejected) as hardlink:
+        protocol.snapshot_collector_exact_handoff(public_handoff)
+    assert hardlink.value.code == "EXACT_RECEIPT_MALFORMED"
+
+
+def test_scheduled_snapshot_rejects_unbounded_artifact_path(tmp_path: Path):
+    protocol, value, _, _ = scheduled_exact_receipt(tmp_path)
+    receipt_path = protocol.collector_exact_receipt_path(
+        RACE_ID, value["capture_attempt_sha256"]
+    )
+    receipt = json.loads(receipt_path.read_bytes())
+    receipt["artifacts"]["form"]["path"] = "/".join(
+        ["nested"] * 33 + ["gunnedah-r5.csv"]
+    )
+    receipt_path.write_bytes(canonical_bytes(receipt))
+    public_handoff = {
+        key: item for key, item in value.items() if not key.startswith("_")
+    }
+
+    with pytest.raises(ProtocolRejected) as unbounded:
+        protocol.snapshot_collector_exact_handoff(public_handoff)
+    assert unbounded.value.code == "PROTOCOL_PATH_UNSAFE"
 
 
 def test_operator_cli_emits_one_canonical_fixture_prediction(

--- a/tests/test_predict_race_now.py
+++ b/tests/test_predict_race_now.py
@@ -1835,6 +1835,20 @@ def test_residual_bundle_replay_reruns_scorer_at_original_timestamp(tmp_path: Pa
     )
     assert verified.result == result
 
+    bundle = tmp_path / "bundles" / index["entries"][0]["directory"]
+    contents = {
+        path.relative_to(bundle).as_posix(): path.read_bytes()
+        for path in bundle.rglob("*")
+        if path.is_file() and path.name != "bundle_manifest.json"
+    }
+    contents["protocol/collector_exact_receipt.json"] = canonical_bytes({})
+    with pytest.raises(PredictionBlocked) as contradictory_protocol:
+        on_demand._validate_sealed_protocol(contents, result)
+    assert contradictory_protocol.value.code == "PREDICTION_BUNDLE_INVALID"
+    assert contradictory_protocol.value.details == {
+        "reason": "sealed_protocol_required"
+    }
+
 
 def test_output_symlink_write_attempt_is_rejected(tmp_path: Path):
     real = tmp_path / "real"


### PR DESCRIPTION
## What changed

Add a distinct sealed protocol-chain variant for scheduled collector exact receipts. The predictor snapshots the receipt and report/form/sidecar members with retained no-follow descriptors, uses those coherent bytes for scoring and sealing, and emits the scheduled receipt into the bundle. The independent bundle verifier now validates the scheduled receipt, race/runner/time identity, source hashes, capture-attempt/append-report hashes, and authenticated history cutoff. Existing manual-request protocol chains remain unchanged.

## Root cause

Scheduled exact-receipt reuse was added in da68ef39. Later descriptor-retained bundle hardening required every selected handoff to resolve through the manual request/claim/attempt/response/consume chain, which scheduled receipts intentionally do not create. The supported scheduled path therefore failed with COLLECTOR_PROTOCOL_INVALID while the collector lock was busy.

## Impact

This restores an existing research-only reuse path without adding capture authority or changing browser/lock, append-only persistence, model/features, corpus, deployment, promotion, EV, or betting behavior. The new provenance surface fails closed on schema, path, identity, hash, membership, timestamp, or source mutation. No live-runtime success claim is made.

## Validation

- red baseline: tests/test_predict_race_now.py had 1 failed, 62 passed
- repaired tests/test_predict_race_now.py: 63 passed in 2.55s
- tests/test_prediction_bundle_sealed.py: 322 passed in 50.67s
- tests/race_collection/test_manual_prediction_collector_request.py: 27 passed in 9.95s
- strengthened scheduled reuse, independent bundle verification, receipt substitution, and post-snapshot source mutation gate: passed
- fatal Ruff E9,F63,F7,F82: passed
- py_compile: passed
- git diff --check: passed