### PR TITLE
GHU-036 C26: seal accepted natural runner sources

### DIFF
--- a/race_collection/synchronous_manual_capture.py
+++ b/race_collection/synchronous_manual_capture.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from config.venue_mapping import normalize_venue
 from race_collection.manual_prediction_collector_request import (
     RECEIPT_READY,
     CollectorRequest,
@@ -829,7 +830,13 @@ def _v2_runner_rows(
     alignment = shadow.get("canonical_final_runner_alignment")
     if not isinstance(alignment, Mapping) or alignment.get("status") != "aligned" or alignment.get("canonical_runner_set_status") != "available":
         raise CaptureOneRejected("CURRENT_INDEX_SOURCE_INVALID", reason="runner_source_not_aligned")
-    if shadow.get("source_url") != race["race_url"] or shadow.get("race_date") != race["date"] or shadow.get("venue") != race["venue"] or shadow.get("race_number") != race["race_number"]:
+    if (
+        shadow.get("source_url") != race["race_url"]
+        or shadow.get("race_date") != race["date"]
+        or not isinstance(shadow.get("venue"), str)
+        or normalize_venue(shadow["venue"]) != normalize_venue(race["venue"])
+        or shadow.get("race_number") != race["race_number"]
+    ):
         raise CaptureOneRejected("CURRENT_INDEX_SOURCE_INVALID", reason="runner_race_identity_mismatch")
     observed = datetime.fromisoformat(str(shadow.get("metadata_captured_at") or ""))
     if observed.tzinfo is None or observed.utcoffset() is None:
@@ -838,8 +845,8 @@ def _v2_runner_rows(
     jump = datetime.fromisoformat(str(race["jump_datetime"]))
     if generated.tzinfo is None or generated.utcoffset() is None:
         raise CaptureOneRejected("CURRENT_INDEX_SOURCE_INVALID", reason="source_generated_at_invalid")
-    source_age = (generated - observed).total_seconds()
-    if source_age < 0 or source_age > 1200 or generated >= jump or observed >= jump:
+    source_distance = abs((generated - observed).total_seconds())
+    if source_distance > 1200 or generated >= jump or observed >= jump:
         raise CaptureOneRejected("CURRENT_INDEX_SOURCE_INVALID", reason="runner_source_stale_or_postjump")
     participants = shadow.get("runner_box_name_list")
     if not isinstance(participants, list) or not participants:
@@ -972,6 +979,7 @@ def _v2_runner_rows(
         reader = csv.DictReader(io.StringIO(csv_text, newline=""), delimiter=delimiters[0], strict=True)
         headers = [str(value or "").lstrip("\ufeff").strip() for value in (reader.fieldnames or [])]
         lowered = {value.lower(): value for value in headers}
+        expert_history = {"dog name", "plc", "box", "date", "track"}.issubset(lowered)
         name_header = next((lowered[value] for value in ("dog_name", "dog name", "runner", "name") if value in lowered), None)
         box_header = next((lowered[value] for value in ("box", "box_number") if value in lowered), None)
         if name_header is None:
@@ -983,7 +991,15 @@ def _v2_runner_rows(
             name_cell = str(record[name_header] or "").strip()
             if not name_cell:
                 continue
-            if box_header is None:
+            if expert_history:
+                import re
+                match = re.match(r"^([0-9]{1,2})\.\s+(.+)$", name_cell)
+                if match is None:
+                    raise ValueError("expert_history_runner_prefix_invalid")
+                box, name = int(match.group(1)), match.group(2).strip()
+                if re.match(r"^[0-9]", name):
+                    raise ValueError("expert_history_runner_prefix_ambiguous")
+            elif box_header is None:
                 import re
                 match = re.match(r"^([0-9]{1,2})\s*[\.\):-]\s*(.+)$", name_cell)
                 if match is None:

--- a/tests/race_collection/test_synchronous_manual_capture.py
+++ b/tests/race_collection/test_synchronous_manual_capture.py
@@ -1129,7 +1129,8 @@ def test_atomic_publish_rejects_mutation_after_rename_and_fsync(
         "csv_malformed_encoding",
         "accepted_status_fail",
         "active_status_missing",
-        "future_observation",
+        "observation_beyond_bound",
+        "post_jump_observation",
         "post_jump_generation",
     ],
 )
@@ -1153,11 +1154,13 @@ def test_v2_runner_seal_rejects_untrusted_runner_sources(
         sidecar["prejump_shadow_metadata"]["status"] = "FAIL"
     elif case == "active_status_missing":
         sidecar["runner_completeness_after_canonical_alignment"].pop("status")
-    elif case == "future_observation":
+    elif case == "observation_beyond_bound":
+        generated = observed - timedelta(seconds=1201)
+    elif case == "post_jump_observation":
         sidecar["prejump_shadow_metadata"]["metadata_captured_at"] = (
-            observed + timedelta(seconds=1)
+            datetime.fromisoformat("2026-07-19T13:00:00+10:00")
         ).isoformat()
-    else:
+    elif case == "post_jump_generation":
         generated = datetime.fromisoformat("2026-07-19T13:00:00+10:00")
     sidecar_path.write_bytes(canonical_bytes(sidecar))
     race = {
@@ -1237,6 +1240,110 @@ def test_v2_runner_hash_binds_source_generated_at(tmp_path: Path):
     assert first[1]["source_generated_at"] == observed.isoformat()
     assert second[1]["source_generated_at"] == changed_at.isoformat()
     assert first[2] != second[2]
+
+
+def test_v2_runner_seal_accepts_later_prejump_observation_and_normalized_venue(
+    tmp_path: Path,
+):
+    evidence_root = tmp_path / "evidence"
+    race_url = "https://www.thedogs.com.au/racing/townsville/2026-07-19/5"
+    generated = datetime.fromisoformat("2026-07-19T12:55:00+10:00")
+    observed = generated + timedelta(seconds=5)
+    coverage = _runner_coverage(evidence_root, race_url, observed)
+    sidecar_path = Path(coverage["races"][0]["sidecar_path"])
+    sidecar = json.loads(sidecar_path.read_bytes())
+    sidecar["prejump_shadow_metadata"]["venue"] = "TOWNSVILLE"
+    sidecar["prejump_shadow_metadata"]["runner_box_name_list"][0]["dog_name"] = "Alpha Display"
+    sidecar["runner_completeness_after_canonical_alignment"]["participants"][0]["dog_name"] = "Alpha Display"
+    Path(coverage["races"][0]["csv_path"]).write_bytes(
+        b"box|dog_name\n1|Alpha Display\n2|Beta\n"
+    )
+    sidecar_path.write_bytes(canonical_bytes(sidecar))
+
+    rows, _, _ = capture._v2_runner_rows(
+        {
+            "date": "2026-07-19", "jump_datetime": "2026-07-19T13:00:00+10:00",
+            "race_number": 5, "race_url": race_url, "venue": "TWN",
+        },
+        {"generated_at": generated.isoformat(), "sidecar_metadata_coverage": coverage},
+        evidence_root=evidence_root,
+    )
+
+    assert rows[0]["display_name"] == "Alpha Display"
+
+
+def test_v2_runner_seal_rejects_unrelated_venue(tmp_path: Path):
+    evidence_root = tmp_path / "evidence"
+    race_url = "https://www.thedogs.com.au/racing/townsville/2026-07-19/5"
+    observed = datetime.fromisoformat("2026-07-19T12:55:00+10:00")
+    coverage = _runner_coverage(evidence_root, race_url, observed)
+
+    with pytest.raises(CaptureOneRejected) as rejected:
+        capture._v2_runner_rows(
+            {
+                "date": "2026-07-19", "jump_datetime": "2026-07-19T13:00:00+10:00",
+                "race_number": 5, "race_url": race_url, "venue": "TWN",
+            },
+            {"generated_at": observed.isoformat(), "sidecar_metadata_coverage": coverage},
+            evidence_root=evidence_root,
+        )
+
+    assert rejected.value.details["reason"] == "runner_race_identity_mismatch"
+
+
+def test_v2_runner_seal_accepts_expert_history_current_runner_prefixes(tmp_path: Path):
+    evidence_root = tmp_path / "evidence"
+    race_url = "https://www.thedogs.com.au/racing/gunnedah/2026-07-19/5"
+    observed = datetime.fromisoformat("2026-07-19T12:55:00+10:00")
+    coverage = _runner_coverage(evidence_root, race_url, observed)
+    Path(coverage["races"][0]["csv_path"]).write_bytes(
+        b"Dog Name|Sex|PLC|BOX|WGT|DIST|DATE|TRACK\n"
+        b"1. Alpha|D|1|7|30|400|2026-07-01|GUNN\n"
+        b"|D|2|4|30|400|2026-06-20|GUNN\n"
+        b"2. Beta|B|3|1|29|400|2026-07-01|GUNN\n"
+        b"|B|1|8|29|400|2026-06-20|GUNN\n"
+    )
+
+    rows, _, _ = capture._v2_runner_rows(
+        {
+            "date": "2026-07-19", "jump_datetime": "2026-07-19T13:00:00+10:00",
+            "race_number": 5, "race_url": race_url, "venue": "GUNN",
+        },
+        {"generated_at": observed.isoformat(), "sidecar_metadata_coverage": coverage},
+        evidence_root=evidence_root,
+    )
+
+    assert [(row["box"], row["identity"]) for row in rows] == [(1, "ALPHA"), (2, "BETA")]
+
+
+@pytest.mark.parametrize("first_name", ["Alpha", "1 Alpha", "2. Alpha", "1. Gamma"])
+def test_v2_runner_seal_rejects_invalid_expert_history_current_prefix(
+    tmp_path: Path, first_name: str,
+):
+    evidence_root = tmp_path / "evidence"
+    race_url = "https://www.thedogs.com.au/racing/gunnedah/2026-07-19/5"
+    observed = datetime.fromisoformat("2026-07-19T12:55:00+10:00")
+    coverage = _runner_coverage(evidence_root, race_url, observed)
+    Path(coverage["races"][0]["csv_path"]).write_text(
+        "Dog Name|PLC|BOX|DATE|TRACK\n"
+        f"{first_name}|1|7|2026-07-01|GUNN\n"
+        "2. Beta|2|1|2026-07-01|GUNN\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CaptureOneRejected) as rejected:
+        capture._v2_runner_rows(
+            {
+                "date": "2026-07-19", "jump_datetime": "2026-07-19T13:00:00+10:00",
+                "race_number": 5, "race_url": race_url, "venue": "GUNN",
+            },
+            {"generated_at": observed.isoformat(), "sidecar_metadata_coverage": coverage},
+            evidence_root=evidence_root,
+        )
+
+    assert rejected.value.details["reason"] in {
+        "csv_runner_rows_invalid", "csv_sidecar_runner_mismatch"
+    }
 
 
 def test_v2_runner_seal_accepts_matching_name_prefix_with_explicit_box(tmp_path: Path):


### PR DESCRIPTION
Correction C26 makes the canonical current-race-index publisher accept the already admitted natural collector artifacts without weakening provenance or pre-jump controls.

Exact candidate:
- commit b53c8d1ac68db6b22bc4819feaa0e30b2d693e24
- tree 2b98b19648940ec0ef5a0dbc5ffe476fd2faea42
- parent 38a3c992669523a0cc34d370e4039ecc658c0fdf
- patch SHA-256 b0b1a8eefb7037788dce192d93ebf8d4919fb706c5526f3c3083b9fa18bb9394

Scope:
- race_collection/synchronous_manual_capture.py
- tests/race_collection/test_synchronous_manual_capture.py

Validation:
- 20 focused tests passed
- complete synchronous capture test file: 71 passed
- read-only replay sealed all eight real natural races with runner counts 8,8,8,8,6,5,6,7
- py_compile passed
- git diff --check passed

Fresh independent exact-tree review:
- session 019fccdb-fcd9-7040-8bbe-81949c706e5a
- ACCEPT
- zero blocking standards findings; zero spec findings
- reviewer independently verified exact commit, tree, parent, two-file scope, py_compile, and diff check
- reviewer environment lacked pytest, so test and replay evidence remained parent-supplied

Preserved controls:
- both timestamps strictly pre-jump
- absolute source-time distance bounded to 1200 seconds
- exact URL/date/race-number binding
- exact ordered active-runner equality
- accepted/aligned/leakage-safe metadata and source hashes
- atomic publication, bounded inputs, no retry, and collector ownership