### PR TITLE
Fix mixed Forecasting CI contract routing

### DIFF
--- a/.github/workflows/forecasting-tests.yml
+++ b/.github/workflows/forecasting-tests.yml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       tier: ${{ steps.classify.outputs.tier }}
       reason: ${{ steps.classify.outputs.reason }}
+      ci_contract_changed: ${{ steps.classify.outputs.ci_contract_changed }}
 
     steps:
       - name: Check out exact validation head with history
@@ -55,6 +56,7 @@ jobs:
 
       - name: Summarize classification
         env:
+          CI_CONTRACT_CHANGED: ${{ steps.classify.outputs.ci_contract_changed }}
           CLASSIFICATION_REASON: ${{ steps.classify.outputs.reason }}
           FORECASTING_TIER: ${{ steps.classify.outputs.tier }}
         run: |
@@ -63,6 +65,7 @@ jobs:
             echo
             echo "- Tier: \`$FORECASTING_TIER\`"
             echo "- Reason: \`$CLASSIFICATION_REASON\`"
+            echo "- CI contract changed: \`$CI_CONTRACT_CHANGED\`"
             echo "- Explicit PR override label: \`ci:full-forecasting\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -78,13 +81,20 @@ jobs:
         if: >-
           needs.classify.result != 'success' ||
           !contains(fromJSON('["ci_contract","manual_prediction","official_results","forward_corpus","operator_ui","forecasting_core","full_forecasting","non_forecasting"]'),
-          needs.classify.outputs.tier)
+          needs.classify.outputs.tier) ||
+          !contains(fromJSON('["true","false"]'),
+          needs.classify.outputs.ci_contract_changed) ||
+          (needs.classify.outputs.tier == 'ci_contract' &&
+          needs.classify.outputs.ci_contract_changed != 'true') ||
+          (needs.classify.outputs.tier == 'non_forecasting' &&
+          needs.classify.outputs.ci_contract_changed != 'false')
         env:
+          CI_CONTRACT_CHANGED: ${{ needs.classify.outputs.ci_contract_changed }}
           CLASSIFIER_RESULT: ${{ needs.classify.result }}
           FORECASTING_TIER: ${{ needs.classify.outputs.tier }}
         run: |
           echo "Change classification did not produce a trusted tier."
-          echo "classifier_result=$CLASSIFIER_RESULT tier=$FORECASTING_TIER"
+          echo "classifier_result=$CLASSIFIER_RESULT tier=$FORECASTING_TIER ci_contract_changed=$CI_CONTRACT_CHANGED"
           exit 1
 
       - name: No forecasting contracts changed
@@ -113,6 +123,7 @@ jobs:
         id: forecasting
         continue-on-error: true
         env:
+          CI_CONTRACT_CHANGED: ${{ needs.classify.outputs.ci_contract_changed }}
           FORECASTING_TIER: ${{ needs.classify.outputs.tier }}
           TMPDIR: ${{ runner.temp }}
         shell: bash
@@ -120,12 +131,46 @@ jobs:
           set -o pipefail
           evidence_dir="${RUNNER_TEMP}/forecasting-acceptance-${GITHUB_RUN_ID}"
           mkdir -p "$evidence_dir"
+          command_manifest="$evidence_dir/forecasting-command-manifest.tsv"
+          combined_command="$evidence_dir/forecasting-command.txt"
+          combined_log="$evidence_dir/forecasting-suite.log"
+          : > "$command_manifest"
+          : > "$combined_command"
+          : > "$combined_log"
+
+          ci_contract_command=(
+            uv run --no-project --with-requirements requirements/all.in
+            --with PyYAML python scripts/ci/run_forecasting_ci_contract.py
+          )
+
+          run_command() {
+            local name="$1"
+            shift
+            local command_file="$evidence_dir/${name}-command.txt"
+            local log_file="$evidence_dir/${name}.log"
+            local exit_code
+            local -a pipeline_status
+            printf '%q ' "$@" > "$command_file"
+            printf '\n' >> "$command_file"
+            printf '%q ' "$@" >> "$combined_command"
+            printf '\n' >> "$combined_command"
+            printf '===== %s =====\n' "$name" >> "$combined_log"
+            "$@" 2>&1 | tee "$log_file" | tee -a "$combined_log"
+            pipeline_status=("${PIPESTATUS[@]}")
+            exit_code="${pipeline_status[0]}"
+            if (( pipeline_status[1] != 0 || pipeline_status[2] != 0 )); then
+              exit_code=125
+            fi
+            printf '%s\t%s\t%s\t%s\n' \
+              "$name" "$exit_code" \
+              "$(basename "$command_file")" "$(basename "$log_file")" \
+              >> "$command_manifest"
+            return "$exit_code"
+          }
+
           case "$FORECASTING_TIER" in
             ci_contract)
-              selected_command=(
-                uv run --no-project --with-requirements requirements/all.in
-                --with PyYAML python scripts/ci/run_forecasting_ci_contract.py
-              )
+              selected_command=("${ci_contract_command[@]}")
               ;;
             manual_prediction)
               selected_command=(
@@ -188,13 +233,20 @@ jobs:
               exit 1
               ;;
           esac
-          printf '%q ' "${selected_command[@]}" > "$evidence_dir/forecasting-command.txt"
-          printf '\n' >> "$evidence_dir/forecasting-command.txt"
-          "${selected_command[@]}" 2>&1 | tee "$evidence_dir/forecasting-suite.log"
+
+          overall_status=0
+          if [[ "$CI_CONTRACT_CHANGED" == "true" && \
+                "$FORECASTING_TIER" != "ci_contract" && \
+                "$FORECASTING_TIER" != "full_forecasting" ]]; then
+            run_command ci_contract "${ci_contract_command[@]}" || overall_status=1
+          fi
+          run_command "$FORECASTING_TIER" "${selected_command[@]}" || overall_status=1
+          exit "$overall_status"
 
       - name: Bind validation evidence to exact commit and tree
         if: always() && needs.classify.outputs.tier != 'non_forecasting'
         env:
+          CI_CONTRACT_CHANGED: ${{ needs.classify.outputs.ci_contract_changed }}
           CLASSIFICATION_REASON: ${{ needs.classify.outputs.reason }}
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
           FORECASTING_TIER: ${{ needs.classify.outputs.tier }}
@@ -213,25 +265,74 @@ jobs:
               Path(os.environ["RUNNER_TEMP"])
               / f"forecasting-acceptance-{os.environ['GITHUB_RUN_ID']}"
           )
-          log = evidence_dir / "forecasting-suite.log"
+          combined_log = evidence_dir / "forecasting-suite.log"
+          manifest = evidence_dir / "forecasting-command-manifest.tsv"
           tier = os.environ["FORECASTING_TIER"]
+          ci_contract_changed_text = os.environ["CI_CONTRACT_CHANGED"]
+          if ci_contract_changed_text not in {"true", "false"}:
+              raise SystemExit("invalid ci_contract_changed classifier output")
+          ci_contract_changed = ci_contract_changed_text == "true"
+          commit = subprocess.check_output(
+              ["git", "rev-parse", "HEAD"], text=True
+          ).strip()
+          tree = subprocess.check_output(
+              ["git", "rev-parse", "HEAD^{tree}"], text=True
+          ).strip()
+          commands = []
+          for line in manifest.read_text(encoding="utf-8").splitlines():
+              fields = line.split("\t")
+              if len(fields) != 4:
+                  raise SystemExit("malformed forecasting command manifest")
+              name, exit_code_text, command_name, log_name = fields
+              if Path(command_name).name != command_name or Path(log_name).name != log_name:
+                  raise SystemExit("unsafe forecasting evidence filename")
+              command_file = evidence_dir / command_name
+              log = evidence_dir / log_name
+              exit_code = int(exit_code_text)
+              commands.append(
+                  {
+                      "name": name,
+                      "command": command_file.read_text(encoding="utf-8").strip(),
+                      "exit_code": exit_code,
+                      "outcome": "success" if exit_code == 0 else "failure",
+                      "log": log.name,
+                      "log_sha256": hashlib.sha256(log.read_bytes()).hexdigest(),
+                      "commit": commit,
+                      "tree": tree,
+                  }
+              )
+          if tier == "ci_contract":
+              expected_commands = ["ci_contract"]
+          elif tier == "full_forecasting":
+              expected_commands = ["full_forecasting"]
+          elif ci_contract_changed:
+              expected_commands = ["ci_contract", tier]
+          else:
+              expected_commands = [tier]
+          if [command["name"] for command in commands] != expected_commands:
+              raise SystemExit("forecasting command manifest does not match classification")
+          expected_outcome = (
+              "success"
+              if all(command["exit_code"] == 0 for command in commands)
+              else "failure"
+          )
+          if os.environ["SUITE_OUTCOME"] != expected_outcome:
+              raise SystemExit("forecasting command outcomes do not match step outcome")
           evidence = {
-              "schema_version": "forecasting-ci-attestation-v2",
+              "schema_version": "forecasting-ci-attestation-v3",
               "tier": tier,
+              "ci_contract_changed": ci_contract_changed,
               "classification_reason": os.environ["CLASSIFICATION_REASON"],
               "command": (evidence_dir / "forecasting-command.txt")
               .read_text(encoding="utf-8")
               .strip(),
+              "commands": commands,
               "outcome": os.environ["SUITE_OUTCOME"],
               "event_sha": os.environ["GITHUB_SHA"],
               "expected_head": os.environ["EXPECTED_HEAD"],
-              "commit": subprocess.check_output(
-                  ["git", "rev-parse", "HEAD"], text=True
-              ).strip(),
-              "tree": subprocess.check_output(
-                  ["git", "rev-parse", "HEAD^{tree}"], text=True
-              ).strip(),
-              "log_sha256": hashlib.sha256(log.read_bytes()).hexdigest(),
+              "commit": commit,
+              "tree": tree,
+              "log_sha256": hashlib.sha256(combined_log.read_bytes()).hexdigest(),
               "python": platform.python_version(),
               "platform": platform.platform(),
               "uv": subprocess.check_output(["uv", "--version"], text=True).strip(),
@@ -250,9 +351,7 @@ jobs:
           name: forecasting-acceptance-${{ github.run_id }}
           if-no-files-found: error
           path: |
-            ${{ runner.temp }}/forecasting-acceptance-${{ github.run_id }}/forecasting-suite.log
-            ${{ runner.temp }}/forecasting-acceptance-${{ github.run_id }}/forecasting-command.txt
-            ${{ runner.temp }}/forecasting-acceptance-${{ github.run_id }}/forecasting-ci-attestation.json
+            ${{ runner.temp }}/forecasting-acceptance-${{ github.run_id }}/
 
       - name: Enforce forecasting acceptance gate
         if: >-

--- a/docs/FORECASTING_PUBLICATION_VALIDATION.md
+++ b/docs/FORECASTING_PUBLICATION_VALIDATION.md
@@ -22,9 +22,10 @@ its checked-in fixture cases, and selects one of the eight risk tiers documented
 in [forecasting_ci_tiers.md](forecasting_ci_tiers.md). CI contract, manual
 prediction, official-result, forward-corpus, Operator UI, and isolated
 forecasting-core changes receive focused validation. Shared or high-risk paths,
-unknown paths, destructive changes, and incompatible focused-tier combinations
-fail closed to `full_forecasting`. Renames and copies classify both old and new
-paths; empty or malformed change sets also fail closed.
+unknown paths, destructive changes, and combinations of two or more focused
+product tiers fail closed to `full_forecasting`. Renames and copies classify
+both old and new paths; empty or malformed change sets and uncertain rules also
+fail closed.
 
 The stable gate checks out the pull-request head explicitly. The full tier runs
 the complete `tests/race_collection` suite plus directly associated top-level
@@ -32,14 +33,20 @@ manual, official-result, and Operator UI tests. It runs on scheduled and manual
 dispatches, for PRs labeled `ci:full-forecasting`, and whenever risk
 classification escalates. CI-only routing changes select `ci_contract`, which
 validates classifier and workflow contracts plus one named smoke from each
-focused tier without invoking the complete race-collection suite.
+focused tier without invoking the complete race-collection suite. If CI routing
+paths accompany exactly one focused product tier, that product tier stays
+primary with `ci_contract_changed=true`; the stable job runs the CI-contract
+command first and then the product suite. CI-contract changes are not
+transparent to two product tiers, a full-risk path, or any uncertain change.
 
 Every tier except `non_forecasting` uploads:
 
-- `forecasting-suite.log`, the complete combined test output; and
+- `forecasting-suite.log`, the complete combined test output, plus one command
+  file and log per executed validation; and
 - `forecasting-ci-attestation.json`, containing the exact expected head, checked
-  out commit, tree, selected tier and command, result, Python/platform/uv
-  environment, and log SHA-256.
+  out commit, tree, selected primary tier, `ci_contract_changed`, ordered
+  commands, per-command result and log SHA-256, combined log SHA-256, and the
+  Python/platform/uv environment.
 
 The unrelated tier returns successfully without dependency setup after stating
 that no forecasting contracts changed. The stable job fails if classification

--- a/docs/forecasting_ci_tiers.md
+++ b/docs/forecasting_ci_tiers.md
@@ -1,9 +1,9 @@
 # Forecasting CI tiers
 
 The stable pull-request check is `tests-race-collection`. A classifier selects
-one tier for the complete change set; unknown paths, destructive changes, shared
-surfaces, and incompatible tier combinations fail closed to
-`full_forecasting`.
+one primary tier for the complete change set and separately reports whether the
+CI contract changed. Unknown paths, destructive changes, shared surfaces, and
+incompatible product-tier combinations fail closed to `full_forecasting`.
 
 | Tier | Intended paths | Validation command |
 | --- | --- | --- |
@@ -16,9 +16,14 @@ surfaces, and incompatible tier combinations fail closed to
 | `full_forecasting` | shared/high-risk, unknown, destructive, or unsafe mixed changes | `uv run --no-project --with-requirements requirements/all.in --with PyYAML python scripts/ci/run_full_forecasting.py` |
 | `non_forecasting` | known unrelated documentation and presentation paths | no Forecasting test command |
 
-`ci_contract` validates the classifier contracts and all workflow YAML files,
-then runs one named smoke from every focused tier. It never invokes the complete
-`tests/race_collection` directory.
+Pure CI routing changes select `ci_contract`. When CI-contract paths accompany
+exactly one focused product tier, the product tier remains primary and
+`ci_contract_changed=true`: the stable job runs the CI-contract command first,
+then that focused product suite. Each command, exit code, log hash, commit, and
+tree is retained in the exact-head attestation. `ci_contract` validates the
+classifier contracts and all workflow YAML files, then runs one named smoke from
+every focused tier. It never invokes the complete `tests/race_collection`
+directory.
 
 The full runner executes the CI contract, the complete `tests/race_collection`
 directory, and the top-level focused suites. It runs weekly, on every workflow dispatch, for PRs
@@ -27,4 +32,5 @@ labeled `ci:full-forecasting`, and whenever the classifier escalates risk.
 Shared identity, timing, provenance, feature, schema, dependency, training,
 evaluation, promotion, runtime-adapter, synchronous-capture, Operator UI
 bootstrap/deployment/live-adapter, and on-demand collector-protocol paths remain
-full. New paths are full until explicitly and safely assigned.
+full. Two or more focused product tiers remain full even when the CI contract
+also changes. New paths are full until explicitly and safely assigned.

--- a/scripts/ci/classify_forecasting_changes.py
+++ b/scripts/ci/classify_forecasting_changes.py
@@ -26,9 +26,9 @@ TIERS = (
     "full_forecasting",
 )
 TIER_RANK = {tier: rank for rank, tier in enumerate(TIERS)}
-KNOWN_STATUS_PREFIXES = frozenset({"A", "C", "D", "M", "R", "T"})
 DESTRUCTIVE_STATUS_PREFIXES = frozenset({"C", "D", "R", "T"})
 FOCUSED_TIERS = frozenset(TIERS) - {"non_forecasting", "full_forecasting"}
+PRODUCT_TIERS = FOCUSED_TIERS - {"ci_contract"}
 
 
 class ClassificationError(RuntimeError):
@@ -39,6 +39,29 @@ class ClassificationError(RuntimeError):
 class Change:
     status: str
     paths: tuple[str, ...]
+
+
+def _is_known_status(status: str) -> bool:
+    if status in {"A", "D", "M", "T"}:
+        return True
+    score = status[1:]
+    if status[:1] not in {"C", "R"} or not 1 <= len(score) <= 3 or not score.isdigit():
+        return False
+    return 0 <= int(score) <= 100
+
+
+def _full_result(
+    reason: str,
+    paths: Sequence[Mapping[str, Any]] = (),
+    *,
+    ci_contract_changed: bool = False,
+) -> dict[str, Any]:
+    return {
+        "tier": "full_forecasting",
+        "reason": reason,
+        "ci_contract_changed": ci_contract_changed,
+        "paths": list(paths),
+    }
 
 
 def _normalize_path(path: str) -> str:
@@ -101,23 +124,19 @@ def classify_changes(
 ) -> dict[str, Any]:
     change_list = list(changes)
     if not change_list:
-        return {
-            "tier": "full_forecasting",
-            "reason": "empty_change_set_defaults_to_full",
-            "paths": [],
-        }
+        return _full_result("empty_change_set_defaults_to_full")
 
     classified_paths: list[dict[str, Any]] = []
     selected_tiers: set[str] = set()
     destructive_change = False
     for change in change_list:
         prefix = change.status[:1]
-        if prefix not in KNOWN_STATUS_PREFIXES or not change.paths:
-            return {
-                "tier": "full_forecasting",
-                "reason": f"unknown_change_status:{change.status or 'empty'}",
-                "paths": classified_paths,
-            }
+        if not _is_known_status(change.status) or not change.paths:
+            return _full_result(
+                f"unknown_change_status:{change.status or 'empty'}",
+                classified_paths,
+                ci_contract_changed="ci_contract" in selected_tiers,
+            )
         destructive_change = (
             destructive_change or prefix in DESTRUCTIVE_STATUS_PREFIXES
         )
@@ -126,11 +145,11 @@ def classify_changes(
                 tier, matched = _path_tier(path, rules)
                 normalized = _normalize_path(path)
             except ClassificationError as exc:
-                return {
-                    "tier": "full_forecasting",
-                    "reason": f"uncertain_path:{exc}",
-                    "paths": classified_paths,
-                }
+                return _full_result(
+                    f"uncertain_path:{exc}",
+                    classified_paths,
+                    ci_contract_changed="ci_contract" in selected_tiers,
+                )
             classified_paths.append(
                 {
                     "path": normalized,
@@ -140,9 +159,11 @@ def classify_changes(
                     "defaulted_to_full": not matched,
                 }
             )
-            selected_tiers.add(tier)
+            selected_tiers.update(matched or (tier,))
 
     risk_tiers = selected_tiers - {"non_forecasting"}
+    ci_contract_changed = "ci_contract" in risk_tiers
+    product_tiers = risk_tiers & PRODUCT_TIERS
     if destructive_change:
         selected = "full_forecasting"
         reason = "destructive_change_defaults_to_full"
@@ -152,16 +173,28 @@ def classify_changes(
     elif "full_forecasting" in risk_tiers:
         selected = "full_forecasting"
         reason = "shared_or_high_risk_path_requires_full"
-    elif len(risk_tiers & FOCUSED_TIERS) > 1:
+    elif len(product_tiers) > 1:
         selected = "full_forecasting"
         reason = "incompatible_mixed_tiers_default_to_full"
-    elif risk_tiers:
-        selected = next(iter(risk_tiers))
+    elif product_tiers:
+        selected = next(iter(product_tiers))
+        reason = (
+            "single_product_tier_with_ci_contract"
+            if ci_contract_changed
+            else "single_trusted_tier"
+        )
+    elif ci_contract_changed:
+        selected = "ci_contract"
         reason = "single_trusted_tier"
     else:
         selected = "non_forecasting"
         reason = "known_non_forecasting_paths"
-    return {"tier": selected, "reason": reason, "paths": classified_paths}
+    return {
+        "tier": selected,
+        "reason": reason,
+        "ci_contract_changed": ci_contract_changed,
+        "paths": classified_paths,
+    }
 
 
 def parse_name_status(raw: bytes) -> list[Change]:
@@ -211,6 +244,10 @@ def write_github_output(path: Path, result: Mapping[str, Any]) -> None:
     with path.open("a", encoding="utf-8") as output:
         output.write(f"tier={result['tier']}\n")
         output.write(f"reason={result['reason']}\n")
+        output.write(
+            "ci_contract_changed="
+            f"{str(bool(result['ci_contract_changed'])).lower()}\n"
+        )
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -228,19 +265,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    try:
-        rules = load_rules(args.rules)
-        if args.force_full:
-            result = {
-                "tier": "full_forecasting",
-                "reason": "explicit_full_validation",
-                "paths": [],
-            }
-        else:
+    if args.force_full:
+        result = _full_result("explicit_full_validation")
+    else:
+        try:
+            rules = load_rules(args.rules)
             result = classify_changes(git_changes(args.base, args.head), rules)
-    except ClassificationError as exc:
-        print(f"classifier error: {exc}", file=sys.stderr)
-        return 2
+        except ClassificationError as exc:
+            print(f"classifier warning: {exc}; defaulting to full", file=sys.stderr)
+            result = _full_result("classifier_error_defaults_to_full")
     print(json.dumps(result, indent=2, sort_keys=True))
     if args.github_output:
         write_github_output(args.github_output, result)

--- a/tests/ci/test_forecasting_change_classifier.py
+++ b/tests/ci/test_forecasting_change_classifier.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import itertools
+import json
+import os
+import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 
@@ -132,7 +138,11 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
         for expected, paths in fixtures.items():
             for path in paths:
                 with self.subTest(expected=expected, path=path):
-                    self.assertEqual(self.classify(("M", path))["tier"], expected)
+                    result = self.classify(("M", path))
+                    self.assertEqual(result["tier"], expected)
+                    self.assertIs(
+                        result["ci_contract_changed"], expected == "ci_contract"
+                    )
 
     def test_ci_only_routing_change_never_selects_complete_suite(self):
         result = self.classify(
@@ -143,6 +153,61 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
         )
         self.assertEqual(result["tier"], "ci_contract")
         self.assertEqual(result["reason"], "single_trusted_tier")
+        self.assertIs(result["ci_contract_changed"], True)
+
+    def test_ci_contract_is_transparent_with_each_single_product_tier(self):
+        for tier, path in self.representative.items():
+            if tier == "ci_contract":
+                continue
+            with self.subTest(tier=tier):
+                result = self.classify(
+                    ("M", ".github/forecasting-paths.ini"),
+                    ("M", path),
+                )
+                self.assertEqual(result["tier"], tier)
+                self.assertEqual(
+                    result["reason"], "single_product_tier_with_ci_contract"
+                )
+                self.assertIs(result["ci_contract_changed"], True)
+
+    def test_ghu_050_path_mix_selects_manual_prediction_with_ci_contract(self):
+        result = self.classify(
+            ("M", ".github/forecasting-paths.ini"),
+            ("M", ".github/workflows/forecasting-tests.yml"),
+            ("A", "configs/prediction/manual-independent-capture-v1/config.schema.json"),
+            ("A", "configs/prediction/manual-independent-capture-v1/example-config.json"),
+            (
+                "A",
+                "configs/prediction/manual-independent-capture-v1/terminal-artifact.schema.json",
+            ),
+            ("M", "docs/forecasting_ci_tiers.md"),
+            ("A", "docs/manual_independent_capture_v1.md"),
+            ("M", "scripts/ci/run_full_forecasting.py"),
+            ("A", "src/predictor/manual_independent_capture.py"),
+            ("M", "tests/ci/test_forecasting_change_classifier.py"),
+            ("A", "tests/test_manual_independent_capture.py"),
+        )
+        self.assertEqual(result["tier"], "manual_prediction")
+        self.assertIs(result["ci_contract_changed"], True)
+
+    def test_future_manual_path_registration_stays_focused(self):
+        future_path = "src/predictor/manual_isolated_executor.py"
+        future_rules = dict(self.rules)
+        future_rules["manual_prediction"] = (
+            *future_rules["manual_prediction"],
+            future_path,
+        )
+        result = CLASSIFIER.classify_changes(
+            [
+                CLASSIFIER.Change(
+                    status="M", paths=(".github/forecasting-paths.ini",)
+                ),
+                CLASSIFIER.Change(status="A", paths=(future_path,)),
+            ],
+            future_rules,
+        )
+        self.assertEqual(result["tier"], "manual_prediction")
+        self.assertIs(result["ci_contract_changed"], True)
 
     def test_same_focused_family_and_docs_are_compatible(self):
         for tier, path in self.representative.items():
@@ -151,16 +216,46 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
                 self.assertEqual(result["tier"], tier)
 
     def test_every_cross_tier_focused_combination_escalates(self):
-        for left, right in itertools.combinations(self.representative, 2):
+        product_tiers = {
+            tier: path
+            for tier, path in self.representative.items()
+            if tier != "ci_contract"
+        }
+        for left, right in itertools.combinations(product_tiers, 2):
             with self.subTest(left=left, right=right):
                 result = self.classify(
-                    ("M", self.representative[left]),
-                    ("M", self.representative[right]),
+                    ("M", product_tiers[left]),
+                    ("M", product_tiers[right]),
                 )
                 self.assertEqual(result["tier"], "full_forecasting")
                 self.assertEqual(
                     result["reason"], "incompatible_mixed_tiers_default_to_full"
                 )
+
+    def test_ci_contract_does_not_hide_two_product_tiers(self):
+        result = self.classify(
+            ("M", ".github/workflows/forecasting-tests.yml"),
+            ("M", "scripts/predict_market_form_residual.py"),
+            ("M", "scripts/ingest_results_for_date.py"),
+        )
+        self.assertEqual(result["tier"], "full_forecasting")
+        self.assertEqual(result["reason"], "incompatible_mixed_tiers_default_to_full")
+        self.assertIs(result["ci_contract_changed"], True)
+
+    def test_one_path_matching_two_product_rules_escalates(self):
+        overlapping_rules = dict(self.rules)
+        path = "src/predictor/manual_independent_capture.py"
+        overlapping_rules["official_results"] = (
+            *overlapping_rules["official_results"],
+            path,
+        )
+        result = CLASSIFIER.classify_changes(
+            [CLASSIFIER.Change(status="M", paths=(path,))],
+            overlapping_rules,
+        )
+        self.assertEqual(result["tier"], "full_forecasting")
+        self.assertEqual(result["reason"], "incompatible_mixed_tiers_default_to_full")
+        self.assertIs(result["ci_contract_changed"], False)
 
     def test_shared_core_mixed_with_focused_escalates(self):
         result = self.classify(
@@ -169,6 +264,16 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
         )
         self.assertEqual(result["tier"], "full_forecasting")
         self.assertEqual(result["reason"], "shared_or_high_risk_path_requires_full")
+
+    def test_full_path_escalates_even_with_ci_contract_and_one_product_tier(self):
+        result = self.classify(
+            ("M", ".github/workflows/forecasting-tests.yml"),
+            ("M", "scripts/predict_market_form_residual.py"),
+            ("M", "race_collection/source_admission.py"),
+        )
+        self.assertEqual(result["tier"], "full_forecasting")
+        self.assertEqual(result["reason"], "shared_or_high_risk_path_requires_full")
+        self.assertIs(result["ci_contract_changed"], True)
 
     def test_unknown_path_escalates(self):
         result = self.classify(("A", "new_subsystem/adapter.py"))
@@ -197,6 +302,9 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
         for change in (
             CLASSIFIER.Change(status="?", paths=("README.md",)),
             CLASSIFIER.Change(status="X", paths=("README.md",)),
+            CLASSIFIER.Change(status="M100", paths=("README.md",)),
+            CLASSIFIER.Change(status="R101", paths=("README.md", "docs/moved.md")),
+            CLASSIFIER.Change(status="R0000", paths=("README.md", "docs/moved.md")),
             CLASSIFIER.Change(status="M", paths=("../outside.py",)),
             CLASSIFIER.Change(status="M", paths=("/absolute.py",)),
         ):
@@ -240,6 +348,48 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
             )
             with self.assertRaises(CLASSIFIER.ClassificationError):
                 CLASSIFIER.load_rules(rules)
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                exit_code = CLASSIFIER.main(
+                    ["--base", "HEAD", "--head", "HEAD", "--rules", str(rules)]
+                )
+            self.assertEqual(exit_code, 0)
+            result = json.loads(stdout.getvalue())
+            self.assertEqual(result["tier"], "full_forecasting")
+            self.assertEqual(result["reason"], "classifier_error_defaults_to_full")
+            self.assertIs(result["ci_contract_changed"], False)
+
+    def test_github_outputs_include_exact_ci_contract_boolean(self):
+        result = self.classify(
+            ("M", ".github/forecasting-paths.ini"),
+            ("M", "scripts/predict_market_form_residual.py"),
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "github-output"
+            CLASSIFIER.write_github_output(output, result)
+            self.assertEqual(
+                output.read_text(encoding="utf-8"),
+                "tier=manual_prediction\n"
+                "reason=single_product_tier_with_ci_contract\n"
+                "ci_contract_changed=true\n",
+            )
+
+    def test_force_full_writes_exact_safe_outputs(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "github-output"
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                exit_code = CLASSIFIER.main(
+                    ["--force-full", "--github-output", str(output)]
+                )
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(json.loads(stdout.getvalue())["tier"], "full_forecasting")
+            self.assertEqual(
+                output.read_text(encoding="utf-8"),
+                "tier=full_forecasting\n"
+                "reason=explicit_full_validation\n"
+                "ci_contract_changed=false\n",
+            )
 
     def test_workflow_preserves_stable_gate_and_full_escape_hatches(self):
         workflow = (ROOT / ".github/workflows/forecasting-tests.yml").read_text(
@@ -251,19 +401,109 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
             "workflow_dispatch:",
             "ci:full-forecasting",
             "--force-full",
-            "forecasting-ci-attestation-v2",
+            "forecasting-ci-attestation-v3",
             '"tier": tier',
-            '"${selected_command[@]}"',
+            "ci_contract_changed: ${{ steps.classify.outputs.ci_contract_changed }}",
+            'CI_CONTRACT_CHANGED: ${{ needs.classify.outputs.ci_contract_changed }}',
+            'run_command ci_contract "${ci_contract_command[@]}"',
+            'run_command "$FORECASTING_TIER" "${selected_command[@]}"',
+            'if [[ "$CI_CONTRACT_CHANGED" == "true"',
+            '"ci_contract_changed": ci_contract_changed',
+            '"commands": commands',
+            '"exit_code": exit_code',
+            '"log_sha256": hashlib.sha256(log.read_bytes()).hexdigest()',
+            "forecasting-command-manifest.tsv",
             'forecasting-command.txt',
             '--with PyYAML python scripts/ci/run_forecasting_ci_contract.py',
-            '"commit": subprocess.check_output',
-            '"tree": subprocess.check_output',
-            '"log_sha256": hashlib.sha256',
+            "commit = subprocess.check_output",
+            "tree = subprocess.check_output",
         ):
             with self.subTest(expected=expected):
                 self.assertIn(expected, workflow)
         for tier in CLASSIFIER.TIERS:
             self.assertIn(tier, workflow)
+        self.assertEqual(workflow.count("scripts/ci/run_full_forecasting.py"), 1)
+        self.assertLess(
+            workflow.index('run_command ci_contract "${ci_contract_command[@]}"'),
+            workflow.index(
+                'run_command "$FORECASTING_TIER" "${selected_command[@]}"'
+            ),
+        )
+
+    def test_mixed_command_attestation_binds_both_logs_to_exact_head_and_tree(self):
+        workflow = (ROOT / ".github/workflows/forecasting-tests.yml").read_text(
+            encoding="utf-8"
+        )
+        marker = "          python - <<'PY'\n"
+        start = workflow.index(marker) + len(marker)
+        source = textwrap.dedent(workflow[start : workflow.index("\n          PY", start)])
+        with tempfile.TemporaryDirectory() as temp_dir:
+            run_id = "123"
+            fake_bin = Path(temp_dir) / "bin"
+            fake_bin.mkdir()
+            fake_uv = fake_bin / "uv"
+            fake_uv.write_text("#!/bin/sh\nprintf 'uv-test 0.0\\n'\n", encoding="utf-8")
+            fake_uv.chmod(0o755)
+            evidence_dir = Path(temp_dir) / f"forecasting-acceptance-{run_id}"
+            evidence_dir.mkdir()
+            (evidence_dir / "forecasting-command-manifest.tsv").write_text(
+                "ci_contract\t0\tci_contract-command.txt\tci_contract.log\n"
+                "manual_prediction\t0\tmanual_prediction-command.txt\tmanual_prediction.log\n",
+                encoding="utf-8",
+            )
+            (evidence_dir / "ci_contract-command.txt").write_text(
+                "ci-contract-command\n", encoding="utf-8"
+            )
+            (evidence_dir / "manual_prediction-command.txt").write_text(
+                "manual-command\n", encoding="utf-8"
+            )
+            (evidence_dir / "ci_contract.log").write_text(
+                "ci contract passed\n", encoding="utf-8"
+            )
+            (evidence_dir / "manual_prediction.log").write_text(
+                "manual suite passed\n", encoding="utf-8"
+            )
+            (evidence_dir / "forecasting-command.txt").write_text(
+                "ci-contract-command\nmanual-command\n", encoding="utf-8"
+            )
+            (evidence_dir / "forecasting-suite.log").write_text(
+                "ci contract passed\nmanual suite passed\n", encoding="utf-8"
+            )
+            head = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+            ).strip()
+            tree = subprocess.check_output(
+                ["git", "rev-parse", "HEAD^{tree}"], cwd=ROOT, text=True
+            ).strip()
+            env = {
+                **os.environ,
+                "CI_CONTRACT_CHANGED": "true",
+                "CLASSIFICATION_REASON": "single_product_tier_with_ci_contract",
+                "EXPECTED_HEAD": head,
+                "FORECASTING_TIER": "manual_prediction",
+                "GITHUB_RUN_ID": run_id,
+                "GITHUB_SHA": head,
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                "RUNNER_TEMP": temp_dir,
+                "SUITE_OUTCOME": "success",
+            }
+            subprocess.run([sys.executable, "-c", source], cwd=ROOT, env=env, check=True)
+            attestation = json.loads(
+                (evidence_dir / "forecasting-ci-attestation.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+        self.assertEqual(attestation["schema_version"], "forecasting-ci-attestation-v3")
+        self.assertIs(attestation["ci_contract_changed"], True)
+        self.assertEqual(attestation["uv"], "uv-test 0.0")
+        self.assertEqual(
+            [command["name"] for command in attestation["commands"]],
+            ["ci_contract", "manual_prediction"],
+        )
+        for command in attestation["commands"]:
+            self.assertEqual(command["commit"], head)
+            self.assertEqual(command["tree"], tree)
+            self.assertEqual(len(command["log_sha256"]), 64)
 
     def test_ci_contract_runner_has_only_named_fast_smokes(self):
         runner = (


### PR DESCRIPTION
## What changed

- make `ci_contract` transparent when it accompanies exactly one focused
  Forecasting product tier
- expose `ci_contract_changed` as a separate classifier/GitHub output
- run CI-contract validation first and the selected focused product suite second
  in the stable `tests-race-collection` job
- attest the ordered commands, exit codes, per-command logs and hashes against
  the exact checked-out head and tree
- preserve full escalation and document the mixed control-plane rule

## Root cause

The v2 classifier treated `ci_contract` as a focused product tier. PR #106 /
GHU-050 therefore combined two focused tiers (`ci_contract` and
`manual_prediction`) and escalated to `full_forecasting`, even though it had
only one product risk family.

## Before / after

- GHU-050 before: `full_forecasting`, reason
  `incompatible_mixed_tiers_default_to_full`
- GHU-050 after: `manual_prediction`, `ci_contract_changed=true`, reason
  `single_product_tier_with_ci_contract`
- expected GHU-051: registering a new manual-prediction path while adding that
  product path selects the manual focused suite after CI-contract validation
- two product tiers, full-risk paths, unknown/malformed/empty/destructive input,
  uncertain rules, `ci:full-forecasting`, schedules and workflow dispatches
  remain full

## Validation

- `scripts/ci/run_forecasting_ci_contract.py`: passed; 23 contract tests, nine
  workflow YAML files, five representative focused smokes
- fatal Ruff: passed
- `py_compile`: passed
- `git diff --check` and `git show --check`: passed
- GHU-050 exact path fixture: passed
- dynamic two-command exact-head/tree attestation fixture: passed
- full forecasting suite intentionally not run; scheduled/manual full validation
  remains the coverage path

## Boundaries

No product, runtime, model, corpus, deployment, promotion, EV, staking or betting
behavior changes.
