### PR TITLE
Restore full producer observer lock handoff

### DIFF
--- a/docs/agent_tasks/full_producer_observer_lock_handoff_rebase_c1_20260805.md
+++ b/docs/agent_tasks/full_producer_observer_lock_handoff_rebase_c1_20260805.md
@@ -1,0 +1,118 @@
+---
+job_id: FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805
+title: Replay the accepted observer handoff on current master
+lane: Evaluation
+supporting_lanes:
+  - Provenance
+  - Query Orchestration
+  - Reporting
+owner: Codex
+approval_required: true
+approval_source: >-
+  The owner's 2026-08-05 /goal authorizes the smallest correction ticket,
+  fresh independent review, protected merge, repository-generated deployment,
+  natural-cycle proof, and one UI research prediction terminal result.
+allow_unapproved_safe_extension: false
+timeout_seconds: 43200
+mutation_mode: safe_extension
+base: 47e76063cfa14d697a4f4805f75aeaf9d597762e
+production_data_access: false
+production_data_boundary: >-
+  No runtime or database mutation in this correction lane. Existing natural
+  collector services remain outside this repository integration claim.
+owner_db_append_only_approval: false
+github_mutation_allowed: true
+git_history_mutation_allowed: true
+live_service_mutation_allowed: false
+closeout_scope: repo_and_publish
+docs_impact: DOCS_REQUIRED
+task_tier: critical
+recommended_model: high_reasoning
+actual_model: gpt-5
+why_this_model: >-
+  The accepted lock handoff must be replayed without broadening it across a
+  newly merged isolated manual-capture executor and exact-head CI contract.
+worker_model_allowed: true
+worker_decision_limit: >-
+  One fresh reviewer is read-only. The primary agent owns the exact replay,
+  validation, protected Git mutation, and handoff to a separate runtime claim.
+escalation_needed: false
+output_dir: reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805
+allowed_files:
+  - docs/agent_tasks/full_producer_observer_lock_handoff_rebase_c1_20260805.md
+  - docs/agent_tasks/full_producer_observer_lock_handoff_v1_20260805.md
+  - scripts/shadow_autopilot_daemon.py
+  - tests/test_shadow_autopilot_daemon.py
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805/README.md
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805/STATE.md
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805/DECISIONS.md
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805/VALIDATION.md
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805/REVIEW.md
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805/RUN_OUTCOME.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805/DECISION_ENTRY.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805/status.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805/guard-preflight.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805/guard-final.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805/github-checks.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805/final-refs.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805/release-receipt.json
+control_contract_version: 2
+project_id: greyhound_racing_collector
+claim_id: FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_REBASE_C1_20260805
+proof_question: >-
+  Does the already accepted observer handoff apply unchanged on master after PR
+  117 while preserving the isolated manual-capture executor and all canonical
+  no-steal, single-browser, provenance, and append-only boundaries?
+hypothesis_id: accepted_observer_handoff_is_compatible_with_pr117_v1
+program_track: prospective_readiness
+entry_state: >-
+  Candidate 8dff748b54a4279d737d0c802bfeb2726f82af91 was accepted and exact-head
+  green on base e4f36999, but remote master advanced through PR 117 to
+  47e76063cfa14d697a4f4805f75aeaf9d597762e before merge.
+target_transition: >-
+  exact current-master candidate preserves the accepted observer handoff and
+  PR 117 manual-capture executor, passes fresh review and exact-head CI, and is
+  protected-merge ready
+exit_predicate: >-
+  The replay changes only the allowlisted historical card, daemon, test, and
+  correction card; focused compatibility validation passes; a fresh reviewer
+  accepts the exact base-to-head diff; every required exact-head check passes;
+  and the SHA-guarded protected merge succeeds without base drift.
+source_class: >-
+  exact_master_47e76063_plus_accepted_candidate_8dff748b_and_pr117_reviewed_merge
+dataset_version: full_producer_observer_handoff_rebase_c1_20260805
+evidence_hash: sha256:488fc99d899a52a5ecf761f651a69256c546c788e44c3ec9f8233453c6d07d96
+capabilities:
+  - READ
+  - REPORT_WRITE
+  - CODE_EDIT
+  - PUBLISH
+resume_only_if: >-
+  Continue only while origin master remains 47e76063cfa14d697a4f4805f75aeaf9d597762e
+  or can be rechecked before mutation, the replayed product diff remains exact,
+  and no runtime, database, model, lock, timer, browser, or prediction mutation
+  occurs in this correction lane.
+---
+
+# Full Producer Observer Lock Handoff Rebase C1
+
+## Objective
+
+Replay the accepted three-file candidate on current master after unrelated PR
+#117 advanced the base. Do not redesign, refactor, or weaken any collector or
+manual-prediction boundary.
+
+## Required validation
+
+- prove the base-to-head product diff is byte-equivalent to accepted candidate
+  `8dff748b54a4279d737d0c802bfeb2726f82af91`;
+- rerun focused daemon/observer/lock tests plus the PR #117 isolated manual
+  executor tests;
+- fatal Ruff, `py_compile`, task contract, allowlist, and `git diff --check`;
+- fresh independent exact-diff review;
+- classifier-selected exact-head GitHub checks.
+
+## Runtime boundary
+
+This correction ends at protected merge. Deployment, natural-cycle proof, and
+the single UI prediction proceed only under a separate runtime-capability claim.

--- a/docs/agent_tasks/full_producer_observer_lock_handoff_v1_20260805.md
+++ b/docs/agent_tasks/full_producer_observer_lock_handoff_v1_20260805.md
@@ -1,0 +1,190 @@
+---
+job_id: FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805
+title: Restore a bounded full-producer observer lock handoff
+lane: Evaluation
+supporting_lanes:
+  - Provenance
+  - Query Orchestration
+  - Reporting
+owner: Codex
+approval_required: true
+approval_source: >-
+  The owner's 2026-08-05 /goal explicitly authorizes the smallest repository
+  scheduling correction, validation, fresh independent review, protected
+  publication and merge, repository-generated deployment, natural-cycle proof,
+  and one exact UI research prediction stopped after its first terminal result.
+allow_unapproved_safe_extension: false
+timeout_seconds: 43200
+mutation_mode: safe_extension
+base: e4f3699986237aad265b34e77d06d536f6046ee4
+production_data_access: false
+production_data_boundary: >-
+  No direct database writes. Existing collector-owned natural full and
+  odds-only services may perform only their already-authorized append-only
+  live-odds and official-result evidence writes. The UI may write no canonical
+  database or history data.
+owner_db_append_only_approval: true
+github_mutation_allowed: true
+git_history_mutation_allowed: true
+live_service_mutation_allowed: true
+closeout_scope: repo_and_publish
+docs_impact: DOCS_REQUIRED
+task_tier: critical
+recommended_model: high_reasoning
+actual_model: gpt-5
+why_this_model: >-
+  The repair crosses generated systemd scheduling, a shared no-steal collector
+  lock, single-browser authority, atomic index publication, and a one-attempt
+  production UI proof.
+worker_model_allowed: true
+worker_decision_limit: >-
+  One fresh implementer may edit only the product and focused test files; one
+  distinct fresh reviewer is read-only. The primary agent retains scope,
+  validation, Git, deployment, runtime, prediction, and final authority.
+escalation_needed: false
+output_dir: reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805
+allowed_files:
+  - docs/agent_tasks/full_producer_observer_lock_handoff_v1_20260805.md
+  - scripts/shadow_autopilot_daemon.py
+  - tests/test_shadow_autopilot_daemon.py
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/README.md
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/STATE.md
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/DECISIONS.md
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/VALIDATION.md
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/REVIEW.md
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/RUN_OUTCOME.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/DECISION_ENTRY.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/status.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/guard-preflight.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/guard-final.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/pr-body.md
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/github-checks.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/final-refs.json
+  - reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/release-receipt.json
+control_contract_version: 2
+project_id: greyhound_racing_collector
+claim_id: FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805
+proof_question: >-
+  Can a scheduled full producer whose observer initially finds an odds-only
+  owner wait at the existing natural no-steal boundary, acquire after release,
+  refresh and atomically publish a fresh index, then allow odds collection to
+  resume without concurrent acquisition or a second browser?
+hypothesis_id: full_producer_observer_reuses_bounded_odds_lock_handoff_v1
+program_track: prospective_readiness
+entry_state: >-
+  Origin master is e4f3699986237aad265b34e77d06d536f6046ee4 with tree
+  ac9cdde82d3a0ede953e36c9a87d9afd216c5826; the UI is deployed and healthy;
+  the full producer returns SKIPPED_LOCK_HELD before its existing bounded
+  handoff because the official-result observer sees the active odds-only lock;
+  no UI prediction has been submitted.
+target_transition: >-
+  one focused protected merge makes the observer use a bounded owner-verified
+  no-steal handoff, followed by repository-generated deployment, one natural
+  fresh index, and exactly one UI research prediction terminal result
+exit_predicate: >-
+  The allowlisted exact diff passes focused and classified validation plus a
+  fresh independent ACCEPT review; exact-head CI and protected merge pass;
+  generated deployment equals merged master; a natural full cycle acquires
+  after odds-only release, publishes a fresh runner-bound future index, and
+  odds-only resumes; the UI submits exactly one selected race and exposes its
+  first truthful terminal result with matching evidence and audit records.
+source_class: >-
+  exact_origin_master_e4f3699_tree_ac9cdde_plus_installed_generated_units_and_natural_timer_lock_reports_20260805
+dataset_version: full_producer_observer_lock_starvation_runtime_20260805
+evidence_hash: sha256:6058ce95a71fed75d03ad8c7a45427d1928bdd62259912225eb2e50292172ea1
+capabilities:
+  - READ
+  - REPORT_WRITE
+  - CODE_EDIT
+  - PUBLISH
+resume_only_if: >-
+  Continue only while the task worktree remains exact-base plus allowlisted
+  changes, no live non-odds lock owner appears, deployment remains repository
+  generated, the one prediction attempt remains unused until fresh-index
+  proof, and no forbidden training, promotion, EV, staking, betting, manual
+  unit edit, lock action, retry, or race substitution is required.
+---
+
+# Full Producer Observer Lock Handoff V1
+
+## Identity
+
+- Task ID: `FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805`
+- owned_programme: `GREYHOUND_OPERATOR_UI_RUNTIME_PROOF`
+- parent_task: `GHU-036`
+- integration_base: `e4f3699986237aad265b34e77d06d536f6046ee4`
+- integration_tree: `ac9cdde82d3a0ede953e36c9a87d9afd216c5826`
+- implementation_role: fresh Codex X implementer
+- review_role: distinct fresh Codex X reviewer
+
+## Objective
+
+Give the scheduled full producer one bounded, deterministic opportunity to run
+its official-result observer after an in-flight odds-only collector naturally
+releases the canonical lock. Preserve the existing no-steal, single-browser,
+collector-owned, provenance, and append-only boundaries.
+
+The verified defect is narrow: `run_once()` performs the official-result
+observer lock acquisition before the existing full-daemon odds-owner retry and
+handoff path. An odds-only owner therefore causes an immediate
+`SHARED_LOCK_BUSY` return and the later bounded handoff is unreachable.
+
+## Allowed Changes
+
+- `scripts/shadow_autopilot_daemon.py`
+- `tests/test_shadow_autopilot_daemon.py`
+- `docs/agent_tasks/full_producer_observer_lock_handoff_v1_20260805.md`
+- `reports/agent_jobs/FULL_PRODUCER_OBSERVER_LOCK_HANDOFF_V1_20260805/README.md`
+
+No other product, test, generated unit, runtime, schema, database, model,
+registry, or evidence file is in scope.
+
+## Required Behaviour
+
+1. When the observer's first lock attempt finds a verified odds-only owner,
+   publish the existing full-daemon wait marker and retry the same atomic
+   no-steal acquisition for a finite budget that covers the configured
+   odds-only timeout.
+2. The active odds-only run remains the lock owner until it exits naturally.
+   A subsequent odds-only start must continue to yield to the active marker.
+3. The observer may proceed only after its own atomic no-steal acquisition.
+   It must release only the lock identity it owns.
+4. A lock owned by any non-odds lifecycle remains an immediate truthful busy
+   result. Retry exhaustion also remains a truthful terminal blocker.
+5. Marker cleanup must remain owner-bound and must occur on acquisition,
+   exhaustion, or error without deleting or replacing the canonical lock.
+6. After the observer releases, the existing full-daemon lifecycle continues
+   unchanged, including its own lock acquisition, refresh, atomic race-index
+   publication, and normal odds-only resumption.
+
+## Explicitly Forbidden
+
+- lock deletion, stealing, stale-lock bypass, or ownership substitution;
+- concurrent collector/browser acquisition or a second browser authority;
+- manual service or timer edits, timer disablement, restarts, or lock action;
+- broad timer redesign or permanent odds-only suppression;
+- direct canonical DB/history writes from the UI;
+- training, promotion, EV, staking, or betting;
+- race substitution or prediction retry.
+
+## Validation
+
+- focused tests for observer wait, natural acquisition, non-odds fail-closed,
+  exhaustion, marker visibility/cleanup, and continued full/odds lifecycle
+  separation;
+- existing daemon, service-generator, lock, and current-index focused tests;
+- `ruff check` on the changed Python files;
+- `python -m py_compile` on the changed Python files;
+- applicable JSON schema validation if a changed/generated JSON artifact has a
+  declared schema;
+- `git diff --check`;
+- classifier-selected broader tests only if the changed paths require them;
+- fresh independent exact-diff review before publication.
+
+## Completion Boundary
+
+Implementation acceptance does not itself prove runtime completion. After
+protected merge and repository-owned generated deployment, completion still
+requires one natural scheduled full-producer cycle, a fresh future-race index,
+one exact UI race selection, and the still-unused single authorised research
+prediction stopped after its first terminal result.

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -527,6 +527,17 @@ def lock_owner_is_odds_capture(lock_details: Mapping[str, Any] | None) -> bool:
     return str(existing.get("run_id") or "").endswith("_odds_capture")
 
 
+def collector_lock_owner_is_odds_capture(
+    lock_details: Mapping[str, Any] | None,
+) -> bool:
+    if not isinstance(lock_details, Mapping):
+        return False
+    return (
+        str(lock_details.get("lock_owner_run_id") or "").endswith("_odds_capture")
+        and lock_details.get("lock_owner_phase") == "odds_capture"
+    )
+
+
 def lock_owner_is_full_daemon(lock_details: Mapping[str, Any] | None) -> bool:
     return lock_owner_report_fields(lock_details).get("lock_owner_kind") == "full_daemon"
 
@@ -550,6 +561,19 @@ def lock_owner_report_fields(lock_details: Mapping[str, Any] | None) -> dict[str
             "lock_owner_pid": wait_marker.get("pid"),
             "lock_owner_started_at": wait_marker.get("started_at"),
             "lock_owner_hostname": wait_marker.get("hostname"),
+        }
+    if "lock_owner_run_id" in lock_details:
+        return {
+            "lock_owner_kind": (
+                "odds_capture"
+                if collector_lock_owner_is_odds_capture(lock_details)
+                else "unknown_lock_owner"
+            ),
+            "lock_owner_run_id": lock_details.get("lock_owner_run_id"),
+            "lock_owner_output_dir": lock_details.get("lock_owner_output_dir"),
+            "lock_owner_pid": lock_details.get("lock_owner_pid"),
+            "lock_owner_started_at": lock_details.get("lock_owner_started_at"),
+            "lock_owner_hostname": lock_details.get("lock_owner_hostname"),
         }
     existing = lock_details.get("existing_lock")
     if not isinstance(existing, Mapping):
@@ -763,6 +787,105 @@ def acquire_lock_with_odds_capture_retry(
                     "last_lock": last_lock,
                 }
             return payload
+    finally:
+        if marker_written:
+            remove_full_daemon_lock_wait_marker(lock_path=lock_path, run_id=run_id)
+
+
+def acquire_observer_lock_with_odds_capture_retry(
+    *,
+    lock_path: Path,
+    run_id: str,
+    output_dir: Path,
+    retry_seconds: int | None = None,
+    poll_seconds: int | None = None,
+) -> tuple[Any, dict[str, Any] | None]:
+    retry_seconds = (
+        DEFAULT_FULL_DAEMON_ODDS_LOCK_RETRY_SECONDS
+        if retry_seconds is None
+        else retry_seconds
+    )
+    poll_seconds = (
+        DEFAULT_FULL_DAEMON_ODDS_LOCK_RETRY_POLL_SECONDS
+        if poll_seconds is None
+        else poll_seconds
+    )
+    first_lock: dict[str, Any] | None = None
+    last_lock: dict[str, Any] | None = None
+    attempt_count = 0
+    waited_seconds = 0.0
+    marker_written = False
+    try:
+        while True:
+            try:
+                lock = acquire_collector_lock_no_steal(
+                    lock_path,
+                    run_id=run_id,
+                    output_dir=output_dir,
+                    phase="forward_official_result_observer",
+                    acquisition_policy="forward_official_result_observer_no_steal_v1",
+                )
+            except CollectorBusy as exc:
+                attempt_count += 1
+                last_lock = dict(exc.evidence)
+                if first_lock is None:
+                    first_lock = dict(last_lock)
+                odds_capture_owner = collector_lock_owner_is_odds_capture(last_lock)
+                should_retry = (
+                    retry_seconds > 0
+                    and poll_seconds > 0
+                    and odds_capture_owner
+                    and waited_seconds < retry_seconds
+                )
+                if not should_retry:
+                    last_lock["lock_retry"] = {
+                        "schema_version": "shadow_autopilot_full_daemon_lock_retry_v1",
+                        "status": "GAVE_UP_LOCK_HELD",
+                        "attempt_count": attempt_count,
+                        "waited_seconds": waited_seconds,
+                        "retry_seconds": retry_seconds,
+                        "poll_seconds": poll_seconds,
+                        "retried_for_odds_capture_lock": odds_capture_owner,
+                        "first_lock": first_lock,
+                        "last_lock": dict(last_lock),
+                    }
+                    raise CollectorBusy(last_lock) from exc
+                if not marker_written:
+                    write_full_daemon_lock_wait_marker(
+                        lock_path=lock_path,
+                        run_id=run_id,
+                        output_dir=output_dir,
+                    )
+                    marker_written = True
+                write_full_daemon_lock_wait_report(
+                    output_dir=output_dir,
+                    lock_path=lock_path,
+                    lock_details=last_lock,
+                    first_lock=first_lock,
+                    attempt_count=attempt_count,
+                    waited_seconds=waited_seconds,
+                    retry_seconds=retry_seconds,
+                    poll_seconds=poll_seconds,
+                )
+                sleep_for = min(
+                    float(poll_seconds), float(retry_seconds) - waited_seconds
+                )
+                time.sleep(sleep_for)
+                waited_seconds += sleep_for
+                continue
+            if not attempt_count:
+                return lock, None
+            return lock, {
+                "schema_version": "shadow_autopilot_full_daemon_lock_retry_v1",
+                "status": "ACQUIRED_AFTER_ODDS_CAPTURE_WAIT",
+                "attempt_count": attempt_count + 1,
+                "waited_seconds": waited_seconds,
+                "retry_seconds": retry_seconds,
+                "poll_seconds": poll_seconds,
+                "retried_for_odds_capture_lock": True,
+                "first_lock": first_lock,
+                "last_lock": last_lock,
+            }
     finally:
         if marker_written:
             remove_full_daemon_lock_wait_marker(lock_path=lock_path, run_id=run_id)
@@ -9127,15 +9250,16 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
         "attempted_race_ids": [],
     }
     observer_shared_lock = None
+    observer_lock_retry = None
     if args.enable_forward_official_result_observer:
         try:
             lock_path.parent.mkdir(parents=True, exist_ok=True)
-            observer_shared_lock = acquire_collector_lock_no_steal(
-                lock_path,
-                run_id=run_id,
-                output_dir=output_dir,
-                phase="forward_official_result_observer",
-                acquisition_policy="forward_official_result_observer_no_steal_v1",
+            observer_shared_lock, observer_lock_retry = (
+                acquire_observer_lock_with_odds_capture_retry(
+                    lock_path=lock_path,
+                    run_id=run_id,
+                    output_dir=output_dir,
+                )
             )
         except CollectorBusy as exc:
             forward_official_result_observer = {
@@ -9236,6 +9360,11 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
                     "lock_path": relpath(lock_path),
                     "phase": "forward_official_result_observer",
                     "acquisition_policy": "forward_official_result_observer_no_steal_v1",
+                    **(
+                        {"lock_retry": observer_lock_retry}
+                        if observer_lock_retry is not None
+                        else {}
+                    ),
                     "release": observer_lock_release,
                 },
             }

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -809,6 +809,71 @@ def test_full_daemon_lock_retry_budget_covers_odds_capture_timeout():
     )
 
 
+def test_observer_lock_retry_exhaustion_preserves_odds_owner_and_cleans_marker(
+    tmp_path, monkeypatch
+):
+    lock_path = tmp_path / "runtime" / "shadow_autopilot.lock"
+    output_dir = tmp_path / "packet"
+    lock_path.parent.mkdir(parents=True)
+    output_dir.mkdir()
+    owner = {
+        "schema_version": "shadow_autopilot_daemon_lock_v1",
+        "run_id": "20260613T182954+1000_odds_capture",
+        "pid": os.getpid(),
+        "hostname": "worker-host",
+        "started_at": "2026-06-13T18:29:54+10:00",
+        "output_dir": "/runtime/active-odds",
+        "phase": "odds_capture",
+    }
+    lock_bytes = json.dumps(owner, sort_keys=True).encode()
+    lock_path.write_bytes(lock_bytes)
+    evidence = {
+        "lock_path": str(lock_path),
+        "lock_owner_run_id": owner["run_id"],
+        "lock_owner_pid": owner["pid"],
+        "lock_owner_hostname": owner["hostname"],
+        "lock_owner_started_at": owner["started_at"],
+        "lock_owner_output_dir": owner["output_dir"],
+        "lock_owner_phase": owner["phase"],
+        "reason": "existing_lock_present_no_steal",
+    }
+    attempts = []
+    sleeps = []
+
+    def busy_acquire(*args, **kwargs):
+        attempts.append((args, kwargs))
+        raise daemon.CollectorBusy(evidence)
+
+    def fake_sleep(seconds):
+        sleeps.append(seconds)
+        marker = daemon.read_active_full_daemon_lock_wait_marker(lock_path)
+        assert marker is not None
+        assert marker["run_id"] == "20260613T183200+1000"
+        assert lock_path.read_bytes() == lock_bytes
+
+    monkeypatch.setattr(daemon, "acquire_collector_lock_no_steal", busy_acquire)
+    monkeypatch.setattr(daemon.time, "sleep", fake_sleep)
+
+    with pytest.raises(daemon.CollectorBusy) as exc_info:
+        daemon.acquire_observer_lock_with_odds_capture_retry(
+            lock_path=lock_path,
+            run_id="20260613T183200+1000",
+            output_dir=output_dir,
+            retry_seconds=10,
+            poll_seconds=5,
+        )
+
+    retry = exc_info.value.evidence["lock_retry"]
+    assert retry["status"] == "GAVE_UP_LOCK_HELD"
+    assert retry["attempt_count"] == 3
+    assert retry["waited_seconds"] == 10.0
+    assert retry["retried_for_odds_capture_lock"] is True
+    assert len(attempts) == 3
+    assert sleeps == [5.0, 5.0]
+    assert lock_path.read_bytes() == lock_bytes
+    assert not daemon.full_daemon_lock_wait_marker_path(lock_path).exists()
+
+
 def test_completed_daemon_run_report_envelope_is_self_describing(tmp_path, monkeypatch):
     monkeypatch.setattr(daemon, "ROOT", tmp_path)
     output_dir = tmp_path / "artifacts/full_evidence_orchestration_20260525/daemon"
@@ -980,6 +1045,119 @@ def test_run_once_defer_observes_result_before_odds_priority_return(
     ) == report["forward_official_result_observer"]
 
 
+def test_run_once_observer_waits_for_natural_odds_release_then_continues(
+    tmp_path, monkeypatch
+):
+    evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
+    output_dir = evidence_root / "shadow_autopilot_daemonization_v1_observer_handoff"
+    odds_state_path = tmp_path / "runtime" / "odds_capture_state.json"
+    lock_path = tmp_path / "runtime" / "shadow_autopilot.lock"
+    lock_path.parent.mkdir(parents=True)
+    owner = {
+        "schema_version": "shadow_autopilot_daemon_lock_v1",
+        "run_id": "20260613T182954+1000_odds_capture",
+        "pid": os.getpid(),
+        "hostname": "worker-host",
+        "started_at": "2026-06-13T18:29:54+10:00",
+        "output_dir": "/runtime/active-odds",
+        "phase": "odds_capture",
+    }
+    lock_bytes = json.dumps(owner, sort_keys=True).encode()
+    lock_path.write_bytes(lock_bytes)
+    sleeps = []
+    observed = {
+        "status": "COMPLETED",
+        "attempted_race_ids": ["race-1"],
+        "counts": {"observed": 1},
+    }
+
+    monkeypatch.setattr(daemon, "ROOT", tmp_path)
+    monkeypatch.setattr(daemon, "copy_if_exists", lambda source, dest: None)
+    monkeypatch.setattr(
+        daemon,
+        "write_service_files",
+        lambda **kwargs: {
+            "status": "SERVICE_FILES_WRITTEN",
+            "systemd_deployment_ready": True,
+        },
+    )
+
+    def fake_sleep(seconds):
+        sleeps.append(seconds)
+        marker = daemon.read_active_full_daemon_lock_wait_marker(lock_path)
+        assert marker is not None
+        assert marker["run_id"] == "observer_handoff"
+        assert marker["reason"] == "full_daemon_waiting_for_odds_capture_lock_handoff"
+        waiting_report = json.loads((output_dir / "daemon_run_report.json").read_text())
+        assert waiting_report["lock_owner_kind"] == "odds_capture"
+        assert waiting_report["lock_retry"]["status"] == (
+            "WAITING_FOR_ODDS_CAPTURE_LOCK"
+        )
+        assert lock_path.read_bytes() == lock_bytes
+        lock_path.unlink()
+
+    def observe(args, run_id):
+        lock = json.loads(lock_path.read_text())
+        assert lock["run_id"] == run_id
+        assert lock["phase"] == "forward_official_result_observer"
+        return observed | {"run_id": run_id}
+
+    monkeypatch.setattr(daemon.time, "sleep", fake_sleep)
+    monkeypatch.setattr(daemon, "run_forward_official_result_observer", observe)
+    monkeypatch.setattr(
+        daemon,
+        "full_daemon_odds_window_defer_decision",
+        lambda odds_state, current_time: {
+            "should_defer": True,
+            "reason": "test_fixed_window_open",
+        },
+    )
+    monkeypatch.setattr(
+        daemon,
+        "acquire_lock_with_odds_capture_retry",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("odds-priority return must remain before the full lock")
+        ),
+    )
+    args = daemon.parse_args(
+        [
+            "run-once",
+            "--run-id",
+            "observer_handoff",
+            "--evidence-root",
+            str(evidence_root),
+            "--output-dir",
+            str(output_dir),
+            "--current-time",
+            "2026-06-13T18:32:06+10:00",
+            "--lock-path",
+            str(lock_path),
+            "--enable-forward-official-result-observer",
+            "--forward-corpus-root",
+            str(tmp_path / "forward-corpus"),
+            "--enable-autonomous-odds-capture",
+            "--odds-capture-state-path",
+            str(odds_state_path),
+        ]
+    )
+
+    report = daemon.run_once(args)
+
+    assert report["final_verdict"] == "DAEMON_DEFERRED_TO_ODDS_CAPTURE_ONLY"
+    assert sleeps == [5.0]
+    shared_lock = report["forward_official_result_observer"]["shared_lock"]
+    assert shared_lock["lock_retry"]["status"] == (
+        "ACQUIRED_AFTER_ODDS_CAPTURE_WAIT"
+    )
+    assert shared_lock["lock_retry"]["attempt_count"] == 2
+    assert shared_lock["release"] == {
+        "released": True,
+        "reason": "released_by_observer_owner",
+    }
+    assert not lock_path.exists()
+    assert not daemon.full_daemon_lock_wait_marker_path(lock_path).exists()
+
+
 def test_run_once_observer_failure_stops_before_odds_defer_and_full_lock(
     tmp_path, monkeypatch
 ):
@@ -1077,12 +1255,12 @@ def test_live_shared_lock_defers_before_observer_service_or_corpus_mutation(
     lock_bytes = json.dumps(
         {
             "schema_version": "shadow_autopilot_daemon_lock_v1",
-            "run_id": "active_odds_capture",
+            "run_id": "active_full_producer",
             "pid": os.getpid(),
             "hostname": "test-host",
             "started_at": "2026-06-13T15:16:00+10:00",
-            "output_dir": "/runtime/active-odds",
-            "phase": "odds_capture",
+            "output_dir": "/runtime/active-full",
+            "phase": "full_daemon",
         },
         sort_keys=True,
     ).encode()
@@ -1101,6 +1279,13 @@ def test_live_shared_lock_defers_before_observer_service_or_corpus_mutation(
         "run_forward_official_result_observer",
         lambda *args, **kwargs: (_ for _ in ()).throw(
             AssertionError("live shared owner must prevent observer I/O")
+        ),
+    )
+    monkeypatch.setattr(
+        daemon.time,
+        "sleep",
+        lambda seconds: (_ for _ in ()).throw(
+            AssertionError("non-odds owner must not enter bounded handoff")
         ),
     )
     args = daemon.parse_args(
@@ -1124,10 +1309,14 @@ def test_live_shared_lock_defers_before_observer_service_or_corpus_mutation(
 
     assert report["status"] == "SKIPPED_LOCK_HELD"
     assert report["runtime_action"] == "DEFER_FORWARD_OBSERVER_SHARED_LOCK_HELD"
-    assert report["lock_owner_phase"] == "odds_capture"
+    assert report["lock_owner_phase"] == "full_daemon"
     assert report["lock_owner_pid"] == os.getpid()
+    assert report["forward_official_result_observer"]["shared_lock"]["lock_retry"][
+        "retried_for_odds_capture_lock"
+    ] is False
     assert report["forward_official_result_observer"]["attempted_race_ids"] == []
     assert lock_path.read_bytes() == lock_bytes
+    assert not daemon.full_daemon_lock_wait_marker_path(lock_path).exists()
     assert list(corpus_root.iterdir()) == [sentinel]
     assert sentinel.read_bytes() == b'{"immutable":true}\n'
 


### PR DESCRIPTION
## What changed

- make the full producer's official-result observer use a bounded no-steal
  handoff when, and only when, the canonical lock owner is verified as the
  odds-only collector;
- reuse the existing full-daemon wait marker and wait report;
- retain immediate fail-closed behavior for non-odds owners and truthful
  exhaustion;
- attach successful handoff evidence to the observer lifecycle report;
- add focused natural-release, exhaustion, cleanup, non-odds, and lifecycle
  regression coverage.

## Root cause

The main full-daemon lock already had a bounded odds-owner handoff, but the
official-result observer attempted the same canonical lock earlier and returned
`SHARED_LOCK_BUSY` before that handoff was reachable. Long, continuously
re-entering odds-only runs therefore starved every scheduled full refresh and
left the Operator UI race index stale.

## Safety boundary

This changes no timer cadence, lock ownership rule, browser authority, capture
source, database schema, model, training, promotion, EV, staking, or betting
behavior. Acquisition remains atomic and no-steal; release remains owner and
inode bound. Runtime deployment and the one authorised UI prediction remain
separate post-merge gates.

## Validation

- 242 daemon, observer, and synchronous collector-lock tests passed;
- fatal Ruff rules `E9,F63,F7,F82` passed;
- `py_compile`, task-contract, allowlist, and `git diff --check` passed;
- fresh exact-diff review: `ACCEPT`, no critical or warning findings;
- classifier result: `full_forecasting`; local full gate is running on an
  NVMe-backed temporary root after the host root filesystem caused an initial
  environment-only `database or disk is full` abort.
