### PR TITLE
GHU-054: route isolated manual prediction through focused CI

### DIFF
--- a/.github/forecasting-paths.ini
+++ b/.github/forecasting-paths.ini
@@ -86,15 +86,20 @@ patterns =
     configs/prediction/manual-independent-capture-v1/**
     configs/prediction/market-only.json
     docs/manual_independent_capture_v1.md
+    docs/manual_research_prediction_cli.md
     scripts/predict_market_form_residual.py
     src/predictor/manual_independent_capture.py
     src/predictor/manual_independent_capture_executor.py
     src/predictor/manual_independent_capture_sealer.py
     src/predictor/market_form_residual.py
+    src/predictor/manual_research_scoring.py
+    src/predictor/manual_research_cli.py
     tests/fixtures/manual_independent_capture_child.py
     tests/test_manual_independent_capture.py
     tests/test_manual_independent_capture_executor.py
     tests/test_manual_independent_capture_sealer.py
+    tests/test_manual_research_scoring.py
+    tests/test_manual_research_cli.py
     tests/test_market_form_residual.py
     tests/test_market_form_residual_portability.py
     tests/test_predict_market_form_residual.py

--- a/.github/workflows/forecasting-tests.yml
+++ b/.github/workflows/forecasting-tests.yml
@@ -180,6 +180,8 @@ jobs:
                 tests/test_manual_independent_capture.py \
                 tests/test_manual_independent_capture_executor.py \
                 tests/test_manual_independent_capture_sealer.py \
+                tests/test_manual_research_scoring.py \
+                tests/test_manual_research_cli.py \
                 tests/test_market_form_residual.py \
                 tests/test_market_form_residual_portability.py \
                 tests/test_predict_market_form_residual.py

--- a/configs/prediction/manual-independent-capture-v1/manual-research-adapter-response.schema.json
+++ b/configs/prediction/manual-independent-capture-v1/manual-research-adapter-response.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://greyhound-racing-collector.invalid/schemas/manual-independent-capture-v1/manual-research-adapter-response.schema.json",
+  "title": "GHU-054 manual research adapter response",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {"type": "string"},
+    "status": {"type": "string"},
+    "bundle_id": {"type": "string"},
+    "bundle_path": {"type": "string"},
+    "verification_status": {"type": "string"},
+    "error_code": {"type": "string"}
+  },
+  "oneOf": [
+    {
+      "required": ["schema_version", "status", "bundle_id", "bundle_path", "verification_status"],
+      "properties": {
+        "schema_version": {"const": "manual_research_invocation_response_v1"},
+        "status": {"const": "SUCCESS"},
+        "bundle_id": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "bundle_path": {"type": "string", "minLength": 1},
+        "verification_status": {"const": "VERIFIED"}
+      },
+      "not": {"required": ["error_code"]}
+    },
+    {
+      "required": ["schema_version", "status", "error_code"],
+      "properties": {
+        "schema_version": {"const": "manual_research_invocation_response_v1"},
+        "status": {"const": "ERROR"},
+        "error_code": {"type": "string", "pattern": "^[A-Z][A-Z0-9_]*$"}
+      },
+      "not": {"anyOf": [
+        {"required": ["bundle_id"]},
+        {"required": ["bundle_path"]},
+        {"required": ["verification_status"]}
+      ]}
+    }
+  ]
+}

--- a/docs/manual_research_prediction_cli.md
+++ b/docs/manual_research_prediction_cli.md
@@ -1,0 +1,51 @@
+# GHU-054 manual research prediction adapter
+
+`src.predictor.manual_research_cli` exposes one bounded, offline invocation of
+the accepted GHU-053 scorer. It reads only caller-supplied regular files and
+directories, then delegates sealed-evidence verification, form validation,
+scoring, atomic publication, and output verification to GHU-052/GHU-053.
+
+The CLI requires absolute paths for:
+
+- the sealed GHU-052 bundle and its isolated run directory;
+- canonical JSON files for `SealExpectations`, `SealingIdentity`, and
+  `ResearchScoringIdentity` (their keys must exactly match the corresponding
+  Python dataclasses);
+- the embedded form, frozen model, model manifest, and scoring config;
+- the caller-owned isolated output root.
+
+The four `--*-sha256` arguments are required and are checked against the bytes
+read from the supplied form, model, model manifest, and config. No input is
+discovered, substituted, retried, or fetched.
+
+Example:
+
+```bash
+python3 -m src.predictor.manual_research_cli \
+  --sealed-bundle-dir /isolated/run/sealed-evidence/<bundle-id> \
+  --run-dir /isolated/run \
+  --evidence-expectations /isolated/args/evidence-expectations.json \
+  --sealing-identity /isolated/args/sealing-identity.json \
+  --embedded-form /isolated/args/form.json \
+  --form-sha256 <sha256> \
+  --model /isolated/args/model.json \
+  --model-manifest /isolated/args/model-manifest.json \
+  --model-sha256 <sha256> \
+  --model-manifest-sha256 <sha256> \
+  --config /isolated/args/config.json \
+  --config-sha256 <sha256> \
+  --scoring-identity /isolated/args/scoring-identity.json \
+  --output-root /isolated/output
+```
+
+Success writes one canonical JSON envelope to stdout and returns exit code 0:
+
+```json
+{"schema_version":"manual_research_invocation_response_v1","status":"SUCCESS","bundle_id":"<bundle-id>","bundle_path":"/isolated/output/<bundle-id>","verification_status":"VERIFIED"}
+```
+
+Failure writes only the same envelope schema with `status: ERROR` and a stable
+`error_code`, and returns exit code 2. The response never exposes prediction,
+EV, staking, betting, outcome, result, or Phase-7 fields. This adapter does not
+provide browser, network, capture, service, timer, database, canonical, live,
+training, calibration, promotion, deployment, or UI authority.

--- a/src/predictor/manual_research_cli.py
+++ b/src/predictor/manual_research_cli.py
@@ -1,0 +1,320 @@
+"""Bounded manual CLI/API adapter for the accepted GHU-053 scorer.
+
+The adapter only loads caller-supplied regular files and directories, converts
+caller-supplied identity documents to GHU-052/GHU-053 contract objects, and
+delegates validation, scoring, publication, and verification to those layers.
+It has no capture, discovery, network, database, result, or runtime surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import stat
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import fields
+from pathlib import Path
+from typing import Any
+
+from src.predictor.manual_independent_capture import (
+    canonical_bytes,
+    parse_canonical_json,
+)
+from src.predictor.manual_independent_capture_sealer import (
+    ManualEvidenceRejected,
+    SealExpectations,
+    SealingIdentity,
+)
+from src.predictor.manual_research_scoring import (
+    ManualResearchScoringRejected,
+    ResearchScoringIdentity,
+    score_verified_manual_evidence,
+)
+from src.predictor.market_form_residual import ResidualContractError, load_frozen_model
+
+RESPONSE_SCHEMA = "manual_research_invocation_response_v1"
+VERIFICATION_STATUS = "VERIFIED"
+_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+_MAX_FORM_BYTES = 4 * 1024 * 1024
+_MAX_CONFIG_BYTES = 64 * 1024
+_MAX_MODEL_BYTES = 16 * 1024 * 1024
+_MAX_METADATA_BYTES = 256 * 1024
+_FORBIDDEN_ERROR_TOKENS = frozenset(("EV", "STAKE", "BET", "OUTCOME", "RESULT", "PHASE7"))
+
+
+class ManualResearchAdapterRejected(RuntimeError):
+    """A deterministic fail-closed adapter rejection."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def _reject(code: str) -> ManualResearchAdapterRejected:
+    return ManualResearchAdapterRejected(code)
+
+
+def _public_error_code(code: str) -> str:
+    if any(token in _FORBIDDEN_ERROR_TOKENS for token in code.split("_")):
+        return "UNAUTHORIZED_INPUT"
+    return code
+
+
+def _path(value: Path | str, *, label: str) -> Path:
+    if not isinstance(value, (Path, str)):
+        raise _reject("ARGUMENTS_INVALID")
+    raw = os.fspath(value)
+    if not raw or "\x00" in raw:
+        raise _reject("PATH_UNSAFE")
+    candidate = Path(raw)
+    if not candidate.is_absolute() or ".." in candidate.parts or "." in candidate.parts:
+        raise _reject("PATH_UNSAFE")
+    current = candidate
+    while True:
+        try:
+            info = current.lstat()
+        except FileNotFoundError as exc:
+            raise _reject("INPUT_MISSING") from exc
+        except OSError as exc:
+            raise _reject("PATH_UNSAFE") from exc
+        if stat.S_ISLNK(info.st_mode):
+            raise _reject("PATH_UNSAFE")
+        if current != candidate and not stat.S_ISDIR(info.st_mode):
+            raise _reject("PATH_UNSAFE")
+        if current == Path("/"):
+            break
+        current = current.parent
+    return candidate
+
+
+def _directory(value: Path | str, *, label: str) -> Path:
+    path = _path(value, label=label)
+    try:
+        if not stat.S_ISDIR(path.lstat().st_mode):
+            raise _reject("PATH_UNSAFE")
+    except FileNotFoundError as exc:
+        raise _reject("INPUT_MISSING") from exc
+    return path
+
+
+def _regular_file(value: Path | str, *, label: str, max_bytes: int) -> tuple[Path, bytes]:
+    path = _path(value, label=label)
+    try:
+        descriptor = os.open(
+            path,
+            os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0),
+        )
+    except FileNotFoundError as exc:
+        raise _reject("INPUT_MISSING") from exc
+    except OSError as exc:
+        raise _reject("PATH_UNSAFE") from exc
+    try:
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode):
+            raise _reject("PATH_UNSAFE")
+        if info.st_size > max_bytes:
+            raise _reject("INPUT_TOO_LARGE")
+        chunks: list[bytes] = []
+        remaining = max_bytes
+        while remaining:
+            chunk = os.read(descriptor, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        if remaining == 0 and os.read(descriptor, 1):
+            raise _reject("INPUT_TOO_LARGE")
+        return path, b"".join(chunks)
+    except OSError as exc:
+        raise _reject("INPUT_MISSING") from exc
+    finally:
+        os.close(descriptor)
+
+
+def _hash(value: Any) -> str:
+    if not isinstance(value, str) or _HASH_RE.fullmatch(value) is None:
+        raise _reject("ARGUMENTS_INVALID")
+    return value
+
+
+def _metadata(path: Path | str, *, label: str) -> Mapping[str, Any]:
+    _, raw = _regular_file(path, label=label, max_bytes=_MAX_METADATA_BYTES)
+    try:
+        value = parse_canonical_json(raw, max_bytes=_MAX_METADATA_BYTES)
+    except Exception as exc:
+        raise _reject("ARGUMENTS_INVALID") from exc
+    if not isinstance(value, Mapping):
+        raise _reject("ARGUMENTS_INVALID")
+    return value
+
+
+def _dataclass_metadata(path: Path | str, *, label: str, type_: Any) -> Any:
+    value = _metadata(path, label=label)
+    expected = {field.name for field in fields(type_)}
+    if set(value) != expected:
+        raise _reject("ARGUMENTS_INVALID")
+    try:
+        return type_(**dict(value))
+    except (TypeError, ValueError) as exc:
+        raise _reject("ARGUMENTS_INVALID") from exc
+
+
+def _error_response(code: str) -> dict[str, str]:
+    return {
+        "schema_version": RESPONSE_SCHEMA,
+        "status": "ERROR",
+        "error_code": code,
+    }
+
+
+def _success_response(bundle_id: str, bundle_path: Path) -> dict[str, Any]:
+    return {
+        "schema_version": RESPONSE_SCHEMA,
+        "status": "SUCCESS",
+        "bundle_id": bundle_id,
+        "bundle_path": str(bundle_path),
+        "verification_status": VERIFICATION_STATUS,
+    }
+
+
+def invoke_manual_research_prediction(
+    *,
+    sealed_bundle_dir: Path | str,
+    run_dir: Path | str,
+    evidence_expectations: Path | str,
+    sealing_identity: Path | str,
+    embedded_form: Path | str,
+    form_sha256: str,
+    model: Path | str,
+    model_manifest: Path | str,
+    model_sha256: str,
+    model_manifest_sha256: str,
+    config: Path | str,
+    config_sha256: str,
+    scoring_identity: Path | str,
+    output_root: Path | str,
+) -> dict[str, Any]:
+    """Invoke GHU-053 from explicit caller-owned, hash-pinned artifacts."""
+
+    bundle_dir = _directory(sealed_bundle_dir, label="sealed_bundle_dir")
+    isolated_run_dir = _directory(run_dir, label="run_dir")
+    isolated_output_root = _directory(output_root, label="output_root")
+    expected = _dataclass_metadata(
+        evidence_expectations, label="evidence_expectations", type_=SealExpectations
+    )
+    evidence_identity = _dataclass_metadata(
+        sealing_identity, label="sealing_identity", type_=SealingIdentity
+    )
+    implementation_identity = _dataclass_metadata(
+        scoring_identity, label="scoring_identity", type_=ResearchScoringIdentity
+    )
+    form_sha256 = _hash(form_sha256)
+    model_sha256 = _hash(model_sha256)
+    model_manifest_sha256 = _hash(model_manifest_sha256)
+    config_sha256 = _hash(config_sha256)
+    _, form_bytes = _regular_file(
+        embedded_form, label="embedded_form", max_bytes=_MAX_FORM_BYTES
+    )
+    model_path, model_bytes = _regular_file(model, label="model", max_bytes=_MAX_MODEL_BYTES)
+    manifest_path, manifest_bytes = _regular_file(
+        model_manifest, label="model_manifest", max_bytes=_MAX_METADATA_BYTES
+    )
+    _config_path, config_bytes = _regular_file(
+        config, label="config", max_bytes=_MAX_CONFIG_BYTES
+    )
+    if hashlib.sha256(form_bytes).hexdigest() != form_sha256:
+        raise _reject("FORM_HASH_MISMATCH")
+    if hashlib.sha256(model_bytes).hexdigest() != model_sha256:
+        raise _reject("MODEL_HASH_MISMATCH")
+    if hashlib.sha256(manifest_bytes).hexdigest() != model_manifest_sha256:
+        raise _reject("MODEL_MANIFEST_HASH_MISMATCH")
+    if hashlib.sha256(config_bytes).hexdigest() != config_sha256:
+        raise _reject("CONFIG_HASH_MISMATCH")
+    try:
+        frozen_model = load_frozen_model(model_path, manifest_path)
+    except (OSError, ValueError, ResidualContractError, KeyError, TypeError) as exc:
+        raise _reject("MODEL_INVALID") from exc
+    try:
+        result = score_verified_manual_evidence(
+            sealed_bundle_dir=bundle_dir,
+            run_dir=isolated_run_dir,
+            evidence_expected=expected,
+            evidence_identity=evidence_identity,
+            embedded_form_bytes=form_bytes,
+            form_sha256=form_sha256,
+            config_bytes=config_bytes,
+            config_sha256=config_sha256,
+            frozen_model=frozen_model,
+            expected_model_sha256=model_sha256,
+            expected_model_manifest_sha256=model_manifest_sha256,
+            scoring_identity=implementation_identity,
+            output_root=isolated_output_root,
+        )
+    except (ManualEvidenceRejected, ManualResearchScoringRejected) as exc:
+        raise _reject(_public_error_code(exc.code)) from exc
+    except (AssertionError, KeyError, TypeError, ValueError) as exc:
+        raise _reject("INPUT_UNVERIFIED") from exc
+    except OSError as exc:
+        raise _reject("OUTPUT_ROOT_UNSAFE") from exc
+    return _success_response(result.prediction["bundle_id"], result.bundle_dir)
+
+
+class _ArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise ValueError(message)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = _ArgumentParser(
+        prog="manual-research-predict",
+        description="Invoke the isolated GHU-053 manual research scorer.",
+        allow_abbrev=False,
+    )
+    for name in (
+        "sealed-bundle-dir",
+        "run-dir",
+        "evidence-expectations",
+        "sealing-identity",
+        "embedded-form",
+        "model",
+        "model-manifest",
+        "config",
+        "scoring-identity",
+        "output-root",
+    ):
+        parser.add_argument(f"--{name}", dest=name.replace("-", "_"), required=True, type=Path)
+    for name in ("form-sha256", "model-sha256", "model-manifest-sha256", "config-sha256"):
+        parser.add_argument(f"--{name}", dest=name.replace("-", "_"), required=True)
+    return parser
+
+
+def _response_bytes(response: Mapping[str, Any]) -> bytes:
+    return canonical_bytes(response)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = _parser().parse_args(argv)
+        response = invoke_manual_research_prediction(**vars(args))
+    except ManualResearchAdapterRejected as exc:
+        response = _error_response(exc.code)
+    except (ValueError, TypeError):
+        response = _error_response("ARGUMENTS_INVALID")
+    sys.stdout.buffer.write(_response_bytes(response))
+    return 0 if response["status"] == "SUCCESS" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "RESPONSE_SCHEMA",
+    "VERIFICATION_STATUS",
+    "ManualResearchAdapterRejected",
+    "invoke_manual_research_prediction",
+    "main",
+]

--- a/tests/ci/test_forecasting_change_classifier.py
+++ b/tests/ci/test_forecasting_change_classifier.py
@@ -232,6 +232,25 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
         self.assertEqual(result["tier"], "manual_prediction")
         self.assertIs(result["ci_contract_changed"], True)
 
+    def test_ghu_054_path_mix_selects_manual_prediction_with_ci_contract(self):
+        result = self.classify(
+            ("M", ".github/forecasting-paths.ini"),
+            ("M", ".github/workflows/forecasting-tests.yml"),
+            (
+                "A",
+                "configs/prediction/manual-independent-capture-v1/manual-research-adapter-response.schema.json",
+            ),
+            ("A", "docs/manual_research_prediction_cli.md"),
+            ("A", "src/predictor/manual_research_scoring.py"),
+            ("A", "src/predictor/manual_research_cli.py"),
+            ("M", "tests/ci/test_forecasting_change_classifier.py"),
+            ("A", "tests/test_manual_research_scoring.py"),
+            ("A", "tests/test_manual_research_cli.py"),
+        )
+        self.assertEqual(result["tier"], "manual_prediction")
+        self.assertEqual(result["reason"], "single_product_tier_with_ci_contract")
+        self.assertIs(result["ci_contract_changed"], True)
+
     def test_future_manual_path_registration_stays_focused(self):
         future_path = "src/predictor/manual_isolated_executor.py"
         future_rules = dict(self.rules)

--- a/tests/test_manual_research_cli.py
+++ b/tests/test_manual_research_cli.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tests"))
+
+import test_manual_research_scoring as ghu053
+
+from src.predictor.manual_independent_capture import canonical_bytes
+from src.predictor.manual_research_cli import (
+    ManualResearchAdapterRejected,
+    invoke_manual_research_prediction,
+    main,
+)
+
+
+def _write(path: Path, value: bytes | dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(value if isinstance(value, bytes) else canonical_bytes(value))
+    return path
+
+
+def _fixture(tmp_path: Path) -> dict:
+    _, _, execution, expected, identity, sealed = ghu053._sealed_fixture(tmp_path / "fixture")
+    form_bytes = ghu053._form(sealed)
+    config_bytes = canonical_bytes(ghu053._config())
+    args_root = tmp_path / "args"
+    model_path = _write(args_root / "model.json", ghu053.MODEL_BYTES)
+    manifest_path = _write(args_root / "model-manifest.json", ghu053.MODEL_MANIFEST_PATH.read_bytes())
+    form_path = _write(args_root / "form.json", form_bytes)
+    config_path = _write(args_root / "config.json", config_bytes)
+    expectations_path = _write(args_root / "evidence-expectations.json", asdict(expected))
+    sealing_identity_path = _write(args_root / "sealing-identity.json", asdict(identity))
+    scoring_identity_path = _write(args_root / "scoring-identity.json", asdict(ghu053.SCORE_IDENTITY))
+    output_root = tmp_path / "isolated-output"
+    output_root.mkdir()
+    return {
+        "sealed_bundle_dir": sealed.bundle_dir,
+        "run_dir": execution.run_dir,
+        "evidence_expectations": expectations_path,
+        "sealing_identity": sealing_identity_path,
+        "embedded_form": form_path,
+        "form_sha256": hashlib.sha256(form_bytes).hexdigest(),
+        "model": model_path,
+        "model_manifest": manifest_path,
+        "model_sha256": hashlib.sha256(ghu053.MODEL_BYTES).hexdigest(),
+        "model_manifest_sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+        "config": config_path,
+        "config_sha256": hashlib.sha256(config_bytes).hexdigest(),
+        "scoring_identity": scoring_identity_path,
+        "output_root": output_root,
+    }
+
+
+def _cli_args(arguments: dict) -> list[str]:
+    flags = {
+        "sealed_bundle_dir": "--sealed-bundle-dir",
+        "run_dir": "--run-dir",
+        "evidence_expectations": "--evidence-expectations",
+        "sealing_identity": "--sealing-identity",
+        "embedded_form": "--embedded-form",
+        "form_sha256": "--form-sha256",
+        "model": "--model",
+        "model_manifest": "--model-manifest",
+        "model_sha256": "--model-sha256",
+        "model_manifest_sha256": "--model-manifest-sha256",
+        "config": "--config",
+        "config_sha256": "--config-sha256",
+        "scoring_identity": "--scoring-identity",
+        "output_root": "--output-root",
+    }
+    result: list[str] = []
+    for key, flag in flags.items():
+        result.extend((flag, str(arguments[key])))
+    return result
+
+
+def test_valid_fixture_invocation_and_exact_replay_are_machine_readable(tmp_path: Path):
+    arguments = _fixture(tmp_path)
+    first = invoke_manual_research_prediction(**arguments)
+    second = invoke_manual_research_prediction(**arguments)
+    assert first == second
+    assert set(first) == {"schema_version", "status", "bundle_id", "bundle_path", "verification_status"}
+    assert first["status"] == "SUCCESS"
+    assert first["verification_status"] == "VERIFIED"
+    bundle = Path(first["bundle_path"])
+    assert bundle.parent == arguments["output_root"]
+    assert sorted(path.name for path in bundle.iterdir()) == ["manifest.json", "prediction.json"]
+    schema = json.loads(
+        (ROOT / "configs/prediction/manual-independent-capture-v1/manual-research-adapter-response.schema.json").read_bytes()
+    )
+    Draft202012Validator(schema).validate(first)
+
+
+def test_cli_returns_only_the_verified_envelope(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    arguments = _fixture(tmp_path)
+    assert main(_cli_args(arguments)) == 0
+    response = json.loads(capsys.readouterr().out)
+    assert response["status"] == "SUCCESS"
+    assert response["verification_status"] == "VERIFIED"
+    assert set(response) == {"schema_version", "status", "bundle_id", "bundle_path", "verification_status"}
+
+
+def test_malformed_arguments_and_unsafe_or_missing_paths_fail_closed(tmp_path: Path, capsys):
+    assert main([]) == 2
+    response = json.loads(capsys.readouterr().out)
+    assert response["error_code"] == "ARGUMENTS_INVALID"
+    schema = json.loads(
+        (ROOT / "configs/prediction/manual-independent-capture-v1/manual-research-adapter-response.schema.json").read_bytes()
+    )
+    Draft202012Validator(schema).validate(response)
+    arguments = _fixture(tmp_path / "paths")
+    missing = dict(arguments, embedded_form=tmp_path / "missing-form.json")
+    with pytest.raises(ManualResearchAdapterRejected, match="INPUT_MISSING"):
+        invoke_manual_research_prediction(**missing)
+    symlink = tmp_path / "symlink-form.json"
+    symlink.symlink_to(arguments["embedded_form"])
+    with pytest.raises(ManualResearchAdapterRejected, match="PATH_UNSAFE"):
+        invoke_manual_research_prediction(**dict(arguments, embedded_form=symlink))
+    with pytest.raises(ManualResearchAdapterRejected, match="PATH_UNSAFE"):
+        invoke_manual_research_prediction(**dict(arguments, output_root=Path("relative-output")))
+    _write(arguments["scoring_identity"], {})
+    with pytest.raises(ManualResearchAdapterRejected, match="ARGUMENTS_INVALID"):
+        invoke_manual_research_prediction(**arguments)
+
+
+@pytest.mark.parametrize(
+    "field,code",
+    [
+        ("form_sha256", "FORM_HASH_MISMATCH"),
+        ("model_sha256", "MODEL_HASH_MISMATCH"),
+        ("model_manifest_sha256", "MODEL_MANIFEST_HASH_MISMATCH"),
+        ("config_sha256", "CONFIG_HASH_MISMATCH"),
+    ],
+)
+def test_form_model_and_config_drift_fail_closed(tmp_path: Path, field: str, code: str):
+    arguments = _fixture(tmp_path)
+    with pytest.raises(ManualResearchAdapterRejected, match=code):
+        invoke_manual_research_prediction(**dict(arguments, **{field: "0" * 64}))
+
+
+def test_evidence_identity_and_temporal_form_drift_delegate_fail_closed(tmp_path: Path):
+    arguments = _fixture(tmp_path / "identity")
+    evidence = json.loads(arguments["evidence_expectations"].read_bytes())
+    evidence["race_identity_sha256"] = "0" * 64
+    _write(arguments["evidence_expectations"], evidence)
+    with pytest.raises(ManualResearchAdapterRejected, match="BUNDLE_CONTRACT_INVALID|IDENTITY_MISMATCH|RACE_IDENTITY"):
+        invoke_manual_research_prediction(**arguments)
+
+    arguments = _fixture(tmp_path / "temporal")
+    form = json.loads(arguments["embedded_form"].read_bytes())
+    form["runners"][0]["history"][0]["event_timestamp"] = "2026-08-05T01:00:00+00:00"
+    form_bytes = canonical_bytes(form)
+    _write(arguments["embedded_form"], form_bytes)
+    arguments["form_sha256"] = hashlib.sha256(form_bytes).hexdigest()
+    with pytest.raises(ManualResearchAdapterRejected, match="FORM_HISTORY_AFTER_CUTOFF"):
+        invoke_manual_research_prediction(**arguments)
+
+
+def test_partial_publication_does_not_expose_final_bundle(tmp_path: Path, monkeypatch):
+    arguments = _fixture(tmp_path)
+    import src.predictor.manual_research_cli as adapter
+
+    original = adapter.score_verified_manual_evidence
+
+    def stop_after_manifest(**kwargs):
+        def hook(stage, _path):
+            if stage == "manifest_written":
+                raise RuntimeError("adapter-stop")
+
+        kwargs["stage_hook"] = hook
+        return original(**kwargs)
+
+    monkeypatch.setattr(adapter, "score_verified_manual_evidence", stop_after_manifest)
+    with pytest.raises(RuntimeError, match="adapter-stop"):
+        invoke_manual_research_prediction(**arguments)
+    assert not [
+        path
+        for path in arguments["output_root"].iterdir()
+        if path.is_dir() and len(path.name) == 64
+    ]
+
+
+def test_forbidden_live_canonical_and_result_surfaces_are_not_touched(tmp_path: Path, monkeypatch):
+    import sqlite3
+
+    arguments = _fixture(tmp_path)
+
+    def explode(*_args, **_kwargs):
+        raise AssertionError("forbidden API touched")
+
+    monkeypatch.setattr(sqlite3, "connect", explode)
+    import src.predictor.manual_research_cli as adapter
+
+    assert not any(
+        token in adapter.__dict__
+        for token in ("sqlite3", "requests", "httpx", "subprocess", "run_capture_one", "live_odds")
+    )
+    result = invoke_manual_research_prediction(**arguments)
+    assert result["verification_status"] == "VERIFIED"
+
+
+def test_forbidden_upstream_error_names_are_not_exposed(tmp_path: Path, monkeypatch):
+    arguments = _fixture(tmp_path)
+    import src.predictor.manual_research_cli as adapter
+
+    def forbidden_error(**_kwargs):
+        from src.predictor.manual_independent_capture_sealer import (
+            ManualEvidenceRejected,
+        )
+
+        raise ManualEvidenceRejected("OUTCOME_MATERIAL_FORBIDDEN")
+
+    monkeypatch.setattr(adapter, "score_verified_manual_evidence", forbidden_error)
+    with pytest.raises(ManualResearchAdapterRejected, match="UNAUTHORIZED_INPUT"):
+        invoke_manual_research_prediction(**arguments)


### PR DESCRIPTION
## Summary

- Register the accepted isolated GHU-054 manual research adapter paths in the `manual_prediction` forecasting tier.
- Add the GHU-054 scorer and CLI tests to the focused manual-prediction command.
- Add an exact GHU-054 classifier fixture proving `manual_prediction` with `ci_contract_changed=true` while retaining fail-closed escalation coverage.

## Scope

This remains GHU-054 only: bounded manual CLI/API invocation over verified GHU-052 evidence and accepted GHU-053 scoring. No browser, network, live capture, services, timers, database, canonical/result/Phase-7 authority, training, calibration, promotion, EV, staking, betting, deployment, or UI changes.

## Validation

- CI-contract runner: passed; 9 workflow YAML files validated; 5 smoke tests passed.
- Focused manual-prediction suite (GHU-050 through GHU-054): 724 passed.
- Classifier suite: 26 passed.
- Fatal Ruff, `py_compile`, 8 JSON Schema checks, and `git diff --check`: passed.
- Exact `origin/master...HEAD` classification: `manual_prediction`, `single_product_tier_with_ci_contract`, `ci_contract_changed=true`.
- Independent exact-tree review: no findings; seven changed paths match the allowlist.

The previously unpreserved `full_forecasting` attempt was not rerun; the corrected final classification has no unknown/shared/high-risk path.

GHU-055 remains the next prerequisite for any subsequent process-safety work; it is not included here.
