### PR TITLE
GHU-055: prove manual process safety fixtures

### DIFF
--- a/src/predictor/manual_independent_capture_executor.py
+++ b/src/predictor/manual_independent_capture_executor.py
@@ -59,6 +59,16 @@ _MAX_SOURCE_BYTES = 2 * 1024 * 1024
 _POLL_SECONDS = 0.01
 
 
+class ChildResponseRejected(ValueError):
+    """A bounded child response rejection with a durable terminal code."""
+
+    def __init__(self, code: str):
+        if code not in TERMINAL_STATUS_BY_FAILURE_CODE:
+            raise ValueError(f"unregistered child failure code: {code}")
+        super().__init__(code)
+        self.code = code
+
+
 class CancellationToken(Protocol):
     def is_set(self) -> bool: ...
 
@@ -371,11 +381,15 @@ def _child_value(
         "source",
     }:
         raise ValueError("SOURCE_MALFORMED")
+    if value["schema_version"] != CHILD_SCHEMA_VERSION:
+        raise ValueError("SOURCE_MALFORMED")
     if (
-        value["schema_version"] != CHILD_SCHEMA_VERSION
-        or value["requested_race_url"] != expected_url
+        value["requested_race_url"] != expected_url
         or value["race_identity_sha256"] != expected_race_sha
-        or not isinstance(value["runners"], list)
+    ):
+        raise ChildResponseRejected("IDENTITY_MISMATCH")
+    if (
+        not isinstance(value["runners"], list)
         or not isinstance(value["source"], Mapping)
         or set(value["source"]) != {
             "content_class",
@@ -437,19 +451,22 @@ def _child_value(
                     or native_id != native_id.strip()
                 )
             )
-            or isinstance(odds, bool)
+        ):
+            raise ChildResponseRejected("RUNNER_SET_MISMATCH")
+        if (
+            isinstance(odds, bool)
             or not isinstance(odds, (int, float))
             or not math.isfinite(float(odds))
             or odds <= 1
         ):
-            raise ValueError("SOURCE_MALFORMED")
+            raise ChildResponseRejected("ODDS_INVALID")
         canonical_runners.append(
             {key: item for key, item in row.items() if key != "decimal_odds"}
         )
     try:
         canonical_runner_set(canonical_runners, "fixture_child.runners")
     except PredictionBlocked as exc:
-        raise ValueError("SOURCE_MALFORMED") from exc
+        raise ChildResponseRejected("RUNNER_SET_MISMATCH") from exc
     try:
         source_bytes = base64.b64decode(value["source"]["bytes_base64"], validate=True)
         source_time = datetime.fromisoformat(value["source"]["source_timestamp"])
@@ -859,6 +876,9 @@ def execute_manual_capture_fixture(
                                     expected_url=requested_race_url,
                                     expected_race_sha=canonical_sha256(race),
                                 )
+                            except ChildResponseRejected as exc:
+                                failure_code = exc.code
+                                capture_at = None
                             except ValueError:
                                 failure_code = "SOURCE_MALFORMED"
                                 capture_at = None

--- a/tests/fixtures/manual_independent_capture_child.py
+++ b/tests/fixtures/manual_independent_capture_child.py
@@ -30,6 +30,8 @@ def _success(source_timestamp: str, race_sha: str, *, mode: str = "success") -> 
         source = b'<div class="winners">Alpha Dog</div>\n'
         content_class = "prejump_race_source"
         content_type = "text/html"
+    if mode == "identity-mismatch":
+        race_sha = "0" * 64
     value = {
         "schema_version": "manual_independent_capture_child_fixture_v2",
         "requested_race_url": os.environ["MANUAL_CAPTURE_EXACT_URL"],
@@ -43,11 +45,11 @@ def _success(source_timestamp: str, race_sha: str, *, mode: str = "success") -> 
                 "decimal_odds": 2.5,
             },
             {
-                "box_number": 2,
+                "box_number": 1 if mode == "runner-mismatch" else 2,
                 "display_name": "Beta Dog",
                 "identity": "BETA DOG",
                 "source_native_runner_id": "dog-2",
-                "decimal_odds": 3.75,
+                "decimal_odds": float("nan") if mode == "invalid-odds" else 3.75,
             },
         ],
         "source": {
@@ -72,6 +74,9 @@ def main() -> int:
             "outcome-json",
             "outcome-csv",
             "outcome-html",
+            "identity-mismatch",
+            "runner-mismatch",
+            "invalid-odds",
             "malformed",
             "hang",
             "ignore-term",
@@ -81,8 +86,8 @@ def main() -> int:
     parser.add_argument("--source-timestamp", required=True)
     parser.add_argument("--race-sha", required=True)
     args = parser.parse_args()
-    if args.mode == "success":
-        return _success(args.source_timestamp, args.race_sha)
+    if args.mode in {"success", "identity-mismatch", "runner-mismatch", "invalid-odds"}:
+        return _success(args.source_timestamp, args.race_sha, mode=args.mode)
     if args.mode.startswith("outcome-"):
         return _success(args.source_timestamp, args.race_sha, mode=args.mode)
     if args.mode == "malformed":

--- a/tests/test_manual_independent_capture_executor.py
+++ b/tests/test_manual_independent_capture_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import signal
 import sqlite3
 import subprocess
@@ -677,3 +678,102 @@ def test_forbidden_apis_explode_and_autonomous_sentinel_is_byte_and_metadata_sta
         before.st_mtime_ns,
     )
     assert _revalidate(result, cfg, forbidden) == result.artifact
+
+
+@pytest.mark.parametrize(
+    ("mode", "failure_code"),
+    [
+        ("identity-mismatch", "IDENTITY_MISMATCH"),
+        ("runner-mismatch", "RUNNER_SET_MISMATCH"),
+        ("invalid-odds", "ODDS_INVALID"),
+    ],
+)
+def test_real_child_protocol_failures_have_specific_terminal_codes(
+    tmp_path: Path, mode: str, failure_code: str
+):
+    result = _execute(tmp_path, command=_command(mode))
+    assert result.artifact["terminal"] == {
+        "status": "FAILED",
+        "failure_code": failure_code,
+    }
+    assert result.artifact["attempt"] == {
+        "attempt_count": 1,
+        "source_attempt_count": 1,
+    }
+    assert result.artifact["capture"]["runner_set"] == []
+    assert result.cleanup.confirmed is True
+
+
+def test_cancellation_before_launch_is_terminal_without_source_attempt(
+    tmp_path: Path,
+):
+    cancelled = threading.Event()
+    cancelled.set()
+    launches = []
+    result = _execute(
+        tmp_path,
+        cancellation_token=cancelled,
+        popen=lambda *args, **kwargs: launches.append((args, kwargs)),
+    )
+    assert result.artifact["terminal"] == {
+        "status": "CANCELLED",
+        "failure_code": "CANCELLED",
+    }
+    assert result.artifact["attempt"] == {
+        "attempt_count": 1,
+        "source_attempt_count": 0,
+    }
+    assert launches == []
+    assert result.artifact["capture"]["runner_set"] == []
+
+
+def test_active_autonomous_fixture_process_and_sentinel_are_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    import race_collection.synchronous_manual_capture as synchronous
+    import scripts.autonomous_live_odds_capture as autonomous_module
+
+    sentinel = tmp_path / "autonomous-shared.lock"
+    sentinel.write_bytes(b"autonomous-lock-sentinel-v1\n")
+    before = sentinel.stat()
+    before_bytes = sentinel.read_bytes()
+    autonomous_process = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    autonomous_identity = (autonomous_process.pid, os.getpgid(autonomous_process.pid))
+    try:
+        def explode(*args, **kwargs):
+            raise AssertionError("autonomous or canonical surface touched")
+
+        monkeypatch.setattr(synchronous, "run_capture_one", explode)
+        monkeypatch.setattr(autonomous_module, "execute_capture_plan", explode)
+        monkeypatch.setattr(autonomous_module, "append_validated_capture", explode)
+        monkeypatch.setattr(sqlite3, "connect", explode)
+        result = _execute(
+            tmp_path,
+            forbidden=_forbidden(tmp_path, sentinel=sentinel),
+        )
+        after = sentinel.stat()
+        assert result.artifact["terminal"] == {
+            "status": "CAPTURE_READY",
+            "failure_code": None,
+        }
+        assert autonomous_process.poll() is None
+        assert (
+            autonomous_process.pid,
+            os.getpgid(autonomous_process.pid),
+        ) == autonomous_identity
+        assert sentinel.read_bytes() == before_bytes
+        assert (after.st_ino, after.st_mode, after.st_size, after.st_mtime_ns) == (
+            before.st_ino,
+            before.st_mode,
+            before.st_size,
+            before.st_mtime_ns,
+        )
+    finally:
+        autonomous_process.terminate()
+        autonomous_process.wait(timeout=3)

--- a/tests/test_manual_research_cli.py
+++ b/tests/test_manual_research_cli.py
@@ -12,6 +12,7 @@ from jsonschema import Draft202012Validator
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "tests"))
 
+import test_manual_independent_capture_executor as ghu051
 import test_manual_research_scoring as ghu053
 
 from src.predictor.manual_independent_capture import canonical_bytes
@@ -98,6 +99,91 @@ def test_valid_fixture_invocation_and_exact_replay_are_machine_readable(tmp_path
         (ROOT / "configs/prediction/manual-independent-capture-v1/manual-research-adapter-response.schema.json").read_bytes()
     )
     Draft202012Validator(schema).validate(first)
+
+
+def test_real_os_capture_seal_and_ghu054_response_is_one_attempt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Exercise the accepted chain with a real child process, not a mock."""
+
+    cfg = ghu051._config(tmp_path)
+    forbidden = ghu051._forbidden(tmp_path)
+    launches = []
+
+    def tracked_popen(*args, **kwargs):
+        launches.append((args, kwargs))
+        return ghu051.subprocess.Popen(*args, **kwargs)
+
+    original_model_bytes = ghu051.MODEL_BYTES
+    ghu051.MODEL_BYTES = ghu053.MODEL_BYTES
+    try:
+        execution = ghu051._execute(
+            tmp_path,
+            cfg=cfg,
+            forbidden=forbidden,
+            popen=tracked_popen,
+        )
+    finally:
+        ghu051.MODEL_BYTES = original_model_bytes
+    expected = ghu053.expectations_from_execution(execution)
+    identity = ghu053.build_sealing_identity(
+        repo_root=ghu053.ROOT,
+        source_commit=ghu051.SOURCE_COMMIT,
+        source_tree=ghu051.SOURCE_TREE,
+    )
+    sealed = ghu053.seal_manual_capture(
+        execution,
+        config=cfg,
+        forbidden_paths=forbidden,
+        expected=expected,
+        identity=identity,
+        repo_root=ghu053.ROOT,
+    )
+
+    arguments_root = tmp_path / "ghu054-arguments"
+    form_bytes = ghu053._form(sealed)
+    config_bytes = canonical_bytes(ghu053._config())
+    model_path = _write(arguments_root / "model.json", ghu053.MODEL_BYTES)
+    manifest_path = _write(
+        arguments_root / "model-manifest.json",
+        ghu053.MODEL_MANIFEST_PATH.read_bytes(),
+    )
+    form_path = _write(arguments_root / "form.json", form_bytes)
+    config_path = _write(arguments_root / "config.json", config_bytes)
+    expectations_path = _write(arguments_root / "evidence-expectations.json", asdict(expected))
+    sealing_identity_path = _write(arguments_root / "sealing-identity.json", asdict(identity))
+    scoring_identity_path = _write(
+        arguments_root / "scoring-identity.json", asdict(ghu053.SCORE_IDENTITY)
+    )
+    output_root = tmp_path / "ghu054-output"
+    output_root.mkdir()
+    import sqlite3
+
+    monkeypatch.setattr(
+        sqlite3,
+        "connect",
+        lambda *args, **kwargs: pytest.fail("GHU-054 chain opened SQLite"),
+    )
+    response = invoke_manual_research_prediction(
+        sealed_bundle_dir=sealed.bundle_dir,
+        run_dir=execution.run_dir,
+        evidence_expectations=expectations_path,
+        sealing_identity=sealing_identity_path,
+        embedded_form=form_path,
+        form_sha256=hashlib.sha256(form_bytes).hexdigest(),
+        model=model_path,
+        model_manifest=manifest_path,
+        model_sha256=hashlib.sha256(ghu053.MODEL_BYTES).hexdigest(),
+        model_manifest_sha256=hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+        config=config_path,
+        config_sha256=hashlib.sha256(config_bytes).hexdigest(),
+        scoring_identity=scoring_identity_path,
+        output_root=output_root,
+    )
+    assert len(launches) == 1
+    assert launches[0][1]["start_new_session"] is True
+    assert response["status"] == "SUCCESS"
+    assert response["verification_status"] == "VERIFIED"
 
 
 def test_cli_returns_only_the_verified_envelope(tmp_path: Path, capsys: pytest.CaptureFixture[str]):


### PR DESCRIPTION
## Summary
- classify real child identity, runner-set, and odds failures with registered terminal codes
- add real OS-child GHU-055 scenarios for one-attempt cleanup, pre-launch cancellation, and autonomous PID/PGID plus sentinel coexistence
- exercise the executor -> GHU-052 seal -> GHU-054 response chain with one real child and no SQLite access

## Evidence
- Base: `7f52e142faee24911e9b9b51effd5a9631dc55ea`
- Head: `a52b5a79`
- Focused: `31 passed in 91.00s`
- Correction-focused: `5 passed in 15.95s`; GHU-054 chain `1 passed in 19.61s`
- `py_compile`, `git diff --check`, and Ruff pass.

## Gate
This remains a draft pending independent ACCEPT and exact-head CI. No live source, service, timer, canonical DB/history/live_odds, Phase 7, outcome, training, promotion, EV, staking, or betting action was performed.