### PR TITLE
GHU-056: package default-off manual deployment

### DIFF
--- a/bin/manual-research-deployment
+++ b/bin/manual-research-deployment
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Executable wrapper for the default-off manual research package generator."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from src.predictor.manual_research_deployment import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/docs/operator_ui_v1/DEPLOYMENT.md
+++ b/docs/operator_ui_v1/DEPLOYMENT.md
@@ -44,6 +44,20 @@ complete live authority observation, but is not permission to install or start a
 The separate unit does not replace the existing UI, which remains available
 until an accepted deployment deliberately changes that state.
 
+## Independent manual research package
+
+`bin/operator-ui-deployment generate-manual` emits the separate
+`greyhound-manual-research.service` package for the GHU-054 bounded adapter.
+It is always generated with `MANUAL_RESEARCH_ENABLED=0`; this command does not
+enable, install, start, or inspect a service. The binding records only the
+manual operations/profile/runs/lock paths, explicit timeout and margin, exact
+source/model/config identities, and pinned executable. The generated unit
+places the repository-declared autonomous and canonical roots in
+`InaccessiblePaths`, grants writes only to the manual operations root, and
+uses control-group TERM/KILL cleanup. Protected roots are rejected when they
+alias or overlap manual paths. Any later activation requires separate
+deployment and runtime authority.
+
 ## Bind and access
 
 The default bind is `127.0.0.1:5055`. The generator accepts only an IP address

--- a/ops/systemd/manual-research-api.service.in
+++ b/ops/systemd/manual-research-api.service.in
@@ -1,0 +1,34 @@
+[Unit]
+Description=Greyhound independent manual research API (generated, default-off)
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=${ENABLE_MARKER}
+
+[Service]
+Type=simple
+WorkingDirectory=${SOURCE_ROOT}
+EnvironmentFile=${ENVIRONMENT_FILE}
+ExecStart=${PYTHON_EXECUTABLE} -m src.predictor.manual_research_worker --binding ${BINDING_PATH}
+Restart=no
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ReadOnlyPaths=${SOURCE_ROOT}
+ReadWritePaths=${MANUAL_ROOT}
+InaccessiblePaths=${PROTECTED_PATHS}
+RestrictAddressFamilies=AF_UNIX
+RestrictSUIDSGID=true
+CapabilityBoundingSet=
+AmbientCapabilities=
+KillMode=control-group
+KillSignal=SIGTERM
+FinalKillSignal=SIGKILL
+SendSIGKILL=yes
+TimeoutStartSec=${TIMEOUT_SECONDS}
+TimeoutStopSec=${TIMEOUT_SECONDS}
+
+[Install]
+WantedBy=default.target

--- a/src/operator_ui/deployment.py
+++ b/src/operator_ui/deployment.py
@@ -629,6 +629,17 @@ def _parser() -> argparse.ArgumentParser:
     generate.add_argument("--ui-version", default="operator-ui-v1"); generate.add_argument("--profile-id", default="repository-v1")
     generate.add_argument("--bind-address", default="127.0.0.1"); generate.add_argument("--port", type=int, default=5055); generate.add_argument("--enable", action="store_true", dest="enabled")
     generate.add_argument("--live-authority", type=Path)
+    manual = commands.add_parser("generate-manual")
+    for name in (
+        "source-root", "pinned-python", "manual-root", "browser-profile-root",
+        "manual-runs-root", "manual-lock", "model", "model-manifest", "config", "output-dir",
+    ):
+        manual.add_argument(f"--{name}", required=True, type=Path)
+    manual.add_argument("--source-commit", required=True)
+    manual.add_argument("--source-tree", required=True)
+    manual.add_argument("--timeout-seconds", type=int, default=900)
+    manual.add_argument("--margin-seconds", type=int, default=120)
+    manual.add_argument("--protected-path", action="append", required=True, metavar="NAME=PATH")
     serve = commands.add_parser("serve")
     serve.add_argument("--source-root", required=True, type=Path); serve.add_argument("--host", required=True); serve.add_argument("--port", required=True, type=int)
     return parser
@@ -636,6 +647,23 @@ def _parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
+    if args.command == "generate-manual":
+        from src.predictor.manual_research_deployment import generate_manual_package
+
+        values = vars(args)
+        raw_protected = values.pop("protected_path")
+        protected: dict[str, Path] = {}
+        for item in raw_protected:
+            name, separator, value = item.partition("=")
+            if not separator or name in protected:
+                raise DeploymentRejected("invalid --protected-path")
+            protected[name] = Path(value)
+        result = generate_manual_package(
+            **{key: value for key, value in values.items() if key != "command"},
+            protected_paths=protected,
+        )
+        print(json.dumps(result, sort_keys=True))
+        return 0
     if args.command == "serve":
         if os.environ.get("OPERATOR_UI_CONNECTED_MODE") != "1" or os.environ.get("OPERATOR_UI_R3_PROFILE") != "repository-v1":
             return 0

--- a/src/predictor/manual_research_deployment.py
+++ b/src/predictor/manual_research_deployment.py
@@ -1,0 +1,412 @@
+"""Generate the default-off deployment package for the manual research lane."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from string import Template
+
+
+class ManualDeploymentRejected(RuntimeError):
+    """The manual deployment cannot be bound without widening its authority."""
+
+
+_HEX40 = re.compile(r"^[0-9a-f]{40}$")
+_HEX64 = re.compile(r"^[0-9a-f]{64}$")
+_SAFE_NAME = re.compile(r"^[a-z][a-z0-9_]{1,63}$")
+_SYSTEMD_SAFE_PATH = re.compile(r"^/[A-Za-z0-9_./+-]+$")
+_PROTECTED_NAMES = frozenset(
+    {
+        "autonomous_browser_profile",
+        "autonomous_shared_lock",
+        "canonical_database",
+        "canonical_history",
+        "live_odds",
+        "forward_corpus",
+        "collector_requests",
+        "collector_state",
+        "result_evidence",
+        "services",
+        "timers",
+    }
+)
+_TEMPLATE_RELATIVE = Path("ops/systemd/manual-research-api.service.in")
+
+
+def _reject(message: str) -> ManualDeploymentRejected:
+    return ManualDeploymentRejected(message)
+
+
+def _absolute(value: Path | str, *, label: str) -> Path:
+    path = Path(value)
+    if (
+        not path.is_absolute()
+        or "." in path.parts
+        or ".." in path.parts
+        or not _SYSTEMD_SAFE_PATH.fullmatch(str(path))
+    ):
+        raise _reject(f"{label} must be a normalized absolute path")
+    return path
+
+
+def _existing(path: Path, *, directory: bool, label: str, executable: bool = False) -> Path:
+    path = _absolute(path, label=label)
+    current = Path(path.anchor)
+    for component in path.parts[1:]:
+        current /= component
+        try:
+            if current.is_symlink():
+                raise _reject(f"{label} contains a symlink")
+        except OSError as exc:
+            raise _reject(f"{label} is unavailable") from exc
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise _reject(f"{label} is unavailable") from exc
+    if (stat.S_ISDIR(info.st_mode) != directory) or (not directory and not stat.S_ISREG(info.st_mode)):
+        raise _reject(f"{label} has the wrong type")
+    if info.st_mode & 0o002 or (info.st_mode & 0o020 and info.st_uid != os.geteuid()):
+        raise _reject(f"{label} has unsafe permissions")
+    if executable and not info.st_mode & 0o100:
+        raise _reject(f"{label} is not executable")
+    return path
+
+
+def _protected(path: Path, *, label: str) -> Path:
+    path = _absolute(path, label=label)
+    try:
+        directory = stat.S_ISDIR(path.lstat().st_mode)
+    except OSError as exc:
+        raise _reject(f"{label} is unavailable") from exc
+    return _existing(path, directory=directory, label=label)
+
+
+def _separate(named: Mapping[str, Path]) -> None:
+    items = tuple(named.items())
+    for index, (left_name, left) in enumerate(items):
+        for right_name, right in items[index + 1 :]:
+            if left == right or left in right.parents or right in left.parents:
+                raise _reject(f"deployment paths overlap: {left_name}/{right_name}")
+
+
+def _sha256(path: Path) -> str:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as exc:
+        raise _reject(f"cannot read deployment artifact: {path}") from exc
+
+
+def _source_identity(source: Path, commit: str, tree: str) -> None:
+    if not _HEX40.fullmatch(commit) or not _HEX40.fullmatch(tree):
+        raise _reject("source commit/tree identity is invalid")
+    try:
+        status = subprocess.run(
+            ["git", "--no-optional-locks", "-C", str(source), "status", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        identity = subprocess.run(
+            ["git", "--no-optional-locks", "-C", str(source), "rev-parse", "HEAD", "HEAD^{tree}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise _reject("source Git identity unavailable") from exc
+    if status.stdout or identity.stdout.splitlines() != [commit, tree]:
+        raise _reject("source Git identity is dirty or mismatched")
+
+
+def _retained_file_read(path: Path, maximum: int = 256 * 1024) -> bytes:
+    """Read a fixed regular file while retaining no-follow component identity."""
+    path = path.absolute()
+    opened: list[tuple[int, Path, tuple[int, int, int, int, int]]] = []
+    descriptor = os.open("/", os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY)
+    try:
+        root = os.fstat(descriptor)
+        opened.append(
+            (descriptor, Path("/"), (root.st_dev, root.st_ino, root.st_mode, root.st_size, root.st_mtime_ns))
+        )
+        current = Path("/")
+        for offset, component in enumerate(path.parts[1:]):
+            current /= component
+            directory = offset < len(path.parts[1:]) - 1
+            descriptor = os.open(
+                component,
+                os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW
+                | (os.O_DIRECTORY if directory else 0),
+                dir_fd=descriptor,
+            )
+            info = os.fstat(descriptor)
+            identity = (info.st_dev, info.st_ino, info.st_mode, info.st_size, info.st_mtime_ns)
+            opened.append((descriptor, current, identity))
+            if (directory and not stat.S_ISDIR(info.st_mode)) or (
+                not directory and not stat.S_ISREG(info.st_mode)
+            ):
+                raise _reject(f"{path} has the wrong type")
+        chunks: list[bytes] = []
+        remaining = maximum + 1
+        while remaining:
+            chunk = os.read(descriptor, min(65536, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        data = b"".join(chunks)
+        if len(data) > maximum:
+            raise _reject(f"deployment artifact is oversized: {path}")
+        for item, item_path, identity in opened:
+            observed = os.fstat(item)
+            named = os.stat(item_path, follow_symlinks=False)
+            observed_identity = (
+                observed.st_dev, observed.st_ino, observed.st_mode,
+                observed.st_size, observed.st_mtime_ns,
+            )
+            named_identity = (
+                named.st_dev, named.st_ino, named.st_mode,
+                named.st_size, named.st_mtime_ns,
+            )
+            if observed_identity != identity or named_identity != identity:
+                raise _reject(f"deployment identity changed during retained read: {path}")
+        return data
+    except ManualDeploymentRejected:
+        raise
+    except OSError as exc:
+        raise _reject(f"cannot read deployment artifact: {path}") from exc
+    finally:
+        for item, _, _ in reversed(opened):
+            try:
+                os.close(item)
+            except OSError:
+                pass
+
+
+def _publish(outputs: tuple[tuple[Path, bytes, int], ...]) -> None:
+    staged: list[tuple[Path, Path]] = []
+    published: list[tuple[Path, bytes, int] | None] = []
+    try:
+        for index, (target, content, mode) in enumerate(outputs):
+            target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            if target.exists() and (target.is_symlink() or not target.is_file()):
+                raise _reject(f"generated target is unsafe: {target}")
+            prior = (target.read_bytes(), stat.S_IMODE(target.stat().st_mode)) if target.exists() else None
+            temporary = target.with_name(f".{target.name}.tmp-{os.getpid()}-{index}")
+            if temporary.exists():
+                raise _reject(f"temporary generated target already exists: {temporary}")
+            descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+            with os.fdopen(descriptor, "wb") as stream:
+                os.fchmod(stream.fileno(), mode)
+                stream.write(content)
+                stream.flush()
+                os.fsync(stream.fileno())
+            staged.append((target, temporary))
+            published.append((target, prior[0], prior[1]) if prior is not None else None)
+        for target, temporary in staged:
+            os.replace(temporary, target)
+    except BaseException:
+        for (target, _), prior in zip(staged, published):
+            try:
+                if prior is None:
+                    target.unlink()
+                else:
+                    target.write_bytes(prior[1])
+                    target.chmod(prior[2])
+            except FileNotFoundError:
+                pass
+        raise
+    finally:
+        for _, temporary in staged:
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def generate_manual_package(
+    *,
+    source_root: Path,
+    pinned_python: Path,
+    manual_root: Path,
+    browser_profile_root: Path,
+    manual_runs_root: Path,
+    manual_lock: Path,
+    model: Path,
+    model_manifest: Path,
+    config: Path,
+    output_dir: Path,
+    source_commit: str,
+    source_tree: str,
+    timeout_seconds: int = 900,
+    margin_seconds: int = 120,
+    protected_paths: Mapping[str, Path] | None = None,
+) -> dict[str, str | bool]:
+    """Validate and publish one disabled manual deployment package."""
+    source = _existing(source_root, directory=True, label="source_root")
+    python = _existing(pinned_python, directory=False, label="pinned_python", executable=True)
+    manual = _existing(manual_root, directory=True, label="manual_root")
+    profile = _existing(browser_profile_root, directory=True, label="browser_profile_root")
+    runs = _existing(manual_runs_root, directory=True, label="manual_runs_root")
+    lock = _absolute(manual_lock, label="manual_lock")
+    model_path = _existing(model, directory=False, label="model")
+    manifest_path = _existing(model_manifest, directory=False, label="model_manifest")
+    config_path = _existing(config, directory=False, label="config")
+    output = _existing(output_dir, directory=True, label="output_dir")
+    _existing(source / "src/predictor/manual_research_cli.py", directory=False, label="manual adapter")
+    _existing(source / "src/predictor/manual_research_worker.py", directory=False, label="manual worker")
+    if not isinstance(timeout_seconds, int) or isinstance(timeout_seconds, bool) or not 1 <= timeout_seconds <= 900:
+        raise _reject("timeout_seconds is invalid")
+    if not isinstance(margin_seconds, int) or isinstance(margin_seconds, bool) or not 1 <= margin_seconds <= 7200:
+        raise _reject("margin_seconds is invalid")
+    if lock.parent != manual or manual not in profile.parents or manual not in runs.parents:
+        raise _reject("manual profile, runs, and lock must be beneath manual_root")
+    protected = dict(protected_paths or {})
+    if set(protected) != _PROTECTED_NAMES:
+        raise _reject("protected path inventory is incomplete")
+    checked_protected = {
+        name: _protected(path, label=f"protected_paths.{name}")
+        for name, path in protected.items()
+    }
+    if os.path.lexists(lock):
+        lock = _existing(lock, directory=False, label="manual_lock")
+        for name, path in checked_protected.items():
+            try:
+                if lock.samefile(path):
+                    raise _reject(f"manual lock aliases protected path: {name}")
+            except FileNotFoundError:
+                raise _reject("manual_lock is unavailable") from None
+    _separate({
+        "manual_root": manual,
+        "output_dir": output,
+        **checked_protected,
+    })
+    if output == source or source in output.parents or output in source.parents:
+        raise _reject("output_dir must be separate from source_root")
+    if any(path == source for path in checked_protected.values()):
+        raise _reject("protected path cannot be the source_root")
+    _source_identity(source, source_commit, source_tree)
+    for path in (model_path, manifest_path, config_path):
+        if source not in path.parents:
+            raise _reject("model/config artifacts must be beneath source_root")
+    template_path = _existing(source / _TEMPLATE_RELATIVE, directory=False, label="manual service template")
+    template_bytes = _retained_file_read(template_path)
+    model_bytes = _retained_file_read(model_path)
+    manifest_bytes = _retained_file_read(manifest_path)
+    config_bytes = _retained_file_read(config_path)
+    _source_identity(source, source_commit, source_tree)
+    hashes = {
+        "model": hashlib.sha256(model_bytes).hexdigest(),
+        "model_manifest": hashlib.sha256(manifest_bytes).hexdigest(),
+        "config": hashlib.sha256(config_bytes).hexdigest(),
+    }
+    binding = {
+        "schema_version": "manual_research_deployment_binding_v1",
+        "deployment": {"source_commit": source_commit, "source_tree": source_tree, "lane": "manual-research-v1"},
+        "executable": str(python),
+        "entrypoint": "src.predictor.manual_research_cli:main",
+        "manual": {
+            "operations_root": str(manual),
+            "browser_profile_root": str(profile),
+            "runs_root": str(runs),
+            "lock": str(lock),
+            "timeout_seconds": timeout_seconds,
+            "margin_seconds": margin_seconds,
+        },
+        "artifacts": hashes,
+        "default_enabled": False,
+        "research_only": True,
+        "canonical": False,
+        "phase7_excluded": True,
+    }
+    binding_path = output / "manual-research.binding.json"
+    environment_path = output / "manual-research.env"
+    service_path = output / "greyhound-manual-research.service"
+    rollback_path = output / "ROLLBACK.md"
+    environment = "\n".join(
+        (
+            "MANUAL_RESEARCH_ENABLED=0",
+            "MANUAL_RESEARCH_PROFILE=manual-research-v1",
+            f"MANUAL_RESEARCH_OPERATIONS_ROOT={manual}",
+            f"MANUAL_RESEARCH_BROWSER_PROFILE={profile}",
+            f"MANUAL_RESEARCH_RUNS_ROOT={runs}",
+            f"MANUAL_RESEARCH_LOCK={lock}",
+            f"MANUAL_RESEARCH_TIMEOUT_SECONDS={timeout_seconds}",
+            f"MANUAL_RESEARCH_MARGIN_SECONDS={margin_seconds}",
+            f"MANUAL_RESEARCH_SOURCE_COMMIT={source_commit}",
+            f"MANUAL_RESEARCH_SOURCE_TREE={source_tree}",
+            f"MANUAL_RESEARCH_MODEL_SHA256={hashes['model']}",
+            f"MANUAL_RESEARCH_MODEL_MANIFEST_SHA256={hashes['model_manifest']}",
+            f"MANUAL_RESEARCH_CONFIG_SHA256={hashes['config']}",
+            "",
+        )
+    ).encode()
+    service = Template(template_bytes.decode("utf-8")).substitute(
+        SOURCE_ROOT=source,
+        ENVIRONMENT_FILE=environment_path,
+        PYTHON_EXECUTABLE=python,
+        BINDING_PATH=output / "manual-research.binding.json",
+        MANUAL_ROOT=manual,
+        ENABLE_MARKER=manual / ".manual-research-enabled",
+        PROTECTED_PATHS=" ".join(
+            str(checked_protected[name]) for name in sorted(checked_protected)
+        ),
+        TIMEOUT_SECONDS=timeout_seconds,
+    ).encode()
+    rollback = (
+        b"# Manual research deployment rollback\n\n"
+        b"This package is default-off. Under separate deployment authority, remove only "
+        b"the manual unit and generated package; do not touch autonomous units, timers, "
+        b"locks, databases, evidence, or model artifacts.\n"
+    )
+    binding_bytes = (json.dumps(binding, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    _publish(
+        (
+            (binding_path, binding_bytes, 0o600),
+            (environment_path, environment, 0o600),
+            (service_path, service, 0o644),
+            (rollback_path, rollback, 0o644),
+        )
+    )
+    return {"enabled": False, "binding": str(binding_path), "service": str(service_path)}
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="manual-research-deployment")
+    for name in (
+        "source-root", "pinned-python", "manual-root", "browser-profile-root",
+        "manual-runs-root", "manual-lock", "model", "model-manifest", "config", "output-dir",
+    ):
+        parser.add_argument(f"--{name}", required=True, type=Path)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--source-tree", required=True)
+    parser.add_argument("--timeout-seconds", type=int, default=900)
+    parser.add_argument("--margin-seconds", type=int, default=120)
+    parser.add_argument("--protected-path", action="append", required=True, metavar="NAME=PATH")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = vars(_parser().parse_args(argv))
+    raw_protected = args.pop("protected_path")
+    protected: dict[str, Path] = {}
+    for item in raw_protected:
+        name, separator, value = item.partition("=")
+        if not separator or not _SAFE_NAME.fullmatch(name) or name in protected:
+            raise SystemExit("invalid --protected-path")
+        protected[name] = Path(value)
+    result = generate_manual_package(**args, protected_paths=protected)
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["ManualDeploymentRejected", "generate_manual_package", "main"]

--- a/src/predictor/manual_research_worker.py
+++ b/src/predictor/manual_research_worker.py
@@ -1,0 +1,49 @@
+"""Default-off process guard for the request-scoped manual research adapter."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Sequence
+from pathlib import Path
+
+_REQUIRED_KEYS = {
+    "schema_version",
+    "deployment",
+    "executable",
+    "entrypoint",
+    "manual",
+    "artifacts",
+    "default_enabled",
+    "research_only",
+    "canonical",
+    "phase7_excluded",
+}
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="manual-research-worker")
+    parser.add_argument("--binding", required=True, type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        binding = json.loads(args.binding.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return 78
+    if not isinstance(binding, dict) or set(binding) != _REQUIRED_KEYS:
+        return 78
+    if os.environ.get("MANUAL_RESEARCH_ENABLED") != "1":
+        return 0
+    # GHU-054 is a request-scoped adapter; activation needs a separately
+    # authorized caller and must not turn this package into a retry loop.
+    return 78
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["main"]

--- a/tests/test_manual_research_deployment.py
+++ b/tests/test_manual_research_deployment.py
@@ -1,0 +1,240 @@
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from string import Template
+
+import pytest
+
+from src.predictor.manual_research_deployment import (
+    ManualDeploymentRejected,
+    generate_manual_package,
+)
+
+PROTECTED_NAMES = (
+    "autonomous_browser_profile",
+    "autonomous_shared_lock",
+    "canonical_database",
+    "canonical_history",
+    "live_odds",
+    "forward_corpus",
+    "collector_requests",
+    "collector_state",
+    "result_evidence",
+    "services",
+    "timers",
+)
+
+
+def _git_identity(monkeypatch, commit: str, tree: str) -> None:
+    def run(command, **kwargs):
+        output = "" if "status" in command else f"{commit}\n{tree}\n"
+        return subprocess.CompletedProcess(command, 0, output, "")
+
+    monkeypatch.setattr("src.predictor.manual_research_deployment.subprocess.run", run)
+
+
+@pytest.fixture
+def deployment_inputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    repository = Path(__file__).parents[1]
+    source = tmp_path / "source"
+    for relative in (
+        "ops/systemd/manual-research-api.service.in",
+        "src/predictor/manual_research_cli.py",
+        "src/predictor/manual_research_worker.py",
+        "configs/prediction/manual-default.json",
+        "artifacts/frozen_models/market_form_residual_v1/model.json",
+        "artifacts/frozen_models/market_form_residual_v1/manifest.json",
+    ):
+        target = source / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(repository / relative, target)
+    source.mkdir(exist_ok=True)
+    manual = tmp_path / "manual-operations"
+    profile = manual / "browser-profile"
+    runs = manual / "runs"
+    output = tmp_path / "package"
+    for directory in (manual, profile, runs, output):
+        directory.mkdir(parents=True, exist_ok=True)
+        directory.chmod(0o700)
+    protected_root = tmp_path / "protected"
+    protected_root.mkdir()
+    protected = {}
+    for index, name in enumerate(PROTECTED_NAMES):
+        if name in {"canonical_database", "autonomous_shared_lock"}:
+            path = protected_root / f"{name}.sentinel"
+            path.write_bytes(name.encode())
+            path.chmod(0o600)
+        else:
+            path = protected_root / name
+            path.mkdir()
+            path.chmod(0o700)
+        protected[name] = path
+    model = source / "artifacts/frozen_models/market_form_residual_v1/model.json"
+    manifest = source / "artifacts/frozen_models/market_form_residual_v1/manifest.json"
+    config = source / "configs/prediction/manual-default.json"
+    commit = "a" * 40
+    tree = "b" * 40
+    _git_identity(monkeypatch, commit, tree)
+    return {
+        "source_root": source,
+        "pinned_python": Path(sys.executable).resolve(),
+        "manual_root": manual,
+        "browser_profile_root": profile,
+        "manual_runs_root": runs,
+        "manual_lock": manual / "manual-capture.lock",
+        "model": model,
+        "model_manifest": manifest,
+        "config": config,
+        "output_dir": output,
+        "source_commit": commit,
+        "source_tree": tree,
+        "protected_paths": protected,
+    }
+
+
+def test_default_off_package_isolated_and_template_bound(deployment_inputs):
+    values = deployment_inputs
+    autonomous_before = {
+        path: path.read_bytes()
+        for path in values["source_root"].glob("ops/systemd/*")
+        if path.is_file()
+    }
+    result = generate_manual_package(**values)
+    output = values["output_dir"]
+    service = (output / "greyhound-manual-research.service").read_text()
+    environment = (output / "manual-research.env").read_text()
+    binding = json.loads((output / "manual-research.binding.json").read_text())
+
+    assert result["enabled"] is False
+    assert "MANUAL_RESEARCH_ENABLED=0" in environment
+    assert "MANUAL_RESEARCH_OPERATIONS_ROOT=" + str(values["manual_root"]) in environment
+    assert "canonical_database" not in environment
+    assert "canonical_database" not in service.split("ExecStart=", 1)[1].splitlines()[0]
+    for protected_path in values["protected_paths"].values():
+        assert str(protected_path) not in environment
+    assert binding["default_enabled"] is False
+    assert binding["research_only"] is True
+    assert binding["canonical"] is False
+    assert binding["phase7_excluded"] is True
+    assert set(binding) == {"artifacts", "canonical", "default_enabled", "deployment", "entrypoint", "executable", "manual", "phase7_excluded", "research_only", "schema_version"}
+    assert "KillMode=control-group" in service
+    assert "FinalKillSignal=SIGKILL" in service
+    assert "RestrictAddressFamilies=AF_UNIX" in service
+    assert "manual_research_worker --binding" in service
+    assert "ConditionPathExists=" + str(values["manual_root"] / ".manual-research-enabled") in service
+    for path in values["protected_paths"].values():
+        assert str(path) in service
+    expected_service = Template(
+        (values["source_root"] / "ops/systemd/manual-research-api.service.in").read_text()
+    ).substitute(
+        SOURCE_ROOT=values["source_root"],
+        ENVIRONMENT_FILE=output / "manual-research.env",
+        PYTHON_EXECUTABLE=values["pinned_python"],
+        BINDING_PATH=output / "manual-research.binding.json",
+        MANUAL_ROOT=values["manual_root"],
+        ENABLE_MARKER=values["manual_root"] / ".manual-research-enabled",
+        PROTECTED_PATHS=" ".join(
+            str(values["protected_paths"][name]) for name in sorted(values["protected_paths"])
+        ),
+        TIMEOUT_SECONDS=900,
+    )
+    assert service == expected_service
+    assert autonomous_before == {
+        path: path.read_bytes()
+        for path in values["source_root"].glob("ops/systemd/*")
+        if path.is_file()
+    }
+
+
+def test_generator_rejects_manual_protected_overlap_without_partial_output(deployment_inputs):
+    values = dict(deployment_inputs)
+    protected = dict(values["protected_paths"])
+    protected["canonical_database"] = values["manual_root"]
+    values["protected_paths"] = protected
+    with pytest.raises(ManualDeploymentRejected, match="overlap"):
+        generate_manual_package(**values)
+    assert not any(values["output_dir"].iterdir())
+
+
+def test_generator_rejects_symlinked_model_without_partial_output(deployment_inputs):
+    values = dict(deployment_inputs)
+    model = values["model"]
+    replacement = model.with_name("model-real.json")
+    model.rename(replacement)
+    model.symlink_to(replacement)
+    with pytest.raises(ManualDeploymentRejected, match="symlink"):
+        generate_manual_package(**values)
+    assert not any(values["output_dir"].iterdir())
+
+
+def test_generator_rejects_manual_lock_hardlink_to_protected_file(deployment_inputs):
+    values = dict(deployment_inputs)
+    protected_file = values["protected_paths"]["canonical_database"]
+    values["manual_lock"].hardlink_to(protected_file)
+    with pytest.raises(ManualDeploymentRejected, match="aliases protected path"):
+        generate_manual_package(**values)
+    assert not any(values["output_dir"].iterdir())
+
+
+@pytest.mark.parametrize("field", ["manual_root", "output_dir"])
+def test_generator_rejects_systemd_unsafe_path(deployment_inputs, field):
+    values = dict(deployment_inputs)
+    unsafe = values[field].parent / (values[field].name + " with-space")
+    unsafe.mkdir()
+    unsafe.chmod(0o700)
+    values[field] = unsafe
+    with pytest.raises(ManualDeploymentRejected, match="normalized absolute path"):
+        generate_manual_package(**values)
+    assert not any(deployment_inputs["output_dir"].iterdir())
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("timeout_seconds", 901), ("margin_seconds", 7201)],
+)
+def test_generator_rejects_out_of_contract_timing(deployment_inputs, field, value):
+    values = dict(deployment_inputs)
+    values[field] = value
+    with pytest.raises(ManualDeploymentRejected, match="invalid"):
+        generate_manual_package(**values)
+
+
+def test_generator_rejects_source_as_output(deployment_inputs):
+    values = dict(deployment_inputs)
+    values["output_dir"] = values["source_root"]
+    with pytest.raises(ManualDeploymentRejected, match="separate"):
+        generate_manual_package(**values)
+
+
+def test_generator_rejects_incomplete_protected_inventory(deployment_inputs):
+    values = dict(deployment_inputs)
+    values["protected_paths"] = {"canonical_database": values["protected_paths"]["canonical_database"]}
+    with pytest.raises(ManualDeploymentRejected, match="inventory"):
+        generate_manual_package(**values)
+
+
+def test_cli_subcommand_uses_same_generator(monkeypatch, deployment_inputs, capsys):
+    from src.operator_ui.deployment import main
+
+    values = deployment_inputs
+    arguments = [
+        "generate-manual",
+        "--source-root", str(values["source_root"]),
+        "--pinned-python", str(values["pinned_python"]),
+        "--manual-root", str(values["manual_root"]),
+        "--browser-profile-root", str(values["browser_profile_root"]),
+        "--manual-runs-root", str(values["manual_runs_root"]),
+        "--manual-lock", str(values["manual_lock"]),
+        "--model", str(values["model"]),
+        "--model-manifest", str(values["model_manifest"]),
+        "--config", str(values["config"]),
+        "--output-dir", str(values["output_dir"]),
+        "--source-commit", values["source_commit"],
+        "--source-tree", values["source_tree"],
+    ]
+    for name, path in values["protected_paths"].items():
+        arguments.extend(("--protected-path", f"{name}={path}"))
+    assert main(arguments) == 0
+    assert json.loads(capsys.readouterr().out)["enabled"] is False


### PR DESCRIPTION
## Summary

- Add the default-off manual research deployment generator, binding, environment, service template, and rollback package.
- Deny declared autonomous/canonical/result/service roots; allow writes only to the isolated manual root.
- Bind exact source commit/tree, model/config hashes, executable, profile/lock/runs paths, timeout and margin.
- Preserve autonomous deployment generation byte-for-byte; no install, enable, start, restart, or runtime mutation.

## Exact identity

- Base: a594992b1b9a41712376ee63d72d4342ac9a4906
- Head: 5726588177914fbd257cdfac6fd852e37f77c2b4
- Tree: 63420afb9cc251655b6a77d8fe70bf3b9ea05db6

## Validation

- Focused deployment tests: 11 passed
- Direct and out-of-tree wrapper --help: passed
- py_compile: passed
- Ruff (new manual deployment files): passed
- git diff --check: passed
- systemd-analyze verify: passed for generated package with safe absolute paths
- Existing deployment generator: 103 passed / 9 pre-existing retained-authority failures observed before this PR; failures are outside this diff

Independent review has completed the repair cycle for retained identity reads, contract timing bounds, source/output separation, network restriction, and standalone wrapper invocation. This PR intentionally contains no installed or active service proof.