### PR TITLE
Add manual and automatic scoring parity contracts

### DIFF
--- a/configs/prediction/manual-independent-capture-v1/research-prediction.schema.json
+++ b/configs/prediction/manual-independent-capture-v1/research-prediction.schema.json
@@ -4,7 +4,7 @@
   "title": "manual research prediction v1",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "bundle_id", "safety", "scorer_id", "race", "race_identity_sha256", "runner_set_sha256", "timing", "evidence", "form", "features", "model", "config", "implementation", "ranking", "predictions"],
+  "required": ["schema_version", "bundle_id", "safety", "scorer_id", "race", "race_identity_sha256", "runner_set_sha256", "timing", "evidence", "form", "features", "model", "config", "scoring_parity", "implementation", "ranking", "predictions"],
   "properties": {
     "schema_version": {"const": "manual_research_prediction_v1"},
     "bundle_id": {"$ref": "#/$defs/sha256"},
@@ -59,6 +59,18 @@
       "properties": {
         "schema_version": {"const": "manual_research_scoring_config_v1"},
         "sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "scoring_parity": {
+      "type": "object", "additionalProperties": false,
+      "required": ["input_schema_version", "input_sha256", "core_output_schema_version", "core_output_sha256", "config_sha256", "numeric_canonicalization_sha256"],
+      "properties": {
+        "input_schema_version": {"const": "market_form_residual_scoring_input_v1"},
+        "input_sha256": {"$ref": "#/$defs/sha256"},
+        "core_output_schema_version": {"const": "market_form_residual_scoring_core_output_v1"},
+        "core_output_sha256": {"$ref": "#/$defs/sha256"},
+        "config_sha256": {"$ref": "#/$defs/sha256"},
+        "numeric_canonicalization_sha256": {"$ref": "#/$defs/sha256"}
       }
     },
     "implementation": {"$ref": "#/$defs/implementation"},

--- a/configs/prediction/market-form-residual-v1/scoring-core-output.schema.json
+++ b/configs/prediction/market-form-residual-v1/scoring-core-output.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://greyhound-racing-collector.invalid/schemas/market-form-residual-v1/scoring-core-output.schema.json",
+  "title": "market form residual canonical scoring core output v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "scoring_input_sha256", "race_id", "runner_set_sha256", "identities", "ranking", "predictions", "ranks"],
+  "properties": {
+    "schema_version": {"const": "market_form_residual_scoring_core_output_v1"},
+    "scoring_input_sha256": {"$ref": "#/$defs/sha256"}, "race_id": {"type": "string", "minLength": 1}, "runner_set_sha256": {"$ref": "#/$defs/sha256"},
+    "identities": {
+      "type": "object", "additionalProperties": false,
+      "required": ["model_id", "model_sha256", "manifest_sha256", "effective_state_schema", "effective_state_sha256", "config_sha256", "numeric_canonicalization_schema", "numeric_canonicalization_sha256"],
+      "properties": {
+        "model_id": {"type": "string", "minLength": 1}, "model_sha256": {"$ref": "#/$defs/sha256"}, "manifest_sha256": {"$ref": "#/$defs/sha256"}, "effective_state_schema": {"const": "market_form_residual_effective_state_v2"}, "effective_state_sha256": {"$ref": "#/$defs/sha256"}, "config_sha256": {"$ref": "#/$defs/sha256"}, "numeric_canonicalization_schema": {"const": "market_form_residual_numeric_canonicalization_v1"}, "numeric_canonicalization_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "ranking": {"type": "object", "additionalProperties": false, "required": ["primary_probability", "tie_break"], "properties": {"primary_probability": {"const": "full_probability"}, "tie_break": {"const": "box_ascending"}}},
+    "predictions": {"type": "array", "minItems": 2, "maxItems": 10, "items": {"$ref": "#/$defs/prediction"}},
+    "ranks": {"type": "array", "minItems": 2, "maxItems": 10, "items": {"type": "object", "additionalProperties": false, "required": ["rank", "runner_id", "box_number"], "properties": {"rank": {"type": "integer", "minimum": 1}, "runner_id": {"type": "string", "minLength": 1}, "box_number": {"type": "integer", "minimum": 1, "maximum": 10}}}}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "probability": {"type": "number", "minimum": 0, "maximum": 1},
+    "prediction": {
+      "type": "object", "additionalProperties": false,
+      "required": ["runner_id", "box_number", "dog_name", "strict_win_odds", "market_probability", "residual_adjustment", "full_probability", "half_probability"],
+      "properties": {
+        "runner_id": {"type": "string", "minLength": 1}, "box_number": {"type": "integer", "minimum": 1, "maximum": 10}, "dog_name": {"type": "string", "minLength": 1}, "strict_win_odds": {"type": "number", "exclusiveMinimum": 1}, "market_probability": {"$ref": "#/$defs/probability"}, "residual_adjustment": {"type": "number"}, "full_probability": {"$ref": "#/$defs/probability"}, "half_probability": {"$ref": "#/$defs/probability"}
+      }
+    }
+  }
+}

--- a/configs/prediction/market-form-residual-v1/scoring-input.schema.json
+++ b/configs/prediction/market-form-residual-v1/scoring-input.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://greyhound-racing-collector.invalid/schemas/market-form-residual-v1/scoring-input.schema.json",
+  "title": "market form residual canonical scoring input v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "race_id", "runner_set_sha256", "runners", "timestamps", "identities", "scoring_parameters", "ranking"],
+  "properties": {
+    "schema_version": {"const": "market_form_residual_scoring_input_v1"},
+    "race_id": {"type": "string", "minLength": 1},
+    "runner_set_sha256": {"$ref": "#/$defs/sha256"},
+    "runners": {"type": "array", "minItems": 2, "maxItems": 10, "items": {"$ref": "#/$defs/runner"}},
+    "timestamps": {
+      "type": "object", "additionalProperties": false,
+      "required": ["cutoff_timestamp", "capture_timestamp", "score_timestamp", "jump_timestamp"],
+      "properties": {
+        "cutoff_timestamp": {"$ref": "#/$defs/timestamp"},
+        "capture_timestamp": {"$ref": "#/$defs/timestamp"},
+        "score_timestamp": {"$ref": "#/$defs/timestamp"},
+        "jump_timestamp": {"$ref": "#/$defs/timestamp"}
+      }
+    },
+    "identities": {
+      "type": "object", "additionalProperties": false,
+      "required": ["model_id", "model_sha256", "manifest_sha256", "effective_state_schema", "effective_state_sha256", "config_sha256", "numeric_canonicalization_schema", "numeric_canonicalization_sha256"],
+      "properties": {
+        "model_id": {"type": "string", "minLength": 1},
+        "model_sha256": {"$ref": "#/$defs/sha256"},
+        "manifest_sha256": {"$ref": "#/$defs/sha256"},
+        "effective_state_schema": {"const": "market_form_residual_effective_state_v2"},
+        "effective_state_sha256": {"$ref": "#/$defs/sha256"},
+        "config_sha256": {"$ref": "#/$defs/sha256"},
+        "numeric_canonicalization_schema": {"const": "market_form_residual_numeric_canonicalization_v1"},
+        "numeric_canonicalization_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "scoring_parameters": {
+      "type": "object", "additionalProperties": false,
+      "required": ["full_strength", "half_strength", "residual_cap", "within_race_centering", "market_offset", "normalization"],
+      "properties": {
+        "full_strength": {"const": 1.0}, "half_strength": {"const": 0.5}, "residual_cap": {"const": 0.35},
+        "within_race_centering": {"const": true},
+        "market_offset": {"const": "fixed_log_normalized_inverse_decimal_win_odds"},
+        "normalization": {"const": "softmax(log(market_probability)+strength*capped_residual)"}
+      }
+    },
+    "ranking": {
+      "type": "object", "additionalProperties": false,
+      "required": ["primary_probability", "tie_break"],
+      "properties": {"primary_probability": {"const": "full_probability"}, "tie_break": {"const": "box_ascending"}}
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "timestamp": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]+)?[+-][0-9]{2}:[0-9]{2}$"},
+    "feature_value": {"type": ["number", "null"]},
+    "features": {
+      "type": "object", "additionalProperties": false,
+      "required": ["prior_start_count", "days_since_last_start", "recent_finish_mean_3", "recent_finish_best_5", "recent_win_rate_5", "recent_place_rate_5", "recent_avg_margin_5", "career_win_rate", "career_place_rate", "career_avg_finish", "starts_same_venue", "win_rate_same_venue", "starts_same_distance", "win_rate_same_distance", "same_grade_start_count", "same_grade_win_rate"],
+      "properties": {
+        "prior_start_count": {"$ref": "#/$defs/feature_value"}, "days_since_last_start": {"$ref": "#/$defs/feature_value"}, "recent_finish_mean_3": {"$ref": "#/$defs/feature_value"}, "recent_finish_best_5": {"$ref": "#/$defs/feature_value"}, "recent_win_rate_5": {"$ref": "#/$defs/feature_value"}, "recent_place_rate_5": {"$ref": "#/$defs/feature_value"}, "recent_avg_margin_5": {"$ref": "#/$defs/feature_value"}, "career_win_rate": {"$ref": "#/$defs/feature_value"}, "career_place_rate": {"$ref": "#/$defs/feature_value"}, "career_avg_finish": {"$ref": "#/$defs/feature_value"}, "starts_same_venue": {"$ref": "#/$defs/feature_value"}, "win_rate_same_venue": {"$ref": "#/$defs/feature_value"}, "starts_same_distance": {"$ref": "#/$defs/feature_value"}, "win_rate_same_distance": {"$ref": "#/$defs/feature_value"}, "same_grade_start_count": {"$ref": "#/$defs/feature_value"}, "same_grade_win_rate": {"$ref": "#/$defs/feature_value"}
+      }
+    },
+    "runner": {
+      "type": "object", "additionalProperties": false,
+      "required": ["runner_id", "box_number", "dog_name", "features", "feature_source_sha256", "strict_win_odds", "odds_source_sha256", "feature_freeze_timestamp", "odds_capture_timestamp"],
+      "properties": {
+        "runner_id": {"type": "string", "minLength": 1}, "box_number": {"type": "integer", "minimum": 1, "maximum": 10}, "dog_name": {"type": "string", "minLength": 1}, "features": {"$ref": "#/$defs/features"}, "feature_source_sha256": {"$ref": "#/$defs/sha256"}, "strict_win_odds": {"type": "number", "exclusiveMinimum": 1}, "odds_source_sha256": {"$ref": "#/$defs/sha256"}, "feature_freeze_timestamp": {"$ref": "#/$defs/timestamp"}, "odds_capture_timestamp": {"$ref": "#/$defs/timestamp"}
+      }
+    }
+  }
+}

--- a/scripts/predict_market_form_residual.py
+++ b/scripts/predict_market_form_residual.py
@@ -44,6 +44,12 @@ from src.predictor.market_form_residual import (  # noqa: E402
     load_frozen_model,
     score_race,
 )
+from src.predictor.scoring_parity import (  # noqa: E402
+    SCORING_CONFIG_SHA256,
+    build_core_output,
+    build_scoring_input,
+    parity_binding,
+)
 from config.venue_mapping import normalize_venue  # noqa: E402
 from utils.csv_metadata import (  # noqa: E402
     THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE,
@@ -251,6 +257,7 @@ EARLY_RESIDUAL_PREDICTION_KEYS = frozenset(
         "runner_set_sha256",
         "schema_version",
         "score_timestamp",
+        "scoring_parity",
         "shadow_output_path",
         "source_contract",
         "status",
@@ -292,6 +299,16 @@ EARLY_RESIDUAL_SOURCE_CONTRACT_KEYS = frozenset(
     }
 )
 EARLY_RESIDUAL_VARIANT_KEYS = frozenset({"full_strength", "half_strength"})
+EARLY_RESIDUAL_PARITY_KEYS = frozenset(
+    {
+        "input_schema_version",
+        "input_sha256",
+        "core_output_schema_version",
+        "core_output_sha256",
+        "config_sha256",
+        "numeric_canonicalization_sha256",
+    }
+)
 VENUE_CODE_PATTERN = r"[A-Z0-9_]+(?:-[A-Z0-9_]+)*"
 FORBIDDEN_EVIDENCE_PATH_MARKERS = frozenset({"form_only_v1", "pr51"})
 # Finite union of the exact GRADE_MAP and GRADE_VOCAB_MAP contracts, their
@@ -538,6 +555,7 @@ def _validate_index_prediction(value: Any, *, expected_race_id: Any) -> None:
         "probability_sums": EARLY_RESIDUAL_PROBABILITY_SUM_KEYS,
         "source_contract": EARLY_RESIDUAL_SOURCE_CONTRACT_KEYS,
         "variants": EARLY_RESIDUAL_VARIANT_KEYS,
+        "scoring_parity": EARLY_RESIDUAL_PARITY_KEYS,
     }
     for key, allowed_keys in nested_mappings.items():
         if key not in prediction:
@@ -2681,16 +2699,35 @@ def score_from_artifacts(
         )
     frozen = load_frozen_model(model_path, manifest_path)
     expected_ids = sorted(runner_ids)
-    provenance = {
-        "race_id": race_id,
-        "expected_runner_ids": expected_ids,
-        "runner_set_sha256": _runner_set_sha256(expected_ids),
-        "jump_timestamp": jump.isoformat(),
-        "score_timestamp": score_time.isoformat(),
-    }
-    record = score_race(frozen, runners, provenance)
+    scoring_input = build_scoring_input(
+        race_id=race_id,
+        runner_set_sha256=_runner_set_sha256(expected_ids),
+        runners=[
+            {key: value for key, value in runner.items() if key != "race_id"}
+            for runner in runners
+        ],
+        cutoff_timestamp=feature_time.isoformat(),
+        capture_timestamp=fetch_time.isoformat(),
+        score_timestamp=score_time.isoformat(),
+        jump_timestamp=jump.isoformat(),
+        model_sha256=frozen.model_sha256,
+        manifest_sha256=frozen.manifest_sha256,
+        effective_state_sha256=frozen.effective_state_sha256,
+        config_sha256=SCORING_CONFIG_SHA256,
+        scoring_parameters={
+            "full_strength": frozen.full_strength,
+            "half_strength": frozen.half_strength,
+            "residual_cap": frozen.residual_cap,
+            "within_race_centering": frozen.within_race_centering,
+            "market_offset": frozen.market_offset,
+            "normalization": frozen.normalization,
+        },
+    )
+    record = score_race(frozen, scoring_input.scorer_runners, scoring_input.provenance)
     if record.get("schema_version") != SHADOW_RECORD_SCHEMA:
         raise ManualPredictionError("scorer_record_schema_mismatch")
+    core_output = build_core_output(scoring_input, record)
+    scoring_parity = parity_binding(scoring_input, core_output)
     ranking = sorted(
         record["predictions"],
         key=lambda row: (-float(row["full_probability"]), int(row["box_number"])),
@@ -2712,6 +2749,7 @@ def score_from_artifacts(
         "record_key": record["record_key"],
         "record_schema_version": record["schema_version"],
         "record_checksum_sha256": record["record_checksum_sha256"],
+        "scoring_parity": scoring_parity,
         "effective_state_schema_version": EFFECTIVE_STATE_SCHEMA,
         "effective_state_sha256": record["effective_state_sha256"],
         "numerical_canonicalization_contract": dict(

--- a/src/predictor/manual_research_scoring.py
+++ b/src/predictor/manual_research_scoring.py
@@ -38,6 +38,16 @@ from src.predictor.market_form_residual import (
     ResidualContractError,
     score_race,
 )
+from src.predictor.scoring_parity import (
+    NUMERIC_CANONICALIZATION_SHA256,
+    SCORING_CONFIG_SHA256,
+    SCORING_CORE_OUTPUT_SCHEMA,
+    SCORING_INPUT_SCHEMA,
+    ScoringParityRejected,
+    build_core_output,
+    build_scoring_input,
+    parity_binding,
+)
 
 EMBEDDED_FORM_SCHEMA = "manual_research_embedded_form_v1"
 PREDICTION_SCHEMA = "manual_research_prediction_v1"
@@ -110,6 +120,8 @@ class ResearchPredictionExpectations:
     effective_state_sha256: str
     implementation: ResearchScoringIdentity
     feature_sha256: str | None = None
+    scoring_input_sha256: str | None = None
+    scoring_core_output_sha256: str | None = None
 
 
 @dataclass(frozen=True)
@@ -445,7 +457,7 @@ def _feature_payload(
 def _prediction_payload(
     *, evidence: SealedManualEvidence, form_sha256: str, config_sha256: str, model: FrozenResidualModel,
     identity: Mapping[str, str], feature_payload: Mapping[str, Any], feature_sha256: str, record: Mapping[str, Any],
-    config: Mapping[str, Any], cutoff: datetime,
+    config: Mapping[str, Any], cutoff: datetime, scoring_parity: Mapping[str, str],
 ) -> dict[str, Any]:
     bundle = evidence.bundle
     normalized = evidence.normalized_odds
@@ -479,6 +491,8 @@ def _prediction_payload(
         "model_manifest_sha256": model.manifest_sha256,
         "feature_sha256": feature_sha256,
         "effective_state_sha256": record["effective_state_sha256"],
+        "scoring_input_sha256": scoring_parity["input_sha256"],
+        "scoring_core_output_sha256": scoring_parity["core_output_sha256"],
         "implementation": identity,
         "runner_set_sha256": bundle["runner_set_sha256"],
         "cutoff_timestamp": cutoff.isoformat(),
@@ -535,6 +549,7 @@ def _prediction_payload(
             "schema_version": config["schema_version"],
             "sha256": config_sha256,
         },
+        "scoring_parity": dict(scoring_parity),
         "implementation": dict(identity),
         "ranking": {"primary_probability": "full_probability", "tie_break": "box_ascending"},
         "predictions": ranked,
@@ -655,7 +670,7 @@ def _publish_prediction(
 
 def _validate_prediction_document(prediction: Mapping[str, Any], expected: ResearchPredictionExpectations) -> dict[str, Any]:
     if set(prediction) != {
-        "schema_version", "bundle_id", "safety", "scorer_id", "race", "race_identity_sha256", "runner_set_sha256", "timing", "evidence", "form", "features", "model", "config", "implementation", "ranking", "predictions"
+        "schema_version", "bundle_id", "safety", "scorer_id", "race", "race_identity_sha256", "runner_set_sha256", "timing", "evidence", "form", "features", "model", "config", "scoring_parity", "implementation", "ranking", "predictions"
     }:
         raise _reject("PREDICTION_SCHEMA_INVALID")
     if prediction["schema_version"] != PREDICTION_SCHEMA or prediction["safety"] != {
@@ -713,6 +728,33 @@ def _validate_prediction_document(prediction: Mapping[str, Any], expected: Resea
         raise _reject("CONFIG_BINDING_INVALID")
     if prediction["scorer_id"] != SCORER_VERSION or prediction["ranking"] != {"primary_probability": "full_probability", "tie_break": "box_ascending"}:
         raise _reject("PREDICTION_CONTRACT_INVALID")
+    parity = _exact(
+        prediction["scoring_parity"],
+        {
+            "input_schema_version",
+            "input_sha256",
+            "core_output_schema_version",
+            "core_output_sha256",
+            "config_sha256",
+            "numeric_canonicalization_sha256",
+        },
+        "scoring_parity",
+    )
+    if (
+        parity["input_schema_version"] != SCORING_INPUT_SCHEMA
+        or parity["core_output_schema_version"] != SCORING_CORE_OUTPUT_SCHEMA
+        or parity["config_sha256"] != SCORING_CONFIG_SHA256
+        or parity["numeric_canonicalization_sha256"] != NUMERIC_CANONICALIZATION_SHA256
+    ):
+        raise _reject("SCORING_PARITY_BINDING_INVALID")
+    _sha(parity["input_sha256"], "scoring_input_sha256")
+    _sha(parity["core_output_sha256"], "scoring_core_output_sha256")
+    _sha(parity["config_sha256"], "scoring_config_sha256")
+    _sha(parity["numeric_canonicalization_sha256"], "numeric_canonicalization_sha256")
+    if expected.scoring_input_sha256 is not None and parity["input_sha256"] != expected.scoring_input_sha256:
+        raise _reject("SCORING_PARITY_BINDING_INVALID")
+    if expected.scoring_core_output_sha256 is not None and parity["core_output_sha256"] != expected.scoring_core_output_sha256:
+        raise _reject("SCORING_PARITY_BINDING_INVALID")
     if not isinstance(prediction["predictions"], list) or len(prediction["predictions"]) < 2:
         raise _reject("PREDICTION_RUNNER_SET_INVALID")
     seen_boxes: set[int] = set()
@@ -852,6 +894,8 @@ def verify_research_prediction_bundle(bundle_dir: Path, *, output_root: Path, ex
         "model_manifest_sha256": validated["model"]["manifest_sha256"],
         "feature_sha256": validated["features"]["sha256"],
         "effective_state_sha256": validated["model"]["effective_state_sha256"],
+        "scoring_input_sha256": validated["scoring_parity"]["input_sha256"],
+        "scoring_core_output_sha256": validated["scoring_parity"]["core_output_sha256"],
         "implementation": validated["implementation"],
         "runner_set_sha256": validated["runner_set_sha256"],
         "cutoff_timestamp": validated["timing"]["sealed_cutoff_timestamp"],
@@ -936,16 +980,40 @@ def score_verified_manual_evidence(
                 "odds_capture_timestamp": evidence.bundle["timing"]["capture_timestamp"],
             }
         )
-    provenance = {
-        "race_id": evidence.bundle["race"]["race_id"],
-        "expected_runner_ids": sorted(runner_ids),
-        "runner_set_sha256": _scorer_runner_set_sha256(runner_ids),
-        "jump_timestamp": evidence.bundle["race"]["scheduled_start"],
-        "score_timestamp": evidence.bundle["timing"]["capture_timestamp"],
-    }
     try:
-        record = score_race(frozen_model, scorer_runners, provenance)
-    except ResidualContractError as exc:
+        scoring_input = build_scoring_input(
+            race_id=evidence.bundle["race"]["race_id"],
+            runner_set_sha256=_scorer_runner_set_sha256(runner_ids),
+            runners=[
+                {key: value for key, value in runner.items() if key != "race_id"}
+                for runner in scorer_runners
+            ],
+            cutoff_timestamp=cutoff.isoformat(),
+            capture_timestamp=evidence.bundle["timing"]["capture_timestamp"],
+            score_timestamp=evidence.bundle["timing"]["capture_timestamp"],
+            jump_timestamp=evidence.bundle["race"]["scheduled_start"],
+            model_sha256=frozen_model.model_sha256,
+            manifest_sha256=frozen_model.manifest_sha256,
+            effective_state_sha256=frozen_model.effective_state_sha256,
+            config_sha256=SCORING_CONFIG_SHA256,
+            scoring_parameters={
+                "full_strength": frozen_model.full_strength,
+                "half_strength": frozen_model.half_strength,
+                "residual_cap": frozen_model.residual_cap,
+                "within_race_centering": frozen_model.within_race_centering,
+                "market_offset": frozen_model.market_offset,
+                "normalization": frozen_model.normalization,
+            },
+        )
+    except ScoringParityRejected as exc:
+        raise _reject("SCORING_BLOCKED", reason=str(exc)) from exc
+    try:
+        record = score_race(
+            frozen_model, scoring_input.scorer_runners, scoring_input.provenance
+        )
+        core_output = build_core_output(scoring_input, record)
+        scoring_parity = parity_binding(scoring_input, core_output)
+    except (ResidualContractError, ScoringParityRejected) as exc:
         raise _reject("SCORING_BLOCKED", reason=str(exc)) from exc
     if record["schema_version"] != SHADOW_RECORD_SCHEMA:
         raise _reject("SCORING_SCHEMA_MISMATCH")
@@ -960,6 +1028,7 @@ def score_verified_manual_evidence(
         record=record,
         config=config,
         cutoff=cutoff,
+        scoring_parity=scoring_parity,
     )
     expected = ResearchPredictionExpectations(
         evidence_bundle_id=evidence.bundle["bundle_id"],
@@ -976,6 +1045,8 @@ def score_verified_manual_evidence(
         effective_state_sha256=record["effective_state_sha256"],
         implementation=scoring_identity,
         feature_sha256=feature_sha256,
+        scoring_input_sha256=scoring_parity["input_sha256"],
+        scoring_core_output_sha256=scoring_parity["core_output_sha256"],
     )
     destination, replayed = _publish_prediction(prediction, output_root=output_root, stage_hook=stage_hook)
     verified = verify_research_prediction_bundle(destination, output_root=output_root, expected=expected)

--- a/src/predictor/scoring_parity.py
+++ b/src/predictor/scoring_parity.py
@@ -1,0 +1,554 @@
+"""Canonical input and core-output contracts for residual scoring parity.
+
+This module owns the bytes that automatic and manual adapters must agree on.
+It deliberately does not load artifacts, read history, persist predictions, or
+call a network/service.  ``score_race`` remains the only scoring
+implementation; this module validates its inputs and canonicalizes its
+outcome-free result.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from types import MappingProxyType
+from typing import Any
+
+from src.predictor.market_form_residual import (
+    EFFECTIVE_STATE_SCHEMA,
+    FEATURES,
+    FROZEN_ALGORITHM_CONTRACT,
+    FROZEN_DERIVATION_CONTRACT,
+    NUMERICAL_CANONICALIZATION_CONTRACT,
+)
+
+SCORING_INPUT_SCHEMA = "market_form_residual_scoring_input_v1"
+SCORING_CORE_OUTPUT_SCHEMA = "market_form_residual_scoring_core_output_v1"
+SCORING_CONFIG_SCHEMA = "market_form_residual_scoring_config_v1"
+RANKING_CONTRACT = MappingProxyType(
+    {"primary_probability": "full_probability", "tie_break": "box_ascending"}
+)
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_OUTCOME_WORDS = frozenset(
+    {
+        "actual_win",
+        "actual_result",
+        "finish",
+        "finish_position",
+        "finishes",
+        "official_result",
+        "outcome",
+        "outcomes",
+        "placing",
+        "result",
+        "results",
+        "winner",
+        "winner_name",
+        "winner_odds",
+    }
+)
+_INPUT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "race_id",
+        "runner_set_sha256",
+        "runners",
+        "timestamps",
+        "identities",
+        "scoring_parameters",
+        "ranking",
+    }
+)
+_RUNNER_FIELDS = frozenset(
+    {
+        "runner_id",
+        "box_number",
+        "dog_name",
+        "features",
+        "feature_source_sha256",
+        "strict_win_odds",
+        "odds_source_sha256",
+        "feature_freeze_timestamp",
+        "odds_capture_timestamp",
+    }
+)
+_TIMESTAMP_FIELDS = frozenset(
+    {"cutoff_timestamp", "capture_timestamp", "score_timestamp", "jump_timestamp"}
+)
+_IDENTITY_FIELDS = frozenset(
+    {
+        "model_id",
+        "model_sha256",
+        "manifest_sha256",
+        "effective_state_schema",
+        "effective_state_sha256",
+        "config_sha256",
+        "numeric_canonicalization_schema",
+        "numeric_canonicalization_sha256",
+    }
+)
+
+
+class ScoringParityRejected(ValueError):
+    """A fail-closed canonical scoring contract rejection."""
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    raise ScoringParityRejected(f"json_value_invalid:{type(value).__name__}")
+
+
+def canonical_bytes(value: Any) -> bytes:
+    try:
+        encoded = json.dumps(
+            _json_value(value),
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ScoringParityRejected("canonical_json_invalid") from exc
+    return (encoded + "\n").encode("utf-8")
+
+
+def sha256_bytes(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _exact(value: Any, fields: frozenset[str], label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != fields:
+        raise ScoringParityRejected(f"{label}_fields_invalid")
+    return value
+
+
+def _sha(value: Any, label: str) -> str:
+    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+        raise ScoringParityRejected(f"{label}_invalid")
+    return value
+
+
+def _finite(value: Any, label: str, *, minimum: float | None = None) -> float:
+    if isinstance(value, bool):
+        raise ScoringParityRejected(f"{label}_nonfinite")
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ScoringParityRejected(f"{label}_nonfinite") from exc
+    if not math.isfinite(number) or (minimum is not None and number <= minimum):
+        raise ScoringParityRejected(f"{label}_invalid")
+    return number
+
+
+def _timestamp(value: Any, label: str) -> datetime:
+    if not isinstance(value, str):
+        raise ScoringParityRejected(f"{label}_invalid")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ScoringParityRejected(f"{label}_invalid") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None or parsed.isoformat() != value:
+        raise ScoringParityRejected(f"{label}_invalid")
+    return parsed
+
+
+def _contains_outcome(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        return any(
+            str(key).strip().lower() in _OUTCOME_WORDS or _contains_outcome(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, list):
+        return any(_contains_outcome(item) for item in value)
+    return False
+
+
+def _runner_set_sha256(runner_ids: Sequence[str]) -> str:
+    return sha256_bytes(("\n".join(sorted(runner_ids)) + "\n").encode("utf-8"))
+
+
+def _dog_token(name: str) -> str:
+    return re.sub(r"[^A-Z0-9]", "", name.upper())
+
+
+def _canonical_scoring_config() -> dict[str, Any]:
+    return {
+        "schema_version": SCORING_CONFIG_SCHEMA,
+        "feature_order": list(FEATURES),
+        "algorithm": _json_value(FROZEN_ALGORITHM_CONTRACT),
+        "derivation": _json_value(FROZEN_DERIVATION_CONTRACT),
+        "numeric_canonicalization": _json_value(NUMERICAL_CANONICALIZATION_CONTRACT),
+        "ranking": dict(RANKING_CONTRACT),
+        "effective_state_schema": EFFECTIVE_STATE_SCHEMA,
+    }
+
+
+SCORING_CONFIG = _canonical_scoring_config()
+SCORING_CONFIG_SHA256 = sha256_bytes(canonical_bytes(SCORING_CONFIG))
+NUMERIC_CANONICALIZATION_SHA256 = sha256_bytes(canonical_bytes(NUMERICAL_CANONICALIZATION_CONTRACT))
+
+
+@dataclass(frozen=True)
+class ScoringInputArtifact:
+    document: Mapping[str, Any]
+    raw: bytes
+    sha256: str
+
+    @property
+    def scorer_runners(self) -> list[dict[str, Any]]:
+        race_id = self.document["race_id"]
+        return [
+            {
+                "race_id": race_id,
+                "runner_id": row["runner_id"],
+                "box_number": row["box_number"],
+                "dog_name": row["dog_name"],
+                "strict_win_odds": row["strict_win_odds"],
+                "features": dict(row["features"]),
+                "feature_source_sha256": row["feature_source_sha256"],
+                "odds_source_sha256": row["odds_source_sha256"],
+                "feature_freeze_timestamp": row["feature_freeze_timestamp"],
+                "odds_capture_timestamp": row["odds_capture_timestamp"],
+            }
+            for row in self.document["runners"]
+        ]
+
+    @property
+    def provenance(self) -> dict[str, Any]:
+        timestamps = self.document["timestamps"]
+        return {
+            "expected_runner_ids": [row["runner_id"] for row in self.document["runners"]],
+            "jump_timestamp": timestamps["jump_timestamp"],
+            "race_id": self.document["race_id"],
+            "runner_set_sha256": self.document["runner_set_sha256"],
+            "score_timestamp": timestamps["score_timestamp"],
+        }
+
+
+@dataclass(frozen=True)
+class CoreOutputArtifact:
+    document: Mapping[str, Any]
+    raw: bytes
+    sha256: str
+
+
+def build_scoring_input(
+    *,
+    race_id: str,
+    runner_set_sha256: str,
+    runners: Sequence[Mapping[str, Any]],
+    cutoff_timestamp: str,
+    capture_timestamp: str,
+    score_timestamp: str,
+    jump_timestamp: str,
+    model_sha256: str,
+    manifest_sha256: str,
+    effective_state_sha256: str,
+    config_sha256: str = SCORING_CONFIG_SHA256,
+    model_id: str = "market_form_residual_v1",
+    scoring_parameters: Mapping[str, Any] | None = None,
+) -> ScoringInputArtifact:
+    if (
+        not isinstance(race_id, str)
+        or not race_id.strip()
+        or _contains_outcome({"race_id": race_id})
+    ):
+        raise ScoringParityRejected("race_id_invalid")
+    if not isinstance(runners, Sequence) or isinstance(runners, (str, bytes)) or len(runners) < 2:
+        raise ScoringParityRejected("runner_set_invalid")
+    if not all(isinstance(row, Mapping) for row in runners):
+        raise ScoringParityRejected("runner_set_invalid")
+    if list(runners) != sorted(runners, key=lambda row: str(row.get("runner_id", ""))):
+        raise ScoringParityRejected("runner_order_invalid")
+    timestamps = {
+        "cutoff_timestamp": cutoff_timestamp,
+        "capture_timestamp": capture_timestamp,
+        "score_timestamp": score_timestamp,
+        "jump_timestamp": jump_timestamp,
+    }
+    parsed_timestamps = {key: _timestamp(value, key) for key, value in timestamps.items()}
+    if not (
+        parsed_timestamps["cutoff_timestamp"] <= parsed_timestamps["score_timestamp"]
+        and parsed_timestamps["capture_timestamp"]
+        <= parsed_timestamps["score_timestamp"]
+        < parsed_timestamps["jump_timestamp"]
+    ):
+        raise ScoringParityRejected("timestamp_order_invalid")
+    normalized_runners: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    seen_boxes: set[int] = set()
+    for index, supplied in enumerate(runners):
+        runner = _exact(supplied, _RUNNER_FIELDS, f"runner[{index}]")
+        if _contains_outcome(runner):
+            raise ScoringParityRejected(f"runner[{index}]_contains_outcome")
+        runner_id = runner["runner_id"]
+        if not isinstance(runner_id, str) or not runner_id or runner_id in seen_ids:
+            raise ScoringParityRejected(f"runner[{index}]_identity_invalid")
+        seen_ids.add(runner_id)
+        box_number = runner["box_number"]
+        if (
+            isinstance(box_number, bool)
+            or not isinstance(box_number, int)
+            or not 1 <= box_number <= 10
+            or box_number in seen_boxes
+        ):
+            raise ScoringParityRejected(f"runner[{index}]_box_invalid")
+        seen_boxes.add(box_number)
+        dog_name = runner["dog_name"]
+        if not isinstance(dog_name, str) or not dog_name or dog_name != dog_name.strip():
+            raise ScoringParityRejected(f"runner[{index}]_name_invalid")
+        if (
+            not _dog_token(dog_name)
+            or runner_id != f"{race_id}|box:{box_number}|dog:{_dog_token(dog_name)}"
+        ):
+            raise ScoringParityRejected(f"runner[{index}]_identity_mismatch")
+        feature_values = runner["features"]
+        if not isinstance(feature_values, Mapping) or tuple(feature_values) != FEATURES:
+            raise ScoringParityRejected(f"runner[{index}]_feature_order_invalid")
+        normalized_features: dict[str, float | None] = {}
+        for feature in FEATURES:
+            value = feature_values[feature]
+            if value is None:
+                normalized_features[feature] = None
+            else:
+                normalized_features[feature] = _finite(
+                    value, f"runner[{index}].{feature}", minimum=None
+                )
+        feature_freeze = _timestamp(
+            runner["feature_freeze_timestamp"], f"runner[{index}].feature_freeze_timestamp"
+        )
+        odds_capture = _timestamp(
+            runner["odds_capture_timestamp"], f"runner[{index}].odds_capture_timestamp"
+        )
+        if (
+            feature_freeze > parsed_timestamps["cutoff_timestamp"]
+            or odds_capture > parsed_timestamps["capture_timestamp"]
+        ):
+            raise ScoringParityRejected(f"runner[{index}]_source_timestamp_invalid")
+        normalized_runners.append(
+            {
+                "runner_id": runner_id,
+                "box_number": box_number,
+                "dog_name": dog_name,
+                "features": normalized_features,
+                "feature_source_sha256": _sha(
+                    runner["feature_source_sha256"], f"runner[{index}].feature_source_sha256"
+                ),
+                "strict_win_odds": _finite(
+                    runner["strict_win_odds"], f"runner[{index}].strict_win_odds", minimum=1.0
+                ),
+                "odds_source_sha256": _sha(
+                    runner["odds_source_sha256"], f"runner[{index}].odds_source_sha256"
+                ),
+                "feature_freeze_timestamp": feature_freeze.isoformat(),
+                "odds_capture_timestamp": odds_capture.isoformat(),
+            }
+        )
+    runner_ids = [row["runner_id"] for row in normalized_runners]
+    if runner_ids != sorted(runner_ids):
+        raise ScoringParityRejected("runner_order_invalid")
+    if _sha(runner_set_sha256, "runner_set_sha256") != _runner_set_sha256(runner_ids):
+        raise ScoringParityRejected("runner_set_hash_mismatch")
+    if not isinstance(model_id, str) or not model_id:
+        raise ScoringParityRejected("model_id_invalid")
+    identities = {
+        "model_id": model_id,
+        "model_sha256": _sha(model_sha256, "model_sha256"),
+        "manifest_sha256": _sha(manifest_sha256, "manifest_sha256"),
+        "effective_state_schema": EFFECTIVE_STATE_SCHEMA,
+        "effective_state_sha256": _sha(effective_state_sha256, "effective_state_sha256"),
+        "config_sha256": _sha(config_sha256, "config_sha256"),
+        "numeric_canonicalization_schema": NUMERICAL_CANONICALIZATION_CONTRACT["schema_version"],
+        "numeric_canonicalization_sha256": NUMERIC_CANONICALIZATION_SHA256,
+    }
+    parameters = dict(
+        scoring_parameters
+        or {
+            "full_strength": 1.0,
+            "half_strength": 0.5,
+            "residual_cap": 0.35,
+            "within_race_centering": True,
+            "market_offset": "fixed_log_normalized_inverse_decimal_win_odds",
+            "normalization": "softmax(log(market_probability)+strength*capped_residual)",
+        }
+    )
+    if _contains_outcome(parameters):
+        raise ScoringParityRejected("scoring_parameters_contains_outcome")
+    if parameters != {
+        "full_strength": 1.0,
+        "half_strength": 0.5,
+        "residual_cap": 0.35,
+        "within_race_centering": True,
+        "market_offset": "fixed_log_normalized_inverse_decimal_win_odds",
+        "normalization": "softmax(log(market_probability)+strength*capped_residual)",
+    }:
+        raise ScoringParityRejected("scoring_parameters_invalid")
+    document = {
+        "schema_version": SCORING_INPUT_SCHEMA,
+        "race_id": race_id,
+        "runner_set_sha256": runner_set_sha256,
+        "runners": normalized_runners,
+        "timestamps": timestamps,
+        "identities": identities,
+        "scoring_parameters": parameters,
+        "ranking": dict(RANKING_CONTRACT),
+    }
+    raw = canonical_bytes(document)
+    return ScoringInputArtifact(document, raw, sha256_bytes(raw))
+
+
+def build_core_output(
+    scoring_input: ScoringInputArtifact, score_record: Mapping[str, Any]
+) -> CoreOutputArtifact:
+    if not isinstance(score_record, Mapping) or _contains_outcome(score_record):
+        raise ScoringParityRejected("core_output_invalid_or_contains_outcome")
+    if score_record.get("outcomes_present") is not False:
+        raise ScoringParityRejected("core_output_outcome_marker_invalid")
+    expected_identities = scoring_input.document["identities"]
+    if any(
+        score_record.get(record_key) != expected_value
+        for record_key, expected_value in (
+            ("race_id", scoring_input.document["race_id"]),
+            ("runner_set_sha256", scoring_input.document["runner_set_sha256"]),
+            ("model_sha256", expected_identities["model_sha256"]),
+            ("manifest_sha256", expected_identities["manifest_sha256"]),
+            ("effective_state_sha256", expected_identities["effective_state_sha256"]),
+        )
+    ):
+        raise ScoringParityRejected("core_output_identity_mismatch")
+    predictions = score_record.get("predictions")
+    if not isinstance(predictions, list):
+        raise ScoringParityRejected("core_output_predictions_invalid")
+    expected_by_id = {row["runner_id"]: row for row in scoring_input.document["runners"]}
+    actual_by_id: dict[str, Mapping[str, Any]] = {}
+    for row in predictions:
+        if not isinstance(row, Mapping) or not isinstance(row.get("runner_id"), str):
+            raise ScoringParityRejected("core_output_runner_set_invalid")
+        if row["runner_id"] in actual_by_id:
+            raise ScoringParityRejected("core_output_runner_set_invalid")
+        actual_by_id[row["runner_id"]] = row
+    if set(actual_by_id) != set(expected_by_id) or len(actual_by_id) != len(predictions):
+        raise ScoringParityRejected("core_output_runner_set_invalid")
+    canonical_predictions: list[dict[str, Any]] = []
+    for runner in scoring_input.document["runners"]:
+        row = actual_by_id[runner["runner_id"]]
+        canonical_predictions.append(
+            {
+                "runner_id": runner["runner_id"],
+                "box_number": runner["box_number"],
+                "dog_name": runner["dog_name"],
+                "strict_win_odds": runner["strict_win_odds"],
+                "market_probability": _finite(row.get("market_probability"), "market_probability"),
+                "residual_adjustment": _finite(
+                    row.get("residual_adjustment"), "residual_adjustment"
+                ),
+                "full_probability": _finite(row.get("full_probability"), "full_probability"),
+                "half_probability": _finite(row.get("half_probability"), "half_probability"),
+            }
+        )
+    ranked = sorted(
+        canonical_predictions,
+        key=lambda row: (-row["full_probability"], row["box_number"]),
+    )
+    if any(
+        not 0.0 <= row[field] <= 1.0
+        for row in canonical_predictions
+        for field in ("market_probability", "full_probability", "half_probability")
+    ):
+        raise ScoringParityRejected("core_output_probability_invalid")
+    ranking = [
+        {
+            "rank": rank,
+            "runner_id": row["runner_id"],
+            "box_number": row["box_number"],
+        }
+        for rank, row in enumerate(ranked, start=1)
+    ]
+    document = {
+        "schema_version": SCORING_CORE_OUTPUT_SCHEMA,
+        "scoring_input_sha256": scoring_input.sha256,
+        "race_id": scoring_input.document["race_id"],
+        "runner_set_sha256": scoring_input.document["runner_set_sha256"],
+        "identities": dict(expected_identities),
+        "ranking": dict(RANKING_CONTRACT),
+        "predictions": canonical_predictions,
+        "ranks": ranking,
+    }
+    raw = canonical_bytes(document)
+    return CoreOutputArtifact(document, raw, sha256_bytes(raw))
+
+
+def parity_binding(
+    scoring_input: ScoringInputArtifact, core_output: CoreOutputArtifact
+) -> dict[str, str]:
+    return {
+        "input_schema_version": SCORING_INPUT_SCHEMA,
+        "input_sha256": scoring_input.sha256,
+        "core_output_schema_version": SCORING_CORE_OUTPUT_SCHEMA,
+        "core_output_sha256": core_output.sha256,
+        "config_sha256": scoring_input.document["identities"]["config_sha256"],
+        "numeric_canonicalization_sha256": scoring_input.document["identities"][
+            "numeric_canonicalization_sha256"
+        ],
+    }
+
+
+def first_difference_diagnostic(expected: bytes, actual: bytes) -> dict[str, Any]:
+    if expected == actual:
+        return {"equal": True}
+    limit = min(len(expected), len(actual))
+    offset = next(
+        (index for index in range(limit) if expected[index] != actual[index]),
+        limit,
+    )
+    return {
+        "equal": False,
+        "offset": offset,
+        "expected_length": len(expected),
+        "actual_length": len(actual),
+        "expected_byte": expected[offset] if offset < len(expected) else None,
+        "actual_byte": actual[offset] if offset < len(actual) else None,
+        "expected_context": expected[max(0, offset - 24) : offset + 24].decode("utf-8", "replace"),
+        "actual_context": actual[max(0, offset - 24) : offset + 24].decode("utf-8", "replace"),
+    }
+
+
+def compare_parity(
+    left_input: ScoringInputArtifact,
+    right_input: ScoringInputArtifact,
+    left_core: CoreOutputArtifact,
+    right_core: CoreOutputArtifact,
+) -> dict[str, Any]:
+    return {
+        "input_hash_equal": left_input.sha256 == right_input.sha256,
+        "core_output_hash_equal": left_core.sha256 == right_core.sha256,
+        "input_first_difference": first_difference_diagnostic(left_input.raw, right_input.raw),
+        "core_output_first_difference": first_difference_diagnostic(left_core.raw, right_core.raw),
+    }
+
+
+__all__ = [
+    "SCORING_CONFIG",
+    "SCORING_CONFIG_SHA256",
+    "SCORING_CORE_OUTPUT_SCHEMA",
+    "SCORING_INPUT_SCHEMA",
+    "CoreOutputArtifact",
+    "ScoringInputArtifact",
+    "ScoringParityRejected",
+    "build_core_output",
+    "build_scoring_input",
+    "canonical_bytes",
+    "compare_parity",
+    "first_difference_diagnostic",
+    "parity_binding",
+    "sha256_bytes",
+]

--- a/tests/test_manual_research_scoring.py
+++ b/tests/test_manual_research_scoring.py
@@ -185,6 +185,8 @@ def _prediction_expected(result, *, form_bytes: bytes, config_bytes: bytes) -> R
         effective_state_sha256=row["model"]["effective_state_sha256"],
         implementation=SCORE_IDENTITY,
         feature_sha256=row["features"]["sha256"],
+        scoring_input_sha256=row["scoring_parity"]["input_sha256"],
+        scoring_core_output_sha256=row["scoring_parity"]["core_output_sha256"],
     )
 
 
@@ -210,6 +212,10 @@ def test_verified_fixture_scores_and_replays_byte_identically(tmp_path: Path):
     assert first.replayed is False
     assert second.replayed is True
     assert first.prediction["safety"] == sealed.bundle["safety"]
+    assert first.prediction["scoring_parity"]["input_schema_version"] == "market_form_residual_scoring_input_v1"
+    assert first.prediction["scoring_parity"]["core_output_schema_version"] == "market_form_residual_scoring_core_output_v1"
+    assert len(first.prediction["scoring_parity"]["input_sha256"]) == 64
+    assert len(first.prediction["scoring_parity"]["core_output_sha256"]) == 64
     assert all(0.0 <= row[field] <= 1.0 for row in first.prediction["predictions"] for field in ("market_probability", "half_probability", "full_probability"))
     assert [row["rank"] for row in first.prediction["predictions"]] == [1, 2]
     assert not any(key in first.prediction for key in ("ev", "stake", "bet", "outcome", "result"))

--- a/tests/test_predict_market_form_residual.py
+++ b/tests/test_predict_market_form_residual.py
@@ -426,6 +426,10 @@ def test_scores_exact_packet_deterministically(tmp_path):
         "history_migration_performed": False,
     }
     assert first["record_schema_version"] == "market_form_residual_shadow_record_v3"
+    assert first["scoring_parity"]["input_schema_version"] == "market_form_residual_scoring_input_v1"
+    assert first["scoring_parity"]["core_output_schema_version"] == "market_form_residual_scoring_core_output_v1"
+    assert len(first["scoring_parity"]["input_sha256"]) == 64
+    assert len(first["scoring_parity"]["core_output_sha256"]) == 64
     assert first["effective_state_schema_version"] == (
         "market_form_residual_effective_state_v2"
     )

--- a/tests/test_scoring_parity.py
+++ b/tests/test_scoring_parity.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from src.predictor.market_form_residual import FEATURES
+from src.predictor.scoring_parity import (
+    SCORING_CORE_OUTPUT_SCHEMA,
+    SCORING_INPUT_SCHEMA,
+    ScoringParityRejected,
+    build_core_output,
+    build_scoring_input,
+    compare_parity,
+    first_difference_diagnostic,
+)
+
+HASHES = {
+    "runner_set": "a" * 64,
+    "feature": "b" * 64,
+    "odds": "c" * 64,
+    "model": "d" * 64,
+    "manifest": "e" * 64,
+    "effective": "f" * 64,
+}
+TIMESTAMPS = {
+    "cutoff_timestamp": "2026-08-06T10:00:00+10:00",
+    "capture_timestamp": "2026-08-06T10:01:00+10:00",
+    "score_timestamp": "2026-08-06T10:02:00+10:00",
+    "jump_timestamp": "2026-08-06T10:05:00+10:00",
+}
+RACE_ID = "Race 3 - TEST - 2026-08-06"
+
+
+def _runner(box: int, name: str, odds: float, *, feature_values=None) -> dict:
+    values = dict(
+        zip(
+            FEATURES,
+            feature_values
+            or (1, None, 2.0, 1.0, 0.5, 0.75, None, 0.2, 0.4, 3.0, 5, 0.2, 4, 0.25, 2, 0.5),
+        )
+    )
+    token = "".join(character for character in name.upper() if character.isalnum())
+    return {
+        "runner_id": f"{RACE_ID}|box:{box}|dog:{token}",
+        "box_number": box,
+        "dog_name": name,
+        "features": values,
+        "feature_source_sha256": HASHES["feature"],
+        "strict_win_odds": odds,
+        "odds_source_sha256": HASHES["odds"],
+        "feature_freeze_timestamp": TIMESTAMPS["cutoff_timestamp"],
+        "odds_capture_timestamp": TIMESTAMPS["capture_timestamp"],
+    }
+
+
+def _input(runners=None, **changes):
+    rows = runners or [
+        _runner(1, "Alpha Dog", 2.5),
+        _runner(2, "Beta Dog", 2.5),
+        _runner(4, "Gamma Dog", 5.0),
+    ]
+    ids = [row["runner_id"] for row in rows]
+    values = {
+        "race_id": RACE_ID,
+        "runner_set_sha256": hashlib.sha256(("\n".join(sorted(ids)) + "\n").encode()).hexdigest(),
+        "runners": rows,
+        **TIMESTAMPS,
+        "model_sha256": HASHES["model"],
+        "manifest_sha256": HASHES["manifest"],
+        "effective_state_sha256": HASHES["effective"],
+    }
+    values.update(changes)
+    return build_scoring_input(**values)
+
+
+def _record(input_artifact, *, probabilities=(0.4, 0.4, 0.2)) -> dict:
+    identities = input_artifact.document["identities"]
+    return {
+        "race_id": input_artifact.document["race_id"],
+        "runner_set_sha256": input_artifact.document["runner_set_sha256"],
+        "model_sha256": identities["model_sha256"],
+        "manifest_sha256": identities["manifest_sha256"],
+        "effective_state_sha256": identities["effective_state_sha256"],
+        "outcomes_present": False,
+        "predictions": [
+            {
+                "runner_id": row["runner_id"],
+                "market_probability": probabilities[index],
+                "residual_adjustment": 0.0,
+                "full_probability": probabilities[index],
+                "half_probability": probabilities[index],
+            }
+            for index, row in enumerate(input_artifact.document["runners"])
+        ],
+    }
+
+
+def test_identical_lane_inputs_are_byte_identical_and_rank_box_ties():
+    automatic = _input()
+    manual = _input(runners=deepcopy(automatic.document["runners"]))
+    automatic_core = build_core_output(automatic, _record(automatic))
+    manual_core = build_core_output(manual, _record(manual))
+
+    assert automatic.raw == manual.raw
+    assert automatic.sha256 == manual.sha256
+    assert automatic_core.raw == manual_core.raw
+    assert automatic_core.sha256 == manual_core.sha256
+    assert [row["runner_id"] for row in automatic_core.document["ranks"][:2]] == [
+        automatic.document["runners"][0]["runner_id"],
+        automatic.document["runners"][1]["runner_id"],
+    ]
+    assert compare_parity(automatic, manual, automatic_core, manual_core) == {
+        "input_hash_equal": True,
+        "core_output_hash_equal": True,
+        "input_first_difference": {"equal": True},
+        "core_output_first_difference": {"equal": True},
+    }
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda rows: rows[0]["features"].__setitem__(FEATURES[0], 9.0),
+        lambda rows: rows[0].__setitem__("strict_win_odds", 3.75),
+        lambda rows: rows[0].__setitem__("runner_id", "wrong"),
+        lambda rows: rows.reverse(),
+        lambda rows: rows[0]["features"].__setitem__(FEATURES[1], 4.0),
+    ],
+)
+def test_input_mutations_never_silently_reconcile(mutation):
+    original = _input()
+    rows = deepcopy(original.document["runners"])
+    mutation(rows)
+    try:
+        changed = _input(runners=rows)
+    except ScoringParityRejected:
+        return
+    assert changed.sha256 != original.sha256
+
+
+def test_missing_extra_or_reordered_features_fail_closed():
+    original = _input()
+    for mutation in (
+        lambda row: row["features"].pop(FEATURES[0]),
+        lambda row: row["features"].__setitem__("unexpected", 1.0),
+        lambda row: row.__setitem__("features", dict(reversed(list(row["features"].items())))),
+    ):
+        rows = deepcopy(original.document["runners"])
+        mutation(rows[0])
+        with pytest.raises(ScoringParityRejected):
+            _input(runners=rows)
+
+
+def test_timestamp_identity_and_outcome_mutations_fail_closed():
+    original = _input()
+    with pytest.raises(ScoringParityRejected):
+        _input(score_timestamp="2026-08-06T10:06:00+10:00")
+    changed_config = _input(config_sha256="0" * 64)
+    assert changed_config.sha256 != original.sha256
+    assert _input(cutoff_timestamp="2026-08-06T10:00:30+10:00").sha256 != original.sha256
+    assert _input(model_sha256="1" * 64).sha256 != original.sha256
+    rows = deepcopy(original.document["runners"])
+    rows[0]["outcome"] = "must reject"
+    with pytest.raises(ScoringParityRejected):
+        _input(runners=rows)
+
+
+def test_first_difference_is_deterministic():
+    assert first_difference_diagnostic(b"abc", b"abX") == {
+        "equal": False,
+        "offset": 2,
+        "expected_length": 3,
+        "actual_length": 3,
+        "expected_byte": 99,
+        "actual_byte": 88,
+        "expected_context": "abc",
+        "actual_context": "abX",
+    }
+    assert first_difference_diagnostic(b"abc", b"abcde")["offset"] == 3
+
+
+def test_contract_schema_versions_are_versioned():
+    artifact = _input()
+    core = build_core_output(artifact, _record(artifact))
+    assert artifact.document["schema_version"] == SCORING_INPUT_SCHEMA
+    assert core.document["schema_version"] == SCORING_CORE_OUTPUT_SCHEMA
+
+
+def test_versioned_input_and_core_schemas_validate():
+    root = Path(__file__).resolve().parents[1] / "configs/prediction/market-form-residual-v1"
+    input_schema = json.loads((root / "scoring-input.schema.json").read_bytes())
+    core_schema = json.loads((root / "scoring-core-output.schema.json").read_bytes())
+    artifact = _input()
+    core = build_core_output(artifact, _record(artifact))
+    Draft202012Validator(input_schema).validate(artifact.document)
+    Draft202012Validator(core_schema).validate(core.document)
+
+
+def test_contract_module_has_no_persistence_or_live_access_surface():
+    import src.predictor.scoring_parity as module
+
+    assert not {"sqlite3", "requests", "httpx", "subprocess", "playwright"} & set(module.__dict__)
+    assert not any(
+        key in module.__dict__
+        for key in ("phase7", "promotion", "ev", "stake", "bet", "outcome", "result")
+    )


### PR DESCRIPTION
## Summary

- Add versioned canonical scoring-input and scoring-core-output contracts shared by the automatic and manual residual-scoring lanes.
- Validate ordered 16-feature inputs, runner identity/order, strict odds, timestamps, hashes, numeric canonicalization, and outcome-free provenance.
- Bind canonical input/core SHA-256 values into both lane outputs and add deterministic first-difference diagnostics.
- Keep `score_race` as the sole scoring implementation; no model/features or eligibility changes.

## Validation

- Exact base: `a6b5a7bcba93716add6ba57c2d501447589e02a5`
- Reviewed commit: `61fed7c81b643786cfe66e41ca7351e8383bb9a6`
- Focused forecasting/manual suite: 333 passed
- Ruff syntax/error subset, targeted Ruff, Black, py_compile, JSON schema parsing, and `git diff --check`: passed

## Scope boundaries

No SQLite/canonical history, results/outcomes, Phase 7, network/browser, service/timer, promotion, EV, staking, betting, retraining, live prediction, or current-index eligibility changes.