### PR TITLE
CI: route backend tests by changed paths

### DIFF
--- a/.github/backend-test-paths.ini
+++ b/.github/backend-test-paths.ini
@@ -1,0 +1,66 @@
+[metadata]
+schema_version = backend-test-routing-v1
+
+[backend_excluded]
+patterns =
+    .editorconfig
+    .gitignore
+    .github/forecasting-paths.ini
+    .github/workflows/forecasting-tests.yml
+    CHANGELOG.md
+    LICENSE
+    LICENSE.*
+    README.md
+    configs/prediction/manual-independent-capture-v1/**
+    configs/prediction/manual-readiness-v1/**
+    configs/prediction/market-only.json
+    docs/**
+    race_collection/manual_prediction_collector_request.py
+    race_collection/manual_scoring_readiness.py
+    race_collection/synchronous_manual_capture.py
+    reports/**
+    scripts/ci/**
+    scripts/predict_race_now.py
+    scripts/predict_market_form_residual.py
+    src/predictor/manual_independent_capture.py
+    src/predictor/manual_independent_capture_executor.py
+    src/predictor/manual_independent_capture_sealer.py
+    src/predictor/market_form_residual.py
+    src/predictor/manual_research_scoring.py
+    src/predictor/manual_research_cli.py
+    src/predictor/on_demand.py
+    src/predictor/scoring_parity.py
+    tests/ci/**
+    tests/fixtures/manual_independent_capture_child.py
+    tests/race_collection/**
+    tests/test_form_guide_delimiter_normalization.py
+    tests/test_manual_independent_capture.py
+    tests/test_manual_independent_capture_executor.py
+    tests/test_manual_independent_capture_sealer.py
+    tests/test_manual_research_scoring.py
+    tests/test_manual_research_cli.py
+    tests/test_market_form_residual.py
+    tests/test_market_form_residual_portability.py
+    tests/test_manual_research_deployment.py
+    tests/test_predict_market_form_residual.py
+    tests/test_predict_race_now.py
+    tests/test_prediction_bundle_sealed.py
+    tests/test_scoring_parity.py
+
+[ui_only]
+patterns =
+    cypress.config.js
+    cypress/**
+    package-lock.json
+    package.json
+    playwright*.config.js
+    postcss.config.js
+    static/**
+    templates/**
+    tests/playwright/**
+    webpack.config.js
+
+[ui_backend]
+patterns =
+    .github/workflows/backend-tests.yml
+    app.py

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -14,7 +14,64 @@ env:
   OPENAI_USE_LIVE: 0
 
 jobs:
-  test:
+  classify:
+    name: backend-tests-routing
+    runs-on: ubuntu-latest
+    outputs:
+      backend_required: ${{ steps.classify.outputs.backend_required }}
+      ui_e2e_required: ${{ steps.classify.outputs.ui_e2e_required }}
+      trusted: ${{ steps.classify.outputs.trusted }}
+      reason: ${{ steps.classify.outputs.reason }}
+
+    steps:
+      - name: Check out exact validation head with history
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Validate backend routing contract
+        run: python3 tests/ci/test_backend_change_classifier.py
+
+      - name: Classify changed paths
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        shell: bash
+        run: |
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            python3 scripts/ci/classify_backend_changes.py \
+              --force-all \
+              --github-output "$GITHUB_OUTPUT"
+          else
+            python3 scripts/ci/classify_backend_changes.py \
+              --base "$BASE_SHA" \
+              --head "$HEAD_SHA" \
+              --github-output "$GITHUB_OUTPUT"
+          fi
+
+      - name: Summarize backend routing
+        env:
+          BACKEND_REQUIRED: ${{ steps.classify.outputs.backend_required }}
+          CLASSIFIER_REASON: ${{ steps.classify.outputs.reason }}
+          ROUTING_TRUSTED: ${{ steps.classify.outputs.trusted }}
+          UI_E2E_REQUIRED: ${{ steps.classify.outputs.ui_e2e_required }}
+        run: |
+          {
+            echo "### Backend test routing"
+            echo
+            echo "- Backend validation: \`$BACKEND_REQUIRED\`"
+            echo "- UI E2E validation: \`$UI_E2E_REQUIRED\`"
+            echo "- Trusted classification: \`$ROUTING_TRUSTED\`"
+            echo "- Reason: \`$CLASSIFIER_REASON\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  backend_heavy:
+    name: backend-unit-tests (3.11)
+    needs: classify
+    if: needs.classify.result == 'success' && needs.classify.outputs.backend_required == 'true'
     runs-on: ubuntu-latest
     
     services:
@@ -151,7 +208,36 @@ jobs:
         name: coverage-report-${{ matrix.python-version }}
         path: htmlcov/
 
-  comprehensive-tests:
+  test:
+    name: test (3.11)
+    needs: [classify, backend_heavy]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enforce backend classification and report stable check
+        env:
+          BACKEND_REQUIRED: ${{ needs.classify.outputs.backend_required }}
+          BACKEND_RESULT: ${{ needs.backend_heavy.result }}
+          CLASSIFIER_RESULT: ${{ needs.classify.result }}
+          ROUTING_TRUSTED: ${{ needs.classify.outputs.trusted }}
+        run: |
+          if [[ "$CLASSIFIER_RESULT" != "success" || "$ROUTING_TRUSTED" != "true" ]]; then
+            echo "Backend routing classification was not trusted."
+            exit 1
+          fi
+          if [[ "$BACKEND_REQUIRED" == "true" && "$BACKEND_RESULT" != "success" ]]; then
+            echo "Backend validation result: $BACKEND_RESULT"
+            exit 1
+          fi
+          if [[ "$BACKEND_REQUIRED" == "false" ]]; then
+            echo "Backend validation skipped: classified as non-backend scope."
+          fi
+
+  comprehensive_heavy:
+    name: comprehensive-backend-tests
+    needs: classify
+    if: needs.classify.result == 'success' && needs.classify.outputs.backend_required == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     
@@ -199,9 +285,40 @@ jobs:
         fail_ci_if_error: false
       if: success()
 
-  ui-e2e:
+  comprehensive-tests:
+    name: comprehensive-tests
+    needs: [classify, comprehensive_heavy]
+    if: always()
     runs-on: ubuntu-latest
-    needs: [test]
+
+    steps:
+      - name: Enforce backend classification and report stable check
+        env:
+          BACKEND_REQUIRED: ${{ needs.classify.outputs.backend_required }}
+          CLASSIFIER_RESULT: ${{ needs.classify.result }}
+          COMPREHENSIVE_RESULT: ${{ needs.comprehensive_heavy.result }}
+          ROUTING_TRUSTED: ${{ needs.classify.outputs.trusted }}
+        run: |
+          if [[ "$CLASSIFIER_RESULT" != "success" || "$ROUTING_TRUSTED" != "true" ]]; then
+            echo "Backend routing classification was not trusted."
+            exit 1
+          fi
+          if [[ "$BACKEND_REQUIRED" == "true" && "$COMPREHENSIVE_RESULT" != "success" ]]; then
+            echo "Comprehensive backend validation result: $COMPREHENSIVE_RESULT"
+            exit 1
+          fi
+          if [[ "$BACKEND_REQUIRED" == "false" ]]; then
+            echo "Comprehensive backend validation skipped: classified as non-backend scope."
+          fi
+
+  ui_e2e_heavy:
+    name: ui-e2e-tests
+    needs: [classify, test]
+    if: >-
+      needs.classify.result == 'success' &&
+      needs.test.result == 'success' &&
+      needs.classify.outputs.ui_e2e_required == 'true'
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       PORT: 5002
@@ -299,3 +416,29 @@ jobs:
           if [ -f server.pid ]; then kill $(cat server.pid) || true; fi
           sleep 1
           pkill -f "python app.py" || true
+
+  ui-e2e:
+    name: ui-e2e
+    needs: [classify, ui_e2e_heavy]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enforce UI E2E classification and report stable check
+        env:
+          CLASSIFIER_RESULT: ${{ needs.classify.result }}
+          ROUTING_TRUSTED: ${{ needs.classify.outputs.trusted }}
+          UI_E2E_REQUIRED: ${{ needs.classify.outputs.ui_e2e_required }}
+          UI_E2E_RESULT: ${{ needs.ui_e2e_heavy.result }}
+        run: |
+          if [[ "$CLASSIFIER_RESULT" != "success" || "$ROUTING_TRUSTED" != "true" ]]; then
+            echo "Backend routing classification was not trusted."
+            exit 1
+          fi
+          if [[ "$UI_E2E_REQUIRED" == "true" && "$UI_E2E_RESULT" != "success" ]]; then
+            echo "UI E2E validation result: $UI_E2E_RESULT"
+            exit 1
+          fi
+          if [[ "$UI_E2E_REQUIRED" == "false" ]]; then
+            echo "UI E2E validation skipped: no UI/API integration paths changed."
+          fi

--- a/scripts/ci/classify_backend_changes.py
+++ b/scripts/ci/classify_backend_changes.py
@@ -1,0 +1,237 @@
+"""Classify changed paths for the stable backend test checks."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import fnmatch
+import json
+import subprocess
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_RULES = ROOT / ".github/backend-test-paths.ini"
+DESTRUCTIVE_STATUS_PREFIXES = frozenset({"C", "D", "R", "T"})
+
+
+class ClassificationError(RuntimeError):
+    """The changed paths or classifier rules cannot be classified safely."""
+
+
+@dataclass(frozen=True)
+class Change:
+    status: str
+    paths: tuple[str, ...]
+
+
+def _is_known_status(status: str) -> bool:
+    if status in {"A", "D", "M", "T"}:
+        return True
+    score = status[1:]
+    return (
+        status[:1] in {"C", "R"}
+        and 1 <= len(score) <= 3
+        and score.isdigit()
+        and 0 <= int(score) <= 100
+    )
+
+
+def _normalize_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    candidate = PurePosixPath(normalized)
+    if (
+        not normalized
+        or normalized.startswith("/")
+        or any(part in {"", ".", ".."} for part in candidate.parts)
+    ):
+        raise ClassificationError(f"unsafe changed path: {path!r}")
+    return candidate.as_posix()
+
+
+def load_rules(path: Path = DEFAULT_RULES) -> dict[str, tuple[str, ...]]:
+    parser = configparser.ConfigParser(interpolation=None)
+    try:
+        with path.open(encoding="utf-8") as rules_file:
+            parser.read_file(rules_file)
+    except (OSError, configparser.Error) as exc:
+        raise ClassificationError(f"unable to load classifier rules: {exc}") from exc
+
+    if parser.get("metadata", "schema_version", fallback=None) != (
+        "backend-test-routing-v1"
+    ):
+        raise ClassificationError("unsupported classifier rules schema")
+    if set(parser.sections()) - {"metadata"} != {
+        "backend_excluded",
+        "ui_only",
+        "ui_backend",
+    }:
+        raise ClassificationError("classifier rules must define exactly three sections")
+
+    rules: dict[str, tuple[str, ...]] = {}
+    for section in ("backend_excluded", "ui_only", "ui_backend"):
+        patterns = tuple(
+            line.strip()
+            for line in parser.get(section, "patterns", fallback="").splitlines()
+            if line.strip()
+        )
+        if not patterns:
+            raise ClassificationError(f"invalid patterns for {section}")
+        rules[section] = patterns
+    return rules
+
+
+def _matches(path: str, patterns: Sequence[str]) -> bool:
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns)
+
+
+def _fail_closed(reason: str, paths: Sequence[Mapping[str, Any]] = ()) -> dict[str, Any]:
+    return {
+        "backend_required": True,
+        "ui_e2e_required": True,
+        "trusted": False,
+        "reason": reason,
+        "paths": list(paths),
+    }
+
+
+def classify_changes(
+    changes: Iterable[Change], rules: Mapping[str, Sequence[str]]
+) -> dict[str, Any]:
+    change_list = list(changes)
+    if not change_list:
+        return _fail_closed("empty_change_set_defaults_to_backend")
+
+    classified_paths: list[dict[str, Any]] = []
+    backend_required = False
+    ui_e2e_required = False
+    for change in change_list:
+        if not _is_known_status(change.status) or not change.paths:
+            return _fail_closed(
+                f"unknown_change_status:{change.status or 'empty'}",
+                classified_paths,
+            )
+        destructive_change = change.status[:1] in DESTRUCTIVE_STATUS_PREFIXES
+        for path in change.paths:
+            try:
+                normalized = _normalize_path(path)
+            except ClassificationError as exc:
+                return _fail_closed(f"uncertain_path:{exc}", classified_paths)
+
+            ui_only = _matches(normalized, rules["ui_only"])
+            ui_match = ui_only or _matches(normalized, rules["ui_backend"])
+            excluded = ui_only or _matches(normalized, rules["backend_excluded"])
+            if destructive_change or not excluded:
+                backend_required = True
+            ui_e2e_required = ui_e2e_required or ui_match
+            classified_paths.append(
+                {
+                    "path": normalized,
+                    "status": change.status,
+                    "backend_excluded": excluded,
+                    "ui_e2e_match": ui_match,
+                    "defaulted_to_backend": not excluded,
+                }
+            )
+
+    if backend_required:
+        reason = "backend_risk_path_or_destructive_change"
+    elif ui_e2e_required:
+        reason = "ui_e2e_only_paths"
+    else:
+        reason = "known_non_backend_paths"
+    return {
+        "backend_required": backend_required,
+        "ui_e2e_required": ui_e2e_required,
+        "trusted": True,
+        "reason": reason,
+        "paths": classified_paths,
+    }
+
+
+def parse_name_status(raw: bytes) -> list[Change]:
+    tokens = raw.split(b"\0")
+    if tokens and tokens[-1] == b"":
+        tokens.pop()
+    changes: list[Change] = []
+    index = 0
+    try:
+        while index < len(tokens):
+            status = tokens[index].decode("utf-8")
+            index += 1
+            path_count = 2 if status[:1] in {"R", "C"} else 1
+            paths = tuple(
+                tokens[position].decode("utf-8")
+                for position in range(index, index + path_count)
+            )
+            index += path_count
+            changes.append(Change(status=status, paths=paths))
+    except (IndexError, UnicodeDecodeError) as exc:
+        raise ClassificationError("malformed git name-status output") from exc
+    if index != len(tokens):
+        raise ClassificationError("trailing git name-status fields")
+    return changes
+
+
+def git_changes(base: str, head: str) -> list[Change]:
+    command = [
+        "git",
+        "diff",
+        "--name-status",
+        "-z",
+        "--find-renames",
+        "--find-copies",
+        f"{base}...{head}",
+    ]
+    try:
+        raw = subprocess.check_output(command, cwd=ROOT)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ClassificationError(f"git diff failed: {exc}") from exc
+    return parse_name_status(raw)
+
+
+def write_github_output(path: Path, result: Mapping[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        for key in ("backend_required", "ui_e2e_required", "trusted"):
+            output.write(f"{key}={str(bool(result[key])).lower()}\n")
+        output.write(f"reason={result['reason']}\n")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base")
+    parser.add_argument("--head")
+    parser.add_argument("--force-all", action="store_true")
+    parser.add_argument("--rules", type=Path, default=DEFAULT_RULES)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args(argv)
+    if not args.force_all and not (args.base and args.head):
+        parser.error("--base and --head are required unless --force-all is used")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.force_all:
+            result = {
+                "backend_required": True,
+                "ui_e2e_required": True,
+                "trusted": True,
+                "reason": "non_pull_request_defaults_to_all_backend_checks",
+                "paths": [],
+            }
+        else:
+            result = classify_changes(git_changes(args.base, args.head), load_rules(args.rules))
+    except ClassificationError as exc:
+        result = _fail_closed(f"classifier_error:{exc}")
+    if args.github_output:
+        write_github_output(args.github_output, result)
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_backend_change_classifier.py
+++ b/tests/ci/test_backend_change_classifier.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import importlib.util
+import itertools
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "classify_backend_changes",
+    ROOT / "scripts/ci/classify_backend_changes.py",
+)
+assert SPEC and SPEC.loader
+CLASSIFIER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CLASSIFIER
+SPEC.loader.exec_module(CLASSIFIER)
+
+
+class BackendChangeClassifierTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rules = CLASSIFIER.load_rules()
+
+    def classify(self, *paths: str) -> dict:
+        return CLASSIFIER.classify_changes(
+            [CLASSIFIER.Change(status="M", paths=(path,)) for path in paths],
+            self.rules,
+        )
+
+    def test_rules_are_explicit_and_nonempty(self):
+        self.assertEqual(
+            set(self.rules), {"backend_excluded", "ui_only", "ui_backend"}
+        )
+        self.assertTrue(self.rules["backend_excluded"])
+        self.assertTrue(self.rules["ui_only"])
+        self.assertTrue(self.rules["ui_backend"])
+
+    def test_ghu058_style_manual_prediction_paths_skip_backend_and_ui(self):
+        result = self.classify(
+            ".github/forecasting-paths.ini",
+            ".github/workflows/forecasting-tests.yml",
+            "configs/prediction/manual-readiness-v1/scoring-readiness.schema.json",
+            "docs/manual_prediction_scoring_readiness.md",
+            "race_collection/manual_scoring_readiness.py",
+            "race_collection/synchronous_manual_capture.py",
+            "scripts/ci/classify_forecasting_changes.py",
+            "scripts/ci/run_forecasting_ci_contract.py",
+            "tests/ci/test_forecasting_change_classifier.py",
+            "tests/race_collection/test_manual_scoring_readiness.py",
+        )
+        self.assertEqual(
+            (result["backend_required"], result["ui_e2e_required"]),
+            (False, False),
+        )
+        self.assertTrue(result["trusted"])
+
+    def test_docs_only_skips_expensive_jobs(self):
+        result = self.classify("docs/forecasting_ci_tiers.md", "README.md")
+        self.assertEqual(
+            (result["backend_required"], result["ui_e2e_required"]),
+            (False, False),
+        )
+
+    def test_manual_prediction_only_paths_skip_backend(self):
+        result = self.classify(
+            "race_collection/manual_prediction_collector_request.py",
+            "scripts/predict_race_now.py",
+            "src/predictor/on_demand.py",
+            "tests/test_predict_race_now.py",
+            "tests/test_prediction_bundle_sealed.py",
+        )
+        self.assertEqual(
+            (result["backend_required"], result["ui_e2e_required"]),
+            (False, False),
+        )
+
+    def test_backend_risk_paths_run_backend_without_unrelated_ui(self):
+        for path in (
+            "app.py",
+            "alembic/versions/123_add_column.py",
+            "migrations/add_db_meta_table.py",
+            "requirements/requirements.lock",
+            "tests/test_flask_api.py",
+            "tests/test_database_integrity.py",
+            "src/shared_backend_helper.py",
+        ):
+            with self.subTest(path=path):
+                result = self.classify(path)
+                self.assertTrue(result["backend_required"])
+                self.assertEqual(result["ui_e2e_required"], path == "app.py")
+
+    def test_ui_only_paths_run_only_ui_e2e(self):
+        for path in (
+            "static/css/operator-ui.css",
+            "templates/operator_ui_connected.jinja",
+            "cypress/e2e/test-helper-routes.cy.js",
+            "tests/playwright/nav-dropdowns-hidden.spec.ts",
+            "package-lock.json",
+        ):
+            with self.subTest(path=path):
+                result = self.classify(path)
+                self.assertEqual(
+                    (result["backend_required"], result["ui_e2e_required"]),
+                    (False, True),
+                )
+
+    def test_mixed_ui_and_backend_paths_run_both(self):
+        result = self.classify("static/app.js", "app.py")
+        self.assertEqual(
+            (result["backend_required"], result["ui_e2e_required"]),
+            (True, True),
+        )
+
+    def test_unknown_source_path_fails_closed_to_backend(self):
+        result = self.classify("src/new_shared_runtime_module.py")
+        self.assertTrue(result["backend_required"])
+        self.assertFalse(result["ui_e2e_required"])
+        self.assertEqual(result["reason"], "backend_risk_path_or_destructive_change")
+
+    def test_workflow_change_runs_backend_and_ui_checks(self):
+        result = self.classify(".github/workflows/backend-tests.yml")
+        self.assertEqual(
+            (result["backend_required"], result["ui_e2e_required"]),
+            (True, True),
+        )
+
+    def test_destructive_changes_fail_closed(self):
+        result = CLASSIFIER.classify_changes(
+            [CLASSIFIER.Change(status="D", paths=("docs/old.md",))], self.rules
+        )
+        self.assertTrue(result["backend_required"])
+
+    def test_malformed_changes_fail_closed(self):
+        result = CLASSIFIER.classify_changes(
+            [CLASSIFIER.Change(status="", paths=())], self.rules
+        )
+        self.assertFalse(result["trusted"])
+        self.assertTrue(result["backend_required"])
+
+    def test_all_pairs_of_known_safe_families_remain_safe(self):
+        safe_paths = (
+            "docs/example.md",
+            "scripts/ci/example.py",
+            "tests/ci/example.py",
+            "scripts/predict_market_form_residual.py",
+        )
+        for left, right in itertools.combinations(safe_paths, 2):
+            with self.subTest(left=left, right=right):
+                result = self.classify(left, right)
+                self.assertFalse(result["backend_required"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_forecasting_change_classifier.py
+++ b/tests/ci/test_forecasting_change_classifier.py
@@ -252,8 +252,33 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
         self.assertIs(result["ci_contract_changed"], True)
 
     def test_ghu_058_exact_changed_path_set_selects_manual_prediction(self):
-        changes = CLASSIFIER.git_changes(
-            "5e9a370477a905a67bdcb26c9b9315ef0050b362", "HEAD"
+        changes = [
+            CLASSIFIER.Change(status=status, paths=(path,))
+            for status, path in (
+                ("M", ".github/forecasting-paths.ini"),
+                ("M", ".github/workflows/forecasting-tests.yml"),
+                (
+                    "A",
+                    "configs/prediction/manual-readiness-v1/scoring-readiness.schema.json",
+                ),
+                ("A", "docs/manual_prediction_scoring_readiness.md"),
+                ("A", "race_collection/manual_scoring_readiness.py"),
+                ("M", "scripts/ci/classify_forecasting_changes.py"),
+                ("M", "scripts/ci/run_forecasting_ci_contract.py"),
+                ("M", "tests/ci/test_forecasting_change_classifier.py"),
+                ("A", "tests/race_collection/test_manual_scoring_readiness.py"),
+            )
+        ]
+        changes.extend(
+            [
+                CLASSIFIER.Change(
+                    status="M",
+                    paths=("race_collection/synchronous_manual_capture.py",),
+                    manual_prediction_paths=(
+                        "race_collection/synchronous_manual_capture.py",
+                    ),
+                ),
+            ]
         )
         changed_paths = {
             path for change in changes for path in change.paths


### PR DESCRIPTION
## Summary

- Add a deterministic, policy-backed changed-path classifier for backend and UI-E2E eligibility.
- Keep the existing required check names (`test (3.11)`, `comprehensive-tests`, and `ui-e2e`) as lightweight always-running gates.
- Run PostgreSQL/Redis backend jobs only for backend-relevant paths; run UI E2E only for UI-only or Flask/UI integration paths.
- Preserve fail-closed behavior for unknown, destructive, shared, dependency, migration, database, backend, and workflow paths.

## Routing matrix

| Changed paths | Backend heavy jobs | UI E2E |
| --- | --- | --- |
| GHU-058-style manual-prediction paths | skipped with successful stable gates | skipped with successful stable gate |
| docs-only | skipped with successful stable gates | skipped with successful stable gate |
| `app.py` / Flask integration | runs | runs |
| migrations, schema, database, backend tests, requirements/lockfiles | runs | skipped unless UI/API integration is also matched |
| static/templates/Cypress/Playwright/package UI paths | skipped | runs |
| unknown/shared source path | runs | only if explicitly UI/API matched |
| pushes to the existing protected branches | runs all existing heavy surfaces, preserving push behavior | runs |

## Validation

- `python3 tests/ci/test_backend_change_classifier.py` — 12 passed
- `python3 tests/ci/test_forecasting_change_classifier.py` — 28 passed
- `uv run --no-project --with ruff ruff check scripts/ci/classify_backend_changes.py tests/ci/test_backend_change_classifier.py`
- Backend workflow YAML parse and stable gate-name assertions passed
- `python3 -m py_compile scripts/ci/classify_backend_changes.py tests/ci/test_backend_change_classifier.py`
- `git diff --check` passed
- Full backend/UI suites were not run because this is a routing-only change.

## Identity and scope

- Base: `1c937b53491787f1e54b16d235f7536af48c3c85`
- Base tree: `78ffa1301b064136f688697ac6881e700232b0ee`
- Candidate: `7a80692de0ea01663c7aeb711f555162b3ad33a0`
- Candidate tree: `ecd3332282f2688c692eeebbfe6d3debee2c69a2`
- Changed paths: `.github/backend-test-paths.ini`, `.github/workflows/backend-tests.yml`, `scripts/ci/classify_backend_changes.py`, `tests/ci/test_backend_change_classifier.py`

No product, runtime, model, database, deployment, or merge changes are included.
