### PR TITLE
GHU-060 add bounded live manual capture runtime

### DIFF
--- a/.github/forecasting-paths.ini
+++ b/.github/forecasting-paths.ini
@@ -86,6 +86,7 @@ patterns =
     configs/prediction/manual-independent-capture-v1/**
     configs/prediction/manual-readiness-v1/**
     configs/prediction/market-only.json
+    docs/agent_tasks/ghu_060_live_manual_capture_runtime_v1_20260808.md
     docs/manual_independent_capture_v1.md
     docs/manual_prediction_scoring_readiness.md
     docs/manual_research_prediction_cli.md
@@ -97,12 +98,19 @@ patterns =
     src/predictor/market_form_residual.py
     src/predictor/manual_research_scoring.py
     src/predictor/manual_research_cli.py
+    src/predictor/manual_live_capture.py
+    src/predictor/manual_live_capture_child.py
+    src/predictor/manual_research_deployment.py
+    src/predictor/manual_research_worker.py
+    ops/systemd/manual-research-api.service.in
     tests/fixtures/manual_independent_capture_child.py
     tests/test_manual_independent_capture.py
     tests/test_manual_independent_capture_executor.py
     tests/test_manual_independent_capture_sealer.py
     tests/test_manual_research_scoring.py
     tests/test_manual_research_cli.py
+    tests/test_manual_live_capture.py
+    tests/test_manual_research_deployment.py
     tests/test_market_form_residual.py
     tests/test_market_form_residual_portability.py
     tests/test_predict_market_form_residual.py

--- a/.github/workflows/forecasting-tests.yml
+++ b/.github/workflows/forecasting-tests.yml
@@ -183,6 +183,8 @@ jobs:
                 tests/test_manual_independent_capture_sealer.py \
                 tests/test_manual_research_scoring.py \
                 tests/test_manual_research_cli.py \
+                tests/test_manual_live_capture.py \
+                tests/test_manual_research_deployment.py \
                 tests/test_market_form_residual.py \
                 tests/test_market_form_residual_portability.py \
                 tests/test_predict_market_form_residual.py \

--- a/configs/prediction/manual-independent-capture-v1/evidence-bundle.schema.json
+++ b/configs/prediction/manual-independent-capture-v1/evidence-bundle.schema.json
@@ -114,7 +114,7 @@
         "status_code": {"const": 200},
         "content_type": {"type": "string", "minLength": 1, "maxLength": 256, "pattern": "^(?!\\s)(?![\\s\\S]*\\s$)[\\u0020-\\u007e]+$"},
         "metadata_sha256": {"$ref": "#/$defs/sha256"},
-        "odds_parser": {"enum": ["manual_fixture_csv_odds_v1", "manual_fixture_json_odds_v1"]},
+        "odds_parser": {"enum": ["manual_fixture_csv_odds_v1", "manual_fixture_json_odds_v1", "manual_live_json_odds_v1"]},
         "parsed_odds_sha256": {"$ref": "#/$defs/sha256"},
         "raw_path": {"const": "source/raw.bin"},
         "bytes": {"type": "integer", "minimum": 1, "maximum": 2097152},

--- a/docs/agent_tasks/ghu_060_live_manual_capture_runtime_v1_20260808.md
+++ b/docs/agent_tasks/ghu_060_live_manual_capture_runtime_v1_20260808.md
@@ -56,6 +56,7 @@ allowed_files:
   - src/predictor/manual_live_capture_child.py
   - src/predictor/manual_research_deployment.py
   - src/predictor/manual_research_worker.py
+  - tests/ci/test_forecasting_change_classifier.py
   - tests/test_manual_independent_capture_executor.py
   - tests/test_manual_independent_capture_sealer.py
   - tests/test_manual_live_capture.py

--- a/docs/agent_tasks/ghu_060_live_manual_capture_runtime_v1_20260808.md
+++ b/docs/agent_tasks/ghu_060_live_manual_capture_runtime_v1_20260808.md
@@ -1,0 +1,132 @@
+---
+job_id: GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808
+title: Implement the bounded live manual capture runtime for GHU-051/GHU-052
+lane: Query Orchestration
+supporting_lanes:
+  - Provenance
+  - Runtime Safety
+  - Reporting
+owner: Codex
+approval_required: true
+approval_source: >-
+  The owner's 2026-08-08 /goal explicitly authorizes the bounded repository
+  implementation, focused validation, independent review, dedicated commit and
+  review-ready PR; it forbids live attempts, deployment, activation, service
+  lifecycle changes, lock manipulation, merge, and canonical/runtime mutation.
+allow_unapproved_safe_extension: false
+timeout_seconds: 43200
+mutation_mode: safe_extension
+base: 1c937b53491787f1e54b16d235f7536af48c3c85
+base_tree: 78ffa1301b064136f688697ac6881e700232b0ee
+production_data_access: false
+production_data_boundary: >-
+  Controlled local fixtures and mocked browser/process tests only. No live
+  browser or source attempt, network execution, SQLite, canonical database or
+  history, result evidence, autonomous lock/profile/state/process, Phase 7,
+  service installation/activation/restart, model/scoring change, betting,
+  promotion, or merge.
+github_mutation_allowed: true
+git_history_mutation_allowed: true
+live_service_mutation_allowed: false
+closeout_scope: repo_and_publish
+docs_impact: DOCS_REQUIRED
+task_tier: large
+recommended_model: high_reasoning
+actual_model: gpt-5
+why_this_model: >-
+  Browser isolation, exact-race provenance, process cleanup, parent validation,
+  deployment binding, and immutable evidence compatibility cross several safety
+  surfaces.
+worker_model_allowed: false
+worker_decision_limit: >-
+  No delegated implementation; the primary agent owns scope, integration,
+  review, GitHub publication, and final claims.
+escalation_needed: false
+output_dir: reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808
+allowed_files:
+  - .github/forecasting-paths.ini
+  - .github/workflows/forecasting-tests.yml
+  - configs/prediction/manual-independent-capture-v1/evidence-bundle.schema.json
+  - docs/agent_tasks/ghu_060_live_manual_capture_runtime_v1_20260808.md
+  - docs/manual_independent_capture_v1.md
+  - ops/systemd/manual-research-api.service.in
+  - src/predictor/manual_independent_capture_executor.py
+  - src/predictor/manual_independent_capture_sealer.py
+  - src/predictor/manual_live_capture.py
+  - src/predictor/manual_live_capture_child.py
+  - src/predictor/manual_research_deployment.py
+  - src/predictor/manual_research_worker.py
+  - tests/test_manual_independent_capture_executor.py
+  - tests/test_manual_independent_capture_sealer.py
+  - tests/test_manual_live_capture.py
+  - tests/test_manual_research_deployment.py
+  - reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/README.md
+  - reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/STATE.md
+  - reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/DECISIONS.md
+  - reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/VALIDATION.md
+  - reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/REVIEW.md
+  - reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/CODE_REVIEW.json
+  - reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/RUN_OUTCOME.json
+  - reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/guard-preflight.json
+  - reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/guard-final.json
+  - reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/pr-body.md
+  - reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/final-refs.json
+control_contract_version: 2
+project_id: greyhound_racing_collector
+claim_id: GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808
+proof_question: >-
+  Can one explicit exact race and bound expected runner set traverse the
+  existing GHU-051 executor through a dedicated manual browser profile and
+  single child attempt, emit the unchanged child envelope, and pass unchanged
+  GHU-052 sealing semantics using a versioned live source identity, while all
+  redirects, challenges, malformed data, mismatches, invalid odds, timing
+  failures, retries, discovery, substitution, and protected-path access fail
+  closed?
+hypothesis_id: ghu_060_bounded_live_manual_child_fixture_proven
+program_track: offline_development
+entry_state: >-
+  GHU-059 stopped fail-closed at the runtime gate: merged GHU-051 remains
+  fixture-only, no live child or default CLI exists, and no safe manual runtime
+  is installed; canonical origin/master is bound to the declared base/tree.
+target_transition: >-
+  One focused review-ready change adds only the bounded live child, explicit
+  executor runner binding, live evidence parser identity, default-off package
+  binding, focused tests, classifier routing, and architecture documentation.
+exit_predicate: >-
+  Exact master identity remains bound; the live adapter has no discovery,
+  fallback, retry, result access, or autonomous dependency; controlled fixtures
+  prove success and every required fail-closed case; existing fixture tests and
+  GHU-052 sealing remain valid; focused classifier/test/compile/diff/review
+  gates pass; no live attempt, install, activation, restart, lock mutation,
+  canonical/Phase 7/scoring/model change, merge, or deployment occurs.
+source_class: exact_origin_master_1c937b53_tree_78ffa130_plus_ghu059_runtime_blocker
+dataset_version: ghu_060_live_manual_child_controlled_fixture_v1
+evidence_hash: sha256:f5754710052f9432a5252495a528c41fbe945db24f88e93bc9e4c3bc1e94853e
+capabilities:
+  - READ
+  - REPORT_WRITE
+  - CODE_EDIT
+  - PUBLISH
+resume_only_if: >-
+  Continue only while origin/master and the clean task worktree remain at the
+  declared base, the diff stays inside allowed_files, the implementation uses
+  the existing GHU-051 executor and GHU-052 validator boundaries, no live or
+  autonomous authority is crossed, and all cleanup/provenance checks pass.
+---
+
+# GHU-060 bounded live manual capture runtime
+
+This implementation closes the GHU-059 runtime gap without creating a second
+capture contract. The live child is a parent-launched Playwright process that
+uses only the exact URL, race ID, dedicated profile, and run directory supplied
+by GHU-051. It extracts only the pre-jump runner/strict WIN-odds surface and
+returns the existing exact child envelope. The parent remains authoritative for
+identity, runner binding, odds, timestamps, source bytes, timeout, and process
+group cleanup.
+
+The default-off GHU-056 package records the reviewed live entrypoints and their
+hashes but does not enable or start them. The bounded CLI requires explicit
+race and expected-runner inputs; it has no discovery or substitution mode.
+
+Acceptance is controlled-fixture proof only. No real browser/source attempt is
+part of this task.

--- a/docs/manual_independent_capture_v1.md
+++ b/docs/manual_independent_capture_v1.md
@@ -80,11 +80,18 @@ runner.
 `src/predictor/manual_live_capture_child.py` is the only live source adapter.
 It receives only the parent-exported URL, race identity/hash, dedicated manual
 profile, and run directory. It opens one persistent manual Playwright context,
-performs one `goto` to that exact canonical TheDogs URL, rejects redirects,
-non-200 responses, login/challenge markers, result selectors, and malformed
-runner rows, and closes the context on every terminal path. It reads only the
-fixed runner-row selectors and explicit decimal WIN odds. It emits a canonical
-runner/odds sidecar with media type
+performs one `goto` to that exact canonical TheDogs URL, and installs a
+fail-closed request allowlist before the navigation. The allowlist permits only
+that exact top-level `GET` document navigation and query-free `GET` static
+assets under the trusted `https://www.thedogs.com.au/assets/` path, limited to
+reviewed stylesheet, script, image, and font extensions. It does not use
+same-origin as a safety rule; XHR, fetch, websocket, event-stream, document,
+subframe, API, result-like, unknown, and all other unclassified requests abort.
+The reviewed surface exposes no odds API endpoint, so no data-bearing request
+family is admitted. Redirects, non-200 responses, login/challenge markers,
+result selectors, and malformed runner rows are also rejected, and the context
+closes on every terminal path. It reads only the fixed runner-row selectors and
+explicit decimal WIN odds. It emits a canonical runner/odds sidecar with media type
 `application/vnd.greyhound.manual-live+json`; GHU-052 recognizes that media
 through the distinct `manual_live_json_odds_v1` parser identity while retaining
 the same strict odds, source-hash, timing, and outcome rejection semantics.

--- a/docs/manual_independent_capture_v1.md
+++ b/docs/manual_independent_capture_v1.md
@@ -1,12 +1,13 @@
 # Manual independent capture V1 contract
 
 `manual-independent-capture-v1` is an exact-race, research-only capture
-boundary. GHU-050 defines and validates the artifact contract. GHU-051 adds a
-fixture-only executor for its lock, path, process, timeout, cancellation, and
-terminal-artifact controls. GHU-052 adds an immutable atomic evidence seal and
-read-only verifier for terminal-success fixture captures with confirmed cleanup.
-The lane still does not provide a live fetch implementation, scoring, UI,
-deployment, or runtime integration.
+boundary. GHU-050 defines and validates the artifact contract. GHU-051 adds the
+executor for its lock, path, process, timeout, cancellation, and
+terminal-artifact controls; its original fixture child protocol remains
+unchanged. GHU-052 adds an immutable atomic evidence seal and read-only
+verifier. GHU-060 adds one versioned live child behind the same executor, plus
+an explicit default-off deployment binding. The lane still has no scoring,
+canonical, Phase 7, or autonomous-runtime authority.
 
 Every accepted configuration and terminal artifact is versioned, exact-field,
 canonically serializable, and validated by
@@ -44,7 +45,7 @@ attempt, no retry, and no replay. Minimum pre-jump margin, one absolute hard
 timeout, and one cancellation cleanup grace are bounded integers. The
 configuration cannot claim canonical or Phase 7 authority.
 
-## GHU-051 fixture executor
+## GHU-051 executor and GHU-060 live child
 
 `src/predictor/manual_independent_capture_executor.py` accepts one exact
 canonical TheDogs URL and its complete bound race identity. It validates the
@@ -64,15 +65,37 @@ and confirm that the process group is absent. PID, PGID, signal escalation, and
 reap proof are returned as `ManualCaptureExecution`; unconfirmed cleanup emits
 `PROCESS_REAP_UNCONFIRMED` and can never emit capture success.
 
-Fixture stdout is an exact-field, bounded child record. The parent accepts only
+Child stdout is an exact-field, bounded record. The parent accepts only
 the requested URL/race hash, one pre-jump source class, final URL equal to the
 requested exact race, HTTP status `200`, a control-free content type, and a
 GHU-050-valid runner/odds set. The returned execution binds those response
 values and the exact source-body hash for the immediate GHU-052 seal. It writes
 fixed members beneath the UUID run directory and writes `terminal.json` last,
 only after `validate_terminal_artifact` accepts the complete byte/hash binding.
-Tests—not production configuration—supply the fixture command. There is
-intentionally no CLI or default live/browser command.
+The legacy fixture schema is still accepted. The live child uses
+`manual_independent_capture_child_live_v1` and additionally binds the exact
+readiness runner set supplied by the parent; it cannot substitute a race or
+runner.
+
+`src/predictor/manual_live_capture_child.py` is the only live source adapter.
+It receives only the parent-exported URL, race identity/hash, dedicated manual
+profile, and run directory. It opens one persistent manual Playwright context,
+performs one `goto` to that exact canonical TheDogs URL, rejects redirects,
+non-200 responses, login/challenge markers, result selectors, and malformed
+runner rows, and closes the context on every terminal path. It reads only the
+fixed runner-row selectors and explicit decimal WIN odds. It emits a canonical
+runner/odds sidecar with media type
+`application/vnd.greyhound.manual-live+json`; GHU-052 recognizes that media
+through the distinct `manual_live_json_odds_v1` parser identity while retaining
+the same strict odds, source-hash, timing, and outcome rejection semantics.
+There is no discovery, retry, fallback, directory scan, autonomous state read,
+or result/outcome request.
+
+`src/predictor/manual_live_capture.py` is an explicit request-scoped wrapper,
+not a service mode. It requires one caller-supplied canonical race document
+and protected-path inventory, then delegates to the existing executor. The
+deployment generator records hashes and entrypoints for this wrapper and child
+but keeps the generated service and `MANUAL_RESEARCH_ENABLED=0` default-off.
 
 ## GHU-052 immutable evidence bundle
 
@@ -94,7 +117,10 @@ actual source response must bind the same exact race URL and bytes, status 200,
 an allowed content type for its source class, and no target outcome-shaped
 JSON/CSV/HTML field. The fixture child protocol is
 `manual_independent_capture_child_fixture_v2`; its source bytes carry the odds
-that the sealer parses through a closed, versioned parser vocabulary.
+that the sealer parses through a closed, versioned parser vocabulary. The live
+child's normalized sidecar is likewise bounded source bytes; it uses the
+distinct `manual_live_json_odds_v1` parser identity and is not an unrestricted
+page-body capture.
 
 The final directory is:
 
@@ -205,10 +231,11 @@ fields.
 
 ## Claims boundary and next ticket
 
-GHU-052 acceptance supports only: `fixture-proven sealed manual evidence`.
-It does not support live-source/browser success, prediction readiness, deployed
-runtime isolation, model quality, canonical coverage, Phase 7 eligibility,
-training, promotion, EV, staking, or betting.
+GHU-060 acceptance supports only controlled-fixture proof of the live child
+through the existing executor and sealer. It does not prove real live-source
+success, a real pre-jump prediction, deployed runtime isolation, model quality,
+canonical coverage, Phase 7 eligibility, training, promotion, EV, staking, or
+betting.
 
 GHU-053 may begin only from the accepted merged GHU-052 head and its reviewed
 exact tree, with the read-only verifier as its sole capture input. It must retain

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/CODE_REVIEW.json
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/CODE_REVIEW.json
@@ -2,46 +2,35 @@
   "status": "SUCCESS",
   "work_log": {
     "assumptions": [
-      "The existing GHU-051 executor remains the authority for process, timeout, lock, identity, and terminal artifacts.",
-      "No live browser or source execution is permitted by this ticket."
+      "The existing GHU-051 executor and GHU-052 sealer remain authoritative.",
+      "No live browser or source execution is permitted for this corrective pass."
     ],
     "sources_used": [
       "AGENTS.md",
       "docs/agent_tasks/ghu_060_live_manual_capture_runtime_v1_20260808.md",
-      "GHU-050/GHU-051/GHU-052 implementation and schemas",
-      "staged git diff"
+      "src/predictor/manual_live_capture_child.py",
+      "tests/test_manual_live_capture.py",
+      "docs/manual_independent_capture_v1.md",
+      "git diff"
     ],
     "files_read": [
-      "src/predictor/manual_independent_capture_executor.py",
-      "src/predictor/manual_independent_capture_sealer.py",
-      "src/predictor/manual_live_capture.py",
       "src/predictor/manual_live_capture_child.py",
-      "src/predictor/manual_research_deployment.py",
-      "src/predictor/manual_research_worker.py",
       "tests/test_manual_live_capture.py",
-      "tests/test_manual_research_deployment.py",
-      ".github/forecasting-paths.ini",
-      ".github/workflows/forecasting-tests.yml"
-    ],
-    "files_modified": [
-      ".github/forecasting-paths.ini",
-      ".github/workflows/forecasting-tests.yml",
-      "configs/prediction/manual-independent-capture-v1/evidence-bundle.schema.json",
       "docs/manual_independent_capture_v1.md",
       "src/predictor/manual_independent_capture_executor.py",
-      "src/predictor/manual_independent_capture_sealer.py",
-      "src/predictor/manual_live_capture.py",
+      "src/predictor/manual_independent_capture_sealer.py"
+    ],
+    "files_modified": [
       "src/predictor/manual_live_capture_child.py",
-      "src/predictor/manual_research_deployment.py",
-      "src/predictor/manual_research_worker.py",
       "tests/test_manual_live_capture.py",
-      "tests/test_manual_research_deployment.py"
+      "docs/manual_independent_capture_v1.md",
+      "reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/"
     ],
     "validation_checks": [
-      "git diff --cached --check",
-      "ruff check on modified implementation and tests",
-      "785 focused manual-tier tests passed",
-      "No live browser, service, lock, database, Phase-7, or merge action performed"
+      "31 focused network-policy tests passed",
+      "806 exact manual_prediction tests passed",
+      "forecasting and backend classifier contracts passed",
+      "Ruff, py_compile, YAML, JSON, schema, hardening, and diff checks passed"
     ]
   },
   "result": {

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/CODE_REVIEW.json
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/CODE_REVIEW.json
@@ -1,0 +1,52 @@
+{
+  "status": "SUCCESS",
+  "work_log": {
+    "assumptions": [
+      "The existing GHU-051 executor remains the authority for process, timeout, lock, identity, and terminal artifacts.",
+      "No live browser or source execution is permitted by this ticket."
+    ],
+    "sources_used": [
+      "AGENTS.md",
+      "docs/agent_tasks/ghu_060_live_manual_capture_runtime_v1_20260808.md",
+      "GHU-050/GHU-051/GHU-052 implementation and schemas",
+      "staged git diff"
+    ],
+    "files_read": [
+      "src/predictor/manual_independent_capture_executor.py",
+      "src/predictor/manual_independent_capture_sealer.py",
+      "src/predictor/manual_live_capture.py",
+      "src/predictor/manual_live_capture_child.py",
+      "src/predictor/manual_research_deployment.py",
+      "src/predictor/manual_research_worker.py",
+      "tests/test_manual_live_capture.py",
+      "tests/test_manual_research_deployment.py",
+      ".github/forecasting-paths.ini",
+      ".github/workflows/forecasting-tests.yml"
+    ],
+    "files_modified": [
+      ".github/forecasting-paths.ini",
+      ".github/workflows/forecasting-tests.yml",
+      "configs/prediction/manual-independent-capture-v1/evidence-bundle.schema.json",
+      "docs/manual_independent_capture_v1.md",
+      "src/predictor/manual_independent_capture_executor.py",
+      "src/predictor/manual_independent_capture_sealer.py",
+      "src/predictor/manual_live_capture.py",
+      "src/predictor/manual_live_capture_child.py",
+      "src/predictor/manual_research_deployment.py",
+      "src/predictor/manual_research_worker.py",
+      "tests/test_manual_live_capture.py",
+      "tests/test_manual_research_deployment.py"
+    ],
+    "validation_checks": [
+      "git diff --cached --check",
+      "ruff check on modified implementation and tests",
+      "785 focused manual-tier tests passed",
+      "No live browser, service, lock, database, Phase-7, or merge action performed"
+    ]
+  },
+  "result": {
+    "critical": [],
+    "warnings": [],
+    "suggestions": []
+  }
+}

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/DECISIONS.md
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/DECISIONS.md
@@ -6,3 +6,12 @@
   sealing, hash, timestamp, or outcome-rejection rules.
 - Kept the GHU-056 package and service default-off; explicit race input is
   required and no service mode performs discovery or capture.
+- Replaced the live child navigation blacklist with a pure allowlist policy:
+  exact canonical race `GET` document navigation, or query-free `GET` static
+  assets on the exact canonical host under `/assets/` with reviewed stylesheet,
+  script, image, or font extensions.
+- Did not admit XHR, fetch, websocket, event-stream, API, result-like,
+  subframe, unknown, or unclassified requests; repository evidence did not
+  prove a safe odds API endpoint.
+- Preserved one exact `goto`, GHU-051 executor/process/timeout/runner binding,
+  GHU-052 media/parser/sealing semantics, and production permission safety.

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/DECISIONS.md
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/DECISIONS.md
@@ -1,0 +1,8 @@
+- Retained the GHU-051 parent executor as the sole process, lock, timeout,
+  identity, runner, odds, timing, and artifact authority.
+- Added only a versioned live child envelope and a parent-side expected runner
+  binding; the fixture child protocol remains accepted unchanged.
+- Added one live JSON media/parser identity to GHU-052 without changing its
+  sealing, hash, timestamp, or outcome-rejection rules.
+- Kept the GHU-056 package and service default-off; explicit race input is
+  required and no service mode performs discovery or capture.

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/README.md
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/README.md
@@ -1,8 +1,14 @@
 # GHU-060 implementation evidence
 
-This report covers the bounded live manual capture runtime implementation from
-exact base `1c937b53491787f1e54b16d235f7536af48c3c85` / tree
-`78ffa1301b064136f688697ac6881e700232b0ee`.
+This report covers the GHU-060 corrective network-policy pass on PR #128,
+starting from exact PR head `8bcb9cd574549871b5f6de71edd4a62e4a2a0cd7` and
+base `0a67f95ea06effa04609faabe0103fe2e69ff94e`.
+
+The child now permits only the exact canonical race document navigation and
+reviewed query-free static assets under the trusted `/assets/` path. XHR,
+fetch, websocket, event-stream, API, result-like, unknown, and unclassified
+requests fail closed. No reviewed odds API endpoint was found, so none is
+allowed.
 
 The implementation is fixture-tested only. No live browser/source attempt,
 deployment, installation, activation, service restart, lock manipulation,

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/README.md
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/README.md
@@ -1,0 +1,9 @@
+# GHU-060 implementation evidence
+
+This report covers the bounded live manual capture runtime implementation from
+exact base `1c937b53491787f1e54b16d235f7536af48c3c85` / tree
+`78ffa1301b064136f688697ac6881e700232b0ee`.
+
+The implementation is fixture-tested only. No live browser/source attempt,
+deployment, installation, activation, service restart, lock manipulation,
+canonical/Phase-7 write, or merge occurred.

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/REVIEW.md
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/REVIEW.md
@@ -1,0 +1,6 @@
+Independent review scope: staged GHU-060 diff only.
+
+Review conclusion: no critical or warning findings. The live browser path is
+intentionally not executed in this ticket; controlled fixtures prove the
+adapter and unchanged parent/sealer path, while real source success remains a
+separate live-proof claim.

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/REVIEW.md
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/REVIEW.md
@@ -1,6 +1,8 @@
-Independent review scope: staged GHU-060 diff only.
+Independent review scope: corrective network-policy diff from PR #128 head
+`8bcb9cd574549871b5f6de71edd4a62e4a2a0cd7`.
 
-Review conclusion: no critical or warning findings. The live browser path is
-intentionally not executed in this ticket; controlled fixtures prove the
-adapter and unchanged parent/sealer path, while real source success remains a
-separate live-proof claim.
+Review conclusion: no critical or warning findings. The pure policy has no
+same-origin blanket allow, admits no data-bearing request family, and keeps
+unknown/unclassified requests fail closed. Controlled fixtures prove the
+adapter and unchanged parent/sealer path; real source success remains outside
+this ticket.

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/RUN_OUTCOME.json
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/RUN_OUTCOME.json
@@ -1,17 +1,52 @@
 {
-  "status": "IMPLEMENTATION_READY_FOR_REVIEW",
-  "implementation_commit": "a053e5b2cb03102468b87c9ebb0bc9f0d9922730",
-  "implementation_tree": "deb36fa709161985516da41404d97e46e65dbe65",
-  "base_commit": "1c937b53491787f1e54b16d235f7536af48c3c85",
-  "base_tree": "78ffa1301b064136f688697ac6881e700232b0ee",
-  "classifier": {
-    "tier": "manual_prediction",
-    "ci_contract_changed": true,
-    "reason": "single_product_tier_with_ci_contract"
+  "status": "ADVANCED",
+  "scope_fingerprint": "17db5f2dddf295bb1d4e04b4794acb35cd0714a6bf35a235cb1e168646d97c98",
+  "state_before": "PR_HEAD_8BCB9CD5_BLACKLISTED_SUBREQUESTS",
+  "state_after": "ALLOWLIST_IMPLEMENTED_VALIDATED_PENDING_PUBLICATION",
+  "decision_delta": "Replaced arbitrary same-origin subrequest continuation with an exact-navigation and reviewed-static allowlist; no odds API was admitted.",
+  "reused_claims": [
+    "GHU-051 remains the sole process, timeout, lock, identity, runner, and artifact authority.",
+    "GHU-052 media/parser, sealing, hash, timestamp, and outcome-rejection semantics remain unchanged.",
+    "No live browser/source attempt, deployment, service, lock, database, model, scoring, or Phase 7 action is permitted."
+  ],
+  "changed_claims": [
+    "Only exact canonical race document GET navigation can pass as navigation.",
+    "Only query-free canonical-host /assets/ GET stylesheet, script, image, or font resources can pass as static assets.",
+    "XHR, fetch, websocket, event-stream, API, result-like, unknown, and unclassified requests abort."
+  ],
+  "new_evidence": [
+    "31 adversarial pure-policy and route-guard tests passed.",
+    "806 exact manual_prediction tests passed.",
+    "Forecasting classifier 28 tests and backend classifier 12 tests passed.",
+    "Forecasting CI contract validated 9 workflow YAML files and 5 focused checks.",
+    "Ruff, py_compile, JSON/schema, hardening, and diff checks passed."
+  ],
+  "produced_artifacts": [
+    "src/predictor/manual_live_capture_child.py",
+    "tests/test_manual_live_capture.py",
+    "docs/manual_independent_capture_v1.md",
+    "reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/CODE_REVIEW.json",
+    "reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/VALIDATION.md"
+  ],
+  "resume_only_if": "Continue only from the clean task worktree while PR #128 remains bound to the expected pre-fix head until publication, the diff stays inside the task-card allowlist, and no live/autonomous authority is crossed.",
+  "new_goal_permitted": false,
+  "used_capabilities": [
+    "READ",
+    "REPORT_WRITE",
+    "CODE_EDIT",
+    "PUBLISH"
+  ],
+  "network_policy": {
+    "navigation": "exact canonical race URL, document, top-level, GET only",
+    "static": "canonical host, /assets/ path, query-free GET, reviewed CSS/JS/image/font extensions",
+    "reviewed_odds_api": false
   },
-  "tests": "785 passed",
+  "docs_impact": "DOCS_UPDATED",
   "live_attempt": false,
   "deployment": false,
   "merge": false,
-  "canonical_or_phase7_mutation": false
+  "canonical_or_phase7_mutation": false,
+  "production_permission_safety_changed": false,
+  "code_review": "SUCCESS; no critical, warning, or suggestion findings",
+  "focused_validation_environment": "uv ephemeral environment; no project dependency files changed"
 }

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/RUN_OUTCOME.json
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/RUN_OUTCOME.json
@@ -1,5 +1,9 @@
 {
   "status": "ADVANCED",
+  "implementation_commit": "216eca848462e3f690274be23758fbdc4221b934",
+  "implementation_tree": "d01b77f385ce5a4aa9495210270fac7c2160b7d2",
+  "base_commit": "0a67f95ea06effa04609faabe0103fe2e69ff94e",
+  "pr_head_before_fix": "8bcb9cd574549871b5f6de71edd4a62e4a2a0cd7",
   "scope_fingerprint": "17db5f2dddf295bb1d4e04b4794acb35cd0714a6bf35a235cb1e168646d97c98",
   "state_before": "PR_HEAD_8BCB9CD5_BLACKLISTED_SUBREQUESTS",
   "state_after": "ALLOWLIST_IMPLEMENTED_VALIDATED_PENDING_PUBLICATION",

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/RUN_OUTCOME.json
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/RUN_OUTCOME.json
@@ -1,0 +1,17 @@
+{
+  "status": "IMPLEMENTATION_READY_FOR_REVIEW",
+  "implementation_commit": "a053e5b2cb03102468b87c9ebb0bc9f0d9922730",
+  "implementation_tree": "deb36fa709161985516da41404d97e46e65dbe65",
+  "base_commit": "1c937b53491787f1e54b16d235f7536af48c3c85",
+  "base_tree": "78ffa1301b064136f688697ac6881e700232b0ee",
+  "classifier": {
+    "tier": "manual_prediction",
+    "ci_contract_changed": true,
+    "reason": "single_product_tier_with_ci_contract"
+  },
+  "tests": "785 passed",
+  "live_attempt": false,
+  "deployment": false,
+  "merge": false,
+  "canonical_or_phase7_mutation": false
+}

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/STATE.md
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/STATE.md
@@ -1,0 +1,8 @@
+status: IMPLEMENTATION_READY_FOR_REVIEW
+base: 1c937b53491787f1e54b16d235f7536af48c3c85
+base_tree: 78ffa1301b064136f688697ac6881e700232b0ee
+live_attempt: false
+deployment: false
+merge: false
+canonical_mutation: false
+phase7_mutation: false

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/STATE.md
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/STATE.md
@@ -1,8 +1,42 @@
-status: IMPLEMENTATION_READY_FOR_REVIEW
-base: 1c937b53491787f1e54b16d235f7536af48c3c85
-base_tree: 78ffa1301b064136f688697ac6881e700232b0ee
+status: VALIDATING
+base: 0a67f95ea06effa04609faabe0103fe2e69ff94e
+pr_head_before_fix: 8bcb9cd574549871b5f6de71edd4a62e4a2a0cd7
 live_attempt: false
 deployment: false
 merge: false
 canonical_mutation: false
 phase7_mutation: false
+
+task_worktree: /mnt/tenn-nvme2/tenn/offloaded-home/l4nd0/greyhound-ghu-060-network-allowlist-20260809
+task_branch: codex/ghu-060-network-allowlist-20260809
+registry_claim: GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808
+duplicate_work: DATA_MISSING_FALLBACK_CHECKED; no matching active GHU-060 job before claim
+docs_impact: DOCS_UPDATED
+docs_checked: docs/manual_independent_capture_v1.md
+docs_changed: docs/manual_independent_capture_v1.md
+docs_followup: none
+task_tier: large
+recommended_model: high_reasoning
+actual_model: gpt-5
+worker_model_allowed: false
+worker_decision_limit: no delegated implementation
+
+Runtime Functionality Proof:
+- intended output: controlled fixture proof that the live child network policy
+  permits only the exact race document and reviewed static assets.
+- live output location: none; live browser/source execution is forbidden by the
+  task card.
+- pre-run max timestamp or count: not applicable; no live capture or runtime
+  data source was read.
+- post-run max timestamp or count: not applicable; no live capture or runtime
+  data source was read.
+- rows/files inserted or updated after run start: no runtime/data files; only
+  allowlisted source, test, documentation, and report artifacts changed.
+- readiness/gate status: controlled-fixture validation ready; live-source proof
+  intentionally not claimed.
+- exact command/query used: `uv run --no-project --with-requirements
+  requirements/all.in --with jsonschema python -m pytest -q --noconftest
+  <manual_prediction suite>` plus the focused policy test command.
+- result: PARTIAL
+- remaining blocker: real browser asset necessity and live-source success remain
+  unobserved by explicit task boundary; no safe odds API endpoint was admitted.

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/VALIDATION.md
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/VALIDATION.md
@@ -1,0 +1,10 @@
+- `python3 -m py_compile` passed for all modified Python modules.
+- Ruff passed for modified implementation and test files.
+- Focused full manual tier command passed: `785 passed`.
+- No-conftest mode was used as in the repository workflow; the normal host
+  environment lacked application dependencies for the repository conftest.
+- Tests include exact URL success, redirect, challenge, outcome, malformed
+  response, invalid/missing odds, runner mismatch, timeout, no retry,
+  navigation guard, parent cleanup, unchanged fixture behavior, GHU-052 seal,
+  default-off binding, and worker guard.
+- Classifier is recorded after the exact review commit in `RUN_OUTCOME.json`.

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/VALIDATION.md
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/VALIDATION.md
@@ -1,10 +1,14 @@
-- `python3 -m py_compile` passed for all modified Python modules.
-- Ruff passed for modified implementation and test files.
-- Focused full manual tier command passed: `785 passed`.
+- `python3 -m py_compile` passed for the modified Python modules.
+- Ruff passed for the modified implementation and test files.
+- Focused network-policy suite passed: `31 passed`.
+- Exact repository `manual_prediction` tier passed: `806 passed in 42.76s`.
+- Forecasting and backend classifier contracts passed (`28` and `12` tests).
+- Forecasting CI contract passed: `9` workflow YAML files and `5` focused checks.
+- JSON parsing, hardening guards, and `git diff --check` passed.
 - No-conftest mode was used as in the repository workflow; the normal host
   environment lacked application dependencies for the repository conftest.
-- Tests include exact URL success, redirect, challenge, outcome, malformed
-  response, invalid/missing odds, runner mismatch, timeout, no retry,
-  navigation guard, parent cleanup, unchanged fixture behavior, GHU-052 seal,
-  default-off binding, and worker guard.
-- Classifier is recorded after the exact review commit in `RUN_OUTCOME.json`.
+- Adversarial policy cases include exact navigation allow; second/different
+  navigation, unknown XHR/fetch, result-like details, websocket/event-stream,
+  outcome API, untrusted host, unreviewed path, query-bearing asset, non-GET,
+  and unknown resource denial; reviewed CSS/JS/image/font asset allow.
+- The real browser/source path was not attempted, per the task boundary.

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/final-refs.json
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/final-refs.json
@@ -6,6 +6,9 @@
   "pull_request": 128,
   "pull_request_url": "https://github.com/0rl4nd0l/greyhound-racing-collector/pull/128",
   "pr_head_commit": "3d5409a7d55b46007dc559328f88b642daba8f59",
+  "final_head_commit": "0869b11567cc7bfbdec9f4ccc77e1ad664ef2c0c",
+  "final_head_tree": "e0b0316ef095793724eaecdc1638b66c95ef72ac",
+  "draft": true,
   "merged": false,
   "deployed": false,
   "live_attempt": false

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/final-refs.json
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/final-refs.json
@@ -1,0 +1,8 @@
+{
+  "implementation_commit": "a053e5b2cb03102468b87c9ebb0bc9f0d9922730",
+  "implementation_tree": "deb36fa709161985516da41404d97e46e65dbe65",
+  "pull_request": null,
+  "merged": false,
+  "deployed": false,
+  "live_attempt": false
+}

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/final-refs.json
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/final-refs.json
@@ -1,7 +1,11 @@
 {
   "implementation_commit": "a053e5b2cb03102468b87c9ebb0bc9f0d9922730",
   "implementation_tree": "deb36fa709161985516da41404d97e46e65dbe65",
-  "pull_request": null,
+  "closeout_commit": "3d5409a7d55b46007dc559328f88b642daba8f59",
+  "closeout_tree": "346e775892202240545d074edc70fe36bc51af84",
+  "pull_request": 128,
+  "pull_request_url": "https://github.com/0rl4nd0l/greyhound-racing-collector/pull/128",
+  "pr_head_commit": "3d5409a7d55b46007dc559328f88b642daba8f59",
   "merged": false,
   "deployed": false,
   "live_attempt": false

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/guard-final.json
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/guard-final.json
@@ -1,0 +1,12 @@
+{
+  "schema": "tenn_git_guard_preflight_v2",
+  "head_at_check": "a053e5b2cb03102468b87c9ebb0bc9f0d9922730",
+  "canonical_head": "1c937b53491787f1e54b16d235f7536af48c3c85",
+  "merge_base": "1c937b53491787f1e54b16d235f7536af48c3c85",
+  "task_worktree": "VALID_TASK_WORKTREE",
+  "dirty_status": [],
+  "decision_ledger_status": "PASS",
+  "ledger_status": "DATA_MISSING",
+  "final_decision": "warning",
+  "warnings": ["committed and live task ledgers are absent", "unrelated stale registry jobs are present"]
+}

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/guard-preflight.json
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/guard-preflight.json
@@ -1,0 +1,12 @@
+{
+  "schema": "tenn_git_guard_preflight_v2",
+  "canonical_head": "1c937b53491787f1e54b16d235f7536af48c3c85",
+  "merge_base": "1c937b53491787f1e54b16d235f7536af48c3c85",
+  "task_worktree": "VALID_TASK_WORKTREE",
+  "dirty_status": [],
+  "decision_ledger_status": "PASS",
+  "ledger_status": "DATA_MISSING",
+  "final_decision": "warning",
+  "substantive_work_permitted": true,
+  "warnings": ["committed and live task ledgers are absent", "unrelated stale registry jobs are present"]
+}

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/pr-body.md
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/pr-body.md
@@ -1,4 +1,17 @@
-## Summary
+## Corrective pass summary
+
+PR #128 now uses a pure fail-closed live browser network allowlist. It permits
+only the exact canonical race `GET` document navigation and query-free `GET`
+stylesheet, script, image, or font assets on the exact canonical host under
+`/assets/`. XHR, fetch, websocket, event-stream, API, result-like, subframe,
+unknown, and unclassified requests abort. No odds API endpoint is allowed
+because repository evidence did not prove one safe to admit.
+
+The existing exact `goto`, GHU-051 executor/process/timeout/runner binding,
+GHU-052 media/parser/sealing semantics, default-off deployment, and production
+permission safety remain unchanged.
+
+## Original implementation context
 
 GHU-059 stopped because GHU-051 had only a fixture child and no bounded live
 manual runtime. This change adds one versioned live Playwright child behind the
@@ -20,9 +33,13 @@ hash-binds the reviewed live entrypoint and child while remaining disabled.
 
 ## Validation
 
-- Exact base: `1c937b53491787f1e54b16d235f7536af48c3c85`.
+- Exact base: `0a67f95ea06effa04609faabe0103fe2e69ff94e`.
+- Corrective source head: `8bcb9cd574549871b5f6de71edd4a62e4a2a0cd7`.
 - Classifier: `manual_prediction`, `ci_contract_changed=true`.
-- Focused manual tier: `785 passed`.
+- Focused network-policy suite: `31 passed`.
+- Exact manual tier: `806 passed`.
+- Forecasting/backend classifier contracts: passed.
+- YAML/JSON/schema, Ruff, compile, hardening, and diff checks: passed.
 - Ruff, compile, diff-check, parent runner binding, GHU-052 sealing, default-off
   deployment binding, process cleanup, redirect/challenge/malformed/odds/
   timeout/result/no-retry tests passed.

--- a/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/pr-body.md
+++ b/reports/agent_jobs/GHU_060_LIVE_MANUAL_CAPTURE_RUNTIME_V1_20260808/pr-body.md
@@ -1,0 +1,28 @@
+## Summary
+
+GHU-059 stopped because GHU-051 had only a fixture child and no bounded live
+manual runtime. This change adds one versioned live Playwright child behind the
+existing GHU-051 executor, parent-side exact readiness runner binding, and an
+explicit request-scoped CLI with no discovery, retry, fallback, or substitution.
+
+GHU-052 keeps its sealing and outcome-rejection semantics; it gains only the
+distinct live JSON media/parser identity. The default-off GHU-056 package now
+hash-binds the reviewed live entrypoint and child while remaining disabled.
+
+## Safety and claims boundary
+
+- Research-only, canonical=false, Phase-7 excluded.
+- No scoring/model/DB/history/result/autonomous/betting/promotion changes.
+- No live browser/source attempt, deployment, installation, activation,
+  restart, lock manipulation, or merge was performed.
+- This proves controlled-fixture traversal only; real live-source success and
+  real pre-jump prediction remain the next ticket.
+
+## Validation
+
+- Exact base: `1c937b53491787f1e54b16d235f7536af48c3c85`.
+- Classifier: `manual_prediction`, `ci_contract_changed=true`.
+- Focused manual tier: `785 passed`.
+- Ruff, compile, diff-check, parent runner binding, GHU-052 sealing, default-off
+  deployment binding, process cleanup, redirect/challenge/malformed/odds/
+  timeout/result/no-retry tests passed.

--- a/src/predictor/manual_independent_capture_executor.py
+++ b/src/predictor/manual_independent_capture_executor.py
@@ -1,9 +1,9 @@
-"""Fixture-only executor for one isolated manual research capture.
+"""Bounded executor for one isolated manual research capture.
 
 The executor owns process, lock, path, timeout, and terminal-artifact control.
-It deliberately has no live fetch implementation, database argument, retry
-surface, autonomous lock locator, or persistence-capable dependency.  A caller
-must supply one reviewed fixture child command.
+It deliberately has no discovery, database argument, retry surface, autonomous
+lock locator, or persistence-capable dependency. A caller must supply one
+reviewed child command; the legacy fixture command remains supported.
 """
 
 from __future__ import annotations
@@ -53,6 +53,7 @@ from utils.csv_metadata import (
 )
 
 CHILD_SCHEMA_VERSION = "manual_independent_capture_child_fixture_v2"
+LIVE_CHILD_SCHEMA_VERSION = "manual_independent_capture_child_live_v1"
 TERMINAL_FILENAME = "terminal.json"
 _MAX_CHILD_OUTPUT_BYTES = 2 * 1024 * 1024
 _MAX_SOURCE_BYTES = 2 * 1024 * 1024
@@ -74,11 +75,15 @@ class CancellationToken(Protocol):
 
 
 @dataclass(frozen=True)
-class FixtureChildLaunch:
+class ManualChildLaunch:
     requested_race_url: str
     selected_race: Mapping[str, Any]
     browser_profile: Path
     run_dir: Path
+
+
+# Compatibility name retained for the existing fixture executor contract.
+FixtureChildLaunch = ManualChildLaunch
 
 
 @dataclass(frozen=True)
@@ -364,8 +369,59 @@ def _no_process_cleanup(reason: str) -> CleanupProof:
     )
 
 
+def _expected_runner_set(value: Sequence[Mapping[str, Any]] | None) -> list[dict[str, Any]] | None:
+    if value is None:
+        return None
+    expected: list[dict[str, Any]] = []
+    for row in value:
+        if not isinstance(row, Mapping) or set(row) != {
+            "runner_id",
+            "box_number",
+            "dog_name",
+            "source_native_runner_id",
+        }:
+            raise ValueError("RUNNER_SET_MISMATCH")
+        runner_id = row["runner_id"]
+        dog_name = row["dog_name"]
+        native_id = row["source_native_runner_id"]
+        if (
+            not isinstance(runner_id, str)
+            or not runner_id
+            or not isinstance(dog_name, str)
+            or not dog_name
+            or isinstance(row["box_number"], bool)
+            or not isinstance(row["box_number"], int)
+            or not 1 <= row["box_number"] <= 10
+            or (
+                native_id is not None
+                and (not isinstance(native_id, str) or not native_id)
+            )
+        ):
+            raise ValueError("RUNNER_SET_MISMATCH")
+        expected.append(
+            {
+                "box_number": row["box_number"],
+                "display_name": dog_name,
+                # The child protocol uses the existing uppercase identity
+                # invariant; readiness runner IDs are case-normalized only
+                # for this parent-side binding comparison.
+                "identity": runner_id.upper(),
+                "source_native_runner_id": native_id,
+            }
+        )
+    try:
+        canonical_runner_set(expected, "expected_runner_set")
+    except PredictionBlocked as exc:
+        raise ValueError("RUNNER_SET_MISMATCH") from exc
+    return expected
+
+
 def _child_value(
-    raw: bytes, *, expected_url: str, expected_race_sha: str
+    raw: bytes,
+    *,
+    expected_url: str,
+    expected_race_sha: str,
+    expected_runner_set: Sequence[Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if not raw or len(raw) > _MAX_CHILD_OUTPUT_BYTES:
         raise ValueError("SOURCE_MALFORMED")
@@ -381,7 +437,7 @@ def _child_value(
         "source",
     }:
         raise ValueError("SOURCE_MALFORMED")
-    if value["schema_version"] != CHILD_SCHEMA_VERSION:
+    if value["schema_version"] not in {CHILD_SCHEMA_VERSION, LIVE_CHILD_SCHEMA_VERSION}:
         raise ValueError("SOURCE_MALFORMED")
     if (
         value["requested_race_url"] != expected_url
@@ -467,6 +523,9 @@ def _child_value(
         canonical_runner_set(canonical_runners, "fixture_child.runners")
     except PredictionBlocked as exc:
         raise ChildResponseRejected("RUNNER_SET_MISMATCH") from exc
+    expected = _expected_runner_set(expected_runner_set)
+    if expected is not None and canonical_runners != expected:
+        raise ChildResponseRejected("RUNNER_SET_MISMATCH")
     try:
         source_bytes = base64.b64decode(value["source"]["bytes_base64"], validate=True)
         source_time = datetime.fromisoformat(value["source"]["source_timestamp"])
@@ -665,6 +724,7 @@ def execute_manual_capture_fixture(
     source_commit: str,
     source_tree: str,
     fixture_child_command: Callable[[FixtureChildLaunch], Sequence[str]],
+    expected_runner_set: Sequence[Mapping[str, Any]] | None = None,
     cancellation_token: CancellationToken | None = None,
     now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
     monotonic: Callable[[], float] = time.monotonic,
@@ -673,7 +733,7 @@ def execute_manual_capture_fixture(
     killpg: Callable[[int, int], None] = os.killpg,
     uuid4: Callable[[], uuid.UUID] = uuid.uuid4,
 ) -> ManualCaptureExecution:
-    """Run one fixture child and emit one validator-accepted terminal bundle."""
+    """Run one reviewed child and emit one validator-accepted terminal bundle."""
 
     validated_config = validate_config(config, forbidden_paths=forbidden_paths)
     if not isinstance(model_bytes, bytes) or not model_bytes:
@@ -768,6 +828,8 @@ def execute_manual_capture_fixture(
                         "MANUAL_CAPTURE_RUN_DIR": str(run_dir),
                         "MANUAL_CAPTURE_EXACT_URL": requested_race_url,
                         "MANUAL_CAPTURE_RACE_ID": race["race_id"],
+                        "MANUAL_CAPTURE_RACE_IDENTITY_SHA256": canonical_sha256(race),
+                        "MANUAL_CAPTURE_EXECUTOR_PROTOCOL": "ghu051-bounded-v1",
                         "PYTHONDONTWRITEBYTECODE": "1",
                     }
                 )
@@ -875,6 +937,7 @@ def execute_manual_capture_fixture(
                                     stdout,
                                     expected_url=requested_race_url,
                                     expected_race_sha=canonical_sha256(race),
+                                    expected_runner_set=expected_runner_set,
                                 )
                             except ChildResponseRejected as exc:
                                 failure_code = exc.code

--- a/src/predictor/manual_independent_capture_sealer.py
+++ b/src/predictor/manual_independent_capture_sealer.py
@@ -628,7 +628,11 @@ def _reject_outcome_material(raw: bytes, content_type: str) -> None:
         text = raw.decode("utf-8-sig")
     except UnicodeDecodeError as exc:
         raise _reject("SOURCE_CONTENT_INVALID", reason="utf8") from exc
-    if media_type in {"application/json", "text/json"}:
+    if media_type in {
+        "application/json",
+        "text/json",
+        "application/vnd.greyhound.manual-live+json",
+    }:
         try:
             value = json.loads(text)
         except (json.JSONDecodeError, RecursionError) as exc:
@@ -709,7 +713,11 @@ def _validate_parsed_odds(
                     ),
                 }
             )
-    elif media_type in {"application/json", "text/json"}:
+    elif media_type in {
+        "application/json",
+        "text/json",
+        "application/vnd.greyhound.manual-live+json",
+    }:
         try:
             value = json.loads(text)
         except (json.JSONDecodeError, RecursionError) as exc:
@@ -717,7 +725,11 @@ def _validate_parsed_odds(
         envelope = _exact(value, {"runners"}, "source.odds")
         if not isinstance(envelope["runners"], list):
             raise _reject("ODDS_PROVENANCE_AMBIGUOUS", reason="json_runners")
-        parser = "manual_fixture_json_odds_v1"
+        parser = (
+            "manual_live_json_odds_v1"
+            if media_type == "application/vnd.greyhound.manual-live+json"
+            else "manual_fixture_json_odds_v1"
+        )
         for index, item in enumerate(envelope["runners"]):
             row = _exact(
                 item,
@@ -790,7 +802,11 @@ def _validate_response(
     media_type = response.content_type.split(";", 1)[0].strip().lower()
     permitted = {
         "prejump_form": {"text/csv", "application/csv"},
-        "prejump_sidecar": {"application/json", "text/json"},
+        "prejump_sidecar": {
+            "application/json",
+            "text/json",
+            "application/vnd.greyhound.manual-live+json",
+        },
         "prejump_race_source": {"application/json", "text/html", "text/json"},
     }
     if (
@@ -1191,7 +1207,11 @@ def _validate_bundle_document(
     )
     permitted_media = {
         "prejump_form": {"text/csv", "application/csv"},
-        "prejump_sidecar": {"application/json", "text/json"},
+        "prejump_sidecar": {
+            "application/json",
+            "text/json",
+            "application/vnd.greyhound.manual-live+json",
+        },
         "prejump_race_source": {"application/json", "text/html", "text/json"},
     }
     if not isinstance(source["content_type"], str) or not isinstance(
@@ -1225,7 +1245,11 @@ def _validate_bundle_document(
         or source["content_type"] != expected.content_type
         or media_type not in permitted_media.get(source["content_class"], set())
         or source["odds_parser"]
-        not in {"manual_fixture_csv_odds_v1", "manual_fixture_json_odds_v1"}
+        not in {
+            "manual_fixture_csv_odds_v1",
+            "manual_fixture_json_odds_v1",
+            "manual_live_json_odds_v1",
+        }
         or not isinstance(source["parsed_odds_sha256"], str)
         or _SHA256_RE.fullmatch(source["parsed_odds_sha256"]) is None
         or source["raw_path"] != "source/raw.bin"

--- a/src/predictor/manual_live_capture.py
+++ b/src/predictor/manual_live_capture.py
@@ -1,0 +1,149 @@
+"""Explicit, request-scoped entrypoint for the GHU-060 live child.
+
+The CLI accepts one caller-bound race document and delegates all process,
+timeout, lock, path, identity, runner, odds, and artifact validation to the
+existing GHU-051 executor. It has no discovery or autonomous mode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from src.predictor.manual_independent_capture import (
+    canonical_bytes,
+    parse_canonical_json,
+)
+from src.predictor.manual_independent_capture_executor import (
+    execute_manual_capture_fixture,
+)
+
+_HASH40_RE = re.compile(r"^[0-9a-f]{40}$")
+_PROTECTED_NAMES = {
+    "autonomous_browser_profile",
+    "autonomous_shared_lock",
+    "canonical_database",
+    "canonical_history",
+    "live_odds",
+    "forward_corpus",
+    "collector_requests",
+    "collector_state",
+    "result_evidence",
+    "services",
+    "timers",
+}
+
+
+class LiveCaptureCliRejected(RuntimeError):
+    """Invalid explicit input; no alternate race or source is attempted."""
+
+
+def live_capture_child_command(_launch: Any) -> Sequence[str]:
+    """Return the only child command accepted by this entrypoint."""
+
+    return (sys.executable, "-m", "src.predictor.manual_live_capture_child")
+
+
+def _canonical_file(path: Path) -> Any:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise LiveCaptureCliRejected("INPUT_MISSING") from exc
+    try:
+        return parse_canonical_json(raw)
+    except (RuntimeError, ValueError) as exc:
+        raise LiveCaptureCliRejected("CANONICAL_INPUT_INVALID") from exc
+
+
+def _model_bytes(path: Path) -> bytes:
+    try:
+        if path.is_symlink() or not path.is_file():
+            raise LiveCaptureCliRejected("MODEL_INPUT_INVALID")
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise LiveCaptureCliRejected("MODEL_INPUT_INVALID") from exc
+    if not raw:
+        raise LiveCaptureCliRejected("MODEL_INPUT_INVALID")
+    return raw
+
+
+def _race_input(value: Any) -> tuple[dict[str, Any], list[Mapping[str, Any]]]:
+    if not isinstance(value, Mapping) or set(value) != {"race", "runners"}:
+        raise LiveCaptureCliRejected("EXACT_INPUT_INVALID")
+    race = value["race"]
+    runners = value["runners"]
+    if not isinstance(race, Mapping) or not isinstance(runners, list) or not runners:
+        raise LiveCaptureCliRejected("EXACT_INPUT_INVALID")
+    return dict(race), runners
+
+
+def _forbidden(values: Sequence[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for item in values:
+        if "=" not in item:
+            raise LiveCaptureCliRejected("PROTECTED_INPUT_INVALID")
+        name, raw_path = item.split("=", 1)
+        if name not in _PROTECTED_NAMES or name in result or not raw_path:
+            raise LiveCaptureCliRejected("PROTECTED_INPUT_INVALID")
+        result[name] = raw_path
+    if set(result) != _PROTECTED_NAMES:
+        raise LiveCaptureCliRejected("PROTECTED_INPUT_INVALID")
+    return result
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="manual-live-capture")
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--race-json", required=True, type=Path)
+    parser.add_argument("--model", required=True, type=Path)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--source-tree", required=True)
+    parser.add_argument("--forbidden-path", action="append", default=[])
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = _parser().parse_args(argv)
+        if not _HASH40_RE.fullmatch(args.source_commit) or not _HASH40_RE.fullmatch(
+            args.source_tree
+        ):
+            raise LiveCaptureCliRejected("SOURCE_IDENTITY_INVALID")
+        config = _canonical_file(args.config)
+        race_document = _canonical_file(args.race_json)
+        race, runners = _race_input(race_document)
+        model_bytes = _model_bytes(args.model)
+        forbidden_paths = _forbidden(args.forbidden_path)
+        requested_url = race.get("url")
+        if not isinstance(requested_url, str) or not requested_url:
+            raise LiveCaptureCliRejected("EXACT_INPUT_INVALID")
+        execution = execute_manual_capture_fixture(
+            config=config,
+            forbidden_paths=forbidden_paths,
+            requested_race_url=requested_url,
+            selected_race=race,
+            expected_runner_set=runners,
+            model_bytes=model_bytes,
+            source_commit=args.source_commit,
+            source_tree=args.source_tree,
+            fixture_child_command=live_capture_child_command,
+        )
+        print(canonical_bytes(execution.artifact).decode("utf-8"))
+        return 0 if execution.artifact["terminal"]["status"] == "CAPTURE_READY" else 78
+    except LiveCaptureCliRejected as exc:
+        print(str(exc), file=sys.stderr)
+        return 78
+    except (OSError, RuntimeError, ValueError, TypeError) as exc:
+        print(f"LIVE_CAPTURE_REJECTED:{type(exc).__name__}", file=sys.stderr)
+        return 78
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["live_capture_child_command", "main"]

--- a/src/predictor/manual_live_capture_child.py
+++ b/src/predictor/manual_live_capture_child.py
@@ -1,0 +1,322 @@
+"""One-attempt live source child for the bounded GHU-051 executor.
+
+This module is intentionally not a capture contract of its own. It accepts
+only the exact values exported by the parent executor, visits that one URL in
+the dedicated manual profile, and emits the existing child envelope with a
+versioned live schema. It reads runner rows and explicit WIN odds only; no
+page body, form history, result fields, or alternate URL is consumed.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import math
+import os
+import re
+import stat
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from src.predictor.manual_independent_capture import canonical_bytes
+from src.predictor.manual_independent_capture_executor import (
+    LIVE_CHILD_SCHEMA_VERSION,
+)
+from utils.csv_metadata import canonical_thedogs_race_identity
+
+CONTENT_TYPE = "application/vnd.greyhound.manual-live+json"
+_MAX_RUNNER_COUNT = 10
+_PAGE_TIMEOUT_MS = 20_000
+_ODDS_RE = re.compile(r"^\d+(?:\.\d+)?$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_CHALLENGE_SELECTORS = (
+    "input[type='password']",
+    "[data-captcha]",
+    "iframe[src*='challenge']",
+    ".cf-challenge",
+    "#challenge-running",
+)
+_OUTCOME_SELECTORS = (
+    "[data-result]",
+    "[data-outcome]",
+    "[data-finishing-position]",
+    ".race-result",
+    ".race-results",
+    ".race-result__winner",
+)
+_OUTCOME_URL_MARKERS = ("/result", "/results", "dividend", "payout", "outcome")
+
+
+class LiveCaptureRejected(RuntimeError):
+    """Fail-closed source rejection with no retry instruction."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "")
+    if not value or "\x00" in value:
+        raise LiveCaptureRejected("EXACT_INPUT_MISSING")
+    return value
+
+
+def _safe_directory(value: str) -> Path:
+    path = Path(value)
+    if not path.is_absolute() or "." in path.parts or ".." in path.parts:
+        raise LiveCaptureRejected("PROFILE_PATH_INVALID")
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise LiveCaptureRejected("PROFILE_PATH_INVALID") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise LiveCaptureRejected("PROFILE_PATH_INVALID")
+    return path
+
+
+def _decimal_odds(value: Any) -> float:
+    if not isinstance(value, str) or not _ODDS_RE.fullmatch(value.strip()):
+        raise LiveCaptureRejected("ODDS_INVALID")
+    try:
+        parsed = Decimal(value)
+    except InvalidOperation as exc:
+        raise LiveCaptureRejected("ODDS_INVALID") from exc
+    if not parsed.is_finite() or parsed <= 1:
+        raise LiveCaptureRejected("ODDS_INVALID")
+    result = float(parsed)
+    if not math.isfinite(result) or result <= 1:
+        raise LiveCaptureRejected("ODDS_INVALID")
+    return result
+
+
+def _identity(race_id: str, box_number: int, display_name: str) -> str:
+    normalized_name = re.sub(r"[^A-Z0-9]", "", display_name.upper())
+    if not normalized_name:
+        raise LiveCaptureRejected("RUNNER_SET_MISMATCH")
+    return f"{race_id}|BOX:{box_number}|DOG:{normalized_name}".upper()
+
+
+def _rows_to_runners(rows: Sequence[Mapping[str, Any]], race_id: str) -> list[dict[str, Any]]:
+    if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
+        raise LiveCaptureRejected("SOURCE_MALFORMED")
+    if not 1 <= len(rows) <= _MAX_RUNNER_COUNT:
+        raise LiveCaptureRejected("SOURCE_MALFORMED")
+    runners: list[dict[str, Any]] = []
+    seen_boxes: set[int] = set()
+    for row in rows:
+        if not isinstance(row, Mapping) or set(row) != {
+            "box_number",
+            "display_name",
+            "source_native_runner_id",
+            "win_odds",
+        }:
+            raise LiveCaptureRejected("SOURCE_MALFORMED")
+        box = row["box_number"]
+        name = row["display_name"]
+        native_id = row["source_native_runner_id"]
+        if (
+            isinstance(box, bool)
+            or not isinstance(box, int)
+            or not 1 <= box <= 10
+            or box in seen_boxes
+            or not isinstance(name, str)
+            or not name
+            or name != name.strip()
+            or (
+                native_id is not None
+                and (not isinstance(native_id, str) or not native_id.strip())
+            )
+        ):
+            raise LiveCaptureRejected("RUNNER_SET_MISMATCH")
+        seen_boxes.add(box)
+        runners.append(
+            {
+                "box_number": box,
+                "display_name": name,
+                "identity": _identity(race_id, box, name),
+                "source_native_runner_id": native_id,
+                "decimal_odds": _decimal_odds(row["win_odds"]),
+            }
+        )
+    if [row["box_number"] for row in runners] != sorted(seen_boxes):
+        raise LiveCaptureRejected("RUNNER_SET_MISMATCH")
+    return runners
+
+
+def _page_probe(page: Any, exact_url: str) -> tuple[int, str]:
+    try:
+        response = page.goto(
+            exact_url,
+            wait_until="domcontentloaded",
+            timeout=_PAGE_TIMEOUT_MS,
+        )
+        final_url = str(page.url)
+        status_code = int(response.status) if response is not None else 0
+        title = str(page.title()).strip().lower()
+        challenge_count = sum(
+            int(page.locator(selector).count()) for selector in _CHALLENGE_SELECTORS
+        )
+        outcome_count = sum(
+            int(page.locator(selector).count()) for selector in _OUTCOME_SELECTORS
+        )
+    except Exception as exc:  # Playwright errors are terminal, never retried.
+        raise LiveCaptureRejected("SOURCE_ATTEMPT_FAILED") from exc
+    if challenge_count or any(token in title for token in ("login", "challenge", "captcha")):
+        raise LiveCaptureRejected("SOURCE_CHALLENGE")
+    if outcome_count:
+        raise LiveCaptureRejected("OUTCOME_MATERIAL_FORBIDDEN")
+    return status_code, final_url
+
+
+def _install_navigation_guard(page: Any, exact_url: str) -> None:
+    def guard(route: Any) -> None:
+        request = route.request
+        request_url = str(request.url)
+        if request_url != exact_url and (
+            request.is_navigation_request()
+            or any(marker in request_url.lower() for marker in _OUTCOME_URL_MARKERS)
+        ):
+            route.abort()
+            return
+        route.continue_()
+
+    page.route("**/*", guard)
+
+
+def capture_from_page(
+    page: Any,
+    *,
+    exact_url: str,
+    race_id: str,
+    race_identity_sha256: str | None = None,
+    now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+) -> dict[str, Any]:
+    """Capture one mocked or real page without reading unrestricted page text."""
+
+    identity = canonical_thedogs_race_identity(exact_url)
+    if identity is None or identity["canonical_url"] != exact_url:
+        raise LiveCaptureRejected("EXACT_INPUT_INVALID")
+    if not race_id or not isinstance(race_id, str):
+        raise LiveCaptureRejected("EXACT_INPUT_INVALID")
+    status_code, final_url = _page_probe(page, exact_url)
+    if final_url != exact_url:
+        raise LiveCaptureRejected("IDENTITY_MISMATCH")
+    if status_code != 200:
+        raise LiveCaptureRejected("SOURCE_ATTEMPT_FAILED")
+    try:
+        rows = page.locator("tr.race-runner").evaluate_all(
+            """
+            rows => rows.map(row => ({
+              box_number: Number(
+                row.querySelector('.race-runners__box')?.getAttribute('data-box')
+                || row.querySelector('sprite-svg[name^="rug_"]')?.getAttribute('name')?.replace('rug_', '')
+                || ''
+              ),
+              display_name: (
+                row.querySelector('.race-runners__name__dog')
+                || row.querySelector('.race-runners__name')
+              )?.textContent?.trim() || '',
+              source_native_runner_id: row.getAttribute('data-runner-id')
+                || row.getAttribute('data-native-runner-id') || null,
+              win_odds: row.querySelector('[data-win-odds]')?.getAttribute('data-win-odds')
+                || row.querySelector('.race-runners__odds')?.textContent?.trim() || ''
+            }))
+            """
+        )
+    except Exception as exc:
+        raise LiveCaptureRejected("SOURCE_MALFORMED") from exc
+    runners = _rows_to_runners(rows, race_id)
+    timestamp = now()
+    if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+        raise LiveCaptureRejected("SOURCE_MALFORMED")
+    timestamp = timestamp.replace(microsecond=0)
+    body = canonical_bytes(
+        {
+            "runners": [
+                {
+                    "box_number": row["box_number"],
+                    "display_name": row["display_name"],
+                    "decimal_odds": row["decimal_odds"],
+                }
+                for row in runners
+            ]
+        }
+    )
+    identity_sha = race_identity_sha256 or _required_env(
+        "MANUAL_CAPTURE_RACE_IDENTITY_SHA256"
+    )
+    if _SHA256_RE.fullmatch(identity_sha) is None:
+        raise LiveCaptureRejected("EXACT_INPUT_INVALID")
+    return {
+        "schema_version": LIVE_CHILD_SCHEMA_VERSION,
+        "requested_race_url": exact_url,
+        "race_identity_sha256": identity_sha,
+        "runners": runners,
+        "source": {
+            "content_class": "prejump_sidecar",
+            "source_timestamp": timestamp.isoformat(),
+            "final_url": final_url,
+            "status_code": status_code,
+            "content_type": CONTENT_TYPE,
+            "bytes_base64": base64.b64encode(body).decode("ascii"),
+        },
+    }
+
+
+def _main() -> int:
+    if os.environ.get("MANUAL_CAPTURE_EXECUTOR_PROTOCOL") != "ghu051-bounded-v1":
+        raise LiveCaptureRejected("EXECUTOR_PROTOCOL_REQUIRED")
+    exact_url = _required_env("MANUAL_CAPTURE_EXACT_URL")
+    _safe_directory(_required_env("MANUAL_CAPTURE_PROFILE"))
+    _safe_directory(_required_env("MANUAL_CAPTURE_RUN_DIR"))
+    race_id = _required_env("MANUAL_CAPTURE_RACE_ID")
+    race_sha = _required_env("MANUAL_CAPTURE_RACE_IDENTITY_SHA256")
+    if _SHA256_RE.fullmatch(race_sha) is None:
+        raise LiveCaptureRejected("EXACT_INPUT_INVALID")
+    identity = canonical_thedogs_race_identity(exact_url)
+    if identity is None or identity["canonical_url"] != exact_url:
+        raise LiveCaptureRejected("EXACT_INPUT_INVALID")
+    try:
+        from playwright.sync_api import sync_playwright
+    except Exception as exc:
+        raise LiveCaptureRejected("LIVE_RUNTIME_UNAVAILABLE") from exc
+    with sync_playwright() as playwright:
+        context = playwright.chromium.launch_persistent_context(
+            user_data_dir=_required_env("MANUAL_CAPTURE_PROFILE"),
+            headless=True,
+        )
+        try:
+            page = context.pages[0] if context.pages else context.new_page()
+            _install_navigation_guard(page, exact_url)
+            record = capture_from_page(
+                page,
+                exact_url=exact_url,
+                race_id=race_id,
+            )
+            print(json.dumps(record, sort_keys=True, separators=(",", ":")))
+            return 0
+        finally:
+            context.close()
+
+
+def main() -> int:
+    try:
+        return _main()
+    except LiveCaptureRejected as exc:
+        print(exc.code, file=sys.stderr)
+        return 78
+    except Exception as exc:  # noqa: BLE001  # pragma: no cover - fail-closed boundary
+        print(f"SOURCE_ATTEMPT_FAILED:{type(exc).__name__}", file=sys.stderr)
+        return 78
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["CONTENT_TYPE", "LiveCaptureRejected", "capture_from_page", "main"]

--- a/src/predictor/manual_live_capture_child.py
+++ b/src/predictor/manual_live_capture_child.py
@@ -21,12 +21,13 @@ from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from src.predictor.manual_independent_capture import canonical_bytes
 from src.predictor.manual_independent_capture_executor import (
     LIVE_CHILD_SCHEMA_VERSION,
 )
-from utils.csv_metadata import canonical_thedogs_race_identity
+from utils.csv_metadata import THEDOGS_CANONICAL_HOST, canonical_thedogs_race_identity
 
 CONTENT_TYPE = "application/vnd.greyhound.manual-live+json"
 _MAX_RUNNER_COUNT = 10
@@ -48,7 +49,13 @@ _OUTCOME_SELECTORS = (
     ".race-results",
     ".race-result__winner",
 )
-_OUTCOME_URL_MARKERS = ("/result", "/results", "dividend", "payout", "outcome")
+_STATIC_ASSET_EXTENSIONS = {
+    "stylesheet": (".css",),
+    "script": (".js", ".mjs"),
+    "image": (".gif", ".ico", ".jpeg", ".jpg", ".png", ".svg", ".webp"),
+    "font": (".eot", ".otf", ".ttf", ".woff", ".woff2"),
+}
+_STATIC_ASSET_PATH_PREFIX = "/assets/"
 
 
 class LiveCaptureRejected(RuntimeError):
@@ -57,6 +64,48 @@ class LiveCaptureRejected(RuntimeError):
     def __init__(self, code: str):
         super().__init__(code)
         self.code = code
+
+
+def network_request_allowed(
+    *,
+    url: str,
+    resource_type: str,
+    is_navigation_request: bool,
+    method: str,
+    exact_race_url: str,
+) -> bool:
+    """Return whether one browser request is inside the reviewed allowlist."""
+
+    if not all(isinstance(value, str) for value in (url, resource_type, method, exact_race_url)):
+        return False
+    if not isinstance(is_navigation_request, bool):
+        return False
+    bound_identity = canonical_thedogs_race_identity(exact_race_url)
+    if bound_identity is None or bound_identity["canonical_url"] != exact_race_url:
+        return False
+    if is_navigation_request:
+        return (
+            url == exact_race_url
+            and resource_type == "document"
+            and method == "GET"
+        )
+    if method != "GET" or resource_type not in _STATIC_ASSET_EXTENSIONS:
+        return False
+    try:
+        requested = urlparse(url)
+        bound = urlparse(exact_race_url)
+    except ValueError:
+        return False
+    if (
+        requested.scheme != "https"
+        or requested.netloc != bound.netloc
+        or requested.netloc != THEDOGS_CANONICAL_HOST
+        or requested.query
+        or requested.fragment
+        or not requested.path.startswith(_STATIC_ASSET_PATH_PREFIX)
+    ):
+        return False
+    return requested.path.lower().endswith(_STATIC_ASSET_EXTENSIONS[resource_type])
 
 
 def _required_env(name: str) -> str:
@@ -176,10 +225,12 @@ def _page_probe(page: Any, exact_url: str) -> tuple[int, str]:
 def _install_navigation_guard(page: Any, exact_url: str) -> None:
     def guard(route: Any) -> None:
         request = route.request
-        request_url = str(request.url)
-        if request_url != exact_url and (
-            request.is_navigation_request()
-            or any(marker in request_url.lower() for marker in _OUTCOME_URL_MARKERS)
+        if not network_request_allowed(
+            url=request.url,
+            resource_type=request.resource_type,
+            is_navigation_request=request.is_navigation_request(),
+            method=request.method,
+            exact_race_url=exact_url,
         ):
             route.abort()
             return
@@ -319,4 +370,10 @@ if __name__ == "__main__":
     raise SystemExit(main())
 
 
-__all__ = ["CONTENT_TYPE", "LiveCaptureRejected", "capture_from_page", "main"]
+__all__ = [
+    "CONTENT_TYPE",
+    "LiveCaptureRejected",
+    "capture_from_page",
+    "main",
+    "network_request_allowed",
+]

--- a/src/predictor/manual_research_deployment.py
+++ b/src/predictor/manual_research_deployment.py
@@ -260,6 +260,16 @@ def generate_manual_package(
     output = _existing(output_dir, directory=True, label="output_dir")
     _existing(source / "src/predictor/manual_research_cli.py", directory=False, label="manual adapter")
     _existing(source / "src/predictor/manual_research_worker.py", directory=False, label="manual worker")
+    live_entrypoint = _existing(
+        source / "src/predictor/manual_live_capture.py",
+        directory=False,
+        label="live manual entrypoint",
+    )
+    live_child = _existing(
+        source / "src/predictor/manual_live_capture_child.py",
+        directory=False,
+        label="live manual child",
+    )
     if not isinstance(timeout_seconds, int) or isinstance(timeout_seconds, bool) or not 1 <= timeout_seconds <= 900:
         raise _reject("timeout_seconds is invalid")
     if not isinstance(margin_seconds, int) or isinstance(margin_seconds, bool) or not 1 <= margin_seconds <= 7200:
@@ -299,17 +309,27 @@ def generate_manual_package(
     model_bytes = _retained_file_read(model_path)
     manifest_bytes = _retained_file_read(manifest_path)
     config_bytes = _retained_file_read(config_path)
+    live_entrypoint_bytes = _retained_file_read(live_entrypoint)
+    live_child_bytes = _retained_file_read(live_child)
     _source_identity(source, source_commit, source_tree)
     hashes = {
         "model": hashlib.sha256(model_bytes).hexdigest(),
         "model_manifest": hashlib.sha256(manifest_bytes).hexdigest(),
         "config": hashlib.sha256(config_bytes).hexdigest(),
+        "live_capture": hashlib.sha256(live_entrypoint_bytes).hexdigest(),
+        "live_capture_child": hashlib.sha256(live_child_bytes).hexdigest(),
     }
     binding = {
         "schema_version": "manual_research_deployment_binding_v1",
         "deployment": {"source_commit": source_commit, "source_tree": source_tree, "lane": "manual-research-v1"},
         "executable": str(python),
         "entrypoint": "src.predictor.manual_research_cli:main",
+        "live_capture": {
+            "entrypoint": "src.predictor.manual_live_capture:main",
+            "child": "src.predictor.manual_live_capture_child:main",
+            "entrypoint_sha256": hashes["live_capture"],
+            "child_sha256": hashes["live_capture_child"],
+        },
         "manual": {
             "operations_root": str(manual),
             "browser_profile_root": str(profile),
@@ -343,6 +363,10 @@ def generate_manual_package(
             f"MANUAL_RESEARCH_MODEL_SHA256={hashes['model']}",
             f"MANUAL_RESEARCH_MODEL_MANIFEST_SHA256={hashes['model_manifest']}",
             f"MANUAL_RESEARCH_CONFIG_SHA256={hashes['config']}",
+            "MANUAL_RESEARCH_LIVE_CAPTURE_ENTRYPOINT=src.predictor.manual_live_capture:main",
+            "MANUAL_RESEARCH_LIVE_CAPTURE_CHILD=src.predictor.manual_live_capture_child:main",
+            f"MANUAL_RESEARCH_LIVE_CAPTURE_SHA256={hashes['live_capture']}",
+            f"MANUAL_RESEARCH_LIVE_CAPTURE_CHILD_SHA256={hashes['live_capture_child']}",
             "",
         )
     ).encode()

--- a/src/predictor/manual_research_worker.py
+++ b/src/predictor/manual_research_worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -12,6 +13,7 @@ _REQUIRED_KEYS = {
     "deployment",
     "executable",
     "entrypoint",
+    "live_capture",
     "manual",
     "artifacts",
     "default_enabled",
@@ -19,6 +21,13 @@ _REQUIRED_KEYS = {
     "canonical",
     "phase7_excluded",
 }
+_LIVE_CAPTURE_KEYS = {
+    "entrypoint",
+    "child",
+    "entrypoint_sha256",
+    "child_sha256",
+}
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -34,6 +43,26 @@ def main(argv: Sequence[str] | None = None) -> int:
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return 78
     if not isinstance(binding, dict) or set(binding) != _REQUIRED_KEYS:
+        return 78
+    live_capture = binding["live_capture"]
+    artifacts = binding["artifacts"]
+    if (
+        not isinstance(live_capture, dict)
+        or set(live_capture) != _LIVE_CAPTURE_KEYS
+        or not isinstance(artifacts, dict)
+        or not isinstance(live_capture["entrypoint"], str)
+        or not isinstance(live_capture["child"], str)
+        or not isinstance(live_capture["entrypoint_sha256"], str)
+        or not isinstance(live_capture["child_sha256"], str)
+        or _SHA256_RE.fullmatch(live_capture["entrypoint_sha256"]) is None
+        or _SHA256_RE.fullmatch(live_capture["child_sha256"]) is None
+        or artifacts.get("live_capture") != live_capture["entrypoint_sha256"]
+        or artifacts.get("live_capture_child") != live_capture["child_sha256"]
+        or binding["default_enabled"] is not False
+        or binding["research_only"] is not True
+        or binding["canonical"] is not False
+        or binding["phase7_excluded"] is not True
+    ):
         return 78
     if os.environ.get("MANUAL_RESEARCH_ENABLED") != "1":
         return 0

--- a/tests/test_manual_live_capture.py
+++ b/tests/test_manual_live_capture.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.predictor.manual_independent_capture import (
+    PROTECTED_PATH_KEYS,
+    canonical_sha256,
+)
+from src.predictor.manual_independent_capture_executor import (
+    execute_manual_capture_fixture,
+)
+from src.predictor.manual_independent_capture_sealer import (
+    build_sealing_identity,
+    expectations_from_execution,
+    seal_manual_capture,
+)
+from src.predictor.manual_live_capture_child import (
+    CONTENT_TYPE,
+    LiveCaptureRejected,
+    _install_navigation_guard,
+    capture_from_page,
+)
+
+NOW = datetime(2026, 8, 5, 1, 0, 0, tzinfo=timezone.utc)
+SOURCE_COMMIT = "e4f3699986237aad265b34e77d06d536f6046ee4"
+SOURCE_TREE = "ac9cdde82d3a0ede953e36c9a87d9afd216c5826"
+
+
+class _Response:
+    def __init__(self, status: int = 200):
+        self.status = status
+
+
+class _Locator:
+    def __init__(self, *, rows=None, count: int = 0):
+        self.rows = rows
+        self._count = count
+
+    def count(self) -> int:
+        return self._count
+
+    def evaluate_all(self, _script: str):
+        if self.rows is None:
+            raise AssertionError("unexpected evaluation")
+        return self.rows
+
+
+class _Page:
+    def __init__(
+        self,
+        rows,
+        *,
+        final_url: str,
+        status: int = 200,
+        challenge: bool = False,
+        outcome: bool = False,
+        title: str = "Race",
+    ):
+        self.rows = rows
+        self.url = final_url
+        self.status = status
+        self.challenge = challenge
+        self.outcome = outcome
+        self.page_title = title
+        self.goto_urls: list[str] = []
+
+    def goto(self, url: str, **_kwargs):
+        self.goto_urls.append(url)
+        return _Response(self.status)
+
+    def title(self) -> str:
+        return self.page_title
+
+    def locator(self, selector: str):
+        if selector == "tr.race-runner":
+            return _Locator(rows=self.rows)
+        if selector in {"input[type='password']", "[data-captcha]", "iframe[src*='challenge']", ".cf-challenge", "#challenge-running"}:
+            return _Locator(count=int(self.challenge))
+        if selector in {"[data-result]", "[data-outcome]", "[data-finishing-position]", ".race-result", ".race-results", ".race-result__winner"}:
+            return _Locator(count=int(self.outcome))
+        raise AssertionError(f"unexpected selector: {selector}")
+
+
+class _TimeoutPage(_Page):
+    def goto(self, _url: str, **_kwargs):
+        self.goto_urls.append(_url)
+        raise TimeoutError("mock timeout")
+
+
+class _Request:
+    def __init__(self, url: str, navigation: bool):
+        self.url = url
+        self.navigation = navigation
+
+    def is_navigation_request(self) -> bool:
+        return self.navigation
+
+
+class _Route:
+    def __init__(self, url: str, navigation: bool):
+        self.request = _Request(url, navigation)
+        self.action = None
+
+    def abort(self):
+        self.action = "abort"
+
+    def continue_(self):
+        self.action = "continue"
+
+
+class _RoutePage:
+    def __init__(self):
+        self.guard = None
+
+    def route(self, _pattern, guard):
+        self.guard = guard
+
+
+def _url() -> str:
+    return "https://www.thedogs.com.au/racing/richmond/2026-08-05/1/race-name"
+
+
+def _race(scheduled: datetime | None = None) -> dict:
+    scheduled = scheduled or NOW + timedelta(hours=1)
+    return {
+        "url": _url(),
+        "race_id": "Race 1 - RICH - 2026-08-05",
+        "race_date": "2026-08-05",
+        "venue": "RICH",
+        "venue_slug": "richmond",
+        "race_number": 1,
+        "scheduled_start": scheduled.isoformat(),
+    }
+
+
+def _rows() -> list[dict]:
+    return [
+        {
+            "box_number": 1,
+            "display_name": "Fast Dog",
+            "source_native_runner_id": "native-1",
+            "win_odds": "2.50",
+        },
+        {
+            "box_number": 2,
+            "display_name": "Quick Dog",
+            "source_native_runner_id": "native-2",
+            "win_odds": "3.10",
+        },
+    ]
+
+
+def _readiness_rows() -> list[dict]:
+    return [
+        {
+            "runner_id": "Race 1 - RICH - 2026-08-05|box:1|dog:FASTDOG",
+            "box_number": 1,
+            "dog_name": "Fast Dog",
+            "source_native_runner_id": "native-1",
+        },
+        {
+            "runner_id": "Race 1 - RICH - 2026-08-05|box:2|dog:QUICKDOG",
+            "box_number": 2,
+            "dog_name": "Quick Dog",
+            "source_native_runner_id": "native-2",
+        },
+    ]
+
+
+def _config(tmp_path: Path) -> dict:
+    operations = tmp_path / "operations"
+    operations.mkdir()
+    manual = operations / "manual-independent-capture-v1"
+    return {
+        "schema_version": "manual_independent_capture_config_v1",
+        "contract_version": "manual-independent-capture-v1",
+        "safety": {
+            "research_only": True,
+            "canonical": False,
+            "phase7_excluded": True,
+            "phase7_eligible": False,
+            "phase7_exclusion_reason": "manual_research_only_noncanonical",
+        },
+        "authority_profile": "manual_independent_capture_research_only_v1",
+        "paths": {
+            "operations_root": str(operations),
+            "manual_root": str(manual),
+            "browser_profile": str(manual / "browser-profile"),
+            "runs_root": str(manual / "runs"),
+            "manual_lock": str(manual / "manual-capture.lock"),
+        },
+        "timing": {
+            "minimum_prejump_margin_seconds": 120,
+            "hard_timeout_seconds": 5,
+            "cancellation_grace_seconds": 1,
+        },
+        "attempt_policy": {
+            "max_concurrent_manual_runs": 1,
+            "max_capture_attempts": 1,
+            "retries_allowed": False,
+            "replay_allowed": False,
+        },
+    }
+
+
+def _forbidden(tmp_path: Path) -> dict[str, str]:
+    root = tmp_path / "protected"
+    root.mkdir()
+    return {name: str(root / name) for name in PROTECTED_PATH_KEYS}
+
+
+def test_exact_url_live_fixture_record_is_strict_and_single_attempt():
+    page = _Page(_rows(), final_url=_url())
+    record = capture_from_page(
+        page,
+        exact_url=_url(),
+        race_id=_race()["race_id"],
+        race_identity_sha256=canonical_sha256(_race()),
+        now=lambda: NOW,
+    )
+    assert page.goto_urls == [_url()]
+    assert record["schema_version"] == "manual_independent_capture_child_live_v1"
+    assert record["source"]["content_type"] == CONTENT_TYPE
+    assert json.loads(base64.b64decode(record["source"]["bytes_base64"])) == {
+        "runners": [
+            {"box_number": 1, "display_name": "Fast Dog", "decimal_odds": 2.5},
+            {"box_number": 2, "display_name": "Quick Dog", "decimal_odds": 3.1},
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "code"),
+    [
+        ({"final_url": "https://www.thedogs.com.au/racing/richmond/2026-08-05/2/other"}, "IDENTITY_MISMATCH"),
+        ({"status": 503}, "SOURCE_ATTEMPT_FAILED"),
+        ({"challenge": True}, "SOURCE_CHALLENGE"),
+        ({"outcome": True}, "OUTCOME_MATERIAL_FORBIDDEN"),
+        ({"rows": [{"box_number": 1, "display_name": "Fast Dog", "source_native_runner_id": None, "win_odds": "2.00", "unexpected": True}]}, "SOURCE_MALFORMED"),
+        ({"rows": [{"box_number": 1, "display_name": "Fast Dog", "source_native_runner_id": None, "win_odds": ""}]}, "ODDS_INVALID"),
+        ({"rows": [{"box_number": 1, "display_name": "Fast Dog", "source_native_runner_id": None, "win_odds": "1.00"}]}, "ODDS_INVALID"),
+        ({"rows": [{"box_number": 2, "display_name": "Fast Dog", "source_native_runner_id": None, "win_odds": "2.00"}, {"box_number": 2, "display_name": "Quick Dog", "source_native_runner_id": None, "win_odds": "3.00"}]}, "RUNNER_SET_MISMATCH"),
+    ],
+)
+def test_live_child_failures_are_terminal_without_fallback(kwargs, code):
+    values = {"rows": _rows(), "final_url": _url()}
+    values.update(kwargs)
+    page = _Page(**values)
+    with pytest.raises(LiveCaptureRejected, match=code):
+        capture_from_page(
+            page,
+            exact_url=_url(),
+            race_id=_race()["race_id"],
+            race_identity_sha256=canonical_sha256(_race()),
+            now=lambda: NOW,
+        )
+    assert page.goto_urls == [_url()]
+
+
+def test_live_child_timeout_is_one_terminal_attempt():
+    page = _TimeoutPage(_rows(), final_url=_url())
+    with pytest.raises(LiveCaptureRejected, match="SOURCE_ATTEMPT_FAILED"):
+        capture_from_page(
+            page,
+            exact_url=_url(),
+            race_id=_race()["race_id"],
+            race_identity_sha256=canonical_sha256(_race()),
+            now=lambda: NOW,
+        )
+    assert page.goto_urls == [_url()]
+
+
+def test_navigation_guard_blocks_redirects_and_outcome_subresources():
+    page = _RoutePage()
+    _install_navigation_guard(page, _url())
+    exact = _Route(_url(), True)
+    redirect = _Route("https://www.thedogs.com.au/results/richmond", True)
+    outcome_api = _Route("https://www.thedogs.com.au/api/outcome/1", False)
+    asset = _Route("https://www.thedogs.com.au/assets/race.css", False)
+    for route in (exact, redirect, outcome_api, asset):
+        page.guard(route)
+    assert [route.action for route in (exact, redirect, outcome_api, asset)] == [
+        "continue",
+        "abort",
+        "abort",
+        "continue",
+    ]
+
+
+def test_live_output_passes_unchanged_ghu051_parent_runner_binding_and_ghu052_sealing(tmp_path: Path):
+    race = _race()
+    readiness = _readiness_rows()
+    config = _config(tmp_path)
+    forbidden = _forbidden(tmp_path)
+    record = capture_from_page(
+        _Page(_rows(), final_url=_url()),
+        exact_url=_url(),
+        race_id=race["race_id"],
+        race_identity_sha256=canonical_sha256(race),
+        now=lambda: NOW,
+    )
+    record["race_identity_sha256"] = canonical_sha256(race)
+    raw = json.dumps(record, sort_keys=True, separators=(",", ":")).encode()
+    result = execute_manual_capture_fixture(
+        config=config,
+        forbidden_paths=forbidden,
+        requested_race_url=_url(),
+        selected_race=race,
+        expected_runner_set=readiness,
+        model_bytes=b"fixture-model",
+        source_commit=SOURCE_COMMIT,
+        source_tree=SOURCE_TREE,
+        fixture_child_command=lambda _launch: [
+            sys.executable,
+            "-c",
+            "import sys; sys.stdout.buffer.write(" + repr(raw) + ")",
+        ],
+        now=lambda: NOW,
+    )
+    assert result.artifact["terminal"] == {"status": "CAPTURE_READY", "failure_code": None}
+    assert result.cleanup.confirmed is True
+    assert result.cleanup.process_group_absent is True
+    assert result.artifact["attempt"] == {"attempt_count": 1, "source_attempt_count": 1}
+    assert result.source_response.content_type == CONTENT_TYPE
+    expected = expectations_from_execution(result)
+    sealed = seal_manual_capture(
+        result,
+            config=config,
+            forbidden_paths=forbidden,
+        expected=expected,
+        identity=build_sealing_identity(
+            repo_root=Path(__file__).parents[1],
+            source_commit=SOURCE_COMMIT,
+            source_tree=SOURCE_TREE,
+        ),
+        repo_root=Path(__file__).parents[1],
+    )
+    assert sealed.bundle["source"]["odds_parser"] == "manual_live_json_odds_v1"
+    assert sealed.bundle["safety"] == {
+        "research_only": True,
+        "canonical": False,
+        "phase7_excluded": True,
+        "phase7_eligible": False,
+        "phase7_exclusion_reason": "manual_research_only_noncanonical",
+    }

--- a/tests/test_manual_live_capture.py
+++ b/tests/test_manual_live_capture.py
@@ -25,6 +25,7 @@ from src.predictor.manual_live_capture_child import (
     LiveCaptureRejected,
     _install_navigation_guard,
     capture_from_page,
+    network_request_allowed,
 )
 
 NOW = datetime(2026, 8, 5, 1, 0, 0, tzinfo=timezone.utc)
@@ -94,17 +95,25 @@ class _TimeoutPage(_Page):
 
 
 class _Request:
-    def __init__(self, url: str, navigation: bool):
+    def __init__(self, url: str, navigation: bool, resource_type: str, method: str):
         self.url = url
         self.navigation = navigation
+        self.resource_type = resource_type
+        self.method = method
 
     def is_navigation_request(self) -> bool:
         return self.navigation
 
 
 class _Route:
-    def __init__(self, url: str, navigation: bool):
-        self.request = _Request(url, navigation)
+    def __init__(
+        self,
+        url: str,
+        navigation: bool,
+        resource_type: str = "other",
+        method: str = "GET",
+    ):
+        self.request = _Request(url, navigation, resource_type, method)
         self.action = None
 
     def abort(self):
@@ -276,13 +285,49 @@ def test_live_child_timeout_is_one_terminal_attempt():
     assert page.goto_urls == [_url()]
 
 
-def test_navigation_guard_blocks_redirects_and_outcome_subresources():
+@pytest.mark.parametrize(
+    ("url", "resource_type", "is_navigation", "method", "expected"),
+    [
+        (_url(), "document", True, "GET", True),
+        (_url(), "document", False, "GET", False),
+        (_url(), "document", True, "POST", False),
+        ("https://www.thedogs.com.au/racing/richmond/2026-08-05/2/other", "document", True, "GET", False),
+        ("https://www.thedogs.com.au/api/race/123/data", "xhr", False, "GET", False),
+        ("https://www.thedogs.com.au/api/meeting/123", "fetch", False, "GET", False),
+        ("https://www.thedogs.com.au/api/race/123/details", "xhr", False, "GET", False),
+        ("wss://www.thedogs.com.au/socket/race/123", "websocket", False, "GET", False),
+        ("https://www.thedogs.com.au/events/race/123", "eventsource", False, "GET", False),
+        ("https://www.thedogs.com.au/assets/race.css", "stylesheet", False, "GET", True),
+        ("https://www.thedogs.com.au/assets/race.js", "script", False, "GET", True),
+        ("https://www.thedogs.com.au/assets/runner.png", "image", False, "GET", True),
+        ("https://www.thedogs.com.au/assets/site.woff2", "font", False, "GET", True),
+        ("https://evil.example/assets/race.css", "stylesheet", False, "GET", False),
+        ("https://www.thedogs.com.au/static/race.css", "stylesheet", False, "GET", False),
+        ("https://www.thedogs.com.au/assets/race.css?outcome=1", "stylesheet", False, "GET", False),
+        ("https://www.thedogs.com.au/api/outcome/1", "xhr", False, "GET", False),
+        ("https://www.thedogs.com.au/assets/race.css", "stylesheet", False, "POST", False),
+        ("https://www.thedogs.com.au/assets/data", "other", False, "GET", False),
+    ],
+)
+def test_network_request_policy_is_explicit_and_fail_closed(
+    url, resource_type, is_navigation, method, expected
+):
+    assert network_request_allowed(
+        url=url,
+        resource_type=resource_type,
+        is_navigation_request=is_navigation,
+        method=method,
+        exact_race_url=_url(),
+    ) is expected
+
+
+def test_navigation_guard_applies_the_allowlist_to_routes():
     page = _RoutePage()
     _install_navigation_guard(page, _url())
-    exact = _Route(_url(), True)
-    redirect = _Route("https://www.thedogs.com.au/results/richmond", True)
-    outcome_api = _Route("https://www.thedogs.com.au/api/outcome/1", False)
-    asset = _Route("https://www.thedogs.com.au/assets/race.css", False)
+    exact = _Route(_url(), True, "document")
+    redirect = _Route("https://www.thedogs.com.au/results/richmond", True, "document")
+    outcome_api = _Route("https://www.thedogs.com.au/api/outcome/1", False, "xhr")
+    asset = _Route("https://www.thedogs.com.au/assets/race.css", False, "stylesheet")
     for route in (exact, redirect, outcome_api, asset):
         page.guard(route)
     assert [route.action for route in (exact, redirect, outcome_api, asset)] == [

--- a/tests/test_manual_research_deployment.py
+++ b/tests/test_manual_research_deployment.py
@@ -1,6 +1,8 @@
 import json
 import os
+import shlex
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -34,6 +36,21 @@ def _git_identity(monkeypatch, commit: str, tree: str) -> None:
         return subprocess.CompletedProcess(command, 0, output, "")
 
     monkeypatch.setattr("src.predictor.manual_research_deployment.subprocess.run", run)
+
+
+def _controlled_pinned_python(tmp_path: Path) -> Path:
+    path = tmp_path / "pinned-python"
+    path.write_text(
+        "#!/bin/sh\n"
+        f"exec {shlex.quote(str(Path(sys.executable).resolve()))} \"$@\"\n"
+    )
+    path.chmod(0o755)
+    info = path.stat()
+    assert path.is_file()
+    assert not path.is_symlink()
+    assert info.st_uid == os.geteuid()
+    assert stat.S_IMODE(info.st_mode) == 0o755
+    return path
 
 
 @pytest.fixture
@@ -82,7 +99,7 @@ def deployment_inputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     _git_identity(monkeypatch, commit, tree)
     return {
         "source_root": source,
-        "pinned_python": Path(sys.executable).resolve(),
+        "pinned_python": _controlled_pinned_python(tmp_path),
         "manual_root": manual,
         "browser_profile_root": profile,
         "manual_runs_root": runs,
@@ -121,6 +138,7 @@ def test_default_off_package_isolated_and_template_bound(deployment_inputs):
     assert binding["research_only"] is True
     assert binding["canonical"] is False
     assert binding["phase7_excluded"] is True
+    assert binding["executable"] == str(values["pinned_python"])
     assert set(binding) == {"artifacts", "canonical", "default_enabled", "deployment", "entrypoint", "executable", "live_capture", "manual", "phase7_excluded", "research_only", "schema_version"}
     assert set(binding["artifacts"]) == {"config", "live_capture", "live_capture_child", "model", "model_manifest"}
     assert binding["live_capture"] == {
@@ -178,6 +196,23 @@ def test_generator_rejects_manual_protected_overlap_without_partial_output(deplo
     protected["canonical_database"] = values["manual_root"]
     values["protected_paths"] = protected
     with pytest.raises(ManualDeploymentRejected, match="overlap"):
+        generate_manual_package(**values)
+    assert not any(values["output_dir"].iterdir())
+
+
+@pytest.mark.parametrize("mode", [0o775, 0o777])
+def test_generator_rejects_group_or_world_writable_pinned_executable(
+    deployment_inputs, monkeypatch, mode
+):
+    values = dict(deployment_inputs)
+    unsafe = values["source_root"].parent / f"unsafe-pinned-python-{mode:o}"
+    unsafe.write_text("#!/bin/sh\nexit 0\n")
+    unsafe.chmod(mode)
+    values["pinned_python"] = unsafe
+    if mode & 0o020 and not mode & 0o002:
+        owner = os.geteuid()
+        monkeypatch.setattr(os, "geteuid", lambda: owner + 1)
+    with pytest.raises(ManualDeploymentRejected, match="unsafe permissions"):
         generate_manual_package(**values)
     assert not any(values["output_dir"].iterdir())
 

--- a/tests/test_manual_research_deployment.py
+++ b/tests/test_manual_research_deployment.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -43,6 +44,8 @@ def deployment_inputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         "ops/systemd/manual-research-api.service.in",
         "src/predictor/manual_research_cli.py",
         "src/predictor/manual_research_worker.py",
+        "src/predictor/manual_live_capture.py",
+        "src/predictor/manual_live_capture_child.py",
         "configs/prediction/manual-default.json",
         "artifacts/frozen_models/market_form_residual_v1/model.json",
         "artifacts/frozen_models/market_form_residual_v1/manifest.json",
@@ -118,7 +121,28 @@ def test_default_off_package_isolated_and_template_bound(deployment_inputs):
     assert binding["research_only"] is True
     assert binding["canonical"] is False
     assert binding["phase7_excluded"] is True
-    assert set(binding) == {"artifacts", "canonical", "default_enabled", "deployment", "entrypoint", "executable", "manual", "phase7_excluded", "research_only", "schema_version"}
+    assert set(binding) == {"artifacts", "canonical", "default_enabled", "deployment", "entrypoint", "executable", "live_capture", "manual", "phase7_excluded", "research_only", "schema_version"}
+    assert set(binding["artifacts"]) == {"config", "live_capture", "live_capture_child", "model", "model_manifest"}
+    assert binding["live_capture"] == {
+        "entrypoint": "src.predictor.manual_live_capture:main",
+        "child": "src.predictor.manual_live_capture_child:main",
+        "entrypoint_sha256": binding["artifacts"]["live_capture"],
+        "child_sha256": binding["artifacts"]["live_capture_child"],
+    }
+    assert "MANUAL_RESEARCH_LIVE_CAPTURE_ENTRYPOINT=src.predictor.manual_live_capture:main" in environment
+    assert "MANUAL_RESEARCH_LIVE_CAPTURE_CHILD=src.predictor.manual_live_capture_child:main" in environment
+    worker = values["source_root"] / "src/predictor/manual_research_worker.py"
+    binding_path = output / "manual-research.binding.json"
+    def run_worker(environment=None):
+        process = subprocess.Popen(
+            [sys.executable, str(worker), "--binding", str(binding_path)],
+            env=environment,
+        )
+        return process.wait()
+
+    assert run_worker() == 0
+    enabled_env = dict(os.environ, MANUAL_RESEARCH_ENABLED="1")
+    assert run_worker(enabled_env) == 78
     assert "KillMode=control-group" in service
     assert "FinalKillSignal=SIGKILL" in service
     assert "RestrictAddressFamilies=AF_UNIX" in service


### PR DESCRIPTION
## Summary

GHU-059 stopped because GHU-051 had only a fixture child and no bounded live
manual runtime. This change adds one versioned live Playwright child behind the
existing GHU-051 executor, parent-side exact readiness runner binding, and an
explicit request-scoped CLI with no discovery, retry, fallback, or substitution.

GHU-052 keeps its sealing and outcome-rejection semantics; it gains only the
distinct live JSON media/parser identity. The default-off GHU-056 package now
hash-binds the reviewed live entrypoint and child while remaining disabled.

## Safety and claims boundary

- Research-only, canonical=false, Phase-7 excluded.
- No scoring/model/DB/history/result/autonomous/betting/promotion changes.
- No live browser/source attempt, deployment, installation, activation,
  restart, lock manipulation, or merge was performed.
- This proves controlled-fixture traversal only; real live-source success and
  real pre-jump prediction remain the next ticket.

## Validation

- Exact base: `1c937b53491787f1e54b16d235f7536af48c3c85`.
- Classifier: `manual_prediction`, `ci_contract_changed=true`.
- Focused manual tier: `785 passed`.
- Ruff, compile, diff-check, parent runner binding, GHU-052 sealing, default-off
  deployment binding, process cleanup, redirect/challenge/malformed/odds/
  timeout/result/no-retry tests passed.
