### PR TITLE
Route report-only forecasting changes to focused CI

### DIFF
--- a/.github/forecasting-paths.ini
+++ b/.github/forecasting-paths.ini
@@ -114,6 +114,8 @@ patterns =
     tests/test_market_form_residual.py
     tests/test_market_form_residual_portability.py
     tests/test_predict_market_form_residual.py
+    scripts/strict_win_odds_fixture_capture.py
+    tests/test_strict_win_odds_fixture_capture.py
     tests/race_collection/test_manual_scoring_readiness.py
 
 [official_results]
@@ -166,6 +168,8 @@ patterns =
     .editorconfig
     .gitignore
     CHANGELOG.md
+    .playwright-mcp/**
+    artifacts/**
     LICENSE
     LICENSE.*
     README.md

--- a/.github/forecasting-paths.ini
+++ b/.github/forecasting-paths.ini
@@ -4,8 +4,13 @@ schema_version = forecasting-change-rules-v2
 [full_forecasting]
 patterns =
     AGENTS.md
+    artifacts/eval/**
     alembic/**
     artifacts/frozen_models/**
+    artifacts/historical_replay_20260525_shepparton_expanded/**
+    artifacts/historical_replay_20260525_shepparton_sample/**
+    artifacts/prediction_snapshots/**
+    artifacts/full_evidence_orchestration_20260525/high_accuracy_refinement_packet_20260610T_accuracy_lane_current/promotion_pr_gate.json
     configs/prediction/schemas/**
     constraints*.txt
     environment*.yml
@@ -169,7 +174,8 @@ patterns =
     .gitignore
     CHANGELOG.md
     .playwright-mcp/**
-    artifacts/**
+    artifacts/full_evidence_orchestration_20260525/*_report_only/**
+    artifacts/full_evidence_orchestration_20260525/daemon_orchestrator_decision_packet_20260616T172233+1000/**
     LICENSE
     LICENSE.*
     README.md

--- a/.github/workflows/forecasting-tests.yml
+++ b/.github/workflows/forecasting-tests.yml
@@ -188,6 +188,7 @@ jobs:
                 tests/test_market_form_residual.py \
                 tests/test_market_form_residual_portability.py \
                 tests/test_predict_market_form_residual.py \
+                tests/test_strict_win_odds_fixture_capture.py \
                 tests/race_collection/test_manual_scoring_readiness.py \
                 tests/test_scoring_parity.py
               )

--- a/tests/ci/test_forecasting_change_classifier.py
+++ b/tests/ci/test_forecasting_change_classifier.py
@@ -82,6 +82,8 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
                 "tests/test_manual_independent_capture.py",
                 "tests/test_manual_independent_capture_sealer.py",
                 "tests/test_predict_market_form_residual.py",
+                "scripts/strict_win_odds_fixture_capture.py",
+                "tests/test_strict_win_odds_fixture_capture.py",
             ),
             "official_results": (
                 "scripts/autonomous_official_result_capture.py",
@@ -114,6 +116,8 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
                 "tests/race_collection/test_phase4_model_serving.py",
             ),
             "full_forecasting": (
+                "AGENTS.md",
+                "artifacts/frozen_models/model.bin",
                 "race_collection/domain.py",
                 "race_collection/features.py",
                 "race_collection/identity.py",
@@ -133,6 +137,8 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
                 "README.md",
                 "docs/race_evidence_inventory.md",
                 "reports/agent_jobs/example/README.md",
+                ".playwright-mcp/page.yml",
+                "artifacts/report_only/packet.json",
                 "static/css/base.css",
                 "templates/index.html",
             ),
@@ -145,6 +151,25 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
                     self.assertIs(
                         result["ci_contract_changed"], expected == "ci_contract"
                     )
+
+    def test_report_only_artifacts_and_strict_fixture_lane_stay_focused(self):
+        result = self.classify(
+            ("A", ".playwright-mcp/page-2026-07-09.yml"),
+            (
+                "A",
+                "artifacts/full_evidence_orchestration_20260525/report_only/packet.json",
+            ),
+            ("A", "scripts/strict_win_odds_fixture_capture.py"),
+            ("A", "tests/test_strict_win_odds_fixture_capture.py"),
+        )
+        self.assertEqual(result["tier"], "manual_prediction")
+        self.assertEqual(result["reason"], "single_trusted_tier")
+        self.assertFalse(result["ci_contract_changed"])
+
+    def test_artifact_allowlist_does_not_hide_frozen_models(self):
+        result = self.classify(("M", "artifacts/frozen_models/model.bin"))
+        self.assertEqual(result["tier"], "full_forecasting")
+        self.assertEqual(result["reason"], "shared_or_high_risk_path_requires_full")
 
     def test_ci_only_routing_change_never_selects_complete_suite(self):
         result = self.classify(
@@ -543,6 +568,7 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
             "forecasting-command-manifest.tsv",
             'forecasting-command.txt',
             '--with PyYAML python scripts/ci/run_forecasting_ci_contract.py',
+            'tests/test_strict_win_odds_fixture_capture.py',
             "commit = subprocess.check_output",
             "tree = subprocess.check_output",
         ):

--- a/tests/ci/test_forecasting_change_classifier.py
+++ b/tests/ci/test_forecasting_change_classifier.py
@@ -117,7 +117,11 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
             ),
             "full_forecasting": (
                 "AGENTS.md",
+                "artifacts/eval/status.txt",
                 "artifacts/frozen_models/model.bin",
+                "artifacts/historical_replay_20260525_shepparton_expanded/snapshots/manifest.jsonl",
+                "artifacts/prediction_snapshots/manifest.jsonl",
+                "artifacts/full_evidence_orchestration_20260525/high_accuracy_refinement_packet_20260610T_accuracy_lane_current/promotion_pr_gate.json",
                 "race_collection/domain.py",
                 "race_collection/features.py",
                 "race_collection/identity.py",
@@ -138,7 +142,8 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
                 "docs/race_evidence_inventory.md",
                 "reports/agent_jobs/example/README.md",
                 ".playwright-mcp/page.yml",
-                "artifacts/report_only/packet.json",
+                "artifacts/full_evidence_orchestration_20260525/example_report_only/packet.json",
+                "artifacts/full_evidence_orchestration_20260525/daemon_orchestrator_decision_packet_20260616T172233+1000/README.md",
                 "static/css/base.css",
                 "templates/index.html",
             ),
@@ -157,7 +162,7 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
             ("A", ".playwright-mcp/page-2026-07-09.yml"),
             (
                 "A",
-                "artifacts/full_evidence_orchestration_20260525/report_only/packet.json",
+                "artifacts/full_evidence_orchestration_20260525/example_report_only/packet.json",
             ),
             ("A", "scripts/strict_win_odds_fixture_capture.py"),
             ("A", "tests/test_strict_win_odds_fixture_capture.py"),
@@ -166,10 +171,21 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
         self.assertEqual(result["reason"], "single_trusted_tier")
         self.assertFalse(result["ci_contract_changed"])
 
-    def test_artifact_allowlist_does_not_hide_frozen_models(self):
-        result = self.classify(("M", "artifacts/frozen_models/model.bin"))
-        self.assertEqual(result["tier"], "full_forecasting")
-        self.assertEqual(result["reason"], "shared_or_high_risk_path_requires_full")
+    def test_protected_artifact_namespaces_remain_full(self):
+        paths = (
+            "artifacts/eval/status.txt",
+            "artifacts/frozen_models/model.bin",
+            "artifacts/historical_replay_20260525_shepparton_expanded/snapshots/manifest.jsonl",
+            "artifacts/prediction_snapshots/manifest.jsonl",
+            "artifacts/full_evidence_orchestration_20260525/high_accuracy_refinement_packet_20260610T_accuracy_lane_current/promotion_pr_gate.json",
+        )
+        for path in paths:
+            with self.subTest(path=path):
+                result = self.classify(("M", path))
+                self.assertEqual(result["tier"], "full_forecasting")
+                self.assertEqual(
+                    result["reason"], "shared_or_high_risk_path_requires_full"
+                )
 
     def test_ci_only_routing_change_never_selects_complete_suite(self):
         result = self.classify(


### PR DESCRIPTION
## What changed

- Route report-only `artifacts/**` and `.playwright-mcp/**` changes to the non-forecasting tier.
- Route the strict WIN fixture writer and its isolated tests to the focused `manual_prediction` tier.
- Execute the strict fixture test in that focused workflow command.
- Preserve full-risk routing for `AGENTS.md` and `artifacts/frozen_models/**`.
- Add regression coverage for the routing and workflow contract.

## Why

Unknown paths intentionally default to `full_forecasting`. The repository's report-only evidence and fixture-only surfaces were missing from the allowlist, so ordinary evidence/fixture PRs were unnecessarily admitted to the long race-collection suite.

## Validation

- `python3 tests/ci/test_forecasting_change_classifier.py` — 30 passed
- `uv run --no-project --with ruff ruff check tests/ci/test_forecasting_change_classifier.py` — passed
- Forecasting workflow YAML parse — passed
- `git diff --check` — passed
- Existing strict WIN fixture suite — 9 passed
