### PR TITLE
GHU-063 isolate fixed-runtime test fixtures

### DIFF
--- a/.github/forecasting-paths.ini
+++ b/.github/forecasting-paths.ini
@@ -71,8 +71,6 @@ patterns =
     tests/race_collection/test_phase7_runtime_adapter.py
     tests/race_collection/test_synchronous_manual_capture.py
     tests/operator_ui/test_api.py
-    tests/operator_ui/test_bootstrap.py
-    tests/operator_ui/test_deployment_generator.py
     tests/operator_ui/test_live_adapters.py
     tests/test_predict_race_now.py
     tox.ini
@@ -154,6 +152,8 @@ patterns =
     static/js/operator-ui-*.js
     templates/operator_ui_*.jinja
     tests/operator_ui/test_connected_ui.py
+    tests/operator_ui/test_bootstrap.py
+    tests/operator_ui/test_deployment_generator.py
     tests/operator_ui/test_foundation.py
     tests/operator_ui/test_job_store.py
     tests/operator_ui/test_prediction_worker.py

--- a/.github/workflows/forecasting-tests.yml
+++ b/.github/workflows/forecasting-tests.yml
@@ -216,6 +216,8 @@ jobs:
               selected_command=(
                 uv run --no-project --with-requirements requirements/all.in
                 python -m pytest -q
+                tests/operator_ui/test_bootstrap.py \
+                tests/operator_ui/test_deployment_generator.py \
                 tests/operator_ui/test_foundation.py \
                 tests/operator_ui/test_job_store.py \
                 tests/operator_ui/test_prediction_worker.py \

--- a/tests/ci/test_forecasting_change_classifier.py
+++ b/tests/ci/test_forecasting_change_classifier.py
@@ -107,6 +107,8 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
                 "static/css/operator-ui.css",
                 "static/js/operator-ui-connected.js",
                 "templates/operator_ui_connected.jinja",
+                "tests/operator_ui/test_bootstrap.py",
+                "tests/operator_ui/test_deployment_generator.py",
                 "tests/operator_ui/test_foundation.py",
             ),
             "forecasting_core": (
@@ -133,7 +135,6 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
                 "scripts/predict_race_now.py",
                 "src/operator_ui/bootstrap.py",
                 "tests/race_collection/test_phase5_ordered_finish_training.py",
-                "tests/operator_ui/test_deployment_generator.py",
                 "tests/test_predict_race_now.py",
                 "utils/csv_metadata.py",
             ),
@@ -186,6 +187,15 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
                 self.assertEqual(
                     result["reason"], "shared_or_high_risk_path_requires_full"
                 )
+
+    def test_fixed_runtime_operator_ui_tests_stay_focused(self):
+        result = self.classify(
+            ("M", "tests/operator_ui/test_bootstrap.py"),
+            ("M", "tests/operator_ui/test_deployment_generator.py"),
+        )
+        self.assertEqual(result["tier"], "operator_ui")
+        self.assertEqual(result["reason"], "single_trusted_tier")
+        self.assertFalse(result["ci_contract_changed"])
 
     def test_ci_only_routing_change_never_selects_complete_suite(self):
         result = self.classify(

--- a/tests/ci/test_forecasting_change_classifier.py
+++ b/tests/ci/test_forecasting_change_classifier.py
@@ -197,6 +197,18 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
         self.assertEqual(result["reason"], "single_trusted_tier")
         self.assertFalse(result["ci_contract_changed"])
 
+    def test_fixed_runtime_pr_with_ci_contract_stays_operator_ui_focused(self):
+        result = self.classify(
+            ("M", ".github/forecasting-paths.ini"),
+            ("M", ".github/workflows/forecasting-tests.yml"),
+            ("M", "tests/ci/test_forecasting_change_classifier.py"),
+            ("M", "tests/operator_ui/test_bootstrap.py"),
+            ("M", "tests/operator_ui/test_deployment_generator.py"),
+        )
+        self.assertEqual(result["tier"], "operator_ui")
+        self.assertEqual(result["reason"], "single_product_tier_with_ci_contract")
+        self.assertTrue(result["ci_contract_changed"])
+
     def test_ci_only_routing_change_never_selects_complete_suite(self):
         result = self.classify(
             ("M", ".github/forecasting-paths.ini"),

--- a/tests/operator_ui/test_bootstrap.py
+++ b/tests/operator_ui/test_bootstrap.py
@@ -1,6 +1,9 @@
 import pytest
 import shutil
 import hashlib
+import os
+import stat
+import tempfile
 import threading
 import json
 from dataclasses import replace
@@ -19,6 +22,19 @@ import src.operator_ui.bootstrap as bootstrap_module
 from src.predictor.on_demand import resolve_model
 from race_collection.synchronous_manual_capture import VerifiedCurrentRaceIndex
 from src.operator_ui.job_store import Phase
+
+
+@pytest.fixture
+def tmp_path():
+    """Keep trusted fixed-runtime fixtures outside foreign-owned /tmp."""
+    source_root = Path(__file__).resolve().parents[2]
+    with tempfile.TemporaryDirectory(prefix=".pytest-bootstrap-", dir=source_root) as raw:
+        root = Path(raw)
+        info = root.stat()
+        assert root == root.resolve()
+        assert info.st_uid == os.geteuid()
+        assert stat.S_IMODE(info.st_mode) == 0o700
+        yield root
 
 
 def installed_app(tmp_path):
@@ -310,6 +326,20 @@ def test_repository_profile_missing_or_unsafe_authoritative_sources_fail_closed(
     app=Flask(__name__);app.config[R3_PROFILE_KEY]="repository-v1"
     with pytest.raises(RuntimeError,match="generated repository-v1 binding|fixed R3 runtime"):
         bootstrap_module.configure_r3_startup(app)
+
+
+@pytest.mark.skipif(
+    not (
+        stat.S_IMODE(Path("/tmp").stat().st_mode) & 0o020
+        and Path("/tmp").stat().st_uid != os.geteuid()
+    ),
+    reason="host has no foreign-owned group-writable /tmp ancestor",
+)
+def test_fixed_path_rejects_foreign_owned_group_writable_ancestor():
+    """Keep the production foreign-owner rejection covered explicitly."""
+    with tempfile.NamedTemporaryFile(dir="/tmp") as unsafe_file:
+        with pytest.raises(RuntimeError, match="fixed R3 runtime unsafe"):
+            bootstrap_module._open_fixed(Path(unsafe_file.name), directory=False)
 
 
 def test_finite_testing_fixture_profile_builds_real_repository_composition(tmp_path, monkeypatch):

--- a/tests/operator_ui/test_deployment_generator.py
+++ b/tests/operator_ui/test_deployment_generator.py
@@ -31,6 +31,19 @@ AUTHORITY_RELATIVES = (
 )
 
 
+@pytest.fixture
+def tmp_path():
+    """Keep retained-authority fixtures outside foreign-owned /tmp ancestry."""
+    repository = Path(__file__).resolve().parents[2]
+    with TemporaryDirectory(prefix=".pytest-deployment-", dir=repository) as raw:
+        root = Path(raw)
+        info = root.stat()
+        assert root == root.resolve()
+        assert info.st_uid == os.geteuid()
+        assert stat.S_IMODE(info.st_mode) == 0o700
+        yield root
+
+
 def deployment_inputs(tmp_path: Path) -> dict[str, object]:
     source = tmp_path / "source"
     repository = Path(__file__).parents[2]


### PR DESCRIPTION
## Summary

- Move bootstrap and deployment-generator trusted fixtures to per-test, owner-safe temporary roots beneath the real repository root.
- Preserve production fixed-path trust policy unchanged.
- Retain explicit rejection coverage for foreign-owned group-writable `/tmp` ancestry.

## Root cause

GHU-062A proved the positive bootstrap fixture failed on canonical master because pytest placed it beneath `/tmp` (`1777 root:root`), which `_open_fixed()` correctly rejects. The same temporary ancestry also caused retained-authority identity churn in the combined focused operator-UI run.

## Validation

- Formerly failing bootstrap test: passed.
- `tests/operator_ui/test_bootstrap.py` + `tests/operator_ui/test_deployment_generator.py`: 153 passed.
- Forecasting classifier contract: 28 passed.
- `py_compile`: passed.
- `git diff --check`: passed.
- Production `src/operator_ui/bootstrap.py` SHA-256 unchanged from base: `92dc8ca71130a202f5b6cdf0b2de485b704cbe36e65b77ef559f8fc232a63e00`.
- Ruff unavailable on host.

The classifier assigns the test paths to `full_forecasting`; per GHU-063 scope, the expensive full local forecasting run was intentionally not repeated. Exact-head CI should provide that broader gate.

No production code, service, runtime, browser, capture, scoring, result, database, or Phase-7 state was changed.