### PR TITLE
ci: make full forecasting suite opt-in

### DIFF
--- a/.github/workflows/forecasting-tests.yml
+++ b/.github/workflows/forecasting-tests.yml
@@ -3,8 +3,6 @@ name: Forecasting acceptance
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-  schedule:
-    - cron: "17 4 * * 0"
   workflow_dispatch:
     inputs:
       reason:
@@ -21,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tier: ${{ steps.classify.outputs.tier }}
+      classified_tier: ${{ steps.classify.outputs.classified_tier }}
       reason: ${{ steps.classify.outputs.reason }}
       ci_contract_changed: ${{ steps.classify.outputs.ci_contract_changed }}
 
@@ -49,6 +48,7 @@ jobs:
               --github-output "$GITHUB_OUTPUT"
           else
             python3 scripts/ci/classify_forecasting_changes.py \
+              --pr-fast \
               --base "$BASE_SHA" \
               --head "$HEAD_SHA" \
               --github-output "$GITHUB_OUTPUT"
@@ -64,9 +64,10 @@ jobs:
             echo "### Forecasting change classification"
             echo
             echo "- Tier: \`$FORECASTING_TIER\`"
+            echo "- Classifier tier: \`${{ steps.classify.outputs.classified_tier }}\`"
             echo "- Reason: \`$CLASSIFICATION_REASON\`"
             echo "- CI contract changed: \`$CI_CONTRACT_CHANGED\`"
-            echo "- Explicit PR override label: \`ci:full-forecasting\`"
+            echo "- Full-suite opt-in: PR label \`ci:full-forecasting\` or manual dispatch"
           } >> "$GITHUB_STEP_SUMMARY"
 
   forecasting-gate:
@@ -80,7 +81,7 @@ jobs:
       - name: Enforce trustworthy classification
         if: >-
           needs.classify.result != 'success' ||
-          !contains(fromJSON('["ci_contract","manual_prediction","official_results","forward_corpus","operator_ui","forecasting_core","full_forecasting","non_forecasting"]'),
+          !contains(fromJSON('["ci_contract","manual_prediction","official_results","forward_corpus","operator_ui","forecasting_core","full_forecasting","pr_fast","non_forecasting"]'),
           needs.classify.outputs.tier) ||
           !contains(fromJSON('["true","false"]'),
           needs.classify.outputs.ci_contract_changed) ||
@@ -235,6 +236,17 @@ jobs:
                 tests/race_collection/test_phase4_model_serving.py
               )
               ;;
+            pr_fast)
+              selected_command=(
+                uv run --no-project --with-requirements requirements/all.in
+                python -m pytest -q --noconftest
+                tests/test_predict_market_form_residual.py::test_scores_exact_packet_deterministically
+                tests/test_results_ingest_official_first.py::test_parse_sportsbet_result_text_extracts_top_four_boxes
+                tests/race_collection/test_scheduled_forward_corpus.py::test_fixture_scheduled_capture_admits_once_and_exact_replay_is_byte_stable
+                tests/operator_ui/test_foundation.py::test_valid_envelope_is_deterministic_finite_immutable_and_serializable
+                tests/race_collection/test_phase3_forecasting.py::test_prediction_rejected_before_close_and_binds_exact_seal_and_pin
+              )
+              ;;
             full_forecasting)
               selected_command=(
                 uv run --no-project --with-requirements requirements/all.in
@@ -260,6 +272,7 @@ jobs:
       - name: Bind validation evidence to exact commit and tree
         if: always() && needs.classify.outputs.tier != 'non_forecasting'
         env:
+          CLASSIFIED_TIER: ${{ needs.classify.outputs.classified_tier }}
           CI_CONTRACT_CHANGED: ${{ needs.classify.outputs.ci_contract_changed }}
           CLASSIFICATION_REASON: ${{ needs.classify.outputs.reason }}
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -282,9 +295,21 @@ jobs:
           combined_log = evidence_dir / "forecasting-suite.log"
           manifest = evidence_dir / "forecasting-command-manifest.tsv"
           tier = os.environ["FORECASTING_TIER"]
+          classified_tier = os.environ["CLASSIFIED_TIER"]
           ci_contract_changed_text = os.environ["CI_CONTRACT_CHANGED"]
           if ci_contract_changed_text not in {"true", "false"}:
               raise SystemExit("invalid ci_contract_changed classifier output")
+          if classified_tier not in {
+              "ci_contract",
+              "manual_prediction",
+              "official_results",
+              "forward_corpus",
+              "operator_ui",
+              "forecasting_core",
+              "full_forecasting",
+              "non_forecasting",
+          }:
+              raise SystemExit("invalid classified_tier classifier output")
           ci_contract_changed = ci_contract_changed_text == "true"
           commit = subprocess.check_output(
               ["git", "rev-parse", "HEAD"], text=True
@@ -335,6 +360,7 @@ jobs:
           evidence = {
               "schema_version": "forecasting-ci-attestation-v3",
               "tier": tier,
+              "classified_tier": classified_tier,
               "ci_contract_changed": ci_contract_changed,
               "classification_reason": os.environ["CLASSIFICATION_REASON"],
               "command": (evidence_dir / "forecasting-command.txt")

--- a/docs/forecasting_ci_tiers.md
+++ b/docs/forecasting_ci_tiers.md
@@ -3,7 +3,9 @@
 The stable pull-request check is `tests-race-collection`. A classifier selects
 one primary tier for the complete change set and separately reports whether the
 CI contract changed. Unknown paths, destructive changes, shared surfaces, and
-incompatible product-tier combinations fail closed to `full_forecasting`.
+incompatible product-tier combinations are classified as `full_forecasting`,
+but normal pull requests execute the bounded `pr_fast` fallback for that risk
+tier. The complete suite is opt-in only.
 
 | Tier | Intended paths | Validation command |
 | --- | --- | --- |
@@ -13,7 +15,8 @@ incompatible product-tier combinations fail closed to `full_forecasting`.
 | `forward_corpus` | scheduled producer, observer, admission, and closure | `uv run --no-project --with-requirements requirements/all.in python -m pytest -q --noconftest tests/race_collection/test_scheduled_forward_corpus.py tests/race_collection/test_forward_official_result_observer.py tests/race_collection/test_phase7_source_admission.py tests/race_collection/test_forward_sealed_corpus.py` |
 | `operator_ui` | isolated foundation, job-store, worker, security, R3, and connected-UI paths | `uv run --no-project --with-requirements requirements/all.in python -m pytest -q tests/operator_ui/test_foundation.py tests/operator_ui/test_job_store.py tests/operator_ui/test_prediction_worker.py tests/operator_ui/test_security.py tests/operator_ui/test_r3_api.py tests/operator_ui/test_r3_e2e_safety.py tests/operator_ui/test_connected_ui.py` |
 | `forecasting_core` | isolated phase-3 forecasting and phase-4 serving | `uv run --no-project --with-requirements requirements/all.in python -m pytest -q --noconftest tests/race_collection/test_phase3_forecasting.py tests/race_collection/test_phase4_model_serving.py` |
-| `full_forecasting` | shared/high-risk, unknown, destructive, or unsafe mixed changes | `uv run --no-project --with-requirements requirements/all.in --with PyYAML --with jsonschema python scripts/ci/run_full_forecasting.py` |
+| `pr_fast` | bounded PR fallback when the classifier reports `full_forecasting` | five named smoke tests covering prediction, results, forward capture, Operator UI, and forecasting core |
+| `full_forecasting` | explicit full-validation request; also the classifier's risk label for PR fallback | `uv run --no-project --with-requirements requirements/all.in --with PyYAML --with jsonschema python scripts/ci/run_full_forecasting.py` |
 | `non_forecasting` | known unrelated documentation and presentation paths | no Forecasting test command |
 
 Pure CI routing changes select `ci_contract`. When CI-contract paths accompany
@@ -26,11 +29,13 @@ every focused tier. It never invokes the complete `tests/race_collection`
 directory.
 
 The full runner executes the CI contract, the complete `tests/race_collection`
-directory, and the top-level focused suites. It runs weekly, on every workflow dispatch, for PRs
-labeled `ci:full-forecasting`, and whenever the classifier escalates risk.
+directory, and the top-level focused suites. It runs only on an explicit manual
+workflow dispatch or on a PR labeled `ci:full-forecasting`. The scheduled
+automatic full run has been removed.
 
 Shared identity, timing, provenance, feature, schema, dependency, training,
 evaluation, promotion, runtime-adapter, synchronous-capture, Operator UI
 bootstrap/deployment/live-adapter, and on-demand collector-protocol paths remain
-full. Two or more focused product tiers remain full even when the CI contract
-also changes. New paths are full until explicitly and safely assigned.
+full-risk in the classifier. On a normal PR they use `pr_fast`; apply the
+`ci:full-forecasting` label when the complete suite is wanted. Two or more
+focused product tiers and new paths follow the same explicit opt-in rule.

--- a/scripts/ci/classify_forecasting_changes.py
+++ b/scripts/ci/classify_forecasting_changes.py
@@ -301,6 +301,10 @@ def git_changes(base: str, head: str) -> list[Change]:
 def write_github_output(path: Path, result: Mapping[str, Any]) -> None:
     with path.open("a", encoding="utf-8") as output:
         output.write(f"tier={result['tier']}\n")
+        output.write(
+            "classified_tier="
+            f"{result.get('classified_tier', result['tier'])}\n"
+        )
         output.write(f"reason={result['reason']}\n")
         output.write(
             "ci_contract_changed="
@@ -313,9 +317,16 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--base")
     parser.add_argument("--head")
     parser.add_argument("--force-full", action="store_true")
+    parser.add_argument(
+        "--pr-fast",
+        action="store_true",
+        help="Use the bounded PR fallback instead of the long suite for full-risk changes",
+    )
     parser.add_argument("--rules", type=Path, default=DEFAULT_RULES)
     parser.add_argument("--github-output", type=Path)
     args = parser.parse_args(argv)
+    if args.force_full and args.pr_fast:
+        parser.error("--force-full and --pr-fast are mutually exclusive")
     if not args.force_full and not (args.base and args.head):
         parser.error("--base and --head are required unless --force-full is used")
     return args
@@ -332,6 +343,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         except ClassificationError as exc:
             print(f"classifier warning: {exc}; defaulting to full", file=sys.stderr)
             result = _full_result("classifier_error_defaults_to_full")
+    classified_tier = result["tier"]
+    if args.pr_fast and result["tier"] == "full_forecasting":
+        result = {
+            **result,
+            "tier": "pr_fast",
+            "classified_tier": classified_tier,
+            "reason": f"pr_fast_fallback:{result['reason']}",
+        }
+    else:
+        result = {**result, "classified_tier": classified_tier}
     print(json.dumps(result, indent=2, sort_keys=True))
     if args.github_output:
         write_github_output(args.github_output, result)

--- a/tests/ci/test_forecasting_change_classifier.py
+++ b/tests/ci/test_forecasting_change_classifier.py
@@ -561,6 +561,7 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
             self.assertEqual(
                 output.read_text(encoding="utf-8"),
                 "tier=manual_prediction\n"
+                "classified_tier=manual_prediction\n"
                 "reason=single_product_tier_with_ci_contract\n"
                 "ci_contract_changed=true\n",
             )
@@ -578,20 +579,41 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
             self.assertEqual(
                 output.read_text(encoding="utf-8"),
                 "tier=full_forecasting\n"
+                "classified_tier=full_forecasting\n"
                 "reason=explicit_full_validation\n"
                 "ci_contract_changed=false\n",
             )
 
-    def test_workflow_preserves_stable_gate_and_full_escape_hatches(self):
+    def test_pr_fast_downgrades_only_full_classifier_results(self):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = CLASSIFIER.main(
+                ["--pr-fast", "--base", "HEAD", "--head", "HEAD"]
+            )
+        self.assertEqual(exit_code, 0)
+        result = json.loads(stdout.getvalue())
+        self.assertEqual(result["tier"], "pr_fast")
+        self.assertEqual(result["classified_tier"], "full_forecasting")
+        self.assertEqual(
+            result["reason"], "pr_fast_fallback:empty_change_set_defaults_to_full"
+        )
+
+    def test_pr_fast_cannot_be_combined_with_explicit_full(self):
+        with self.assertRaises(SystemExit):
+            CLASSIFIER.parse_args(["--force-full", "--pr-fast"])
+
+    def test_workflow_makes_full_suite_an_explicit_opt_in(self):
         workflow = (ROOT / ".github/workflows/forecasting-tests.yml").read_text(
             encoding="utf-8"
         )
         for expected in (
             "name: tests-race-collection",
-            "schedule:",
             "workflow_dispatch:",
             "ci:full-forecasting",
             "--force-full",
+            "--pr-fast",
+            "pr_fast)",
+            "classified_tier",
             "forecasting-ci-attestation-v3",
             '"tier": tier',
             "ci_contract_changed: ${{ steps.classify.outputs.ci_contract_changed }}",
@@ -615,6 +637,7 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
         for tier in CLASSIFIER.TIERS:
             self.assertIn(tier, workflow)
         self.assertEqual(workflow.count("scripts/ci/run_full_forecasting.py"), 1)
+        self.assertNotIn("  schedule:", workflow)
         self.assertLess(
             workflow.index('run_command ci_contract "${ci_contract_command[@]}"'),
             workflow.index(
@@ -670,6 +693,7 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
             env = {
                 **os.environ,
                 "CI_CONTRACT_CHANGED": "true",
+                "CLASSIFIED_TIER": "manual_prediction",
                 "CLASSIFICATION_REASON": "single_product_tier_with_ci_contract",
                 "EXPECTED_HEAD": head,
                 "FORECASTING_TIER": "manual_prediction",
@@ -686,6 +710,7 @@ class ForecastingChangeClassifierTests(unittest.TestCase):
                 )
             )
         self.assertEqual(attestation["schema_version"], "forecasting-ci-attestation-v3")
+        self.assertEqual(attestation["classified_tier"], "manual_prediction")
         self.assertIs(attestation["ci_contract_changed"], True)
         self.assertEqual(attestation["uv"], "uv-test 0.0")
         self.assertEqual(


### PR DESCRIPTION
## What changed

- Keep the stable `tests-race-collection` check for normal pull requests.
- Route classifier results that would previously select `full_forecasting` to a bounded `pr_fast` smoke tier on ordinary PRs.
- Run the complete forecasting suite only for an explicit `ci:full-forecasting` PR label or manual workflow dispatch.
- Remove the scheduled automatic full-suite run.
- Record both the raw classifier tier and the executed validation tier in the attestation.

## Why

Normal pull requests were spending up to 70 minutes in the full forecasting suite. This keeps focused validation while making the long suite an explicit opt-in.

## Validation

- `python3 tests/ci/test_forecasting_change_classifier.py` — 34 passed
- `uv run --no-project --with-requirements requirements/all.in --with PyYAML python scripts/ci/run_forecasting_ci_contract.py`
- Workflow YAML validation — 9 workflows passed
- Bounded smoke tests — 5 passed in 3.09s

The branch is based on current `origin/master`; no full 70-minute suite was run locally.