### PR TITLE
Add fail-closed August official result evidence writer

### DIFF
--- a/docs/official_result_identity_contract.md
+++ b/docs/official_result_identity_contract.md
@@ -1,0 +1,39 @@
+# Official result identity contract
+
+This path labels no race by name alone. Its canonical pre-jump identity is the
+single preserved Sportsbet win-odds tuple:
+
+`(race_id, race_date, venue, race_number, Sportsbet source URL, latest capture timestamp, complete box+runner set)`.
+
+An official result is accepted only when all of these gates pass:
+
+1. Every win-odds row is Sportsbet evidence from a declared autonomous pre-jump
+   capture, with a source URL, timezone-aware timestamp before the scheduled
+   start, valid decimal price, and mutually consistent race date, venue and
+   number.
+2. The textual `race_id` components exactly equal those stored components.
+3. Venue maps through the explicit repository TheDogs mapping, or its preserved
+   venue slug exactly equals the Sportsbet URL slug. No fuzzy alias is used.
+4. The HTTPS TheDogs URL path encodes exactly that venue slug, date and race
+   number. Redirects and multiple candidate URLs are rejected.
+5. The official table contains one named runner per box and a complete,
+   contiguous finish order. Terminal/partial results are rejected.
+6. Official and latest pre-jump Sportsbet runner sets agree exactly on both box
+   and normalized full name. Names are normalized only after box identity is
+   fixed; collisions on either side are rejected.
+
+The raw HTTP response is stored byte-for-byte under its SHA-256. The evidence
+rows retain that hash and artifact path, fetch timestamp, official and
+Sportsbet URLs, and a hash of all sealed odds identity rows. Inserts target only
+the append-only `autonomous_official_result_evidence_*` tables. An identical
+re-run is a no-op only after the complete stored race and runner bundle and its
+provenance are reverified. Conflicting, incomplete, or orphaned existing
+evidence fails closed and is never altered. New race and runner rows commit
+together or roll back together.
+
+`scripts/append_august_official_results.py` is dry-run by default. `--execute`
+only authorizes the evidence-table append; it never writes `race_metadata`,
+`dog_race_data`, odds, features, labels, models, or runtime/service state.
+Offline `--raw-html` use also requires the preserved official `--source-url`
+and a timezone-aware `--fetched-at`; filesystem timestamps are not treated as
+official fetch provenance.

--- a/scripts/append_august_official_results.py
+++ b/scripts/append_august_official_results.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env python3
+"""Append strictly matched TheDogs results for sealed Sportsbet odds races.
+
+The input identity is read from ``live_odds`` without modifying it.  Official
+HTML is retained byte-for-byte in a content-addressed artifact.  Evidence is
+only appended when date, venue slug, race number, and the complete (box, dog)
+runner set agree.  Default operation is a report-only dry-run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import datetime, time, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+from urllib.parse import urlparse
+
+import requests
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.ingest_results_for_date import (
+    THEDOGS_PUBLIC_HEADERS,
+    VENUE_TO_THEDOGS_SLUG,
+    parse_thedogs_result_html_runner_rows,
+)
+
+
+OFFICIAL_SOURCE = "thedogs_official"
+RACE_TABLE = "autonomous_official_result_evidence_races"
+RUNNER_TABLE = "autonomous_official_result_evidence_runners"
+RACE_ID_RE = re.compile(r"^Race\s+(\d+)\s+-\s+(.+?)\s+-\s+(\d{4}-\d{2}-\d{2})$")
+
+
+class MatchRejected(ValueError):
+    """Raised when preserved evidence cannot support one exact join."""
+
+
+def canonical_name(value: Any) -> str:
+    return re.sub(r"[^A-Z0-9]", "", str(value or "").upper())
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _one(values: Iterable[Any], reason: str) -> Any:
+    unique = {value for value in values if value not in (None, "")}
+    if len(unique) != 1:
+        raise MatchRejected(reason)
+    return next(iter(unique))
+
+
+@dataclass(frozen=True)
+class SealedRace:
+    race_id: str
+    race_date: str
+    venue: str
+    venue_slug: str
+    race_number: int
+    sportsbet_url: str
+    runners: tuple[tuple[int, str], ...]
+    odds_rows_sha256: str
+    scheduled_start: datetime
+
+    @property
+    def official_url(self) -> str:
+        return (
+            f"https://www.thedogs.com.au/racing/{self.venue_slug}/"
+            f"{self.race_date}/{self.race_number}/results?trial=false"
+        )
+
+
+def _venue_slug(venue: str, sportsbet_url: str, race_number: int) -> str:
+    key = venue.strip().upper().replace(" ", "_")
+    mapped = VENUE_TO_THEDOGS_SLUG.get(key)
+    parsed = urlparse(sportsbet_url)
+    sportsbet_match = re.search(
+        r"^/greyhound-racing/australia-nz/([^/]+)/race-(\d+)(?:-|$)", parsed.path, re.I
+    )
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname not in {"sportsbet.com.au", "www.sportsbet.com.au"}
+        or not sportsbet_match
+        or int(sportsbet_match.group(2)) != race_number
+    ):
+        raise MatchRejected("sportsbet_url_identity_mismatch")
+    sportsbet_slug = sportsbet_match.group(1).lower()
+    # Only an identical preserved venue/market slug is accepted without an
+    # explicit mapping.  Fuzzy venue aliases are intentionally unsupported.
+    venue_slug = re.sub(r"[^a-z0-9]+", "-", venue.lower()).strip("-")
+    official_slug = mapped or venue_slug
+    if official_slug == sportsbet_slug:
+        return official_slug
+    raise MatchRejected("venue_has_no_deterministic_thedogs_slug")
+
+
+def seal_race_from_db(db_path: Path, race_id: str) -> SealedRace:
+    uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    with sqlite3.connect(uri, uri=True) as conn:
+        conn.execute("PRAGMA query_only=ON")
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """
+            SELECT race_id, race_date, venue, race_number, source_url,
+                   box_number, dog_name, dog_clean_name, odds_decimal,
+                   capture_timestamp, capture_mode, race_time,
+                   market_type, source, odds_level,
+                   sportsbet_box_source
+            FROM live_odds
+            WHERE race_id = ? AND lower(COALESCE(market_type, '')) = 'win'
+            ORDER BY capture_timestamp, box_number, id
+            """,
+            (race_id,),
+        ).fetchall()
+    if not rows:
+        raise MatchRejected("missing_sportsbet_win_odds")
+    if any(str(row["source"] or "").lower() != "sportsbet" for row in rows):
+        raise MatchRejected("non_sportsbet_odds_source")
+    if any(
+        not re.fullmatch(r"autonomous_prejump_t\d+m", str(row["capture_mode"] or ""))
+        for row in rows
+    ):
+        raise MatchRejected("non_prejump_odds_capture")
+    race_date = str(_one((str(r["race_date"] or "")[:10] for r in rows), "ambiguous_race_date"))
+    venue = str(_one((str(r["venue"] or "").strip() for r in rows), "ambiguous_venue"))
+    race_number = int(_one((r["race_number"] for r in rows), "ambiguous_race_number"))
+    sportsbet_url = str(
+        _one((str(r["source_url"] or "").strip() for r in rows), "ambiguous_sportsbet_url")
+    )
+    race_time = str(_one((str(r["race_time"] or "").strip() for r in rows), "ambiguous_race_time"))
+    match = RACE_ID_RE.match(race_id)
+    if (
+        not match
+        or int(match.group(1)) != race_number
+        or match.group(3) != race_date
+        or match.group(2) != venue
+    ):
+        raise MatchRejected("race_id_components_disagree")
+    if not all(
+        r["capture_timestamp"] and r["odds_decimal"] and float(r["odds_decimal"]) > 1 for r in rows
+    ):
+        raise MatchRejected("incomplete_odds_provenance")
+    try:
+        start_clock = time.fromisoformat(race_time)
+        captures = []
+        for row in rows:
+            captured = datetime.fromisoformat(str(row["capture_timestamp"]))
+            if captured.tzinfo is None:
+                raise ValueError
+            captures.append(captured)
+    except (TypeError, ValueError):
+        raise MatchRejected("invalid_temporal_odds_provenance") from None
+    for captured in captures:
+        scheduled = datetime.combine(
+            datetime.fromisoformat(race_date).date(), start_clock, tzinfo=captured.tzinfo
+        )
+        if captured >= scheduled:
+            raise MatchRejected("odds_capture_not_before_scheduled_start")
+    latest = max(captures)
+    snapshot = [r for r, captured in zip(rows, captures) if captured == latest]
+    runners: list[tuple[int, str]] = []
+    for row in snapshot:
+        box = int(row["box_number"] or 0)
+        name = str(row["dog_name"] or row["dog_clean_name"] or "").strip()
+        if (
+            box <= 0
+            or not name
+            or str(row["odds_level"] or "dog").lower() not in {"", "dog", "runner"}
+        ):
+            raise MatchRejected("invalid_latest_odds_runner")
+        runners.append((box, name))
+    keys = [(box, canonical_name(name)) for box, name in runners]
+    if (
+        len(keys) < 2
+        or len(keys) != len(set(keys))
+        or len({b for b, _ in keys}) != len(keys)
+        or len({n for _, n in keys}) != len(keys)
+    ):
+        raise MatchRejected("ambiguous_latest_odds_runner_set")
+    sealed_rows = [dict(row) for row in rows]
+    digest = sha256_bytes(
+        json.dumps(sealed_rows, sort_keys=True, separators=(",", ":"), default=str).encode()
+    )
+    return SealedRace(
+        race_id=race_id,
+        race_date=race_date,
+        venue=venue,
+        venue_slug=_venue_slug(venue, sportsbet_url, race_number),
+        race_number=race_number,
+        sportsbet_url=sportsbet_url,
+        runners=tuple(sorted(runners)),
+        odds_rows_sha256=digest,
+        scheduled_start=datetime.combine(
+            datetime.fromisoformat(race_date).date(), start_clock, tzinfo=captures[0].tzinfo
+        ),
+    )
+
+
+def validate_official_html(sealed: SealedRace, source_url: str, raw: bytes) -> list[dict[str, Any]]:
+    parsed = urlparse(source_url)
+    expected_path = f"/racing/{sealed.venue_slug}/{sealed.race_date}/{sealed.race_number}/results"
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname not in {"thedogs.com.au", "www.thedogs.com.au"}
+        or parsed.path.rstrip("/") != expected_path
+    ):
+        raise MatchRejected("official_url_identity_mismatch")
+    rows = parse_thedogs_result_html_runner_rows(raw.decode("utf-8", errors="strict"))
+    if not rows:
+        raise MatchRejected("official_result_missing")
+    if any(row.get("finish_position") is None or row.get("status") for row in rows):
+        raise MatchRejected("partial_or_terminal_official_result")
+    official = [
+        (int(r["box_number"]), str(r.get("dog_name") or "").strip(), int(r["finish_position"]))
+        for r in rows
+    ]
+    keys = [(box, canonical_name(name)) for box, name, _ in official]
+    sealed_keys = [(box, canonical_name(name)) for box, name in sealed.runners]
+    positions = [position for _, _, position in official]
+    if not all(name for _, name in keys) or len(keys) != len(set(keys)):
+        raise MatchRejected("ambiguous_official_runner_set")
+    if sorted(keys) != sorted(sealed_keys):
+        raise MatchRejected("runner_set_mismatch")
+    if sorted(positions) != list(range(1, len(official) + 1)):
+        raise MatchRejected("incomplete_finish_positions")
+    return [
+        {"box_number": box, "dog_name": name, "finish_position": position}
+        for box, name, position in sorted(official, key=lambda item: item[2])
+    ]
+
+
+def fetch_raw(url: str) -> tuple[str, bytes, str]:
+    fetched_at = datetime.now(timezone.utc).isoformat()
+    response = requests.get(url, headers=THEDOGS_PUBLIC_HEADERS, timeout=30, allow_redirects=False)
+    if response.status_code != 200:
+        raise MatchRejected(f"official_http_status:{response.status_code}")
+    if response.url != url:
+        raise MatchRejected("official_redirect_not_accepted")
+    return fetched_at, response.content, response.url
+
+
+def write_raw_artifact(output_dir: Path, raw: bytes) -> tuple[Path, str]:
+    digest = sha256_bytes(raw)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"thedogs_official_{digest}.html"
+    if path.exists() and path.read_bytes() != raw:
+        raise MatchRejected("raw_artifact_hash_collision")
+    if not path.exists():
+        path.write_bytes(raw)
+    if sha256_bytes(path.read_bytes()) != digest:
+        raise MatchRejected("raw_artifact_hash_verification_failed")
+    return path, digest
+
+
+def _ensure_tables(conn: sqlite3.Connection) -> None:
+    required = {RACE_TABLE, RUNNER_TABLE}
+    present = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    if not required <= present:
+        raise MatchRejected("official_evidence_tables_missing")
+
+
+def _verified_existing_bundle(
+    conn: sqlite3.Connection,
+    sealed: SealedRace,
+    runners: Sequence[Mapping[str, Any]],
+    *,
+    source_url: str,
+    raw_sha256: str,
+) -> bool:
+    race_rows = conn.execute(
+        f"""SELECT race_date, venue, race_number, source, source_url, status,
+                   winner_name, winner_box, position_count, participant_count,
+                   box_order_json, participant_source, captured_at,
+                   source_artifact_dir, row_json
+            FROM {RACE_TABLE} WHERE race_id = ?""",
+        (sealed.race_id,),
+    ).fetchall()
+    runner_rows = conn.execute(
+        f"""SELECT race_date, venue, race_number, source, source_url, box_number,
+                   dog_name, finish_position, is_winner, captured_at,
+                   source_artifact_dir, row_json
+            FROM {RUNNER_TABLE} WHERE race_id = ?""",
+        (sealed.race_id,),
+    ).fetchall()
+    if not race_rows and not runner_rows:
+        return False
+    if len(race_rows) != 1 or len(runner_rows) != len(runners):
+        raise MatchRejected("conflicting_or_incomplete_existing_evidence")
+
+    winner = next(r for r in runners if int(r["finish_position"]) == 1)
+    expected_runner_signatures = {
+        (int(r["box_number"]), canonical_name(r["dog_name"]), int(r["finish_position"]))
+        for r in runners
+    }
+    race = race_rows[0]
+    try:
+        race_json = json.loads(race[-1])
+        stored_fetched_at = datetime.fromisoformat(str(race_json.get("official_fetched_at")))
+        if stored_fetched_at.tzinfo is None or stored_fetched_at <= sealed.scheduled_start:
+            raise MatchRejected("conflicting_or_unverifiable_existing_evidence")
+        stored_artifact = Path(str(race_json.get("raw_artifact_path") or ""))
+        if (
+            not stored_artifact.is_file()
+            or sha256_bytes(stored_artifact.read_bytes()) != raw_sha256
+            or race[12] != race_json.get("official_fetched_at")
+            or race[13] != str(stored_artifact.parent)
+        ):
+            raise MatchRejected("conflicting_or_unverifiable_existing_evidence")
+        stored_runner_rows = set()
+        for row in runner_rows:
+            row_json = json.loads(row[-1])
+            if (
+                row_json.get("identity_contract") != "sealed_sportsbet_box_name_v1"
+                or row_json.get("raw_sha256") != raw_sha256
+                or row_json.get("sealed_odds_rows_sha256") != sealed.odds_rows_sha256
+                or row_json.get("official_source_url") != source_url
+                or row_json.get("sportsbet_source_url") != sealed.sportsbet_url
+                or row_json.get("race_id") != sealed.race_id
+                or int(row_json.get("box_number")) != int(row[5])
+                or canonical_name(row_json.get("dog_name")) != canonical_name(row[6])
+                or int(row_json.get("finish_position")) != int(row[7])
+                or row_json.get("official_fetched_at") != race_json.get("official_fetched_at")
+                or row_json.get("raw_artifact_path") != str(stored_artifact)
+                or row[9] != race_json.get("official_fetched_at")
+                or row[10] != str(stored_artifact.parent)
+            ):
+                raise MatchRejected("conflicting_or_unverifiable_existing_evidence")
+            stored_runner_rows.add(
+                (
+                    row[0],
+                    row[1],
+                    int(row[2]),
+                    row[3],
+                    row[4],
+                    int(row[5]),
+                    canonical_name(row[6]),
+                    int(row[7]),
+                    int(row[8]),
+                )
+            )
+    except (TypeError, ValueError, json.JSONDecodeError, IndexError):
+        raise MatchRejected("conflicting_or_unverifiable_existing_evidence") from None
+
+    expected_race = (
+        sealed.race_date,
+        sealed.venue,
+        sealed.race_number,
+        OFFICIAL_SOURCE,
+        source_url,
+        "resulted",
+        winner["dog_name"],
+        winner["box_number"],
+        len(runners),
+        len(runners),
+        json.dumps([int(r["box_number"]) for r in runners]),
+        "sealed_sportsbet_latest_win_snapshot",
+    )
+    expected_runner_rows = {
+        (
+            sealed.race_date,
+            sealed.venue,
+            sealed.race_number,
+            OFFICIAL_SOURCE,
+            source_url,
+            int(r["box_number"]),
+            canonical_name(r["dog_name"]),
+            int(r["finish_position"]),
+            int(int(r["finish_position"]) == 1),
+        )
+        for r in runners
+    }
+    try:
+        race_json_runners = {
+            (int(r["box_number"]), canonical_name(r["dog_name"]), int(r["finish_position"]))
+            for r in race_json.get("runners", [])
+        }
+    except (TypeError, ValueError, KeyError):
+        raise MatchRejected("conflicting_or_unverifiable_existing_evidence") from None
+    if (
+        tuple(race[:12]) != expected_race
+        or race_json.get("identity_contract") != "sealed_sportsbet_box_name_v1"
+        or race_json.get("raw_sha256") != raw_sha256
+        or race_json.get("sealed_odds_rows_sha256") != sealed.odds_rows_sha256
+        or race_json.get("official_source_url") != source_url
+        or race_json.get("sportsbet_source_url") != sealed.sportsbet_url
+        or race_json.get("race_id") != sealed.race_id
+        or race_json_runners != expected_runner_signatures
+        or stored_runner_rows != expected_runner_rows
+    ):
+        raise MatchRejected("conflicting_or_unverifiable_existing_evidence")
+    return True
+
+
+def append_evidence(
+    conn: sqlite3.Connection,
+    sealed: SealedRace,
+    runners: Sequence[Mapping[str, Any]],
+    *,
+    source_url: str,
+    fetched_at: str,
+    artifact_path: Path,
+    raw_sha256: str,
+) -> tuple[int, int]:
+    _ensure_tables(conn)
+    if _verified_existing_bundle(
+        conn, sealed, runners, source_url=source_url, raw_sha256=raw_sha256
+    ):
+        return 0, 0
+    provenance = {
+        "identity_contract": "sealed_sportsbet_box_name_v1",
+        "sportsbet_source_url": sealed.sportsbet_url,
+        "sealed_odds_rows_sha256": sealed.odds_rows_sha256,
+        "official_source_url": source_url,
+        "official_fetched_at": fetched_at,
+        "raw_artifact_path": str(artifact_path),
+        "raw_sha256": raw_sha256,
+    }
+    winner = next(r for r in runners if int(r["finish_position"]) == 1)
+    box_order = [int(r["box_number"]) for r in runners]
+    race_row = {**provenance, "race_id": sealed.race_id, "runners": list(runners)}
+    before = conn.total_changes
+    conn.execute(
+        f"""INSERT INTO {RACE_TABLE}
+        (race_id,race_date,venue,race_number,race_time,start_datetime,source,source_url,status,winner_name,winner_box,position_count,participant_count,box_order_json,participant_source,captured_at,source_artifact_dir,row_json)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            sealed.race_id,
+            sealed.race_date,
+            sealed.venue,
+            sealed.race_number,
+            None,
+            None,
+            OFFICIAL_SOURCE,
+            source_url,
+            "resulted",
+            winner["dog_name"],
+            winner["box_number"],
+            len(runners),
+            len(runners),
+            json.dumps(box_order),
+            "sealed_sportsbet_latest_win_snapshot",
+            fetched_at,
+            str(artifact_path.parent),
+            json.dumps(race_row, sort_keys=True),
+        ),
+    )
+    race_inserted = conn.total_changes - before
+    runner_inserted = 0
+    for runner in runners:
+        row_json = json.dumps(
+            {**provenance, **dict(runner), "race_id": sealed.race_id}, sort_keys=True
+        )
+        before = conn.total_changes
+        conn.execute(
+            f"""INSERT INTO {RUNNER_TABLE}
+            (race_id,race_date,venue,race_number,source,source_url,box_number,dog_name,finish_position,is_winner,captured_at,source_artifact_dir,row_json)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                sealed.race_id,
+                sealed.race_date,
+                sealed.venue,
+                sealed.race_number,
+                OFFICIAL_SOURCE,
+                source_url,
+                runner["box_number"],
+                runner["dog_name"],
+                runner["finish_position"],
+                int(runner["finish_position"] == 1),
+                fetched_at,
+                str(artifact_path.parent),
+                row_json,
+            ),
+        )
+        runner_inserted += conn.total_changes - before
+    if race_inserted != 1 or runner_inserted != len(runners):
+        raise MatchRejected("partial_evidence_insert")
+    return race_inserted, runner_inserted
+
+
+def run(
+    *,
+    db_path: Path,
+    race_id: str,
+    output_dir: Path,
+    execute: bool,
+    raw_path: Path | None = None,
+    source_url: str | None = None,
+    raw_fetched_at: str | None = None,
+) -> dict[str, Any]:
+    sealed = seal_race_from_db(db_path, race_id)
+    if raw_path:
+        if not source_url or not raw_fetched_at:
+            raise MatchRejected("raw_html_requires_source_url_and_fetched_at")
+        try:
+            parsed_fetched_at = datetime.fromisoformat(raw_fetched_at)
+            if parsed_fetched_at.tzinfo is None:
+                raise ValueError
+        except (TypeError, ValueError):
+            raise MatchRejected("invalid_official_fetched_at") from None
+        raw = raw_path.read_bytes()
+        fetched_at = parsed_fetched_at.isoformat()
+        resolved_url = source_url
+    else:
+        if raw_fetched_at:
+            raise MatchRejected("fetched_at_only_valid_with_raw_html")
+        fetched_at, raw, resolved_url = fetch_raw(source_url or sealed.official_url)
+        parsed_fetched_at = datetime.fromisoformat(fetched_at)
+    if parsed_fetched_at <= sealed.scheduled_start:
+        raise MatchRejected("official_result_fetched_before_scheduled_start")
+    runners = validate_official_html(sealed, resolved_url, raw)
+    artifact_path, raw_sha = write_raw_artifact(output_dir, raw)
+    inserted = (0, 0)
+    if execute:
+        try:
+            with sqlite3.connect(db_path) as conn:
+                inserted = append_evidence(
+                    conn,
+                    sealed,
+                    runners,
+                    source_url=resolved_url,
+                    fetched_at=fetched_at,
+                    artifact_path=artifact_path,
+                    raw_sha256=raw_sha,
+                )
+                conn.commit()
+        except sqlite3.IntegrityError as exc:
+            raise MatchRejected("conflicting_evidence_constraint") from exc
+    return {
+        "status": (
+            "APPENDED"
+            if any(inserted)
+            else ("NOOP_ALREADY_PRESENT" if execute else "ACCEPTED_DRY_RUN")
+        ),
+        "race_id": sealed.race_id,
+        "canonical_identity": [sealed.race_date, sealed.venue_slug, sealed.race_number],
+        "runner_count": len(runners),
+        "sportsbet_source_url": sealed.sportsbet_url,
+        "sealed_odds_rows_sha256": sealed.odds_rows_sha256,
+        "official_source_url": resolved_url,
+        "official_fetched_at": fetched_at,
+        "raw_artifact_path": str(artifact_path),
+        "raw_sha256": raw_sha,
+        "execute": execute,
+        "inserted_race_rows": inserted[0],
+        "inserted_runner_rows": inserted[1],
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, required=True)
+    parser.add_argument("--race-id", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--raw-html", type=Path)
+    parser.add_argument("--source-url")
+    parser.add_argument("--fetched-at")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        report = run(
+            db_path=args.db,
+            race_id=args.race_id,
+            output_dir=args.output_dir,
+            execute=args.execute,
+            raw_path=args.raw_html,
+            source_url=args.source_url,
+            raw_fetched_at=args.fetched_at,
+        )
+        code = 0
+    except MatchRejected as exc:
+        report = {
+            "status": "REJECTED",
+            "race_id": args.race_id,
+            "reason": str(exc),
+            "execute": args.execute,
+        }
+        code = 2
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.report:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(text, encoding="utf-8")
+    print(text, end="")
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_append_august_official_results.py
+++ b/tests/test_append_august_official_results.py
@@ -1,0 +1,278 @@
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts import append_august_official_results as subject
+
+
+RACE_ID = "Race 1 - WPK - 2026-08-03"
+URL = "https://www.thedogs.com.au/racing/wentworth-park/2026-08-03/1/results?trial=false"
+
+
+def _db(path: Path, *, duplicate_identity: bool = False) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            f"""
+            CREATE TABLE live_odds (
+              id INTEGER PRIMARY KEY, race_id TEXT, race_date TEXT, venue TEXT,
+              race_number INTEGER, source_url TEXT, box_number INTEGER,
+              dog_name TEXT, dog_clean_name TEXT, odds_decimal REAL,
+              capture_timestamp TEXT, market_type TEXT, source TEXT,
+              odds_level TEXT, sportsbet_box_source TEXT, capture_mode TEXT,
+              race_time TEXT
+            );
+            CREATE TABLE {subject.RACE_TABLE} (
+              id INTEGER PRIMARY KEY, race_id TEXT NOT NULL, race_date TEXT NOT NULL,
+              venue TEXT, race_number INTEGER, race_time TEXT, start_datetime TEXT,
+              source TEXT NOT NULL, source_url TEXT NOT NULL, status TEXT NOT NULL,
+              winner_name TEXT, winner_box INTEGER, position_count INTEGER NOT NULL,
+              participant_count INTEGER, box_order_json TEXT NOT NULL,
+              participant_source TEXT, captured_at TEXT NOT NULL, inserted_at TEXT DEFAULT CURRENT_TIMESTAMP,
+              source_artifact_dir TEXT NOT NULL, row_json TEXT NOT NULL,
+              UNIQUE(race_id, source_url, box_order_json)
+            );
+            CREATE TABLE {subject.RUNNER_TABLE} (
+              id INTEGER PRIMARY KEY, race_id TEXT NOT NULL, race_date TEXT NOT NULL,
+              venue TEXT, race_number INTEGER, source TEXT NOT NULL, source_url TEXT NOT NULL,
+              box_number INTEGER NOT NULL, dog_name TEXT NOT NULL, finish_position INTEGER NOT NULL,
+              is_winner INTEGER NOT NULL, captured_at TEXT NOT NULL, inserted_at TEXT DEFAULT CURRENT_TIMESTAMP,
+              source_artifact_dir TEXT NOT NULL, row_json TEXT NOT NULL,
+              UNIQUE(race_id, source_url, box_number, dog_name, finish_position)
+            );
+            """
+        )
+        rows = [(1, "Alpha", 2.4), (2, "Bravo", 3.2)]
+        for box, name, odds in rows:
+            conn.execute(
+                "INSERT INTO live_odds VALUES (NULL,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    RACE_ID,
+                    "2026-08-03",
+                    "WPK",
+                    1,
+                    "https://www.sportsbet.com.au/greyhound-racing/australia-nz/wentworth-park/race-1-1",
+                    box,
+                    name,
+                    name.upper(),
+                    odds,
+                    "2026-08-03T10:00:00+10:00",
+                    "win",
+                    "sportsbet",
+                    "dog",
+                    "explicit_dom",
+                    "autonomous_prejump_t60m",
+                    "11:00",
+                ),
+            )
+        if duplicate_identity:
+            conn.execute(
+                "INSERT INTO live_odds VALUES (NULL,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    RACE_ID,
+                    "2026-08-03",
+                    "WPK",
+                    2,
+                    "https://www.sportsbet.com.au/greyhound-racing/australia-nz/wentworth-park/race-1-1",
+                    3,
+                    "Charlie",
+                    "CHARLIE",
+                    4.0,
+                    "2026-08-03T10:00:00+10:00",
+                    "win",
+                    "sportsbet",
+                    "dog",
+                    "explicit_dom",
+                    "autonomous_prejump_t60m",
+                    "11:00",
+                ),
+            )
+
+
+def _html(rows=((1, "Alpha", "1st"), (2, "Bravo", "2nd"))) -> bytes:
+    body = "".join(
+        f'<tr class="race-runner"><td class="race-runners__finish-position">{position}</td>'
+        f'<td class="race-runners__box"><span name="rug_{box}">{box}</span></td>'
+        f'<td class="race-runners__name">{name}</td></tr>'
+        for box, name, position in rows
+    )
+    return f'<table class="race-runners--result">{body}</table>'.encode()
+
+
+def test_exact_match_appends_and_is_idempotent(tmp_path):
+    db = tmp_path / "test.db"
+    _db(db)
+    raw = tmp_path / "raw.html"
+    raw.write_bytes(_html())
+    kwargs = {"raw_path": raw, "source_url": URL, "raw_fetched_at": "2026-08-03T12:00:00+10:00"}
+    first = subject.run(
+        db_path=db, race_id=RACE_ID, output_dir=tmp_path / "evidence", execute=True, **kwargs
+    )
+    second = subject.run(
+        db_path=db, race_id=RACE_ID, output_dir=tmp_path / "evidence", execute=True, **kwargs
+    )
+    assert (first["status"], first["inserted_race_rows"], first["inserted_runner_rows"]) == (
+        "APPENDED",
+        1,
+        2,
+    )
+    assert second["status"] == "NOOP_ALREADY_PRESENT"
+    with sqlite3.connect(db) as conn:
+        race_json = json.loads(
+            conn.execute(f"SELECT row_json FROM {subject.RACE_TABLE}").fetchone()[0]
+        )
+        assert race_json["raw_sha256"] == subject.sha256_bytes(_html())
+        assert conn.execute(f"SELECT count(*) FROM {subject.RUNNER_TABLE}").fetchone()[0] == 2
+
+
+@pytest.mark.parametrize(
+    ("rows", "reason"),
+    [
+        (((1, "Alpha", "1st"), (2, "Charlie", "2nd")), "runner_set_mismatch"),
+        (((1, "Alpha", "1st"),), "runner_set_mismatch"),
+        (((1, "Alpha", "1st"), (2, "Bravo", "3rd")), "incomplete_finish_positions"),
+    ],
+)
+def test_rejects_runner_mismatch_and_partial_results(tmp_path, rows, reason):
+    db = tmp_path / "test.db"
+    _db(db)
+    sealed = subject.seal_race_from_db(db, RACE_ID)
+    with pytest.raises(subject.MatchRejected, match=reason):
+        subject.validate_official_html(sealed, URL, _html(rows))
+
+
+def test_rejects_ambiguous_race_identity(tmp_path):
+    db = tmp_path / "test.db"
+    _db(db, duplicate_identity=True)
+    with pytest.raises(subject.MatchRejected, match="ambiguous_race_number"):
+        subject.seal_race_from_db(db, RACE_ID)
+
+
+def test_rejects_provenance_url_mismatch(tmp_path):
+    db = tmp_path / "test.db"
+    _db(db)
+    sealed = subject.seal_race_from_db(db, RACE_ID)
+    with pytest.raises(subject.MatchRejected, match="official_url_identity_mismatch"):
+        subject.validate_official_html(
+            sealed,
+            "https://www.thedogs.com.au/racing/wentworth-park/2026-08-03/2/results?trial=false",
+            _html(),
+        )
+
+
+def test_rejects_conflicting_existing_evidence_without_partial_insert(tmp_path):
+    db = tmp_path / "test.db"
+    _db(db)
+    raw = tmp_path / "raw.html"
+    raw.write_bytes(_html())
+    kwargs = {"raw_path": raw, "source_url": URL, "raw_fetched_at": "2026-08-03T12:00:00+10:00"}
+    subject.run(
+        db_path=db, race_id=RACE_ID, output_dir=tmp_path / "evidence", execute=True, **kwargs
+    )
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            f"UPDATE {subject.RACE_TABLE} SET row_json = ?",
+            (json.dumps({"raw_sha256": "conflict"}),),
+        )
+    with pytest.raises(subject.MatchRejected, match="conflicting_or_unverifiable"):
+        subject.run(
+            db_path=db, race_id=RACE_ID, output_dir=tmp_path / "evidence", execute=True, **kwargs
+        )
+    with sqlite3.connect(db) as conn:
+        assert conn.execute(f"SELECT count(*) FROM {subject.RUNNER_TABLE}").fetchone()[0] == 2
+
+
+def test_rejects_existing_artifact_with_failed_hash_verification(tmp_path, monkeypatch):
+    payload = _html()
+    monkeypatch.setattr(subject, "sha256_bytes", lambda _: "0" * 64)
+    path = tmp_path / f"thedogs_official_{'0' * 64}.html"
+    path.write_bytes(b"different")
+    with pytest.raises(subject.MatchRejected, match="raw_artifact_hash_collision"):
+        subject.write_raw_artifact(tmp_path, payload)
+
+
+def test_rejects_post_jump_or_unclassified_odds(tmp_path):
+    db = tmp_path / "test.db"
+    _db(db)
+    with sqlite3.connect(db) as conn:
+        conn.execute("UPDATE live_odds SET capture_timestamp = '2026-08-03T11:01:00+10:00'")
+    with pytest.raises(subject.MatchRejected, match="odds_capture_not_before"):
+        subject.seal_race_from_db(db, RACE_ID)
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "UPDATE live_odds SET capture_timestamp = '2026-08-03T10:00:00+10:00', capture_mode = NULL"
+        )
+    with pytest.raises(subject.MatchRejected, match="non_prejump_odds_capture"):
+        subject.seal_race_from_db(db, RACE_ID)
+
+
+def test_rejects_sportsbet_venue_or_race_url_mismatch(tmp_path):
+    db = tmp_path / "test.db"
+    _db(db)
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "UPDATE live_odds SET source_url = 'https://www.sportsbet.com.au/greyhound-racing/australia-nz/hobart/race-2-1'"
+        )
+    with pytest.raises(subject.MatchRejected, match="sportsbet_url_identity_mismatch"):
+        subject.seal_race_from_db(db, RACE_ID)
+
+
+@pytest.mark.parametrize("missing", ["race", "runner"])
+def test_rejects_partial_existing_bundle_without_writes(tmp_path, missing):
+    db = tmp_path / "test.db"
+    _db(db)
+    raw = tmp_path / "raw.html"
+    raw.write_bytes(_html())
+    kwargs = {"raw_path": raw, "source_url": URL, "raw_fetched_at": "2026-08-03T12:00:00+10:00"}
+    subject.run(
+        db_path=db, race_id=RACE_ID, output_dir=tmp_path / "evidence", execute=True, **kwargs
+    )
+    with sqlite3.connect(db) as conn:
+        if missing == "race":
+            conn.execute(f"DELETE FROM {subject.RACE_TABLE}")
+        else:
+            conn.execute(f"DELETE FROM {subject.RUNNER_TABLE} WHERE box_number = 2")
+    with pytest.raises(subject.MatchRejected, match="conflicting_or_incomplete"):
+        subject.run(
+            db_path=db, race_id=RACE_ID, output_dir=tmp_path / "evidence", execute=True, **kwargs
+        )
+    with sqlite3.connect(db) as conn:
+        counts = (
+            conn.execute(f"SELECT count(*) FROM {subject.RACE_TABLE}").fetchone()[0],
+            conn.execute(f"SELECT count(*) FROM {subject.RUNNER_TABLE}").fetchone()[0],
+        )
+    assert counts == ((0, 2) if missing == "race" else (1, 1))
+
+
+def test_raw_html_requires_explicit_fetch_provenance(tmp_path):
+    db = tmp_path / "test.db"
+    _db(db)
+    raw = tmp_path / "raw.html"
+    raw.write_bytes(_html())
+    with pytest.raises(subject.MatchRejected, match="requires_source_url_and_fetched_at"):
+        subject.run(
+            db_path=db,
+            race_id=RACE_ID,
+            output_dir=tmp_path / "evidence",
+            execute=False,
+            raw_path=raw,
+            source_url=URL,
+        )
+
+
+def test_rejects_official_fetch_time_before_scheduled_start(tmp_path):
+    db = tmp_path / "test.db"
+    _db(db)
+    raw = tmp_path / "raw.html"
+    raw.write_bytes(_html())
+    with pytest.raises(subject.MatchRejected, match="fetched_before_scheduled_start"):
+        subject.run(
+            db_path=db,
+            race_id=RACE_ID,
+            output_dir=tmp_path / "evidence",
+            execute=False,
+            raw_path=raw,
+            source_url=URL,
+            raw_fetched_at="2026-08-03T10:30:00+10:00",
+        )


### PR DESCRIPTION
## Summary
- append TheDogs official-result evidence only after exact race and complete box/name runner-set matching
- seal strict pre-jump Sportsbet provenance and preserve raw bytes, URLs, fetch time, and SHA-256 hashes
- make identical reruns fully verified no-ops and reject conflicting, incomplete, or orphaned evidence transactionally
- document the identity contract and keep dry-run as the default

## Review repairs
Independent review found and this branch fixes: missing temporal enforcement, partial/idempotency gaps around `INSERT OR IGNORE`, unbound Sportsbet URL identity, and fabricated offline fetch-time provenance.

## Validation
- `14 passed` — `tests/test_append_august_official_results.py` (`--noconftest`)
- `5 passed` — repository-mandated `pr_fast` forecasting checks
- Black check passed for the script and focused test
- Python compile passed
- `git diff --check` passed
- Hobart R2 2026-08-03 preserved-byte dry-run: `ACCEPTED_DRY_RUN`, 7 runners, raw SHA-256 `56330378c350b1df14ef9dcad5c93bb954360102e3ed9147a1b39cfe9eced65e`
- live writer-specific August evidence count remained 0; SQLite `quick_check` returned `ok`

No bulk August ingestion or labeling was performed.