### PR TITLE
Publish only safe races from mixed refresh coverage

### DIFF
--- a/docs/agent_tasks/manual_live_prediction_current_index_subset_r3_2e0f118d_20260818.md
+++ b/docs/agent_tasks/manual_live_prediction_current_index_subset_r3_2e0f118d_20260818.md
@@ -1,0 +1,122 @@
+---
+job_id: MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818
+title: Publish only safe races from mixed refresh coverage and finish live proof
+lane: Query Orchestration
+supporting_lanes: [Provenance, Reporting]
+owner: Codex
+approval_required: true
+approval_source: >-
+  The owner's active 2026-08-18 /goal authorizes the smallest current-index
+  repair, tests, review, GitHub publication and merge, exact generated runtime
+  deployment, natural cycles, and guarded one-at-a-time prediction POSTs until
+  one valid sealed On-demand Forecast succeeds. It forbids predictive-semantic
+  change, frozen-test alteration, result-aware repair, promotion, ROI/edge or
+  betting claims, wagering, blind retry, provenance relaxation, and direct
+  canonical database mutation.
+allow_unapproved_safe_extension: false
+timeout_seconds: 43200
+mutation_mode: safe_extension
+allow_audit_code_changes: false
+base: 2e0f118d02ec35270d2a04c89df54578342da792
+production_data_access: false
+production_data_boundary: >-
+  Read installed generated services, immutable collector evidence, sealed
+  reports/publications, identities, operation stores, and the canonical racing
+  database. Existing collector-owned cycles retain only established append-only
+  writes. Each freshly admitted prediction job may write its isolated job,
+  audit, request, receipt, attempt, and sealed bundle. No direct canonical DB
+  write, training, scoring, model/config/pointer mutation, result use, lock
+  deletion, service-file hand edit, experiment activation, or betting action.
+owner_db_append_only_approval: true
+github_mutation_allowed: true
+git_history_mutation_allowed: true
+live_service_mutation_allowed: true
+closeout_scope: repo_and_publish
+docs_impact: DOCS_REQUIRED
+task_tier: critical
+recommended_model: high_reasoning
+actual_model: gpt-5
+why_this_model: >-
+  The repair crosses a hash-bound producer/publisher contract, an odds-capture
+  shared-data boundary, generated deployment, live collection, and sealed job
+  verification.
+worker_model_allowed: true
+worker_decision_limit: >-
+  Independent read-only reviewers may inspect the exact diff. The primary agent
+  retains implementation, Git, deployment, runtime, POST, and final authority.
+escalation_needed: false
+output_dir: reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818
+allowed_files:
+  - docs/agent_tasks/manual_live_prediction_current_index_subset_r3_2e0f118d_20260818.md
+  - docs/operator_ui_v1/MANUAL_LIVE_PREDICTION_RUNBOOK.md
+  - race_collection/synchronous_manual_capture.py
+  - scripts/refresh_prejump_upcoming.py
+  - tests/test_prejump_prediction_loop.py
+  - tests/race_collection/test_synchronous_manual_capture.py
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/README.md
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/STATE.md
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/DECISIONS.md
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/VALIDATION.md
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/REVIEW.md
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/CODE_REVIEW.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/RUN_OUTCOME.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/DECISION_ENTRY.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/status.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/guard-preflight.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/guard-final.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/pr-body.md
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/github-checks.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/final-refs.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/deployment-evidence.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/live-attempts.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/SHA256SUMS
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818/release-receipt.json
+control_contract_version: 2
+project_id: greyhound_racing_collector
+claim_id: MANUAL_LIVE_PREDICTION_CURRENT_INDEX_SUBSET_R3_2E0F118D_20260818
+proof_question: >-
+  Can the refresh producer expose a bounded safe current-index subset without
+  removing candidates needed by odds capture, so mixed coverage publishes only
+  complete races, zero-complete coverage remains rejected, and exact deployed
+  master can produce one valid sealed manual prediction?
+hypothesis_id: explicit_safe_current_index_subset_and_live_prediction_r3
+program_track: prospective_readiness
+entry_state: >-
+  PR #139 merged as exact master 2e0f118d, tree bd3d6aac, with all CI green. Its
+  exact deployed collector completed a natural cycle, appended 14 live-odds
+  rows, and had two fully safe plus two incomplete selected races. The refresh
+  globally emitted METADATA_COVERAGE_INCOMPLETE and the strict publisher
+  correctly rejected it. selected_races is also the odds-capture fallback
+  input, so it must remain intact. No prediction POST has occurred.
+target_transition: >-
+  A reviewed clean PR introduces a distinct bounded current-index subset while
+  retaining all odds candidates; exact merged master is generated and deployed;
+  a fresh natural internally consistent current index is sealed; and guarded
+  distinct jobs stop at the first valid sealed prediction with probabilities.
+exit_predicate: >-
+  Tests prove all-complete SUCCESS, mixed subset exclusion, zero-complete
+  rejection, odds-candidate preservation, stale/hash conflicts, contradictory
+  publication rejection, and replay; focused checks, independent review, and
+  exact-head CI pass; merge/deployment identities match; fresh natural index
+  and each guarded POST satisfy provenance; one terminal success passes bundle,
+  request, receipt, model, config, schema, race, runner, timing, hash, and
+  probability checks; issue #135 and the runbook are updated; V2 closeout and
+  registry release succeed.
+source_class: exact_origin_master_2e0f118d_plus_hash_bound_mixed_coverage_runtime_report_20260818
+dataset_version: manual_live_prediction_current_index_subset_runtime_r3_20260818
+evidence_hash: sha256:1b77a7d2674ea44cc82ad7b560df47d3f40bb7812cda05fb8f9592ef5dfe3ea1
+capabilities: [READ, REPORT_WRITE, CODE_EDIT, PUBLISH, RUNTIME_CHANGE]
+resume_only_if: >-
+  Continue only while identities remain verifiable, the canonical lock is never
+  bypassed, predictive semantics and frozen experiments stay unchanged, only
+  complete races enter the current index, all selected races remain available
+  to odds capture, deployment stays generator-owned, and every further POST has
+  fresh readiness plus a distinct repair or genuinely new race after a
+  pre-POST availability stop.
+---
+
+# Safe current-index subset and live proof
+
+This task owns the producer/publisher contract repair reproduced by the first
+exact-2e0f118d natural cycle and continues issue #135 through one valid sealed
+On-demand Forecast. It may not weaken publication or predictive semantics.

--- a/docs/operator_ui_v1/MANUAL_LIVE_PREDICTION_RUNBOOK.md
+++ b/docs/operator_ui_v1/MANUAL_LIVE_PREDICTION_RUNBOOK.md
@@ -50,9 +50,13 @@ following before opening prediction controls:
 - `GET /operator-ui/api/v1/r3-capability` reports authorized and runtime
   configured at level 2.
 
-Any partial, mixed, stale, missing, hash-conflicting, post-jump, ambiguous, or
-contradictory evidence is an availability stop. Never reinterpret
-`METADATA_COVERAGE_INCOMPLETE` as a successful publication.
+Exclude every race with partial metadata. A mixed candidate batch is usable
+only when the refresh report itself is `SUCCESS`, its
+`current_index_metadata_selection` is `READY_WITH_EXCLUSIONS`, its counts and
+exclusions reconcile exactly with `selected_races`, and the published packet
+contains only `current_index_races`. Stale, missing, hash-conflicting,
+post-jump, ambiguous, or contradictory evidence is an availability stop. Never
+reinterpret `METADATA_COVERAGE_INCOMPLETE` as a successful publication.
 
 ## 3. Submit once
 

--- a/race_collection/synchronous_manual_capture.py
+++ b/race_collection/synchronous_manual_capture.py
@@ -691,8 +691,66 @@ def _normalize_current_index_rows(
     *,
     max_races: int,
 ) -> list[dict[str, Any]]:
+    from scripts.refresh_prejump_upcoming import (
+        current_index_metadata_selection,
+        stable_race_id,
+        stable_race_id_variants,
+    )
+
     selected = source.get("selected_races")
     selected_count = source.get("selected_count")
+    subset_fields = {
+        "current_index_races",
+        "current_index_race_count",
+        "current_index_metadata_selection",
+    }
+    if any(field in source for field in subset_fields):
+        if not all(field in source for field in subset_fields):
+            raise CaptureOneRejected(
+                "CURRENT_INDEX_SOURCE_INVALID",
+                reason="current_index_metadata_selection_incomplete",
+            )
+        candidates = selected
+        candidate_count = selected_count
+        selection = source.get("current_index_metadata_selection")
+        selected = source.get("current_index_races")
+        selected_count = source.get("current_index_race_count")
+        coverage = source.get("sidecar_metadata_coverage")
+        if (
+            not isinstance(candidates, list)
+            or any(not isinstance(race, Mapping) for race in candidates)
+            or isinstance(candidate_count, bool)
+            or not isinstance(candidate_count, int)
+            or candidate_count != len(candidates)
+            or not isinstance(selected, list)
+            or any(not isinstance(race, Mapping) for race in selected)
+            or isinstance(selected_count, bool)
+            or not isinstance(selected_count, int)
+            or not isinstance(selection, Mapping)
+            or not isinstance(coverage, Mapping)
+        ):
+            raise CaptureOneRejected(
+                "CURRENT_INDEX_SOURCE_INVALID",
+                reason="current_index_metadata_selection_invalid",
+            )
+        expected_races, expected_selection = current_index_metadata_selection(
+            candidates,
+            coverage,
+        )
+        if (
+            selected_count != len(selected)
+            or selected != expected_races
+            or dict(selection) != expected_selection
+            or expected_selection["status"] not in {
+                "READY",
+                "READY_WITH_EXCLUSIONS",
+                "NOT_REQUESTED_NO_SELECTED_RACES",
+            }
+        ):
+            raise CaptureOneRejected(
+                "CURRENT_INDEX_SOURCE_INVALID",
+                reason="current_index_metadata_selection_invalid",
+            )
     if (
         not isinstance(selected, list)
         or isinstance(selected_count, bool)
@@ -706,7 +764,6 @@ def _normalize_current_index_rows(
             selected_count=selected_count,
             max_races=max_races,
         )
-    from scripts.refresh_prejump_upcoming import stable_race_id, stable_race_id_variants
     from utils.csv_metadata import canonical_thedogs_race_identity
 
     normalized: list[dict[str, Any]] = []

--- a/scripts/refresh_prejump_upcoming.py
+++ b/scripts/refresh_prejump_upcoming.py
@@ -24,7 +24,10 @@ ROOT_STR = str(ROOT)
 sys.path = [path for path in sys.path if path != ROOT_STR]
 sys.path.insert(0, ROOT_STR)
 
-from utils.csv_metadata import load_safe_weather_track_metadata  # noqa: E402
+from utils.csv_metadata import (  # noqa: E402
+    canonical_thedogs_race_identity,
+    load_safe_weather_track_metadata,
+)
 from utils.expert_form_metadata import safe_expert_form_metadata_from_payload  # noqa: E402
 from utils.race_lifecycle import melbourne_now  # noqa: E402
 
@@ -593,6 +596,91 @@ def sidecar_metadata_coverage(
     }
 
 
+def current_index_metadata_selection(
+    selected_records: Sequence[Mapping[str, Any]],
+    metadata_coverage: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Select only source-safe races without narrowing odds-capture candidates."""
+
+    coverage_rows = metadata_coverage.get("races")
+    if not isinstance(coverage_rows, list) or len(coverage_rows) != len(selected_records):
+        coverage_rows = []
+    eligible: list[dict[str, Any]] = []
+    exclusions: list[dict[str, Any]] = []
+    for index, selected in enumerate(selected_records):
+        row = coverage_rows[index] if index < len(coverage_rows) else None
+        selected_url = str(selected.get("race_url") or "").strip()
+        selected_ids = {
+            str(value)
+            for value in [
+                selected.get("race_id"),
+                *(selected.get("race_id_aliases") or []),
+            ]
+            if value
+        }
+        row_url = str(row.get("race_url") or "").strip() if isinstance(row, Mapping) else ""
+        row_id = str(row.get("race_id") or "").strip() if isinstance(row, Mapping) else ""
+        selected_identity = canonical_thedogs_race_identity(selected_url)
+        row_identity = canonical_thedogs_race_identity(row_url)
+        aligned = bool(
+            isinstance(row, Mapping)
+            and selected_identity is not None
+            and row_identity is not None
+            and selected_identity == row_identity
+            and row_id in selected_ids
+        )
+        safe_components = bool(
+            isinstance(row, Mapping)
+            and row.get("csv_path")
+            and row.get("safe_weather_present") is True
+            and row.get("safe_track_condition_present") is True
+            and row.get("safe_expert_form_present") is True
+            and row.get("safe_all_weather_track_expert_form_present") is True
+        )
+        if aligned and safe_components:
+            eligible.append(dict(selected))
+            continue
+        missing = []
+        if not aligned:
+            missing.append("metadata_alignment")
+        elif isinstance(row, Mapping):
+            if not row.get("csv_path"):
+                missing.append("accepted_csv")
+            if not row.get("safe_weather_present"):
+                missing.append("weather")
+            if not row.get("safe_track_condition_present"):
+                missing.append("track_condition")
+            if not row.get("safe_expert_form_present"):
+                missing.append("expert_form")
+        exclusions.append(
+            {
+                "race_id": selected.get("race_id"),
+                "race_url": selected_url or None,
+                "reason": "safe_metadata_incomplete",
+                "missing_safe_metadata": missing,
+            }
+        )
+
+    candidate_count = len(selected_records)
+    eligible_count = len(eligible)
+    if candidate_count == 0:
+        status = "NOT_REQUESTED_NO_SELECTED_RACES"
+    elif eligible_count == 0:
+        status = "INCOMPLETE"
+    elif exclusions:
+        status = "READY_WITH_EXCLUSIONS"
+    else:
+        status = "READY"
+    return eligible, {
+        "schema_version": "current_index_metadata_selection_v1",
+        "status": status,
+        "candidate_race_count": candidate_count,
+        "eligible_race_count": eligible_count,
+        "excluded_race_count": len(exclusions),
+        "exclusions": exclusions,
+    }
+
+
 def refresh_prejump_upcoming(args: argparse.Namespace) -> dict[str, Any]:
     upcoming_dir = Path(args.upcoming_dir)
     if not upcoming_dir.is_absolute():
@@ -638,6 +726,10 @@ def refresh_prejump_upcoming(args: argparse.Namespace) -> dict[str, Any]:
     artifact_counts = _artifact_counts(upcoming_dir)
     selected_records = list(selected_prejump_records(records, limit=int(args.limit)))
     metadata_coverage = sidecar_metadata_coverage(upcoming_dir, selected_records)
+    current_index_races, current_index_selection = current_index_metadata_selection(
+        selected_records,
+        metadata_coverage,
+    )
     report = {
         "status": "SUCCESS",
         "dry_run": bool(args.dry_run),
@@ -669,6 +761,9 @@ def refresh_prejump_upcoming(args: argparse.Namespace) -> dict[str, Any]:
         "selected_races": list(
             selected_records
         ),
+        "current_index_race_count": len(current_index_races),
+        "current_index_races": current_index_races,
+        "current_index_metadata_selection": current_index_selection,
         "downloads": downloads,
         **artifact_counts,
         "artifact_counts": artifact_counts,
@@ -682,8 +777,7 @@ def refresh_prejump_upcoming(args: argparse.Namespace) -> dict[str, Any]:
     }
     if (
         bool(getattr(args, "require_safe_metadata", False))
-        and metadata_coverage.get("status")
-        not in {"READY", "NOT_REQUESTED_NO_SELECTED_RACES"}
+        and current_index_selection.get("status") == "INCOMPLETE"
     ):
         report["status"] = "METADATA_COVERAGE_INCOMPLETE"
         report["reason"] = metadata_coverage.get("reason") or "safe_metadata_incomplete"
@@ -714,8 +808,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--require-safe-metadata",
         action="store_true",
         help=(
-            "Return a non-success status when any selected race lacks source-safe "
-            "weather, track_condition, or expert-form sidecar metadata."
+            "Exclude races lacking source-safe weather, track_condition, or "
+            "expert-form sidecar metadata from current-index eligibility; return "
+            "a non-success status when selected races exist but none is eligible."
         ),
     )
     parser.add_argument("--output")

--- a/tests/race_collection/test_synchronous_manual_capture.py
+++ b/tests/race_collection/test_synchronous_manual_capture.py
@@ -15,7 +15,10 @@ import pytest
 
 import race_collection.synchronous_manual_capture as capture
 from scripts import shadow_autopilot_daemon as daemon
-from scripts.refresh_prejump_upcoming import race_window_record
+from scripts.refresh_prejump_upcoming import (
+    current_index_metadata_selection,
+    race_window_record,
+)
 from race_collection.manual_prediction_collector_request import (
     ManualPredictionCollectorProtocol,
     ProtocolRejected,
@@ -553,6 +556,164 @@ def test_current_race_index_publication_is_atomic_bounded_and_source_sealed(
 
     assert rejected["status"] == "REJECTED"
     assert index_path.read_bytes() == original
+
+
+def test_current_race_index_publishes_explicit_safe_subset_from_mixed_candidates(
+    tmp_path: Path,
+):
+    evidence_root = tmp_path / "evidence"
+    state = evidence_root / "shadow_autopilot_daemon_runtime/odds_capture_state.json"
+    source = evidence_root / "run/odds_capture_refresh_report.json"
+    source.parent.mkdir(parents=True)
+    generated = datetime.fromisoformat("2026-07-19T12:55:00+10:00")
+    safe_url = "https://www.thedogs.com.au/racing/gunnedah/2026-07-19/5"
+    safe_race = {
+        "date": "2026-07-19",
+        "jump_datetime": "2026-07-19T13:00:00+10:00",
+        "race_id": "Race 5 - GUNN - 2026-07-19",
+        "race_id_aliases": [
+            "Race 5 - GUNN - 2026-07-19",
+            "Race 5 - GUNNEDAH - 2026-07-19",
+        ],
+        "race_number": 5,
+        "race_time": "13:00",
+        "race_url": safe_url,
+        "venue": "GUNN",
+    }
+    incomplete_race = {
+        "date": "2026-07-19",
+        "jump_datetime": "2026-07-19T13:05:00+10:00",
+        "race_id": "Race 6 - GUNN - 2026-07-19",
+        "race_id_aliases": [
+            "Race 6 - GUNN - 2026-07-19",
+            "Race 6 - GUNNEDAH - 2026-07-19",
+        ],
+        "race_number": 6,
+        "race_time": "13:05",
+        "race_url": "https://www.thedogs.com.au/racing/gunnedah/2026-07-19/6",
+        "venue": "GUNN",
+    }
+    coverage = _runner_coverage(evidence_root, safe_url, generated)
+    coverage["races"][0].update({
+        "race_id": safe_race["race_id"],
+        "safe_weather_present": True,
+        "safe_track_condition_present": True,
+        "safe_expert_form_present": True,
+        "safe_all_weather_track_expert_form_present": True,
+    })
+    coverage["races"].append({
+        "race_id": incomplete_race["race_id"],
+        "race_url": incomplete_race["race_url"],
+        "csv_path": None,
+        "safe_weather_present": False,
+        "safe_track_condition_present": False,
+        "safe_expert_form_present": False,
+        "safe_all_weather_track_expert_form_present": False,
+    })
+    current_index_races, selection = current_index_metadata_selection(
+        [safe_race, incomplete_race],
+        coverage,
+    )
+    source.write_bytes(canonical_bytes({
+        "status": "SUCCESS",
+        "generated_at": generated.isoformat(),
+        "sidecar_metadata_coverage": coverage,
+        "selected_count": 2,
+        "selected_races": [safe_race, incomplete_race],
+        "current_index_race_count": len(current_index_races),
+        "current_index_races": current_index_races,
+        "current_index_metadata_selection": selection,
+    }))
+
+    published = publish_current_race_index(
+        state_path=state,
+        evidence_root=evidence_root,
+        source_refresh_report_path=source,
+        run_id="mixed",
+    )
+
+    assert published["status"] == "PUBLISHED"
+    packet = json.loads(current_race_index_path(state).read_bytes())
+    assert packet["race_count"] == 1
+    assert [race["race_id"] for race in packet["races"]] == [safe_race["race_id"]]
+
+    tampered = json.loads(source.read_bytes())
+    tampered["current_index_races"] = [incomplete_race]
+    source.write_bytes(canonical_bytes(tampered))
+    rejected = publish_current_race_index(
+        state_path=state,
+        evidence_root=evidence_root,
+        source_refresh_report_path=source,
+        run_id="mixed-swapped-subset",
+    )
+    assert rejected["status"] == "REJECTED"
+    assert rejected["reason"] == "CURRENT_INDEX_SOURCE_INVALID"
+
+
+def test_current_race_index_rejects_contradictory_explicit_subset_report(
+    tmp_path: Path,
+):
+    evidence_root = tmp_path / "evidence"
+    state = evidence_root / "runtime/odds_capture_state.json"
+    source = evidence_root / "run/odds_capture_refresh_report.json"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(canonical_bytes({
+        "status": "SUCCESS",
+        "generated_at": "2026-07-19T12:55:00+10:00",
+        "selected_count": 1,
+        "selected_races": [{}],
+        "current_index_race_count": 1,
+        "current_index_races": [{}],
+        "current_index_metadata_selection": {
+            "schema_version": "current_index_metadata_selection_v1",
+            "status": "INCOMPLETE",
+            "candidate_race_count": 1,
+            "eligible_race_count": 0,
+            "excluded_race_count": 1,
+            "exclusions": [{}],
+        },
+    }))
+
+    rejected = publish_current_race_index(
+        state_path=state,
+        evidence_root=evidence_root,
+        source_refresh_report_path=source,
+        run_id="contradictory",
+    )
+
+    assert rejected["status"] == "REJECTED"
+    assert rejected["reason"] == "CURRENT_INDEX_SOURCE_INVALID"
+
+
+def test_current_race_index_rejects_partial_explicit_subset_contract(tmp_path: Path):
+    evidence_root = tmp_path / "evidence"
+    state = evidence_root / "runtime/odds_capture_state.json"
+    source = evidence_root / "run/odds_capture_refresh_report.json"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(canonical_bytes({
+        "status": "SUCCESS",
+        "generated_at": "2026-07-19T12:55:00+10:00",
+        "selected_count": 0,
+        "selected_races": [],
+        "current_index_metadata_selection": {
+            "schema_version": "current_index_metadata_selection_v1",
+            "status": "NOT_REQUESTED_NO_SELECTED_RACES",
+            "candidate_race_count": 0,
+            "eligible_race_count": 0,
+            "excluded_race_count": 0,
+            "exclusions": [],
+        },
+    }))
+
+    rejected = publish_current_race_index(
+        state_path=state,
+        evidence_root=evidence_root,
+        source_refresh_report_path=source,
+        run_id="partial-contract",
+    )
+
+    assert rejected["status"] == "REJECTED"
+    assert rejected["reason"] == "CURRENT_INDEX_SOURCE_INVALID"
 
 
 def test_current_race_index_rejects_stale_or_changed_source(tmp_path: Path):

--- a/tests/test_prejump_prediction_loop.py
+++ b/tests/test_prejump_prediction_loop.py
@@ -10,6 +10,7 @@ from zoneinfo import ZoneInfo
 
 from scripts import prejump_prediction_loop as loop
 from scripts.refresh_prejump_upcoming import (
+    current_index_metadata_selection,
     expand_excluded_race_ids,
     refresh_prejump_upcoming,
     refresh_timing_summary,
@@ -865,6 +866,69 @@ def test_sidecar_metadata_coverage_accepts_safe_weather_track_and_expert_form(tm
     assert coverage["safe_all_weather_track_expert_form_race_count"] == 1
 
 
+def test_current_index_metadata_selection_rejects_conflicting_sidecar_url():
+    selected = [{
+        "race_id": "Race 9 - SAL - 2026-06-17",
+        "race_id_aliases": ["Race 9 - SAL - 2026-06-17"],
+        "race_url": (
+            "https://www.thedogs.com.au/racing/sale/2026-06-17/9/test?trial=false"
+        ),
+    }]
+    coverage = {
+        "races": [{
+            "race_id": "Race 9 - SAL - 2026-06-17",
+            "race_url": (
+                "https://www.thedogs.com.au/racing/gunnedah/2026-06-17/9/test"
+            ),
+            "safe_all_weather_track_expert_form_present": True,
+        }]
+    }
+
+    eligible, selection = current_index_metadata_selection(selected, coverage)
+
+    assert eligible == []
+    assert selection["status"] == "INCOMPLETE"
+    assert selection["exclusions"][0]["missing_safe_metadata"] == [
+        "metadata_alignment"
+    ]
+
+
+def test_current_index_metadata_selection_requires_complete_consistent_identity():
+    race_url = "https://www.thedogs.com.au/racing/sale/2026-06-17/9/test"
+    selected = [{
+        "race_id": "Race 9 - SAL - 2026-06-17",
+        "race_id_aliases": ["Race 9 - SAL - 2026-06-17"],
+        "race_url": race_url,
+    }]
+    row = {
+        "race_id": "",
+        "race_url": race_url,
+        "csv_path": "/evidence/Race 9 - SAL - 2026-06-17.csv",
+        "safe_weather_present": True,
+        "safe_track_condition_present": True,
+        "safe_expert_form_present": True,
+        "safe_all_weather_track_expert_form_present": True,
+    }
+
+    eligible, selection = current_index_metadata_selection(
+        selected,
+        {"races": [row]},
+    )
+    assert eligible == []
+    assert selection["exclusions"][0]["missing_safe_metadata"] == [
+        "metadata_alignment"
+    ]
+
+    row["race_id"] = selected[0]["race_id"]
+    row["safe_weather_present"] = False
+    eligible, selection = current_index_metadata_selection(
+        selected,
+        {"races": [row]},
+    )
+    assert eligible == []
+    assert selection["exclusions"][0]["missing_safe_metadata"] == ["weather"]
+
+
 def test_refresh_prejump_upcoming_can_fail_closed_on_incomplete_safe_metadata(
     tmp_path,
     monkeypatch,
@@ -912,9 +976,86 @@ def test_refresh_prejump_upcoming_can_fail_closed_on_incomplete_safe_metadata(
 
     assert report["status"] == "METADATA_COVERAGE_INCOMPLETE"
     assert report["metadata_collection_status"] == "PARTIAL"
+    assert report["current_index_race_count"] == 0
+    assert report["current_index_races"] == []
+    assert report["current_index_metadata_selection"]["status"] == "INCOMPLETE"
     assert report["sidecar_metadata_coverage"]["safe_both_weather_track_race_count"] == 1
     assert report["sidecar_metadata_coverage"]["safe_expert_form_race_count"] == 0
     assert report["reason"] == "missing_safe_expert_form"
+
+
+def test_refresh_prejump_upcoming_exposes_only_safe_current_index_subset(
+    tmp_path,
+    monkeypatch,
+):
+    refresh_module = sys.modules[refresh_prejump_upcoming.__module__]
+    now = datetime(2026, 6, 17, 12, 30, tzinfo=ZoneInfo("Australia/Melbourne"))
+    monkeypatch.setattr(refresh_module, "melbourne_now", lambda: now)
+    safe_url = (
+        "https://www.thedogs.com.au/racing/sale/2026-06-17/9/test?trial=false"
+    )
+    incomplete_url = (
+        "https://www.thedogs.com.au/racing/wagga/2026-06-17/4/test?trial=false"
+    )
+
+    class FakeUpcomingRaceBrowser:
+        def get_upcoming_races(self, days_ahead):
+            return [
+                {
+                    "url": safe_url,
+                    "date": "2026-06-17",
+                    "race_time": "1:57 PM",
+                    "race_number": 9,
+                    "venue": "SAL",
+                },
+                {
+                    "url": incomplete_url,
+                    "date": "2026-06-17",
+                    "race_time": "2:00 PM",
+                    "race_number": 4,
+                    "venue": "WAG",
+                },
+            ]
+
+        def download_race_csv(self, url, *, race_info_hint=None):
+            if url == safe_url:
+                csv_path = tmp_path / "upcoming" / "Race 9 - SAL - 2026-06-17.csv"
+                _write_safe_collection_sidecar(csv_path)
+                return {"success": True, "filepath": str(csv_path)}
+            return {"success": False, "reason": "source_unavailable"}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "upcoming_race_browser",
+        types.SimpleNamespace(UpcomingRaceBrowser=FakeUpcomingRaceBrowser),
+    )
+
+    report = refresh_prejump_upcoming(
+        Namespace(
+            upcoming_dir=str(tmp_path / "upcoming"),
+            days_ahead=0,
+            min_minutes=20,
+            max_minutes=160,
+            limit=16,
+            exclude_race_id=[],
+            exclude_race_ids_file=None,
+            dry_run=False,
+            require_safe_metadata=True,
+        )
+    )
+
+    assert report["status"] == "SUCCESS"
+    assert report["selected_count"] == 2
+    assert len(report["selected_races"]) == 2
+    assert report["current_index_race_count"] == 1
+    assert [row["race_url"] for row in report["current_index_races"]] == [safe_url]
+    selection = report["current_index_metadata_selection"]
+    assert selection["status"] == "READY_WITH_EXCLUSIONS"
+    assert selection["candidate_race_count"] == 2
+    assert selection["eligible_race_count"] == 1
+    assert selection["excluded_race_count"] == 1
+    assert selection["exclusions"][0]["race_url"] == incomplete_url
+    assert selection["exclusions"][0]["reason"] == "safe_metadata_incomplete"
 
 
 def test_prejump_loop_operator_action_surfaces_refresh_rerun_window(


### PR DESCRIPTION
## Summary

- preserve the full selected race list used by the odds-capture fallback lane
- derive an explicit current-index subset containing only races with aligned identities and complete source-safe weather, track condition, and expert form
- make the strict publisher recompute and exactly verify that subset and its exclusions before sealing
- keep zero-eligible and contradictory reports rejected
- document the mixed-coverage operator contract

## Validation

- 158 producer/publisher tests passed
- 14 adjacent current-index integration checks passed before final hardening
- focused post-review tamper matrix: 7 passed
- Python compilation and diff/task-card allowlist checks passed
- independent Standards review: no findings
- independent Spec review: no findings

No model, feature, fitting, experiment, scoring, promotion, or betting semantics changed.
