### PR TITLE
Exclude stale and post-jump runner sources

### DIFF
--- a/docs/agent_tasks/manual_live_prediction_runner_timing_r4_7ba3af86_20260818.md
+++ b/docs/agent_tasks/manual_live_prediction_runner_timing_r4_7ba3af86_20260818.md
@@ -1,0 +1,110 @@
+---
+job_id: MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818
+title: Exclude late runner sources and finish one sealed manual prediction
+lane: Query Orchestration
+supporting_lanes: [Provenance, Reporting]
+owner: Codex
+approval_required: true
+approval_source: >-
+  The owner's active 2026-08-18 /goal authorizes reproduced readiness repairs,
+  tests, review, publication, merge, exact generated deployment, natural cycles,
+  and guarded one-at-a-time prediction POSTs until one valid sealed On-demand
+  Forecast succeeds. It forbids predictive-semantic change, frozen-test
+  alteration, result-aware repair, promotion, ROI/edge or betting claims,
+  wagering, blind retry, provenance relaxation, and direct canonical DB writes.
+allow_unapproved_safe_extension: false
+timeout_seconds: 43200
+mutation_mode: safe_extension
+allow_audit_code_changes: false
+base: 7ba3af86aaaad337ce1319ce9e18c3504cde20e3
+production_data_access: false
+production_data_boundary: >-
+  Read installed services and immutable evidence. Existing collector cycles may
+  perform only established append-only writes. Each freshly admitted prediction
+  job may write its isolated job/audit/request/receipt/attempt/bundle. No direct
+  canonical DB write, training, scoring, model/config/pointer mutation, result
+  use, lock deletion, unit hand edit, experiment activation, or betting action.
+owner_db_append_only_approval: true
+github_mutation_allowed: true
+git_history_mutation_allowed: true
+live_service_mutation_allowed: true
+closeout_scope: repo_and_publish
+docs_impact: DOCS_REQUIRED
+task_tier: critical
+recommended_model: high_reasoning
+actual_model: gpt-5
+why_this_model: >-
+  The repair must keep producer timing eligibility identical to the strict
+  publisher without weakening provenance, then continue through live sealing.
+worker_model_allowed: true
+worker_decision_limit: >-
+  Independent reviewers are read-only. The primary agent retains implementation,
+  Git, deployment, runtime, POST, and final authority.
+escalation_needed: false
+output_dir: reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818
+allowed_files:
+  - docs/agent_tasks/manual_live_prediction_runner_timing_r4_7ba3af86_20260818.md
+  - docs/operator_ui_v1/MANUAL_LIVE_PREDICTION_RUNBOOK.md
+  - race_collection/synchronous_manual_capture.py
+  - scripts/refresh_prejump_upcoming.py
+  - tests/test_prejump_prediction_loop.py
+  - tests/race_collection/test_synchronous_manual_capture.py
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/README.md
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/STATE.md
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/DECISIONS.md
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/VALIDATION.md
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/REVIEW.md
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/CODE_REVIEW.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/RUN_OUTCOME.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/DECISION_ENTRY.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/status.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/guard-preflight.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/guard-final.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/pr-body.md
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/github-checks.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/final-refs.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/deployment-evidence.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/live-attempts.json
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/SHA256SUMS
+  - reports/agent_jobs/MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818/release-receipt.json
+control_contract_version: 2
+project_id: greyhound_racing_collector
+claim_id: MANUAL_LIVE_PREDICTION_RUNNER_TIMING_R4_7BA3AF86_20260818
+proof_question: >-
+  Can runner-source timing be included in the exact per-race eligibility set so
+  a post-jump observation is excluded, later safe races publish consistently,
+  and exact deployed master completes one valid sealed manual prediction?
+hypothesis_id: runner_observation_timing_subset_and_live_prediction_r4
+program_track: prospective_readiness
+entry_state: >-
+  PR #140 merged as master 7ba3af86/tree 5bc2cbf3 and was exactly deployed.
+  Natural run 20260818T194102+1000_odds_capture emitted SUCCESS with three
+  metadata-eligible races and one exclusion, but publication rejected because
+  DARW race 3 runner metadata was captured at 19:42:06 for a 19:42:00 jump.
+  WRGL race 4 and TWN race 4 sealed individually. No prediction POST occurred.
+target_transition: >-
+  One reviewed clean PR binds runner-source observation timing into the exact
+  current-index subset; exact merged master is generated/deployed; a natural
+  consistent current index is verified; and guarded distinct jobs stop at the
+  first valid sealed prediction with probabilities.
+exit_predicate: >-
+  Tests prove pre-jump inclusion, post-jump exclusion, stale observation
+  exclusion, mixed and zero-eligible behavior, exact publisher recomputation,
+  and prior stale/hash contradictions; review/CI pass; exact merge/deployment
+  and natural index identities match; one guarded POST succeeds and all sealed
+  provenance/hash/probability checks pass; issue #135/runbook/V2 closeout finish.
+source_class: exact_origin_master_7ba3af86_plus_hash_bound_runner_timing_rejection_20260818
+dataset_version: manual_live_prediction_runner_timing_runtime_r4_20260818
+evidence_hash: sha256:f6f4b8a955f2ea70a9e8f4aa1b5a47afc1deb2067b7f35ae2403c99a0b211aef
+capabilities: [READ, REPORT_WRITE, CODE_EDIT, PUBLISH, RUNTIME_CHANGE]
+resume_only_if: >-
+  Continue only while identities are verifiable, the lock is never bypassed,
+  predictive semantics/frozen experiments stay unchanged, every admitted race
+  has a fresh pre-jump runner source, deployment stays generator-owned, and
+  every further POST has fresh readiness plus a distinct repair or new race.
+---
+
+# Runner-source timing repair and live proof
+
+This task owns the reproduced post-jump runner-source eligibility omission and
+continues issue #135 without weakening the publisher or predictive semantics.

--- a/docs/operator_ui_v1/MANUAL_LIVE_PREDICTION_RUNBOOK.md
+++ b/docs/operator_ui_v1/MANUAL_LIVE_PREDICTION_RUNBOOK.md
@@ -54,7 +54,9 @@ Exclude every race with partial metadata. A mixed candidate batch is usable
 only when the refresh report itself is `SUCCESS`, its
 `current_index_metadata_selection` is `READY_WITH_EXCLUSIONS`, its counts and
 exclusions reconcile exactly with `selected_races`, and the published packet
-contains only `current_index_races`. Stale, missing, hash-conflicting,
+contains only `current_index_races`. Each included race's runner-source
+observation must be timezone-aware, within 20 minutes of the report generation
+time, and strictly before the scheduled jump. Stale, missing, hash-conflicting,
 post-jump, ambiguous, or contradictory evidence is an availability stop. Never
 reinterpret `METADATA_COVERAGE_INCOMPLETE` as a successful publication.
 

--- a/race_collection/synchronous_manual_capture.py
+++ b/race_collection/synchronous_manual_capture.py
@@ -736,6 +736,7 @@ def _normalize_current_index_rows(
         expected_races, expected_selection = current_index_metadata_selection(
             candidates,
             coverage,
+            source_generated_at=source.get("generated_at"),
         )
         if (
             selected_count != len(selected)

--- a/scripts/refresh_prejump_upcoming.py
+++ b/scripts/refresh_prejump_upcoming.py
@@ -459,6 +459,12 @@ def _metadata_record_for_csv(csv_path: Path) -> dict[str, Any]:
     payload = _read_json_object(sidecar_path) if sidecar_path.exists() else None
     weather_track = load_safe_weather_track_metadata(csv_path)
     expert_form = safe_expert_form_metadata_from_payload(payload or {})
+    shadow = (
+        payload.get("prejump_shadow_metadata")
+        if isinstance(payload, Mapping)
+        and isinstance(payload.get("prejump_shadow_metadata"), Mapping)
+        else {}
+    )
     weather_present = bool(weather_track.get("weather"))
     track_present = bool(weather_track.get("track_condition"))
     expert_form_safe = bool(expert_form.get("metadata_is_leakage_safe"))
@@ -475,6 +481,7 @@ def _metadata_record_for_csv(csv_path: Path) -> dict[str, Any]:
         "safe_all_weather_track_expert_form_present": (
             weather_present and track_present and expert_form_safe
         ),
+        "runner_source_observed_at": shadow.get("metadata_captured_at"),
         "weather": weather_track.get("weather"),
         "track_condition": weather_track.get("track_condition"),
         "weather_track_metadata_source": weather_track.get("weather_track_metadata_source"),
@@ -502,6 +509,7 @@ def _missing_metadata_record(record: Mapping[str, Any]) -> dict[str, Any]:
         "safe_both_weather_track_present": False,
         "safe_expert_form_present": False,
         "safe_all_weather_track_expert_form_present": False,
+        "runner_source_observed_at": None,
         "weather": None,
         "track_condition": None,
         "weather_track_metadata_source": None,
@@ -599,6 +607,8 @@ def sidecar_metadata_coverage(
 def current_index_metadata_selection(
     selected_records: Sequence[Mapping[str, Any]],
     metadata_coverage: Mapping[str, Any],
+    *,
+    source_generated_at: datetime | str | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Select only source-safe races without narrowing odds-capture candidates."""
 
@@ -607,6 +617,14 @@ def current_index_metadata_selection(
         coverage_rows = []
     eligible: list[dict[str, Any]] = []
     exclusions: list[dict[str, Any]] = []
+    try:
+        generated = (
+            source_generated_at
+            if isinstance(source_generated_at, datetime)
+            else datetime.fromisoformat(str(source_generated_at or ""))
+        )
+    except ValueError:
+        generated = None
     for index, selected in enumerate(selected_records):
         row = coverage_rows[index] if index < len(coverage_rows) else None
         selected_url = str(selected.get("race_url") or "").strip()
@@ -637,7 +655,29 @@ def current_index_metadata_selection(
             and row.get("safe_expert_form_present") is True
             and row.get("safe_all_weather_track_expert_form_present") is True
         )
-        if aligned and safe_components:
+        try:
+            observed = datetime.fromisoformat(
+                str(row.get("runner_source_observed_at") or "")
+            )
+            jump = datetime.fromisoformat(str(selected.get("jump_datetime") or ""))
+        except (AttributeError, ValueError):
+            observed = None
+            jump = None
+        safe_runner_timing = bool(
+            generated is not None
+            and generated.tzinfo is not None
+            and generated.utcoffset() is not None
+            and observed is not None
+            and observed.tzinfo is not None
+            and observed.utcoffset() is not None
+            and jump is not None
+            and jump.tzinfo is not None
+            and jump.utcoffset() is not None
+            and abs((generated - observed).total_seconds()) <= 1200
+            and generated < jump
+            and observed < jump
+        )
+        if aligned and safe_components and safe_runner_timing:
             eligible.append(dict(selected))
             continue
         missing = []
@@ -652,6 +692,8 @@ def current_index_metadata_selection(
                 missing.append("track_condition")
             if not row.get("safe_expert_form_present"):
                 missing.append("expert_form")
+            if not safe_runner_timing:
+                missing.append("runner_source_timing")
         exclusions.append(
             {
                 "race_id": selected.get("race_id"),
@@ -729,6 +771,7 @@ def refresh_prejump_upcoming(args: argparse.Namespace) -> dict[str, Any]:
     current_index_races, current_index_selection = current_index_metadata_selection(
         selected_records,
         metadata_coverage,
+        source_generated_at=now,
     )
     report = {
         "status": "SUCCESS",

--- a/tests/race_collection/test_synchronous_manual_capture.py
+++ b/tests/race_collection/test_synchronous_manual_capture.py
@@ -600,6 +600,7 @@ def test_current_race_index_publishes_explicit_safe_subset_from_mixed_candidates
         "safe_track_condition_present": True,
         "safe_expert_form_present": True,
         "safe_all_weather_track_expert_form_present": True,
+        "runner_source_observed_at": generated.isoformat(),
     })
     coverage["races"].append({
         "race_id": incomplete_race["race_id"],
@@ -609,10 +610,12 @@ def test_current_race_index_publishes_explicit_safe_subset_from_mixed_candidates
         "safe_track_condition_present": False,
         "safe_expert_form_present": False,
         "safe_all_weather_track_expert_form_present": False,
+        "runner_source_observed_at": generated.isoformat(),
     })
     current_index_races, selection = current_index_metadata_selection(
         [safe_race, incomplete_race],
         coverage,
+        source_generated_at=generated,
     )
     source.write_bytes(canonical_bytes({
         "status": "SUCCESS",

--- a/tests/test_prejump_prediction_loop.py
+++ b/tests/test_prejump_prediction_loop.py
@@ -10,6 +10,7 @@ from zoneinfo import ZoneInfo
 
 from scripts import prejump_prediction_loop as loop
 from scripts.refresh_prejump_upcoming import (
+    _metadata_record_for_csv,
     current_index_metadata_selection,
     expand_excluded_race_ids,
     refresh_prejump_upcoming,
@@ -818,7 +819,10 @@ def _write_safe_collection_sidecar(csv_path: Path, *, expert_form: bool = True):
     payload = {
         "schema_version": "form_guide_download_provenance_v1",
         "metadata_is_leakage_safe": True,
-        "metadata_captured_at": "2026-06-17T03:00:00Z",
+        "metadata_captured_at": "2026-06-17T02:45:00Z",
+        "prejump_shadow_metadata": {
+            "metadata_captured_at": "2026-06-17T02:45:00Z",
+        },
         "race_url": "https://www.thedogs.com.au/racing/sale/2026-06-17/9/test?trial=false",
         "race_info": {
             "date": "2026-06-17",
@@ -873,6 +877,7 @@ def test_current_index_metadata_selection_rejects_conflicting_sidecar_url():
         "race_url": (
             "https://www.thedogs.com.au/racing/sale/2026-06-17/9/test?trial=false"
         ),
+        "jump_datetime": "2026-06-17T13:57:00+10:00",
     }]
     coverage = {
         "races": [{
@@ -899,6 +904,7 @@ def test_current_index_metadata_selection_requires_complete_consistent_identity(
         "race_id": "Race 9 - SAL - 2026-06-17",
         "race_id_aliases": ["Race 9 - SAL - 2026-06-17"],
         "race_url": race_url,
+        "jump_datetime": "2026-06-17T13:57:00+10:00",
     }]
     row = {
         "race_id": "",
@@ -908,11 +914,13 @@ def test_current_index_metadata_selection_requires_complete_consistent_identity(
         "safe_track_condition_present": True,
         "safe_expert_form_present": True,
         "safe_all_weather_track_expert_form_present": True,
+        "runner_source_observed_at": "2026-06-17T12:45:00+10:00",
     }
 
     eligible, selection = current_index_metadata_selection(
         selected,
         {"races": [row]},
+        source_generated_at="2026-06-17T12:30:00+10:00",
     )
     assert eligible == []
     assert selection["exclusions"][0]["missing_safe_metadata"] == [
@@ -924,9 +932,88 @@ def test_current_index_metadata_selection_requires_complete_consistent_identity(
     eligible, selection = current_index_metadata_selection(
         selected,
         {"races": [row]},
+        source_generated_at="2026-06-17T12:30:00+10:00",
     )
     assert eligible == []
     assert selection["exclusions"][0]["missing_safe_metadata"] == ["weather"]
+
+
+def test_current_index_metadata_selection_excludes_postjump_runner_observation():
+    race_url = "https://www.thedogs.com.au/racing/sale/2026-06-17/9/test"
+    race = {
+        "race_id": "Race 9 - SAL - 2026-06-17",
+        "race_id_aliases": ["Race 9 - SAL - 2026-06-17"],
+        "race_url": race_url,
+        "jump_datetime": "2026-06-17T13:00:00+10:00",
+    }
+    row = {
+        "race_id": race["race_id"],
+        "race_url": race_url,
+        "csv_path": "/evidence/Race 9 - SAL - 2026-06-17.csv",
+        "safe_weather_present": True,
+        "safe_track_condition_present": True,
+        "safe_expert_form_present": True,
+        "safe_all_weather_track_expert_form_present": True,
+        "runner_source_observed_at": "2026-06-17T13:00:06+10:00",
+    }
+
+    eligible, selection = current_index_metadata_selection(
+        [race],
+        {"races": [row]},
+        source_generated_at="2026-06-17T12:59:00+10:00",
+    )
+
+    assert eligible == []
+    assert selection["status"] == "INCOMPLETE"
+    assert selection["exclusions"][0]["missing_safe_metadata"] == [
+        "runner_source_timing"
+    ]
+
+
+def test_metadata_record_does_not_substitute_top_level_runner_timestamp(tmp_path):
+    csv_path = tmp_path / "Race 9 - SAL - 2026-06-17.csv"
+    csv_path.write_text("box|dog_name\n1|Alpha Runner\n", encoding="utf-8")
+    csv_path.with_name(csv_path.name + ".metadata.json").write_text(
+        json.dumps({"metadata_captured_at": "2026-06-17T12:45:00+10:00"}),
+        encoding="utf-8",
+    )
+
+    record = _metadata_record_for_csv(csv_path)
+
+    assert record["runner_source_observed_at"] is None
+
+
+def test_current_index_metadata_selection_enforces_runner_source_age_boundary():
+    race_url = "https://www.thedogs.com.au/racing/sale/2026-06-17/9/test"
+    race = {
+        "race_id": "Race 9 - SAL - 2026-06-17",
+        "race_id_aliases": ["Race 9 - SAL - 2026-06-17"],
+        "race_url": race_url,
+        "jump_datetime": "2026-06-17T13:30:00+10:00",
+    }
+    row = {
+        "race_id": race["race_id"],
+        "race_url": race_url,
+        "csv_path": "/evidence/Race 9 - SAL - 2026-06-17.csv",
+        "safe_weather_present": True,
+        "safe_track_condition_present": True,
+        "safe_expert_form_present": True,
+        "safe_all_weather_track_expert_form_present": True,
+    }
+    cases = [
+        ("2026-06-17T12:50:00+10:00", True),
+        ("2026-06-17T12:50:01+10:00", False),
+        ("2026-06-17T12:45:00", False),
+    ]
+    for observed_at, expected_eligible in cases:
+        row["runner_source_observed_at"] = observed_at
+        eligible, selection = current_index_metadata_selection(
+            [race],
+            {"races": [row]},
+            source_generated_at="2026-06-17T12:30:00+10:00",
+        )
+        assert bool(eligible) is expected_eligible
+        assert selection["status"] == ("READY" if expected_eligible else "INCOMPLETE")
 
 
 def test_refresh_prejump_upcoming_can_fail_closed_on_incomplete_safe_metadata(


### PR DESCRIPTION
## Summary

- bind the runner-source observation timestamp from accepted pre-jump shadow metadata into current-index eligibility
- exclude post-jump, stale, missing, or timezone-naive runner observations per race
- use the same strict 1200-second boundary as the publisher
- keep the full selected race set available to the odds-capture fallback lane
- document runner-source timing in the operator runbook

## Live reproduction

Exact deployed run `20260818T194102+1000_odds_capture` produced three metadata-eligible races. Strict publication rejected because DARW race 3 was observed at 19:42:06 for a 19:42:00 jump; Warragul race 4 and Townsville race 4 sealed individually. Candidate replay excludes DARW for `runner_source_timing` and keeps the two valid races.

## Validation

- 161 producer/publisher tests passed
- exact 1200 seconds accepted; 1201 seconds, post-jump, missing nested timestamp, and timezone-naive timestamps rejected
- Python compilation, diff check, and task-card allowlist passed
- independent Standards review: no findings
- independent Spec review: no findings

No model, feature, fitting, scoring, experiment, promotion, or betting semantics changed.
