### PR TITLE
Fix connected UI read-only runtime paths

### DIFF
--- a/config/paths.py
+++ b/config/paths.py
@@ -2,6 +2,14 @@ import os
 from pathlib import Path
 
 
+def _bound_connected_dir(name: str) -> Path | None:
+    if os.environ.get("OPERATOR_UI_R3_PROFILE") != "repository-v1":
+        return None
+    from src.operator_ui.deployment import bound_operator_ui_runtime_dir
+
+    return bound_operator_ui_runtime_dir(name)
+
+
 def get_dir(name: str, default: str) -> Path:
     """Resolve and ensure a directory from env var with fallback default.
 
@@ -9,6 +17,9 @@ def get_dir(name: str, default: str) -> Path:
     - Creates the directory if it doesn't exist
     - Returns a Path object
     """
+    bound = _bound_connected_dir(name)
+    if bound is not None:
+        return bound
     p = Path(os.getenv(name, default)).expanduser().resolve()
     p.mkdir(parents=True, exist_ok=True)
     return p
@@ -30,7 +41,7 @@ RACE_DATA_DIR: Path = get_dir("RACE_DATA_DIR", str(DATA_DIR / "race_data"))
 ARCHIVE_DIR: Path = get_dir("ARCHIVE_DIR", "./archive")
 
 # Optional OS Downloads watch directory (not created by default; just resolved)
-DOWNLOADS_WATCH_DIR: Path = (
+DOWNLOADS_WATCH_DIR: Path = _bound_connected_dir("DOWNLOADS_WATCH_DIR") or (
     Path(os.getenv("DOWNLOADS_WATCH_DIR", str(Path.home() / "Downloads")))
     .expanduser()
     .resolve()

--- a/docs/operator_ui_v1/DEPLOYMENT.md
+++ b/docs/operator_ui_v1/DEPLOYMENT.md
@@ -43,8 +43,12 @@ closed before current publication.
 
 Browser requests and environment values cannot select paths or commands.
 Runtime log modules derive their fixed `operations_root/logs` directory from
-the retained, validated repository binding. The generated environment does not
-carry a log path, and a changed or conflicting binding fails before log setup.
+the retained, validated repository binding. Connected legacy application paths
+are likewise fixed below `operations_root/runtime`; hostile or inherited
+`DATA_DIR`, `UPCOMING_RACES_DIR`, `RACE_DATA_DIR`, `ARCHIVE_DIR`, and
+`DOWNLOADS_WATCH_DIR` values cannot redirect them. The generated environment
+does not carry these paths, and a changed or conflicting binding fails before
+runtime directory setup.
 
 The default package is disabled. Omitting `--enable` writes
 `OPERATOR_UI_CONNECTED_MODE=0`, `OPERATOR_UI_LEVEL=1`, and

--- a/docs/operator_ui_v1/MANUAL_LIVE_PREDICTION_RUNBOOK.md
+++ b/docs/operator_ui_v1/MANUAL_LIVE_PREDICTION_RUNBOOK.md
@@ -24,6 +24,9 @@ hand-edited. Its working directory, binding commit/tree, pinned Python, source
 hashes, and generated package hashes must match the reviewed deployment. The
 source, collector evidence, producer evidence, and canonical database must be
 read-only; only the dedicated Operator UI operations root may be writable.
+Confirm connected legacy data/upcoming/archive/download directories resolve
+under the binding-derived operations root rather than the source checkout or
+environment-selected paths.
 Use `systemd-analyze verify` on the generated unit before installation. Follow
 `DEPLOYMENT.md` for complete generation, secret, installation, and rollback
 requirements.

--- a/src/operator_ui/deployment.py
+++ b/src/operator_ui/deployment.py
@@ -226,6 +226,83 @@ def _strict_json(raw: bytes) -> Any:
     )
 
 
+def _ensure_bound_directory(root: Path, relatives: tuple[str, ...]) -> Path:
+    """Create fixed descendants through retained, no-follow directory descriptors."""
+    if (
+        not relatives
+        or any(
+            not component
+            or component in {".", ".."}
+            or "/" in component
+            for component in relatives
+        )
+    ):
+        raise DeploymentRejected("runtime directory selection is invalid")
+    root = Path(root).absolute()
+    flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_DIRECTORY
+    retained: list[tuple[int, Path, tuple[int, int, int]]] = []
+    descriptor = os.open("/", flags)
+    current = Path("/")
+    try:
+        info = os.fstat(descriptor)
+        retained.append(
+            (descriptor, current, (info.st_dev, info.st_ino, stat.S_IFMT(info.st_mode)))
+        )
+        for component in root.parts[1:]:
+            current /= component
+            descriptor = os.open(component, flags, dir_fd=descriptor)
+            info = os.fstat(descriptor)
+            retained.append(
+                (
+                    descriptor,
+                    current,
+                    (info.st_dev, info.st_ino, stat.S_IFMT(info.st_mode)),
+                )
+            )
+        root_info = os.fstat(descriptor)
+        if (
+            root_info.st_mode & 0o002
+            or (root_info.st_mode & 0o020 and root_info.st_uid != os.geteuid())
+        ):
+            raise DeploymentRejected("runtime directory root is permission-unsafe")
+        for component in relatives:
+            try:
+                os.mkdir(component, mode=0o700, dir_fd=descriptor)
+            except FileExistsError:
+                pass
+            current /= component
+            descriptor = os.open(component, flags, dir_fd=descriptor)
+            info = os.fstat(descriptor)
+            retained.append(
+                (
+                    descriptor,
+                    current,
+                    (info.st_dev, info.st_ino, stat.S_IFMT(info.st_mode)),
+                )
+            )
+        for item, path, identity in retained:
+            observed = os.fstat(item)
+            named = os.stat(path, follow_symlinks=False)
+            if (
+                (observed.st_dev, observed.st_ino, stat.S_IFMT(observed.st_mode))
+                != identity
+                or (named.st_dev, named.st_ino, stat.S_IFMT(named.st_mode))
+                != identity
+            ):
+                raise DeploymentRejected("runtime directory identity changed")
+        return current
+    except DeploymentRejected:
+        raise
+    except OSError as error:
+        raise DeploymentRejected("runtime directory unavailable") from error
+    finally:
+        for item, _, _ in reversed(retained):
+            try:
+                os.close(item)
+            except OSError:
+                pass
+
+
 @lru_cache(maxsize=1)
 def bound_operator_ui_log_dir() -> Path:
     """Return the fixed runtime log directory from the generated binding."""
@@ -277,12 +354,25 @@ def bound_operator_ui_log_dir() -> Path:
     _separate((source, evidence, producer, operations))
     if database == operations or database.is_relative_to(operations):
         raise DeploymentRejected("generated runtime log binding is invalid")
-    log_dir = operations / "logs"
-    try:
-        log_dir.mkdir(mode=0o700, exist_ok=True)
-    except OSError as error:
-        raise DeploymentRejected("runtime log directory unavailable") from error
-    return _safe_existing(log_dir, directory=True)
+    return _ensure_bound_directory(operations, ("logs",))
+
+
+def bound_operator_ui_runtime_dir(name: str) -> Path:
+    """Return one finite legacy runtime directory below the bound operations root."""
+    relatives = {
+        "DATA_DIR": "data",
+        "UPCOMING_RACES_DIR": "upcoming_races",
+        "RACE_DATA_DIR": "race_data",
+        "ARCHIVE_DIR": "archive",
+        "DOWNLOADS_WATCH_DIR": "downloads_watch",
+    }
+    if (
+        os.environ.get("OPERATOR_UI_R3_PROFILE") != "repository-v1"
+        or name not in relatives
+    ):
+        raise DeploymentRejected("runtime directory selection is invalid")
+    operations = bound_operator_ui_log_dir().parent
+    return _ensure_bound_directory(operations, ("runtime", relatives[name]))
 
 
 def _live_authority(path: Path) -> dict[str, Any]:

--- a/tests/operator_ui/test_deployment_generator.py
+++ b/tests/operator_ui/test_deployment_generator.py
@@ -13,6 +13,7 @@ from flask import Flask
 from src.operator_ui.deployment import DeploymentRejected, generate_package, main
 from src.operator_ui.security import load_connected_environment
 import src.operator_ui.bootstrap as bootstrap_module
+import src.operator_ui.deployment as deployment_module
 
 
 COMMIT = "881a3cee0c7f93dd26f5ece9185052f59c4c1aed"
@@ -831,6 +832,187 @@ def test_generated_operator_logger_uses_operations_root_with_read_only_source(
     assert stdout.rstrip().endswith("|".join([str(runtime_logs)] * 3))
     assert runtime_logs.is_dir()
     assert not (values["source_root"] / "logs").exists()
+
+
+def test_generated_connected_config_paths_use_only_bound_operations_root(
+    real_startup_tmp_path, monkeypatch
+):
+    values = deployment_inputs(real_startup_tmp_path)
+    git_identity(monkeypatch)
+    generate_package(**values, enabled=True)
+    generated = dict(
+        line.split("=", 1)
+        for line in (values["output_dir"] / "operator-ui-r3.env").read_text().splitlines()
+        if line
+    )
+    values["source_root"].chmod(0o500)
+    environment = os.environ.copy()
+    environment.update(generated)
+    environment["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    environment.update(
+        DATA_DIR=str(values["source_root"] / "hostile-data"),
+        UPCOMING_RACES_DIR=str(values["source_root"] / "hostile-upcoming"),
+        RACE_DATA_DIR=str(values["source_root"] / "hostile-race-data"),
+        ARCHIVE_DIR=str(values["source_root"] / "hostile-archive"),
+        DOWNLOADS_WATCH_DIR=str(values["source_root"] / "hostile-downloads"),
+    )
+
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from pathlib import Path; "
+                "from src.operator_ui import deployment; "
+                f"deployment._RUNTIME_SOURCE_ROOT=Path({str(values['source_root'])!r}); "
+                "deployment.bound_operator_ui_log_dir.cache_clear(); "
+                "from config.paths import (ARCHIVE_DIR, DATA_DIR, "
+                "DOWNLOADS_WATCH_DIR, RACE_DATA_DIR, UPCOMING_RACES_DIR); "
+                "print(DATA_DIR, UPCOMING_RACES_DIR, RACE_DATA_DIR, "
+                "ARCHIVE_DIR, DOWNLOADS_WATCH_DIR, sep='|')"
+            ),
+        ],
+        cwd=values["source_root"],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    stdout, stderr = process.communicate(timeout=10)
+
+    runtime_root = values["operations_root"] / "runtime"
+    expected = [
+        runtime_root / "data",
+        runtime_root / "upcoming_races",
+        runtime_root / "race_data",
+        runtime_root / "archive",
+        runtime_root / "downloads_watch",
+    ]
+    assert process.returncode == 0, stderr
+    assert stdout.rstrip().endswith("|".join(map(str, expected)))
+    assert all(path.is_dir() for path in expected)
+    assert not any(values["source_root"].glob("hostile-*"))
+
+
+def test_bound_runtime_parent_symlink_is_rejected_before_outside_write(
+    real_startup_tmp_path, monkeypatch
+):
+    values = deployment_inputs(real_startup_tmp_path)
+    git_identity(monkeypatch)
+    generate_package(**values, enabled=True)
+    load_generated_environment(monkeypatch, values)
+    outside = real_startup_tmp_path / "outside"
+    outside.mkdir(mode=0o700)
+    (values["operations_root"] / "runtime").symlink_to(
+        outside, target_is_directory=True
+    )
+    monkeypatch.setattr(
+        deployment_module, "_RUNTIME_SOURCE_ROOT", values["source_root"]
+    )
+    deployment_module.bound_operator_ui_log_dir.cache_clear()
+    try:
+        with pytest.raises(DeploymentRejected, match="runtime directory unavailable"):
+            deployment_module.bound_operator_ui_runtime_dir("DATA_DIR")
+    finally:
+        deployment_module.bound_operator_ui_log_dir.cache_clear()
+    assert not (outside / "data").exists()
+
+
+def test_generated_connected_app_import_uses_no_source_runtime_directories(
+    real_startup_tmp_path, monkeypatch
+):
+    values = deployment_inputs(real_startup_tmp_path)
+    git_identity(monkeypatch)
+    generate_package(**values, enabled=True)
+    generated = dict(
+        line.split("=", 1)
+        for line in (values["output_dir"] / "operator-ui-r3.env").read_text().splitlines()
+        if line
+    )
+    values["source_root"].chmod(0o500)
+    environment = os.environ.copy()
+    environment.update(generated)
+    environment.update(line.split("=", 1) for line in SECRET_LINES)
+    environment["OPERATOR_UI_SECRET_KEY"] = "startup-test-" + "x" * 40
+    environment["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    environment.update(
+        DATA_DIR=str(values["source_root"] / "hostile-data"),
+        UPCOMING_RACES_DIR=str(values["source_root"] / "hostile-upcoming"),
+        RACE_DATA_DIR=str(values["source_root"] / "hostile-race-data"),
+        ARCHIVE_DIR=str(values["source_root"] / "hostile-archive"),
+        DOWNLOADS_WATCH_DIR=str(values["source_root"] / "hostile-downloads"),
+    )
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from pathlib import Path; import runpy; "
+                "from src.operator_ui import bootstrap, deployment; "
+                f"deployment._RUNTIME_SOURCE_ROOT=Path({str(values['source_root'])!r}); "
+                f"bootstrap._REPOSITORY_ROOT=Path({str(values['source_root'])!r}); "
+                "deployment.bound_operator_ui_log_dir.cache_clear(); "
+                f"runpy.run_path({str(values['source_root'] / 'app.py')!r}); "
+                "print('CONNECTED_APP_IMPORT_READY')"
+            ),
+        ],
+        cwd=values["source_root"],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    stdout, stderr = process.communicate(timeout=75)
+    assert process.returncode == 0, stderr
+    assert "CONNECTED_APP_IMPORT_READY" in stdout
+    assert not any(values["source_root"].glob("hostile-*"))
+    assert not any(
+        (values["source_root"] / name).exists()
+        for name in (
+            "data",
+            "upcoming_races_temp",
+            "race_data",
+            "archive",
+            "downloads_watch",
+            "logs",
+        )
+    )
+
+
+def test_disabled_config_paths_preserve_environment_selected_directories(tmp_path):
+    selected = {
+        "DATA_DIR": tmp_path / "selected-data",
+        "UPCOMING_RACES_DIR": tmp_path / "selected-upcoming",
+        "RACE_DATA_DIR": tmp_path / "selected-race-data",
+        "ARCHIVE_DIR": tmp_path / "selected-archive",
+        "DOWNLOADS_WATCH_DIR": tmp_path / "selected-downloads",
+    }
+    environment = os.environ.copy()
+    environment["OPERATOR_UI_R3_PROFILE"] = "disabled"
+    environment["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    environment.update({name: str(path) for name, path in selected.items()})
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from config.paths import (ARCHIVE_DIR, DATA_DIR, "
+                "DOWNLOADS_WATCH_DIR, RACE_DATA_DIR, UPCOMING_RACES_DIR); "
+                "print(DATA_DIR, UPCOMING_RACES_DIR, RACE_DATA_DIR, "
+                "ARCHIVE_DIR, DOWNLOADS_WATCH_DIR, sep='|')"
+            ),
+        ],
+        cwd=tmp_path,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    stdout, stderr = process.communicate(timeout=10)
+    assert process.returncode == 0, stderr
+    assert stdout.rstrip().endswith("|".join(map(str, selected.values())))
+    assert all(selected[name].is_dir() for name in selected if name != "DOWNLOADS_WATCH_DIR")
+    assert not selected["DOWNLOADS_WATCH_DIR"].exists()
 
 
 def test_generated_serve_refuses_later_runtime_source_mutation_before_exec(


### PR DESCRIPTION
## Summary
- derive all connected legacy runtime directories from the validated repository binding operations root
- create fixed descendants through retained descriptor-relative O_NOFOLLOW traversal
- preserve disabled and non-connected environment path behavior
- add hostile symlink, read-only full app import, and disabled-mode regression tests

## Live reproduction
Exact master 74f6ea7a failed before binding the loopback listener because config.paths attempted mkdir ./data inside the read-only source checkout. No prediction POST occurred.

## Validation
- 158 deployment/bootstrap tests passed
- focused connected path, hostile symlink, full app import, and disabled-mode tests passed
- py_compile and git diff --check passed
- independent Standards and Spec re-reviews: no findings

Predictive semantics, model/config artifacts, canonical DB behavior, frozen experiments, and betting/ROI boundaries are unchanged.