### PR TITLE
Keep natural daemon runs source-immutable

### DIFF
--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -9300,7 +9300,9 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
             return result
 
     try:
+        run_service_dir = output_dir / "systemd"
         service_info = write_service_files(
+            service_dir=run_service_dir,
             repo_path=ROOT,
             timeout_seconds=args.timeout_seconds,
             python_path=Path(sys.executable),
@@ -9315,13 +9317,9 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
             else None,
             pause_path=lock_path.parent / "pause-heavy-scheduling",
         )
-        service_path = DEFAULT_SERVICE_DIR / SERVICE_NAME
-        timer_path = DEFAULT_SERVICE_DIR / TIMER_NAME
         write_text(output_dir / "daemon_design.md", daemon_design_markdown())
         write_json(output_dir / "lifecycle_diagram.json", lifecycle_diagram())
         write_text(output_dir / "service_install.md", install_markdown(service_info))
-        copy_if_exists(service_path, output_dir / "systemd" / SERVICE_NAME)
-        copy_if_exists(timer_path, output_dir / "systemd" / TIMER_NAME)
         write_json(output_dir / "output_manifest.json", output_manifest(output_dir))
 
         if args.enable_forward_official_result_observer:

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -9317,6 +9317,8 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
             else None,
             pause_path=lock_path.parent / "pause-heavy-scheduling",
         )
+        service_path = run_service_dir / SERVICE_NAME
+        timer_path = run_service_dir / TIMER_NAME
         write_text(output_dir / "daemon_design.md", daemon_design_markdown())
         write_json(output_dir / "lifecycle_diagram.json", lifecycle_diagram())
         write_text(output_dir / "service_install.md", install_markdown(service_info))

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -955,6 +955,74 @@ def test_run_once_defer_writes_startup_output_manifest(tmp_path, monkeypatch):
     assert any(path.endswith("full_daemon_odds_window_defer.json") for path in manifest["files"])
 
 
+def test_run_once_keeps_source_service_templates_immutable(tmp_path, monkeypatch):
+    source_root = tmp_path / "source"
+    source_service_dir = source_root / "ops/systemd"
+    source_service_dir.mkdir(parents=True)
+    source_service = source_service_dir / daemon.SERVICE_NAME
+    source_timer = source_service_dir / daemon.TIMER_NAME
+    source_service.write_text("reviewed service template\n", encoding="utf-8")
+    source_timer.write_text("reviewed timer template\n", encoding="utf-8")
+    evidence_root = tmp_path / "evidence/full_evidence_orchestration_20260525"
+    output_dir = evidence_root / "shadow_autopilot_daemonization_v1_immutable"
+    odds_state_path = tmp_path / "runtime/odds_capture_state.json"
+
+    monkeypatch.setattr(daemon, "ROOT", source_root)
+    monkeypatch.setattr(daemon, "DEFAULT_SERVICE_DIR", source_service_dir)
+    write_service_files = daemon.write_service_files
+
+    def safe_write_service_files(**kwargs):
+        kwargs.setdefault("service_dir", source_service_dir)
+        return write_service_files(**kwargs)
+
+    monkeypatch.setattr(daemon, "write_service_files", safe_write_service_files)
+    monkeypatch.setattr(
+        daemon,
+        "full_daemon_odds_window_defer_decision",
+        lambda odds_state, current_time: {
+            "should_defer": True,
+            "reason": "test_fixed_window_open",
+        },
+    )
+    monkeypatch.setattr(
+        daemon,
+        "acquire_lock",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("deferred full daemon should not acquire lock")
+        ),
+    )
+
+    args = daemon.parse_args(
+        [
+            "run-once",
+            "--run-id",
+            "immutable",
+            "--evidence-root",
+            str(evidence_root),
+            "--output-dir",
+            str(output_dir),
+            "--current-time",
+            "2026-06-13T15:17:11+10:00",
+            "--enable-autonomous-odds-capture",
+            "--odds-capture-state-path",
+            str(odds_state_path),
+        ]
+    )
+
+    report = daemon.run_once(args)
+
+    assert report["final_verdict"] == "DAEMON_DEFERRED_TO_ODDS_CAPTURE_ONLY"
+    assert source_service.read_text(encoding="utf-8") == "reviewed service template\n"
+    assert source_timer.read_text(encoding="utf-8") == "reviewed timer template\n"
+    generated_service = output_dir / "systemd" / daemon.SERVICE_NAME
+    generated_timer = output_dir / "systemd" / daemon.TIMER_NAME
+    assert generated_service.is_file()
+    assert generated_timer.is_file()
+    assert f"WorkingDirectory={source_root}" in generated_service.read_text(
+        encoding="utf-8"
+    )
+
+
 def test_run_once_defer_observes_result_before_odds_priority_return(
     tmp_path, monkeypatch
 ):

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -1023,6 +1023,114 @@ def test_run_once_keeps_source_service_templates_immutable(tmp_path, monkeypatch
     )
 
 
+def test_run_once_non_deferred_validates_run_owned_service_files(
+    tmp_path, monkeypatch
+):
+    source_root = tmp_path / "source"
+    source_service_dir = source_root / "ops/systemd"
+    source_service_dir.mkdir(parents=True)
+    source_service = source_service_dir / daemon.SERVICE_NAME
+    source_timer = source_service_dir / daemon.TIMER_NAME
+    source_service.write_text("reviewed service template\n", encoding="utf-8")
+    source_timer.write_text("reviewed timer template\n", encoding="utf-8")
+    evidence_root = tmp_path / "evidence/full_evidence_orchestration_20260525"
+    output_dir = evidence_root / "shadow_autopilot_daemonization_v1_validation"
+
+    monkeypatch.setattr(daemon, "ROOT", source_root)
+    monkeypatch.setattr(daemon, "DEFAULT_SERVICE_DIR", source_service_dir)
+    monkeypatch.setattr(daemon, "protected_hashes", lambda: {})
+    monkeypatch.setattr(
+        daemon,
+        "acquire_lock_with_odds_capture_retry",
+        lambda **kwargs: {"run_id": kwargs["run_id"]},
+    )
+    monkeypatch.setattr(
+        daemon,
+        "probe_duplicate_lock",
+        lambda *args, **kwargs: {"status": "PASS"},
+    )
+    monkeypatch.setattr(
+        daemon,
+        "probe_stale_lock_cleanup",
+        lambda *args, **kwargs: {"status": "PASS"},
+    )
+    monkeypatch.setattr(
+        daemon,
+        "simulate_timeout_recovery",
+        lambda *args, **kwargs: {"status": "PASS"},
+    )
+    monkeypatch.setattr(
+        daemon,
+        "release_lock",
+        lambda *args, **kwargs: {"status": "RELEASED"},
+    )
+    monkeypatch.setattr(
+        daemon,
+        "run_command",
+        lambda **kwargs: {
+            "name": kwargs["name"],
+            "returncode": 0,
+            "timed_out": False,
+            "status": "PASS",
+        },
+    )
+    monkeypatch.setattr(
+        daemon,
+        "rejoin_pending_shadow_runs",
+        lambda **kwargs: {"status": "PASS", "joined_races": []},
+    )
+    monkeypatch.setattr(
+        daemon,
+        "build_rejoin_unified_evidence_datasets",
+        lambda **kwargs: ({"status": "NOT_RUN"}, [], []),
+    )
+    monkeypatch.setattr(daemon, "systemd_deployment_status", lambda **kwargs: {})
+    monkeypatch.setattr(
+        daemon,
+        "full_daemon_odds_window_defer_decision",
+        lambda odds_state, current_time: {
+            "should_defer": False,
+            "reason": "test_no_fixed_window_open",
+        },
+    )
+
+    class ServiceValidationReached(Exception):
+        pass
+
+    def verify_run_owned_service_files(service_path, timer_path, verify_output_dir):
+        assert service_path == output_dir / "systemd" / daemon.SERVICE_NAME
+        assert timer_path == output_dir / "systemd" / daemon.TIMER_NAME
+        assert verify_output_dir == output_dir
+        assert service_path.is_file()
+        assert timer_path.is_file()
+        assert source_service.read_text(encoding="utf-8") == (
+            "reviewed service template\n"
+        )
+        assert source_timer.read_text(encoding="utf-8") == (
+            "reviewed timer template\n"
+        )
+        raise ServiceValidationReached
+
+    monkeypatch.setattr(daemon, "systemd_verify", verify_run_owned_service_files)
+
+    args = daemon.parse_args(
+        [
+            "run-once",
+            "--run-id",
+            "validation",
+            "--evidence-root",
+            str(evidence_root),
+            "--output-dir",
+            str(output_dir),
+            "--current-time",
+            "2026-06-13T15:17:11+10:00",
+        ]
+    )
+
+    with pytest.raises(ServiceValidationReached):
+        daemon.run_once(args)
+
+
 def test_run_once_defer_observes_result_before_odds_priority_return(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## What changed

- Generate the full-daemon systemd snapshot directly under each run evidence directory.
- Stop rewriting tracked ops/systemd templates during run-once.
- Add a supported-seam regression test that preserves source bytes while proving the run snapshot exists.

## Root cause

run-once called write_service_files without a service directory, so the default tracked ops/systemd directory was overwritten on every natural full cycle before those bytes were copied into run evidence.

## Impact

Natural Race Collection Service cycles retain their systemd evidence without dirtying the exact deployed master checkout. The explicit write-service-files deployment command keeps its existing behavior.

## Validation

- New regression test: red on master, green on this branch.
- 10 adjacent run_once and write_service_files tests passed.
- py_compile passed.
- git diff --check passed.