### PR TITLE
Seal current race index before odds capture

### DIFF
--- a/docs/on_demand_race_prediction.md
+++ b/docs/on_demand_race_prediction.md
@@ -29,6 +29,12 @@ replaces this fixed packet with at most 32 selected races and seals the source
 refresh-report path and SHA-256. Publication occurs immediately after that
 bounded refresh completes, before the slower multi-race odds-capture batch, so
 a later batch timeout cannot leave discovery dependent on an older index. The
+publisher also seals a run-local `current_race_index_publish.json` and then
+atomically advances the dedicated
+`manual_prediction_current_race_index.state.json` lifecycle. Discovery binds
+the packet to those completed-refresh artifacts; it does not require the
+separate odds-capture daemon state to claim that the slower batch has already
+finished.
 predictor validates the packet schema,
 canonical bytes, source path and hash, exact TheDogs identities, timezone-aware
 jump timestamps, uniqueness, row bound, and configured 1,200-second maximum

--- a/race_collection/synchronous_manual_capture.py
+++ b/race_collection/synchronous_manual_capture.py
@@ -45,8 +45,8 @@ CURRENT_RACE_INDEX_FILENAME = "manual_prediction_current_race_index.json"
 CURRENT_RACE_INDEX_PUBLICATION_FILENAME = (
     "manual_prediction_current_race_index.publication.json"
 )
-ODDS_CAPTURE_ONLY_STATE_FILENAME = "odds_capture_state.json"
-ODDS_CAPTURE_ONLY_REPORT_FILENAME = "odds_capture_only_daemon_report.json"
+CURRENT_RACE_INDEX_STATE_FILENAME = "manual_prediction_current_race_index.state.json"
+CURRENT_RACE_INDEX_PUBLISH_REPORT_FILENAME = "current_race_index_publish.json"
 MAX_CURRENT_INDEX_RACES = 32
 MAX_CURRENT_INDEX_BYTES = 2 * 1024 * 1024
 CANONICAL_LOCK_RELATIVE_PATH = Path(
@@ -1370,6 +1370,56 @@ def publish_current_race_index(
     return report
 
 
+def publish_current_race_index_lifecycle(
+    *,
+    state_path: Path,
+    evidence_root: Path,
+    publication_report_path: Path,
+    publication: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    """Commit the immutable refresh publication as the discoverable lifecycle."""
+
+    if (
+        publication.get("schema_version")
+        != "collector_current_race_index_publish_v2"
+        or publication.get("status") != "PUBLISHED"
+    ):
+        raise CaptureOneRejected("CURRENT_INDEX_REPORT_INVALID")
+    retained = _RetainedSafeFiles(evidence_root)
+    report_raw = retained.read(
+        publication_report_path,
+        missing_code="CURRENT_INDEX_REPORT_MISSING",
+    )
+    try:
+        report = json.loads(report_raw)
+    except json.JSONDecodeError as exc:
+        raise CaptureOneRejected("CURRENT_INDEX_REPORT_INVALID") from exc
+    if canonical_bytes(report) != report_raw or report != publication:
+        raise CaptureOneRejected("CURRENT_INDEX_REPORT_INVALID")
+    try:
+        report_locator = publication_report_path.absolute().relative_to(
+            evidence_root.absolute()
+        ).as_posix()
+    except ValueError as exc:
+        raise CaptureOneRejected("CURRENT_INDEX_REPORT_INVALID") from exc
+    lifecycle = {
+        "schema_version": "collector_current_race_index_state_v1",
+        "status": "PUBLISHED",
+        "updated_at": publication["source_generated_at"],
+        "run_id": publication["run_id"],
+        "packet_sha256": publication["packet_sha256"],
+        "publication_report_path": report_locator,
+        "publication_report_sha256": sha256_bytes(report_raw),
+    }
+    _atomic_replace_canonical(
+        current_race_index_path(state_path).parent / CURRENT_RACE_INDEX_STATE_FILENAME,
+        lifecycle,
+        evidence_root=evidence_root,
+        _pre_replace=retained.validate,
+    )
+    return lifecycle
+
+
 def _aware_datetime(value: object) -> datetime | None:
     try:
         parsed = datetime.fromisoformat(str(value))
@@ -1380,39 +1430,29 @@ def _aware_datetime(value: object) -> datetime | None:
     return parsed
 
 
-def _validate_current_odds_evidence(
+def _validate_current_index_lifecycle(
     *,
     state: Mapping[str, Any],
     report: Mapping[str, Any],
     packet: Mapping[str, Any],
-    publication: Mapping[str, Any],
     current_time: datetime,
     max_age_seconds: int,
     enforce_max_age: bool = True,
 ) -> None:
-    """Bind the producer's current state/report lifecycle to this publication."""
+    """Bind discovery to the completed refresh publication, not slower capture."""
 
     state_time = _aware_datetime(state.get("updated_at"))
-    report_time = _aware_datetime(report.get("generated_at"))
+    report_time = _aware_datetime(report.get("source_generated_at"))
     source_time = _aware_datetime(packet.get("source_generated_at"))
-    allowed = {
-        "ODDS_CAPTURE_ONLY_READY": {"READY", "READY_WITH_BLOCKED_ATTEMPTS"},
-        "ODDS_CAPTURE_ONLY_HANDLED_NO_WRITE": {"HANDLED_NO_WRITE"},
-    }
-    final_status = report.get("final_status")
     if (
-        set(publication).isdisjoint({"packet_sha256"})
-        or state_time is None
+        state_time is None
         or report_time is None
         or source_time is None
-        or final_status not in allowed
-        or report.get("status") not in allowed[final_status]
-        or state.get("final_status") != final_status
-        or state.get("status") != report.get("status")
-        or state.get("output_dir") != report.get("output_dir")
-        or state.get("autopilot_output_dir") != report.get("autopilot_output_dir")
+        or state.get("status") != "PUBLISHED"
+        or report.get("status") != "PUBLISHED"
         or state.get("run_id") != report.get("run_id")
         or report.get("run_id") != packet.get("run_id")
+        or state.get("packet_sha256") != report.get("packet_sha256")
         or state_time != report_time
         or any(
             (current_time - moment).total_seconds() < 0
@@ -1558,23 +1598,33 @@ def bounded_current_race_index(
                 or publication != expected_publication
             ):
                 raise CaptureOneRejected("CURRENT_INDEX_PUBLICATION_INVALID")
-            state_path = index_path.parent / ODDS_CAPTURE_ONLY_STATE_FILENAME
+            state_path = index_path.parent / CURRENT_RACE_INDEX_STATE_FILENAME
             state_raw = snapshot.read(state_path, missing_code="CURRENT_INDEX_REPORT_MISSING")
             state = json.loads(state_raw)
+            state_keys = {
+                "schema_version", "status", "updated_at", "run_id",
+                "packet_sha256", "publication_report_path",
+                "publication_report_sha256",
+            }
             if (
                 not isinstance(state, Mapping)
                 or state.get("schema_version")
-                != "shadow_autopilot_odds_capture_only_state_v1"
+                != "collector_current_race_index_state_v1"
+                or canonical_bytes(state) != state_raw
+                or set(state) != state_keys
                 or state.get("run_id") != packet["run_id"]
+                or state.get("packet_sha256") != publication["packet_sha256"]
             ):
                 raise CaptureOneRejected("CURRENT_INDEX_REPORT_INVALID")
-            output_dir = _evidence_locator_path(
-                state.get("output_dir"), evidence_root=evidence_root
+            report_path = _evidence_locator_path(
+                state.get("publication_report_path"), evidence_root=evidence_root
             )
             report_raw = snapshot.read(
-                output_dir / ODDS_CAPTURE_ONLY_REPORT_FILENAME,
+                report_path,
                 missing_code="CURRENT_INDEX_REPORT_MISSING",
             )
+            if sha256_bytes(report_raw) != state.get("publication_report_sha256"):
+                raise CaptureOneRejected("CURRENT_INDEX_REPORT_INVALID")
             report = json.loads(report_raw)
             expected_publish = {
                 "schema_version": "collector_current_race_index_publish_v2",
@@ -1594,18 +1644,17 @@ def bounded_current_race_index(
             }
             if (
                 not isinstance(report, Mapping)
+                or canonical_bytes(report) != report_raw
                 or report.get("schema_version")
-                != "shadow_autopilot_odds_capture_only_daemon_report_v1"
+                != "collector_current_race_index_publish_v2"
                 or report.get("run_id") != packet["run_id"]
-                or report.get("output_dir") != state.get("output_dir")
-                or report.get("current_race_index_publish") != expected_publish
+                or report != expected_publish
             ):
                 raise CaptureOneRejected("CURRENT_INDEX_REPORT_INVALID")
-            _validate_current_odds_evidence(
+            _validate_current_index_lifecycle(
                 state=state,
                 report=report,
                 packet=packet,
-                publication=publication,
                 current_time=current_time,
                 max_age_seconds=max_age_seconds,
                 enforce_max_age=not return_verified_view,

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -1808,7 +1808,6 @@ def odds_capture_only_autopilot_command(
     odds_capture_max_minutes: float,
     odds_capture_refresh_limit: int,
     timeout_seconds: int,
-    state_path: Path | None = None,
     forward_corpus_root: Path | None = None,
     refresh_command_mode: str = "auto",
     require_safe_refresh_metadata: bool = True,
@@ -1853,8 +1852,6 @@ def odds_capture_only_autopilot_command(
     ]
     if require_safe_refresh_metadata:
         command.append("--require-safe-refresh-metadata")
-    if state_path is not None:
-        command.extend(["--current-race-index-state-path", str(state_path)])
     if forward_corpus_root is not None:
         command.extend(["--forward-corpus-root", str(forward_corpus_root)])
     return command
@@ -3682,7 +3679,6 @@ def run_odds_capture_once(args: argparse.Namespace) -> dict[str, Any]:
             odds_capture_max_minutes=args.odds_capture_max_minutes,
             odds_capture_refresh_limit=args.odds_capture_refresh_limit,
             timeout_seconds=args.timeout_seconds,
-            state_path=args.state_path,
             forward_corpus_root=args.forward_corpus_root,
             refresh_command_mode=args.refresh_command_mode,
             require_safe_refresh_metadata=args.require_safe_refresh_metadata,

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -1808,6 +1808,7 @@ def odds_capture_only_autopilot_command(
     odds_capture_max_minutes: float,
     odds_capture_refresh_limit: int,
     timeout_seconds: int,
+    state_path: Path | None = None,
     forward_corpus_root: Path | None = None,
     refresh_command_mode: str = "auto",
     require_safe_refresh_metadata: bool = True,
@@ -1852,6 +1853,8 @@ def odds_capture_only_autopilot_command(
     ]
     if require_safe_refresh_metadata:
         command.append("--require-safe-refresh-metadata")
+    if state_path is not None:
+        command.extend(["--current-race-index-state-path", str(state_path)])
     if forward_corpus_root is not None:
         command.extend(["--forward-corpus-root", str(forward_corpus_root)])
     return command
@@ -3679,6 +3682,7 @@ def run_odds_capture_once(args: argparse.Namespace) -> dict[str, Any]:
             odds_capture_max_minutes=args.odds_capture_max_minutes,
             odds_capture_refresh_limit=args.odds_capture_refresh_limit,
             timeout_seconds=args.timeout_seconds,
+            state_path=args.state_path,
             forward_corpus_root=args.forward_corpus_root,
             refresh_command_mode=args.refresh_command_mode,
             require_safe_refresh_metadata=args.require_safe_refresh_metadata,

--- a/scripts/shadow_autopilot_v1.py
+++ b/scripts/shadow_autopilot_v1.py
@@ -6655,7 +6655,7 @@ def publish_current_race_index_after_refresh(
             run_id=run_id,
         )
     report_path = output_dir / CURRENT_RACE_INDEX_PUBLISH_REPORT_FILENAME
-    write_json(report_path, publication)
+    report_path.write_bytes(canonical_bytes(publication))
     if state_path is not None and publication.get("status") == "PUBLISHED":
         publish_current_race_index_lifecycle(
             state_path=state_path,

--- a/scripts/shadow_autopilot_v1.py
+++ b/scripts/shadow_autopilot_v1.py
@@ -42,7 +42,9 @@ from race_collection.manual_prediction_collector_request import (  # noqa: E402
     canonical_bytes,
 )
 from race_collection.synchronous_manual_capture import (  # noqa: E402
+    CURRENT_RACE_INDEX_PUBLISH_REPORT_FILENAME,
     publish_current_race_index,
+    publish_current_race_index_lifecycle,
 )
 from scripts.shadow_feature_audit_packet import feature_activation_gate_input_paths  # noqa: E402
 
@@ -6638,19 +6640,30 @@ def publish_current_race_index_after_refresh(
     """Publish the bounded index before the slower odds-capture batch begins."""
 
     if state_path is None:
-        return {
+        publication = {
             "schema_version": "collector_current_race_index_publish_v1",
             "status": "SKIPPED",
             "reason": "state_path_missing",
         }
-    return publish_current_race_index(
-        state_path=state_path,
-        evidence_root=evidence_root,
-        source_refresh_report_path=(
-            output_dir / "odds_capture_refresh_report.json"
-        ),
-        run_id=run_id,
-    )
+    else:
+        publication = publish_current_race_index(
+            state_path=state_path,
+            evidence_root=evidence_root,
+            source_refresh_report_path=(
+                output_dir / "odds_capture_refresh_report.json"
+            ),
+            run_id=run_id,
+        )
+    report_path = output_dir / CURRENT_RACE_INDEX_PUBLISH_REPORT_FILENAME
+    write_json(report_path, publication)
+    if state_path is not None and publication.get("status") == "PUBLISHED":
+        publish_current_race_index_lifecycle(
+            state_path=state_path,
+            evidence_root=evidence_root,
+            publication_report_path=report_path,
+            publication=publication,
+        )
+    return publication
 
 
 def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
@@ -6849,10 +6862,6 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
         evidence_root=evidence_root,
         output_dir=output_dir,
         run_id=collector_run_id or run_id,
-    )
-    write_json(
-        output_dir / "current_race_index_publish.json",
-        current_race_index_publish,
     )
     if args.enable_autonomous_odds_capture:
         capture_current_time = (

--- a/tests/race_collection/test_synchronous_manual_capture.py
+++ b/tests/race_collection/test_synchronous_manual_capture.py
@@ -77,24 +77,13 @@ def _write_publication_evidence(
     output_locator = "daemon_publication"
     output_dir = evidence_root / output_locator
     output_dir.mkdir(parents=True, exist_ok=True)
-    state.parent.mkdir(parents=True, exist_ok=True)
-    state.write_bytes(canonical_bytes({
-        "schema_version": "shadow_autopilot_odds_capture_only_state_v1",
-        "updated_at": published["source_generated_at"],
-        "run_id": published["run_id"], "output_dir": output_locator,
-        "autopilot_output_dir": output_locator,
-        "final_status": "ODDS_CAPTURE_ONLY_READY", "status": "READY",
-    }))
-    (output_dir / capture.ODDS_CAPTURE_ONLY_REPORT_FILENAME).write_bytes(
-        canonical_bytes({
-            "schema_version": "shadow_autopilot_odds_capture_only_daemon_report_v1",
-            "generated_at": published["source_generated_at"],
-            "run_id": published["run_id"],
-            "output_dir": output_locator,
-            "autopilot_output_dir": output_locator,
-            "final_status": "ODDS_CAPTURE_ONLY_READY", "status": "READY",
-            "current_race_index_publish": dict(published),
-        })
+    report_path = output_dir / capture.CURRENT_RACE_INDEX_PUBLISH_REPORT_FILENAME
+    report_path.write_bytes(canonical_bytes(dict(published)))
+    capture.publish_current_race_index_lifecycle(
+        state_path=state,
+        evidence_root=evidence_root,
+        publication_report_path=report_path,
+        publication=published,
     )
 
 NOW = datetime.fromisoformat("2026-07-30T16:55:00+10:00")
@@ -358,30 +347,17 @@ def test_current_race_index_publication_is_atomic_bounded_and_source_sealed(
     index_path = current_race_index_path(state)
     original = index_path.read_bytes()
     _write_publication_evidence(evidence_root, state, published)
+    # The slower capture lifecycle is deliberately still on the preceding run.
+    # Current-index admission must depend on the completed refresh publication,
+    # so an in-progress or timed-out capture cannot invalidate discovery.
+    state.write_bytes(canonical_bytes({
+        "schema_version": "shadow_autopilot_odds_capture_only_state_v1",
+        "updated_at": (index_now - timedelta(minutes=1)).isoformat(),
+        "run_id": "preceding-capture-run",
+        "final_status": "ODDS_CAPTURE_ONLY_RUNNING",
+    }))
     producer_root = evidence_root.parent
     monkeypatch.setattr(capture, "ROOT", producer_root)
-    monkeypatch.setattr(daemon, "ROOT", producer_root)
-    producer_output_dir = evidence_root / "daemon_publication"
-    producer_output_locator = daemon.relpath(producer_output_dir)
-    daemon.write_json(state, {
-        "schema_version": "shadow_autopilot_odds_capture_only_state_v1",
-        "updated_at": published["source_generated_at"],
-        "run_id": published["run_id"], "output_dir": producer_output_locator,
-        "autopilot_output_dir": producer_output_locator,
-        "final_status": "ODDS_CAPTURE_ONLY_READY", "status": "READY",
-    })
-    daemon.write_json(
-        producer_output_dir / capture.ODDS_CAPTURE_ONLY_REPORT_FILENAME,
-        {
-            "schema_version": "shadow_autopilot_odds_capture_only_daemon_report_v1",
-            "generated_at": published["source_generated_at"],
-            "run_id": published["run_id"],
-            "output_dir": producer_output_locator,
-            "autopilot_output_dir": producer_output_locator,
-            "final_status": "ODDS_CAPTURE_ONLY_READY", "status": "READY",
-            "current_race_index_publish": dict(published),
-        },
-    )
 
     assert published["status"] == "PUBLISHED"
     assert json.loads(original)["source_refresh_report_sha256"] == sha256_bytes(
@@ -446,12 +422,10 @@ def test_current_race_index_publication_is_atomic_bounded_and_source_sealed(
     assert replaced.value.code == "CURRENT_INDEX_PATH_UNSAFE"
     assert replaced.value.details["reason"] == "path_replaced"
 
-    state_bytes = state.read_bytes()
+    lifecycle_path = index_path.parent / capture.CURRENT_RACE_INDEX_STATE_FILENAME
+    state_bytes = lifecycle_path.read_bytes()
     state_payload = json.loads(state_bytes)
-    report_path = (
-        producer_root / state_payload["output_dir"]
-        / capture.ODDS_CAPTURE_ONLY_REPORT_FILENAME
-    )
+    report_path = evidence_root / state_payload["publication_report_path"]
     report_bytes = report_path.read_bytes()
     report_payload = json.loads(report_bytes)
 
@@ -465,11 +439,10 @@ def test_current_race_index_publication_is_atomic_bounded_and_source_sealed(
     report_path.write_bytes(report_bytes)
 
     for target, field, value in (
-        (state, "updated_at", (index_now + timedelta(seconds=1)).isoformat()),
-        (state, "final_status", "SKIPPED_LOCK_HELD"),
-        (report_path, "generated_at", (index_now - timedelta(seconds=901)).isoformat()),
-        (report_path, "generated_at", (index_now + timedelta(seconds=1)).isoformat()),
-        (report_path, "final_status", "ODDS_CAPTURE_ONLY_FAILED"),
+        (lifecycle_path, "updated_at", (index_now + timedelta(seconds=1)).isoformat()),
+        (lifecycle_path, "status", "RUNNING"),
+        (report_path, "source_generated_at", (index_now - timedelta(seconds=901)).isoformat()),
+        (report_path, "source_generated_at", (index_now + timedelta(seconds=1)).isoformat()),
         (report_path, "status", "SKIPPED"),
     ):
         original_target = target.read_bytes()
@@ -496,25 +469,25 @@ def test_current_race_index_publication_is_atomic_bounded_and_source_sealed(
     report_path.write_bytes(report_bytes)
 
     for unsafe_output in ("../outside", str(evidence_root / "outside")):
-        unsafe_state = dict(state_payload, output_dir=unsafe_output)
-        state.write_bytes(canonical_bytes(unsafe_state))
+        unsafe_state = dict(state_payload, publication_report_path=unsafe_output)
+        lifecycle_path.write_bytes(canonical_bytes(unsafe_state))
         with pytest.raises(CaptureOneRejected) as unsafe:
             bounded_current_race_index(
                 current_time=index_now, timeout_seconds=1, index_path=index_path,
                 evidence_root=evidence_root, max_age_seconds=900,
             )
         assert unsafe.value.code == "CURRENT_INDEX_REPORT_INVALID"
-    state.write_bytes(state_bytes)
+    lifecycle_path.write_bytes(state_bytes)
 
     stale_state = dict(state_payload, run_id="stale-run")
-    state.write_bytes(canonical_bytes(stale_state))
+    lifecycle_path.write_bytes(canonical_bytes(stale_state))
     with pytest.raises(CaptureOneRejected) as stale_run:
         bounded_current_race_index(
             current_time=index_now, timeout_seconds=1, index_path=index_path,
             evidence_root=evidence_root, max_age_seconds=900,
         )
     assert stale_run.value.code == "CURRENT_INDEX_REPORT_INVALID"
-    state.write_bytes(state_bytes)
+    lifecycle_path.write_bytes(state_bytes)
 
     for field, value in (
         ("run_id", "wrong-run"),
@@ -524,9 +497,9 @@ def test_current_race_index_publication_is_atomic_bounded_and_source_sealed(
     ):
         changed_report = json.loads(report_bytes)
         if field == "publish_status":
-            changed_report["current_race_index_publish"]["status"] = value
+            changed_report["status"] = value
         elif field == "packet_sha256":
-            changed_report["current_race_index_publish"][field] = value
+            changed_report[field] = value
         else:
             changed_report[field] = value
         report_path.write_bytes(canonical_bytes(changed_report))

--- a/tests/race_collection/test_synchronous_manual_capture.py
+++ b/tests/race_collection/test_synchronous_manual_capture.py
@@ -15,6 +15,7 @@ import pytest
 
 import race_collection.synchronous_manual_capture as capture
 from scripts import shadow_autopilot_daemon as daemon
+from scripts import shadow_autopilot_v1 as autopilot
 from scripts.refresh_prejump_upcoming import (
     current_index_metadata_selection,
     race_window_record,
@@ -338,15 +339,12 @@ def test_current_race_index_publication_is_atomic_bounded_and_source_sealed(
         )
     )
 
-    published = publish_current_race_index(
-        state_path=state,
-        evidence_root=evidence_root,
-        source_refresh_report_path=source,
-        run_id="fixture",
+    published = autopilot.publish_current_race_index_after_refresh(
+        state_path=state, evidence_root=evidence_root,
+        output_dir=source.parent, run_id="fixture",
     )
     index_path = current_race_index_path(state)
     original = index_path.read_bytes()
-    _write_publication_evidence(evidence_root, state, published)
     # The slower capture lifecycle is deliberately still on the preceding run.
     # Current-index admission must depend on the completed refresh publication,
     # so an in-progress or timed-out capture cannot invalidate discovery.

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -1890,7 +1890,6 @@ def test_odds_capture_only_autopilot_command_is_narrow_and_append_only():
         odds_capture_max_minutes=60.0,
         odds_capture_refresh_limit=8,
         timeout_seconds=600,
-        state_path=Path("/runtime/odds_capture_state.json"),
         forward_corpus_root=Path("/evidence/forward-corpus"),
     )
 
@@ -1909,9 +1908,7 @@ def test_odds_capture_only_autopilot_command_is_narrow_and_append_only():
     assert command[command.index("--collector-lock-path") + 1] == (
         "/runtime/shared.lock"
     )
-    assert command[command.index("--current-race-index-state-path") + 1] == (
-        "/runtime/odds_capture_state.json"
-    )
+    assert "--current-race-index-state-path" not in command
     assert command[command.index("--forward-corpus-root") + 1] == (
         "/evidence/forward-corpus"
     )
@@ -2921,6 +2918,11 @@ def test_run_odds_capture_once_uses_lock_and_writes_compact_report(tmp_path, mon
         assert "--enable-autonomous-odds-capture" in command
         assert "--allow-auto-scrape-odds" in command
         assert "--require-safe-refresh-metadata" in command
+        # The parent daemon is the sole current-index publisher.  Passing its
+        # state path into the child publishes a new packet before the bounded
+        # odds-capture cycle and leaves the packet/report/state contract
+        # contradictory for the duration of every live run.
+        assert "--current-race-index-state-path" not in command
         assert command[command.index("--collector-lock-path") + 1] == str(lock_path)
         running_report = json.loads(
             (output_dir / "odds_capture_only_daemon_report.json").read_text(

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -1890,6 +1890,7 @@ def test_odds_capture_only_autopilot_command_is_narrow_and_append_only():
         odds_capture_max_minutes=60.0,
         odds_capture_refresh_limit=8,
         timeout_seconds=600,
+        state_path=Path("/runtime/odds_capture_state.json"),
         forward_corpus_root=Path("/evidence/forward-corpus"),
     )
 
@@ -1908,7 +1909,9 @@ def test_odds_capture_only_autopilot_command_is_narrow_and_append_only():
     assert command[command.index("--collector-lock-path") + 1] == (
         "/runtime/shared.lock"
     )
-    assert "--current-race-index-state-path" not in command
+    assert command[command.index("--current-race-index-state-path") + 1] == (
+        "/runtime/odds_capture_state.json"
+    )
     assert command[command.index("--forward-corpus-root") + 1] == (
         "/evidence/forward-corpus"
     )
@@ -2918,11 +2921,9 @@ def test_run_odds_capture_once_uses_lock_and_writes_compact_report(tmp_path, mon
         assert "--enable-autonomous-odds-capture" in command
         assert "--allow-auto-scrape-odds" in command
         assert "--require-safe-refresh-metadata" in command
-        # The parent daemon is the sole current-index publisher.  Passing its
-        # state path into the child publishes a new packet before the bounded
-        # odds-capture cycle and leaves the packet/report/state contract
-        # contradictory for the duration of every live run.
-        assert "--current-race-index-state-path" not in command
+        assert command[command.index("--current-race-index-state-path") + 1] == str(
+            state_path
+        )
         assert command[command.index("--collector-lock-path") + 1] == str(lock_path)
         running_report = json.loads(
             (output_dir / "odds_capture_only_daemon_report.json").read_text(

--- a/tests/test_shadow_autopilot_v1.py
+++ b/tests/test_shadow_autopilot_v1.py
@@ -65,15 +65,26 @@ def test_current_race_index_is_published_from_completed_refresh(
 ):
     evidence_root = tmp_path / "evidence"
     output_dir = evidence_root / "run"
+    output_dir.mkdir(parents=True)
     state_path = evidence_root / "runtime/odds_capture_state.json"
     source_path = output_dir / "odds_capture_refresh_report.json"
     observed = {}
+    lifecycle = {}
 
     def fake_publish(**kwargs):
         observed.update(kwargs)
         return {"status": "PUBLISHED", "race_count": 1}
 
+    def fake_lifecycle(**kwargs):
+        lifecycle.update(kwargs)
+        assert json.loads(
+            kwargs["publication_report_path"].read_text(encoding="utf-8")
+        ) == kwargs["publication"]
+
     monkeypatch.setattr(autopilot, "publish_current_race_index", fake_publish)
+    monkeypatch.setattr(
+        autopilot, "publish_current_race_index_lifecycle", fake_lifecycle
+    )
 
     result = autopilot.publish_current_race_index_after_refresh(
         state_path=state_path,
@@ -88,6 +99,12 @@ def test_current_race_index_is_published_from_completed_refresh(
         "evidence_root": evidence_root,
         "source_refresh_report_path": source_path,
         "run_id": "scheduled-run",
+    }
+    assert lifecycle == {
+        "state_path": state_path,
+        "evidence_root": evidence_root,
+        "publication_report_path": output_dir / "current_race_index_publish.json",
+        "publication": result,
     }
 
 

--- a/tests/test_shadow_autopilot_v1.py
+++ b/tests/test_shadow_autopilot_v1.py
@@ -69,22 +69,18 @@ def test_current_race_index_is_published_from_completed_refresh(
     state_path = evidence_root / "runtime/odds_capture_state.json"
     source_path = output_dir / "odds_capture_refresh_report.json"
     observed = {}
-    lifecycle = {}
-
     def fake_publish(**kwargs):
         observed.update(kwargs)
-        return {"status": "PUBLISHED", "race_count": 1}
-
-    def fake_lifecycle(**kwargs):
-        lifecycle.update(kwargs)
-        assert json.loads(
-            kwargs["publication_report_path"].read_text(encoding="utf-8")
-        ) == kwargs["publication"]
+        return {
+            "schema_version": "collector_current_race_index_publish_v2",
+            "status": "PUBLISHED",
+            "source_generated_at": "2026-06-12T00:01:01+10:00",
+            "run_id": "scheduled-run",
+            "packet_sha256": "a" * 64,
+            "race_count": 1,
+        }
 
     monkeypatch.setattr(autopilot, "publish_current_race_index", fake_publish)
-    monkeypatch.setattr(
-        autopilot, "publish_current_race_index_lifecycle", fake_lifecycle
-    )
 
     result = autopilot.publish_current_race_index_after_refresh(
         state_path=state_path,
@@ -93,19 +89,24 @@ def test_current_race_index_is_published_from_completed_refresh(
         run_id="scheduled-run",
     )
 
-    assert result == {"status": "PUBLISHED", "race_count": 1}
+    assert result["status"] == "PUBLISHED"
+    assert result["race_count"] == 1
     assert observed == {
         "state_path": state_path,
         "evidence_root": evidence_root,
         "source_refresh_report_path": source_path,
         "run_id": "scheduled-run",
     }
-    assert lifecycle == {
-        "state_path": state_path,
-        "evidence_root": evidence_root,
-        "publication_report_path": output_dir / "current_race_index_publish.json",
-        "publication": result,
-    }
+    report_path = output_dir / "current_race_index_publish.json"
+    assert report_path.read_bytes() == canonical_bytes(result)
+    lifecycle_path = state_path.parent / "manual_prediction_current_race_index.state.json"
+    lifecycle = json.loads(lifecycle_path.read_text(encoding="utf-8"))
+    assert lifecycle["run_id"] == "scheduled-run"
+    assert lifecycle["packet_sha256"] == "a" * 64
+    assert lifecycle["publication_report_path"] == "run/current_race_index_publish.json"
+    assert lifecycle["publication_report_sha256"] == sha256_bytes(
+        canonical_bytes(result)
+    )
 
 
 def test_step_command_records_timeout_and_logs_output(tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed

- seal a dedicated current-index lifecycle state after the bounded refresh publication
- bind discovery to the run-local publish report and its hash instead of the slower odds-capture daemon's mutable final state
- retain publication before the browser-based capture batch, including when that later batch times out

## Root cause

The child correctly refreshed and published a new index before running browser-based odds capture. Admission incorrectly required the separate odds-capture daemon state and final report to identify the same run. Those artifacts cannot become final until the slower batch ends. When live capture exceeded the timer cadence, every valid refresh remained unreadable for the whole cycle and the next cycle immediately repeated the contradiction.

The new lifecycle state is advanced only after both the canonical packet/publication pair and the canonical run-local publish report exist and agree byte-for-byte. The reader retains and validates all of them, including hashes, identity, path safety, timestamps, exact source report, runner sets, and replacement detection. The independent capture lifecycle remains free to be running, time out, or finish without weakening or invalidating the already completed refresh publication.

## Validation

- current-index contract suite: 74 passed
- refresh-before-capture and adjacent daemon selection: 19 passed
- Operator UI security/R3/bootstrap suite: 157 passed
- predictor receipt/current-index selection: 7 passed
- `py_compile` for daemon and child autopilot
- `git diff --check`

No model, feature, odds, scoring, authentication, database, timer, or frozen experiment semantics change.
