### PR TITLE
Fix Operator UI V2 runner projection

### DIFF
--- a/src/operator_ui/live_adapters.py
+++ b/src/operator_ui/live_adapters.py
@@ -1093,7 +1093,7 @@ class LiveEvidenceAdapters:
                     "runners": [{
                         "runner_id": runner["identity"],
                         "source_runner_id": runner["source_native_runner_id"],
-                        "box": runner["box_number"], "name": runner["dog_name"],
+                        "box": runner["box"], "name": runner["display_name"],
                         "scratch_state": runner["scratch_state"],
                     } for runner in row["runners"]],
                     "runner_set_sha256": row["runner_set_sha256"],

--- a/tests/operator_ui/test_live_adapters.py
+++ b/tests/operator_ui/test_live_adapters.py
@@ -1628,8 +1628,8 @@ def test_upcoming_verified_view_exact_boundaries_and_identity(
         "jump_datetime": (NOW + timedelta(seconds=jump_offset)).isoformat(),
         "runner_set_sha256": "a" * 64,
         "runners": [
-            {"box_number": 1, "dog_name": "ONE", "identity": "ONE", "source_native_runner_id": None, "scratch_state": "ACTIVE"},
-            {"box_number": 2, "dog_name": "TWO", "identity": "TWO", "source_native_runner_id": "22", "scratch_state": "ACTIVE"},
+            {"box": 1, "display_name": "ONE", "identity": "ONE", "source_native_runner_id": None, "scratch_state": "ACTIVE"},
+            {"box": 2, "display_name": "TWO", "identity": "TWO", "source_native_runner_id": "22", "scratch_state": "ACTIVE"},
         ],
     }
     view = VerifiedCurrentRaceIndex(
@@ -1652,6 +1652,7 @@ def test_upcoming_verified_view_exact_boundaries_and_identity(
         assert race["meeting_slug"] is None and race["venue"] == "GUNN"
         assert [runner["runner_id"] for runner in race["runners"]] == ["ONE", "TWO"]
         assert [runner["source_runner_id"] for runner in race["runners"]] == [None, "22"]
+        assert [(runner["box"], runner["name"]) for runner in race["runners"]] == [(1, "ONE"), (2, "TWO")]
         assert {runner["scratch_state"] for runner in race["runners"]} == {"ACTIVE"}
         assert adapter.race_detail(race["route_id"], NOW).data["race"] == race
         assert adapter.race_detail("hostile..route", NOW).data == {}
@@ -1663,7 +1664,7 @@ def test_fresh_source_with_only_post_jump_rows_is_verified_empty(tmp_path, monke
         "race_url": "https://www.thedogs.com.au/racing/gunnedah/2026-07-19/5",
         "date": "2026-07-19", "venue": "GUNN", "race_number": 5,
         "jump_datetime": NOW.isoformat(), "runner_set_sha256": "a" * 64,
-        "runners": ({"box_number": 1, "dog_name": "ONE", "identity": "ONE", "source_native_runner_id": None, "scratch_state": "ACTIVE"},),
+        "runners": ({"box": 1, "display_name": "ONE", "identity": "ONE", "source_native_runner_id": None, "scratch_state": "ACTIVE"},),
     }
     view = VerifiedCurrentRaceIndex(
         "collector_current_race_index_v2", "run-1", NOW.isoformat(), "1" * 64,


### PR DESCRIPTION
## Summary
- consume the canonical `VerifiedCurrentRaceIndex` runner fields (`box`, `display_name`) in the Operator UI adapter
- update the adapter contract tests to use the actual normalized V2 runner shape
- retain fail-closed behavior; no legacy-field fallback is added

## Live reproduction
A naturally published, strictly verified V2 index was accepted by `bounded_current_race_index`, but `/operator-ui/api/v1/races/upcoming` returned 503 because the adapter indexed legacy `box_number` / `dog_name` fields. No prediction POST occurred.

## Validation
- `6 passed, 240 deselected` focused upcoming-race cases
- `50 passed` adjacent R3 API and bootstrap tests
- full live-adapter file: `242 passed`; four host shared-`/tmp` trust-policy failures separately passed (`4 passed`) under an owner-only trusted temp root
- `python -m py_compile src/operator_ui/live_adapters.py`
- `git diff --check`

Supports the guarded live proof in #135; does not close it by itself.
