### PR TITLE
Serve connected Operator UI on main thread

### DIFF
--- a/app.py
+++ b/app.py
@@ -28004,6 +28004,12 @@ Examples:
     parser.add_argument("--debug", action="store_true", help="Enable Flask debug mode")
 
     parser.add_argument(
+        "--single-threaded",
+        action="store_true",
+        help="Serve requests on the main interpreter thread",
+    )
+
+    parser.add_argument(
         "--enable-profiling",
         action="store_true",
         help="Enable profiling for performance analysis (default: disabled for zero overhead)",
@@ -28111,7 +28117,12 @@ def main():
     print(f"🚀 Setting server port to {args.port}")
 
     # Run Flask app with configured options
-    app.run(host=host_arg, port=args.port, debug=args.debug)
+    app.run(
+        host=host_arg,
+        port=args.port,
+        debug=args.debug,
+        threaded=not args.single_threaded,
+    )
 
 
 if __name__ == "__main__":

--- a/src/operator_ui/deployment.py
+++ b/src/operator_ui/deployment.py
@@ -824,7 +824,10 @@ def main(argv: list[str] | None = None) -> int:
         if not _COMMIT.fullmatch(deployed_commit) or not _COMMIT.fullmatch(deployed_tree):
             raise DeploymentRejected("deployed source commit/tree identity is invalid")
         _verify_source_identity(source, deployed_commit, deployed_tree)
-        os.execv(sys.executable, [sys.executable, str(source / "app.py"), "--host", args.host, "--port", str(args.port)])
+        os.execv(sys.executable, [
+            sys.executable, str(source / "app.py"), "--host", args.host,
+            "--port", str(args.port), "--single-threaded",
+        ])
     values = vars(args); values.pop("command")
     result = generate_package(**values)
     print(json.dumps(result, sort_keys=True))

--- a/tests/operator_ui/test_deployment_generator.py
+++ b/tests/operator_ui/test_deployment_generator.py
@@ -779,7 +779,8 @@ def test_clean_exact_generated_serve_identity_reaches_exec(real_startup_tmp_path
         main(["serve", "--source-root", str(values["source_root"]),
               "--host", "127.0.0.1", "--port", "5055"])
     assert executed[0][1][1:] == [str(values["source_root"] / "app.py"),
-                                  "--host", "127.0.0.1", "--port", "5055"]
+                                  "--host", "127.0.0.1", "--port", "5055",
+                                  "--single-threaded"]
 
 
 def test_generated_operator_logger_uses_operations_root_with_read_only_source(


### PR DESCRIPTION
## Summary
- make the generated connected Operator UI launch `app.py --single-threaded`
- keep ordinary direct app launches on Flask's existing threaded default
- preserve the strict current-index reader's signal-backed hard deadline on the main interpreter thread

## Live reproduction
A naturally published V2 index passes `bounded_current_race_index` and the live adapter/API validators directly, but the threaded Flask request returns 503. Calling the reader in a worker thread reproduces `ValueError: signal only works in main thread of the main interpreter`. No prediction POST occurred.

## Validation
- `1 passed` exact generated serve command regression
- `8 passed, 109 deselected` adjacent deployment/startup tests
- `317 passed` Operator UI security and API tests
- `python -m py_compile app.py src/operator_ui/deployment.py`
- `git diff --check`

Supports the guarded live proof in #135; does not close it by itself.
