### PR TITLE
Make current index reader safe for request threads

### DIFF
--- a/app.py
+++ b/app.py
@@ -28004,9 +28004,9 @@ Examples:
     parser.add_argument("--debug", action="store_true", help="Enable Flask debug mode")
 
     parser.add_argument(
-        "--single-threaded",
+        "--operator-ui-current-index-worker",
         action="store_true",
-        help="Serve requests on the main interpreter thread",
+        help="Start the pre-request strict current-index reader worker",
     )
 
     parser.add_argument(
@@ -28116,13 +28116,17 @@ def main():
     CURRENT_SERVER_PORT = args.port
     print(f"🚀 Setting server port to {args.port}")
 
+    if args.operator_ui_current_index_worker:
+        from race_collection.synchronous_manual_capture import (
+            initialize_current_index_reader_worker,
+        )
+
+        initialize_current_index_reader_worker()
+
     # Run Flask app with configured options
-    app.run(
-        host=host_arg,
-        port=args.port,
-        debug=args.debug,
-        threaded=not args.single_threaded,
-    )
+    from src.operator_ui.deployment import run_threaded_server
+
+    run_threaded_server(app, host=host_arg, port=args.port, debug=args.debug)
 
 
 if __name__ == "__main__":

--- a/race_collection/current_index_reader_worker.py
+++ b/race_collection/current_index_reader_worker.py
@@ -1,0 +1,109 @@
+"""Private fixed-frame worker for threaded current-index readers."""
+
+from __future__ import annotations
+
+import argparse
+import socket
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+from race_collection.synchronous_manual_capture import (
+    _CURRENT_INDEX_READER_MAX_REQUEST_BYTES,
+    _CURRENT_INDEX_READER_MAX_RESPONSE_BYTES,
+    _CURRENT_INDEX_READER_WIRE_SCHEMA,
+    _bounded_current_race_index_main_thread,
+    _serialize_current_index_reader_result,
+    _socket_receive_frame,
+    _socket_send_frame,
+    CaptureOneRejected,
+)
+
+
+def _arguments(payload: object) -> Mapping[str, Any]:
+    expected = {
+        "current_time", "timeout_seconds", "index_path", "evidence_root",
+        "max_age_seconds", "max_races", "return_verified_view",
+    }
+    if not isinstance(payload, Mapping) or set(payload) != expected:
+        raise ValueError("current index reader arguments are invalid")
+    return {
+        **payload,
+        "current_time": datetime.fromisoformat(str(payload["current_time"])),
+        "index_path": Path(str(payload["index_path"])),
+        "evidence_root": Path(str(payload["evidence_root"])),
+    }
+
+
+def serve(connection: socket.socket) -> int:
+    _socket_send_frame(
+        connection,
+        {"schema_version": _CURRENT_INDEX_READER_WIRE_SCHEMA, "status": "READY"},
+        deadline=None,
+        maximum=4096,
+    )
+    while True:
+        try:
+            request = _socket_receive_frame(
+                connection, deadline=None,
+                maximum=_CURRENT_INDEX_READER_MAX_REQUEST_BYTES,
+            )
+        except EOFError:
+            return 0
+        request_id = request.get("request_id")
+        if (
+            request.get("schema_version") != _CURRENT_INDEX_READER_WIRE_SCHEMA
+            or not isinstance(request_id, str)
+            or len(request_id) != 32
+            or set(request) != {"schema_version", "request_id", "arguments"}
+        ):
+            return 2
+        try:
+            result = _bounded_current_race_index_main_thread(
+                **_arguments(request.get("arguments"))
+            )
+        except CaptureOneRejected as exc:
+            response = {
+                "schema_version": _CURRENT_INDEX_READER_WIRE_SCHEMA,
+                "request_id": request_id,
+                "status": "rejected",
+                "code": exc.code,
+                "details": exc.details,
+            }
+        except BaseException:
+            response = {
+                "schema_version": _CURRENT_INDEX_READER_WIRE_SCHEMA,
+                "request_id": request_id,
+                "status": "failed",
+                "code": "CURRENT_INDEX_INVALID",
+                "details": {"reason": "reader_process_failed"},
+            }
+        else:
+            response = {
+                "schema_version": _CURRENT_INDEX_READER_WIRE_SCHEMA,
+                "request_id": request_id,
+                "status": "ok",
+                "result": _serialize_current_index_reader_result(result),
+            }
+        try:
+            _socket_send_frame(
+                connection, response, deadline=None,
+                maximum=_CURRENT_INDEX_READER_MAX_RESPONSE_BYTES,
+            )
+        except (BrokenPipeError, ConnectionError, OSError):
+            return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--socket-fd", type=int, required=True)
+    args = parser.parse_args()
+    connection = socket.socket(fileno=args.socket_fd)
+    try:
+        return serve(connection)
+    finally:
+        connection.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/race_collection/synchronous_manual_capture.py
+++ b/race_collection/synchronous_manual_capture.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
+import atexit
+import base64
 import contextlib
 import csv
 import io
 import json
 import os
+import queue
 import signal
 import socket
 import stat
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 import uuid
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -1466,7 +1471,7 @@ def _validate_current_index_lifecycle(
         raise CaptureOneRejected("CURRENT_INDEX_REPORT_INVALID")
 
 
-def bounded_current_race_index(
+def _bounded_current_race_index_main_thread(
     *,
     current_time: datetime,
     timeout_seconds: float,
@@ -1689,6 +1694,379 @@ def bounded_current_race_index(
             snapshot.__exit__()
         signal.setitimer(signal.ITIMER_REAL, 0)
         signal.signal(signal.SIGALRM, previous_handler)
+
+
+_CURRENT_INDEX_READER_WIRE_SCHEMA = "current_index_reader_wire_v1"
+_CURRENT_INDEX_READER_MAX_REQUEST_BYTES = 64 * 1024
+_CURRENT_INDEX_READER_MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+_current_index_reader_client: _CurrentIndexReaderClient | None = None
+_current_index_reader_client_guard = threading.Lock()
+_current_index_reader_atexit_registered = False
+
+
+def _socket_remaining(deadline: float | None) -> float | None:
+    if deadline is None:
+        return None
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError("current index reader deadline expired")
+    return remaining
+
+
+def _socket_send_frame(
+    connection: socket.socket,
+    payload: Mapping[str, Any],
+    *,
+    deadline: float | None,
+    maximum: int,
+) -> None:
+    _socket_remaining(deadline)
+    encoded = canonical_bytes(payload)
+    _socket_remaining(deadline)
+    if len(encoded) > maximum:
+        raise ValueError("current index reader frame exceeds maximum")
+    connection.settimeout(_socket_remaining(deadline))
+    connection.sendall(len(encoded).to_bytes(8, "big") + encoded)
+
+
+def _socket_receive_exact(
+    connection: socket.socket, size: int, *, deadline: float | None,
+) -> bytes:
+    output = bytearray()
+    while len(output) < size:
+        connection.settimeout(_socket_remaining(deadline))
+        chunk = connection.recv(size - len(output))
+        if not chunk:
+            raise EOFError("current index reader closed its transport")
+        output.extend(chunk)
+    return bytes(output)
+
+
+def _socket_receive_frame(
+    connection: socket.socket, *, deadline: float | None, maximum: int,
+) -> Mapping[str, Any]:
+    header = _socket_receive_exact(connection, 8, deadline=deadline)
+    size = int.from_bytes(header, "big")
+    if size <= 0 or size > maximum:
+        raise ValueError("current index reader frame size is invalid")
+    encoded = _socket_receive_exact(connection, size, deadline=deadline)
+    _socket_remaining(deadline)
+    payload = json.loads(encoded)
+    if not isinstance(payload, Mapping) or canonical_bytes(payload) != encoded:
+        raise ValueError("current index reader frame is not canonical")
+    _socket_remaining(deadline)
+    return payload
+
+
+def _serialize_current_index_reader_result(
+    result: list[Mapping[str, Any]] | VerifiedCurrentRaceIndex,
+) -> Mapping[str, Any]:
+    if isinstance(result, VerifiedCurrentRaceIndex):
+        return {
+            "kind": "verified",
+            "schema_version": result.schema_version,
+            "run_id": result.run_id,
+            "source_generated_at": result.source_generated_at,
+            "packet_sha256": result.packet_sha256,
+            "packet_bytes_base64": base64.b64encode(result.packet_bytes).decode("ascii"),
+            "races": list(result.races),
+            "source_refresh_report_path": result.source_refresh_report_path,
+            "source_refresh_report_sha256": result.source_refresh_report_sha256,
+            "publication_sha256": result.publication_sha256,
+            "state_sha256": result.state_sha256,
+            "report_sha256": result.report_sha256,
+        }
+    return {"kind": "races", "races": result}
+
+
+def _deserialize_current_index_reader_result(
+    payload: object,
+) -> list[Mapping[str, Any]] | VerifiedCurrentRaceIndex:
+    if not isinstance(payload, Mapping):
+        raise ValueError("current index reader result is invalid")
+    if payload.get("kind") == "races" and set(payload) == {"kind", "races"}:
+        races = payload["races"]
+        if not isinstance(races, list) or not all(isinstance(row, Mapping) for row in races):
+            raise ValueError("current index reader races are invalid")
+        return races
+    expected = {
+        "kind", "schema_version", "run_id", "source_generated_at",
+        "packet_sha256", "packet_bytes_base64", "races",
+        "source_refresh_report_path", "source_refresh_report_sha256",
+        "publication_sha256", "state_sha256", "report_sha256",
+    }
+    if payload.get("kind") != "verified" or set(payload) != expected:
+        raise ValueError("current index reader verified result is invalid")
+    races = payload["races"]
+    if not isinstance(races, list) or not all(isinstance(row, Mapping) for row in races):
+        raise ValueError("current index reader verified races are invalid")
+    packet_bytes = base64.b64decode(
+        str(payload["packet_bytes_base64"]), validate=True
+    )
+    if (
+        len(packet_bytes) > MAX_CURRENT_INDEX_BYTES
+        or sha256_bytes(packet_bytes) != payload["packet_sha256"]
+    ):
+        raise ValueError("current index reader packet identity is invalid")
+    strings = expected - {"kind", "packet_bytes_base64", "races"}
+    if any(not isinstance(payload[key], str) or not payload[key] for key in strings):
+        raise ValueError("current index reader identity is invalid")
+    return VerifiedCurrentRaceIndex(
+        schema_version=payload["schema_version"],
+        run_id=payload["run_id"],
+        source_generated_at=payload["source_generated_at"],
+        packet_sha256=payload["packet_sha256"],
+        packet_bytes=packet_bytes,
+        races=tuple(races),
+        source_refresh_report_path=payload["source_refresh_report_path"],
+        source_refresh_report_sha256=payload["source_refresh_report_sha256"],
+        publication_sha256=payload["publication_sha256"],
+        state_sha256=payload["state_sha256"],
+        report_sha256=payload["report_sha256"],
+    )
+
+
+class _CurrentIndexReaderClient:
+    def __init__(self, process: subprocess.Popen[bytes], connection: socket.socket) -> None:
+        self.process = process
+        self.connection = connection
+        self.invalidated = threading.Event()
+        self.closed = threading.Event()
+        self.close_guard = threading.Lock()
+        self.tasks: queue.SimpleQueue[Any] = queue.SimpleQueue()
+        self.broker = threading.Thread(
+            target=self._serve,
+            name="current-index-reader-broker",
+            daemon=True,
+        )
+        self.broker.start()
+
+    def close(self) -> None:
+        with self.close_guard:
+            if self.closed.is_set():
+                return
+            self.closed.set()
+            self.tasks.put(None)
+        try:
+            self.connection.close()
+        finally:
+            if self.process.poll() is None:
+                self.process.kill()
+                try:
+                    self.process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    threading.Thread(
+                        target=self.process.wait,
+                        name="current-index-reader-reaper",
+                        daemon=True,
+                    ).start()
+
+    def invalidate(self) -> None:
+        if self.invalidated.is_set():
+            return
+        self.invalidated.set()
+        threading.Thread(
+            target=self.close,
+            name="current-index-reader-invalidator",
+            daemon=True,
+        ).start()
+
+    def _serve(self) -> None:
+        while True:
+            task = self.tasks.get()
+            if task is None:
+                return
+            arguments, timeout_seconds, completed, outcome = task
+            try:
+                result = self._request(arguments, timeout_seconds=timeout_seconds)
+            except BaseException as exc:
+                outcome.append(("error", exc))
+            else:
+                outcome.append(("ok", result))
+            finally:
+                completed.set()
+
+    def request(
+        self, arguments: Mapping[str, Any], *, timeout_seconds: float,
+    ) -> list[Mapping[str, Any]] | VerifiedCurrentRaceIndex:
+        if self.invalidated.is_set() or self.closed.is_set():
+            raise CaptureOneRejected(
+                "CURRENT_INDEX_INVALID", reason="reader_process_unavailable"
+            )
+        completed = threading.Event()
+        outcome: list[tuple[str, Any]] = []
+        self.tasks.put((arguments, timeout_seconds, completed, outcome))
+        if not completed.wait(timeout_seconds):
+            self.invalidate()
+            raise CaptureOneRejected(
+                "DISCOVERY_TIMEOUT", budget_seconds=timeout_seconds
+            )
+        if len(outcome) != 1:
+            self.invalidate()
+            raise CaptureOneRejected(
+                "CURRENT_INDEX_INVALID", reason="reader_process_failed"
+            )
+        status, value = outcome[0]
+        if status == "error":
+            raise value
+        return value
+
+    def _request(
+        self, arguments: Mapping[str, Any], *, timeout_seconds: float,
+    ) -> list[Mapping[str, Any]] | VerifiedCurrentRaceIndex:
+        deadline = time.monotonic() + timeout_seconds
+        invalidate = False
+        try:
+            if self.invalidated.is_set() or self.process.poll() is not None:
+                invalidate = True
+                raise CaptureOneRejected(
+                    "CURRENT_INDEX_INVALID", reason="reader_process_unavailable"
+                )
+            request_id = uuid.uuid4().hex
+            child_budget = max(0.001, timeout_seconds - min(0.1, timeout_seconds / 5))
+            request = {
+                "schema_version": _CURRENT_INDEX_READER_WIRE_SCHEMA,
+                "request_id": request_id,
+                "arguments": {
+                    **arguments,
+                    "current_time": arguments["current_time"].isoformat(),
+                    "timeout_seconds": child_budget,
+                    "index_path": str(arguments["index_path"]),
+                    "evidence_root": str(arguments["evidence_root"]),
+                },
+            }
+            _socket_send_frame(
+                self.connection, request, deadline=deadline,
+                maximum=_CURRENT_INDEX_READER_MAX_REQUEST_BYTES,
+            )
+            response = _socket_receive_frame(
+                self.connection, deadline=deadline,
+                maximum=_CURRENT_INDEX_READER_MAX_RESPONSE_BYTES,
+            )
+            if (
+                response.get("schema_version") != _CURRENT_INDEX_READER_WIRE_SCHEMA
+                or response.get("request_id") != request_id
+                or set(response) not in (
+                    {"schema_version", "request_id", "status", "result"},
+                    {"schema_version", "request_id", "status", "code", "details"},
+                )
+            ):
+                raise ValueError("current index reader response identity is invalid")
+            _socket_remaining(deadline)
+            if response.get("status") == "rejected":
+                code, details = response.get("code"), response.get("details")
+                if not isinstance(code, str) or not isinstance(details, Mapping):
+                    raise ValueError("current index reader rejection is invalid")
+                _socket_remaining(deadline)
+                raise CaptureOneRejected(code, **dict(details))
+            if response.get("status") != "ok":
+                raise ValueError("current index reader response failed")
+            result = _deserialize_current_index_reader_result(response.get("result"))
+            _socket_remaining(deadline)
+            return result
+        except CaptureOneRejected:
+            raise
+        except (TimeoutError, socket.timeout) as exc:
+            invalidate = True
+            raise CaptureOneRejected(
+                "DISCOVERY_TIMEOUT", budget_seconds=timeout_seconds
+            ) from exc
+        except Exception as exc:
+            invalidate = True
+            raise CaptureOneRejected(
+                "CURRENT_INDEX_INVALID", reason="reader_process_failed"
+            ) from exc
+        finally:
+            if invalidate:
+                self.invalidate()
+
+
+def initialize_current_index_reader_worker(*, startup_timeout_seconds: float = 5) -> None:
+    """Start the safe pre-request reader process used by connected threaded UI."""
+
+    global _current_index_reader_client, _current_index_reader_atexit_registered
+    with _current_index_reader_client_guard:
+        if (
+            _current_index_reader_client is not None
+            and _current_index_reader_client.process.poll() is None
+        ):
+            return
+        parent, child = socket.socketpair()
+        process: subprocess.Popen[bytes] | None = None
+        try:
+            process = subprocess.Popen(
+                [
+                    sys.executable, "-m", "race_collection.current_index_reader_worker",
+                    "--socket-fd", str(child.fileno()),
+                ],
+                cwd=Path(__file__).resolve().parents[1],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                pass_fds=(child.fileno(),),
+                close_fds=True,
+            )
+            child.close()
+            ready = _socket_receive_frame(
+                parent, deadline=time.monotonic() + startup_timeout_seconds,
+                maximum=4096,
+            )
+            if ready != {
+                "schema_version": _CURRENT_INDEX_READER_WIRE_SCHEMA,
+                "status": "READY",
+            }:
+                raise ValueError("current index reader readiness is invalid")
+            _current_index_reader_client = _CurrentIndexReaderClient(process, parent)
+            if not _current_index_reader_atexit_registered:
+                atexit.register(shutdown_current_index_reader_worker)
+                _current_index_reader_atexit_registered = True
+        except BaseException:
+            parent.close()
+            child.close()
+            if process is not None and process.poll() is None:
+                process.kill()
+                process.wait()
+            raise
+
+
+def shutdown_current_index_reader_worker() -> None:
+    global _current_index_reader_client
+    with _current_index_reader_client_guard:
+        client, _current_index_reader_client = _current_index_reader_client, None
+        if client is not None:
+            client.close()
+
+
+def bounded_current_race_index(
+    *,
+    current_time: datetime,
+    timeout_seconds: float,
+    index_path: Path,
+    evidence_root: Path,
+    max_age_seconds: int,
+    max_races: int = MAX_CURRENT_INDEX_RACES,
+    return_verified_view: bool = False,
+) -> list[Mapping[str, Any]] | VerifiedCurrentRaceIndex:
+    """Read the strict index within a hard deadline from any caller thread."""
+
+    arguments = {
+        "current_time": current_time,
+        "timeout_seconds": timeout_seconds,
+        "index_path": index_path,
+        "evidence_root": evidence_root,
+        "max_age_seconds": max_age_seconds,
+        "max_races": max_races,
+        "return_verified_view": return_verified_view,
+    }
+    if threading.current_thread() is threading.main_thread() or timeout_seconds <= 0:
+        return _bounded_current_race_index_main_thread(**arguments)
+
+    client = _current_index_reader_client
+    if client is None:
+        raise CaptureOneRejected(
+            "CURRENT_INDEX_INVALID", reason="reader_process_unavailable"
+        )
+    return client.request(arguments, timeout_seconds=timeout_seconds)
 
 
 def release_owned_collector_lock(lock: Any) -> None:

--- a/src/operator_ui/deployment.py
+++ b/src/operator_ui/deployment.py
@@ -21,6 +21,12 @@ class DeploymentRejected(RuntimeError):
     """The requested package cannot safely bind the repository deployment."""
 
 
+def run_threaded_server(application: Any, *, host: str, port: int, debug: bool) -> None:
+    """Serve connected UI requests concurrently after its worker is ready."""
+
+    application.run(host=host, port=port, debug=debug, threaded=True)
+
+
 _COMMIT = re.compile(r"^[0-9a-f]{40}$")
 _VERSION = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 _SYSTEMD_SAFE_PATH = re.compile(r"^/[A-Za-z0-9_./+-]+$")
@@ -826,7 +832,7 @@ def main(argv: list[str] | None = None) -> int:
         _verify_source_identity(source, deployed_commit, deployed_tree)
         os.execv(sys.executable, [
             sys.executable, str(source / "app.py"), "--host", args.host,
-            "--port", str(args.port), "--single-threaded",
+            "--port", str(args.port), "--operator-ui-current-index-worker",
         ])
     values = vars(args); values.pop("command")
     result = generate_package(**values)

--- a/tests/operator_ui/test_deployment_generator.py
+++ b/tests/operator_ui/test_deployment_generator.py
@@ -780,7 +780,23 @@ def test_clean_exact_generated_serve_identity_reaches_exec(real_startup_tmp_path
               "--host", "127.0.0.1", "--port", "5055"])
     assert executed[0][1][1:] == [str(values["source_root"] / "app.py"),
                                   "--host", "127.0.0.1", "--port", "5055",
-                                  "--single-threaded"]
+                                  "--operator-ui-current-index-worker"]
+
+
+def test_connected_server_is_explicitly_threaded():
+    calls = []
+
+    class Application:
+        def run(self, **kwargs):
+            calls.append(kwargs)
+
+    deployment_module.run_threaded_server(
+        Application(), host="127.0.0.1", port=5055, debug=False
+    )
+
+    assert calls == [{
+        "host": "127.0.0.1", "port": 5055, "debug": False, "threaded": True,
+    }]
 
 
 def test_generated_operator_logger_uses_operations_root_with_read_only_source(

--- a/tests/race_collection/test_synchronous_manual_capture.py
+++ b/tests/race_collection/test_synchronous_manual_capture.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import os
 import signal
+import socket
+import subprocess
 import sys
 import threading
 import time
@@ -379,6 +381,30 @@ def test_current_race_index_publication_is_atomic_bounded_and_source_sealed(
     assert verified_view.races[0]["race_id"] == "Race 5 - GUNN - 2026-07-19"
     assert verified_view.races[0]["runners"][0]["source_native_runner_id"] is None
 
+    threaded_results: list[Any] = []
+
+    def read_from_request_thread() -> None:
+        try:
+            threaded_results.append(bounded_current_race_index(
+                current_time=index_now, timeout_seconds=2,
+                index_path=index_path, evidence_root=evidence_root,
+                max_age_seconds=900, return_verified_view=True,
+            ))
+        except BaseException as exc:
+            threaded_results.append(exc)
+
+    capture.initialize_current_index_reader_worker()
+    try:
+        request_thread = threading.Thread(target=read_from_request_thread)
+        request_thread.start()
+        request_thread.join(3)
+        assert not request_thread.is_alive()
+        assert len(threaded_results) == 1
+        assert isinstance(threaded_results[0], capture.VerifiedCurrentRaceIndex)
+        assert threaded_results[0].packet_bytes == original
+    finally:
+        capture.shutdown_current_index_reader_worker()
+
     boundary = index_now + timedelta(seconds=1200)
     assert bounded_current_race_index(
         current_time=boundary, timeout_seconds=1, index_path=index_path,
@@ -527,6 +553,143 @@ def test_current_race_index_publication_is_atomic_bounded_and_source_sealed(
 
     assert rejected["status"] == "REJECTED"
     assert index_path.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    ("worker_action", "expected_code", "slow_validation"),
+    (
+        ("time.sleep(60)", "DISCOVERY_TIMEOUT", False),
+        (
+            "connection.sendall((100).to_bytes(8,'big')+b'{');time.sleep(60)",
+            "DISCOVERY_TIMEOUT",
+            False,
+        ),
+        (
+            "connection.sendall((9*1024*1024).to_bytes(8,'big'))",
+            "CURRENT_INDEX_INVALID",
+            False,
+        ),
+        (
+            "_socket_send_frame(connection,{'schema_version':_CURRENT_INDEX_READER_WIRE_SCHEMA,'request_id':request['request_id'],'status':'failed','code':'CURRENT_INDEX_INVALID','details':{'reason':'reader_process_failed'}},deadline=None,maximum=_CURRENT_INDEX_READER_MAX_RESPONSE_BYTES);time.sleep(60)",
+            "CURRENT_INDEX_INVALID",
+            False,
+        ),
+        (
+            "_socket_send_frame(connection,{'schema_version':_CURRENT_INDEX_READER_WIRE_SCHEMA,'request_id':request['request_id'],'status':'ok','result':{'kind':'races','races':[]}},deadline=None,maximum=_CURRENT_INDEX_READER_MAX_RESPONSE_BYTES)",
+            "DISCOVERY_TIMEOUT",
+            True,
+        ),
+        ("raise SystemExit(0)", "CURRENT_INDEX_INVALID", False),
+    ),
+)
+def test_threaded_current_race_index_transport_is_bounded_and_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    worker_action: str, expected_code: str, slow_validation: bool,
+):
+    parent, child = socket.socketpair()
+    code = f"""
+import socket,sys,time
+from race_collection.synchronous_manual_capture import (
+    _CURRENT_INDEX_READER_MAX_REQUEST_BYTES, _CURRENT_INDEX_READER_MAX_RESPONSE_BYTES,
+    _CURRENT_INDEX_READER_WIRE_SCHEMA,
+    _socket_receive_frame, _socket_send_frame,
+)
+connection=socket.socket(fileno=int(sys.argv[1]))
+_socket_send_frame(connection,{{'schema_version':_CURRENT_INDEX_READER_WIRE_SCHEMA,'status':'READY'}},deadline=None,maximum=4096)
+request=_socket_receive_frame(connection,deadline=None,maximum=_CURRENT_INDEX_READER_MAX_REQUEST_BYTES)
+{worker_action}
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", code, str(child.fileno())],
+        cwd=capture.ROOT, pass_fds=(child.fileno(),),
+        stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    child.close()
+    ready = capture._socket_receive_frame(
+        parent, deadline=time.monotonic() + 3, maximum=4096
+    )
+    assert ready["status"] == "READY"
+    capture._current_index_reader_client = capture._CurrentIndexReaderClient(
+        process, parent
+    )
+    validation_started = threading.Event()
+    release_validation = threading.Event()
+    if slow_validation:
+        deserialize = capture._deserialize_current_index_reader_result
+
+        def delayed_deserialize(payload: object):
+            validation_started.set()
+            release_validation.wait(2)
+            return deserialize(payload)
+
+        monkeypatch.setattr(
+            capture, "_deserialize_current_index_reader_result", delayed_deserialize
+        )
+    errors: list[BaseException] = []
+
+    def read_from_request_thread() -> None:
+        try:
+            bounded_current_race_index(
+                current_time=NOW, timeout_seconds=0.2,
+                index_path=tmp_path / "index.json", evidence_root=tmp_path,
+                max_age_seconds=900,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    started = time.monotonic()
+    request_thread = threading.Thread(target=read_from_request_thread)
+    request_thread.start()
+    request_thread.join(1)
+
+    assert not request_thread.is_alive()
+    assert time.monotonic() - started < 0.75
+    if slow_validation:
+        assert validation_started.is_set()
+        assert not release_validation.is_set()
+    assert len(errors) == 1
+    assert isinstance(errors[0], CaptureOneRejected)
+    assert errors[0].code == expected_code
+    if expected_code == "DISCOVERY_TIMEOUT":
+        assert errors[0].details == {"budget_seconds": 0.2}
+    reaped_deadline = time.monotonic() + 2
+    while process.poll() is None and time.monotonic() < reaped_deadline:
+        time.sleep(0.01)
+    assert process.poll() is not None
+    assert capture._current_index_reader_client is not None
+    assert capture._current_index_reader_client.invalidated.is_set()
+    release_validation.set()
+    capture.shutdown_current_index_reader_worker()
+
+
+def test_threaded_current_race_index_preserves_child_rejection(tmp_path: Path):
+    capture.initialize_current_index_reader_worker()
+    errors: list[BaseException] = []
+
+    def read_from_request_thread() -> None:
+        try:
+            bounded_current_race_index(
+                current_time=NOW, timeout_seconds=1,
+                index_path=tmp_path / "missing.json", evidence_root=tmp_path,
+                max_age_seconds=900,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    try:
+        request_thread = threading.Thread(target=read_from_request_thread)
+        request_thread.start()
+        request_thread.join(2)
+        assert not request_thread.is_alive()
+        assert len(errors) == 1
+        assert isinstance(errors[0], CaptureOneRejected)
+        assert errors[0].code == "CURRENT_INDEX_UNAVAILABLE"
+        assert errors[0].details == {"path": str(tmp_path / "missing.json")}
+        assert capture._current_index_reader_client is not None
+        assert capture._current_index_reader_client.process.poll() is None
+    finally:
+        capture.shutdown_current_index_reader_worker()
 
 
 def test_current_race_index_publishes_explicit_safe_subset_from_mixed_candidates(


### PR DESCRIPTION
## Summary
- preserve the strict SIGALRM current-index reader on main-thread callers
- run that same retained-file validation in a bounded fork child for request-thread callers, with fail-closed IPC handling and forced cleanup
- restore the generated connected UI to normal threaded serving now that strict discovery is thread-safe

## Live reproduction
- exact-master single-threaded UI reads took about 88 seconds under legacy background work, preventing an unlocked readiness observation between one-minute collector cycles
- this branch read the live canonical V2 index from a request thread in 0.017 seconds and returned a `VerifiedCurrentRaceIndex`
- no prediction POST was issued; operations counts remain 5 jobs / 5 attempts / 35 events

## Validation
- `75 passed` — full `tests/race_collection/test_synchronous_manual_capture.py`
- `446 passed` across live adapters, prediction worker, bootstrap, and deployment generator
- four shared-`/tmp` trust-policy cases passed under an owner-only `TMPDIR`
- one unrelated prediction-worker wall-clock assertion fails at ~3.16s on both this branch and unchanged master
- focused threaded success and hard-timeout tests pass
- `py_compile` and `git diff --check` pass
