### PR TITLE
Preserve pinned Python launch prefix

### DIFF
--- a/docs/operator_ui_v1/CONTRACTS.md
+++ b/docs/operator_ui_v1/CONTRACTS.md
@@ -465,6 +465,17 @@ invoke the one fixed-argv collector-owned `capture-one` entrypoint described in
 sections 1 and 7; the background timer remains unchanged and is not manual
 request transport.
 
+The worker's descriptor-bound exact-byte launch identity covers the fixed
+Python executable and predictor script. CPython still resolves `pyvenv.cfg`,
+the standard library and installed packages from the deployment-pinned Python
+installation named by the generated binding. The binding selects but does not
+hash or request-time revalidate that import tree, and service filesystem
+controls do not hide host-side changes. Those dependencies are deliberately
+outside the descriptor-sealed exact-byte claim; this worker does not detect or
+stop an external same-owner mutation or a writable-root overlap in a
+misconfigured package. Any stronger interpreter-environment integrity claim is
+unsupported by this contract.
+
 ## 9. Release and proof gates
 
 R1 requires fixture-only values, both mandatory labels, no operational

--- a/src/operator_ui/deployment.py
+++ b/src/operator_ui/deployment.py
@@ -701,6 +701,8 @@ def generate_package(*, source_root: Path, pinned_python: Path, evidence_root: P
     if stat.S_IMODE(secrets_info.st_mode) != 0o600:
         raise DeploymentRejected("secrets file must have exact mode 0600")
     _separate((source, evidence, producer, operations, output))
+    if python == operations or operations in python.parents:
+        raise DeploymentRejected("pinned Python must be separate from the writable operations root")
     if any(database == root or root in database.parents for root in (source, evidence, producer, operations, output)):
         raise DeploymentRejected("canonical database must be separate from deployment roots")
     if secrets.samefile(database):

--- a/src/operator_ui/prediction_worker.py
+++ b/src/operator_ui/prediction_worker.py
@@ -335,8 +335,10 @@ def run_once(store:JobStore,job_id:str,config:WorkerConfig,*,now:Callable[[],dat
     try:
         _validate_runtime(config); _validate_choice(job,config)
         runtime_fds=_open_runtime_descriptors(config)
-        retained=(f"/proc/self/fd/{runtime_fds[0]}",f"/proc/self/fd/{runtime_fds[1]}",*argv[2:])
-        try: process=popen(retained,executable=retained[0],pass_fds=runtime_fds,shell=False,stdin=subprocess.DEVNULL,stdout=subprocess.PIPE,stderr=subprocess.PIPE,start_new_session=False)
+        # Execute the retained bytes, but preserve argv[0] so CPython can resolve pyvenv.cfg.
+        executable=f"/proc/self/fd/{runtime_fds[0]}"
+        retained=(argv[0],f"/proc/self/fd/{runtime_fds[1]}",*argv[2:])
+        try: process=popen(retained,executable=executable,pass_fds=runtime_fds,shell=False,stdin=subprocess.DEVNULL,stdout=subprocess.PIPE,stderr=subprocess.PIPE,start_new_session=False)
         finally:
             for fd in runtime_fds:
                 try: os.close(fd)

--- a/tests/operator_ui/test_deployment_generator.py
+++ b/tests/operator_ui/test_deployment_generator.py
@@ -424,6 +424,21 @@ def test_generator_rejects_unsafe_missing_or_overlapping_inputs_without_partial_
     assert not (values["source_root"] / "var/operator_ui/generated/repository-v1.binding.json").exists()
 
 
+def test_generator_rejects_pinned_python_inside_writable_operations_root(tmp_path, monkeypatch):
+    values = deployment_inputs(tmp_path)
+    git_identity(monkeypatch)
+    python = values["operations_root"] / "python"
+    python.write_text("python")
+    python.chmod(0o700)
+    values["pinned_python"] = python
+
+    with pytest.raises(DeploymentRejected, match="separate from the writable operations root"):
+        generate_package(**values)
+
+    assert not (values["output_dir"] / "greyhound-operator-ui-r3.service").exists()
+    assert not (values["source_root"] / "var/operator_ui/generated/repository-v1.binding.json").exists()
+
+
 @pytest.mark.parametrize(
     "root_name",
     ["source_root", "evidence_root", "producer_root", "operations_root", "output_dir"],

--- a/tests/operator_ui/test_prediction_worker.py
+++ b/tests/operator_ui/test_prediction_worker.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import hashlib,io,json,sqlite3,subprocess,threading,time
+import hashlib,io,json,os,sqlite3,subprocess,sys,threading,time,venv
 from dataclasses import replace
 from datetime import datetime,timezone
 from pathlib import Path
@@ -62,12 +62,25 @@ def test_launch_uses_only_retained_runtime_descriptors(tmp_path):
     cfg,store,job=setup(tmp_path); calls=[]
     def popen(argv,**kwargs):
         calls.append((argv,kwargs))
-        assert argv[0].startswith("/proc/self/fd/") and argv[1].startswith("/proc/self/fd/")
-        assert kwargs["executable"]==argv[0]
-        assert tuple(sorted(kwargs["pass_fds"]))==tuple(sorted((int(argv[0].rsplit("/",1)[1]),int(argv[1].rsplit("/",1)[1]))))
+        assert argv[0]==str(cfg.pinned_python) and argv[1].startswith("/proc/self/fd/")
+        assert kwargs["executable"].startswith("/proc/self/fd/")
+        assert tuple(sorted(kwargs["pass_fds"]))==tuple(sorted((int(kwargs["executable"].rsplit("/",1)[1]),int(argv[1].rsplit("/",1)[1]))))
         return Process(ready(job))
     assert run_once(store,job.job_id,cfg,now=lambda:NOW,confirm_audit=CONFIRM,popen=popen,reader=lambda **_:view()).phase is Phase.PRODUCER_COMPLETED
     assert len(calls)==1
+
+def test_descriptor_backed_python_preserves_venv_prefix_via_fixed_argv0(tmp_path):
+    runtime=tmp_path/"runtime"; venv.EnvBuilder(with_pip=False,symlinks=False).create(runtime)
+    python=runtime/("Scripts/python.exe" if sys.platform=="win32" else "bin/python")
+    def launch(argv0):
+        fd=os.open(python,os.O_RDONLY|os.O_CLOEXEC|os.O_NOFOLLOW)
+        descriptor=f"/proc/self/fd/{fd}"
+        try:
+            return subprocess.run((argv0(descriptor),"-c","import encodings,json,sys;print(json.dumps({'prefix':sys.prefix}))"),executable=descriptor,pass_fds=(fd,),stdin=subprocess.DEVNULL,stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True,timeout=10,check=False)
+        finally:os.close(fd)
+    old=launch(lambda descriptor:descriptor); repaired=launch(lambda _descriptor:str(python))
+    assert repaired.returncode==0 and Path(json.loads(repaired.stdout)["prefix"]).resolve()==runtime.resolve()
+    assert old.returncode!=0 or Path(json.loads(old.stdout)["prefix"]).resolve()!=runtime.resolve()
 
 @pytest.mark.parametrize("races,reason",[([],"RACE_ID_MISSING_OR_AMBIGUOUS"),([{"race_id":RACE_ID,"jump_datetime":"bad","runner_set_sha256":H}],"RACE_JUMP_CHANGED"),([{"race_id":RACE_ID,"jump_datetime":"2026-08-01T01:00:00+00:00","runner_set_sha256":"0"*64}],"RUNNER_SET_CHANGED")])
 def test_revalidation_missing_changed(tmp_path,races,reason):


### PR DESCRIPTION
Fixes the reproduced Operator UI predictor launch failure where descriptor-as-argv0 made the deployment-pinned CPython lose its venv prefix and fail importing encodings.

- execute retained validated Python bytes while preserving the fixed validated Python path as argv0
- add a real temporary-venv subprocess regression plus retained-descriptor contract coverage
- reject pinned Python beneath the writable operations root before package output
- document the exact executable/script byte boundary and unsupported import-tree integrity claim

Validation:
- exact runtime reproduction: old launch exits 1; repaired launch exits 0
- 47 worker tests passed, 1 baseline timing case deselected after failing identically on unchanged master
- 9 adjacent R3 API tests passed
- focused final repair tests: 3 passed
- py_compile and git diff --check passed
- independent Standards and Spec review: CLEAR

The failed live job remains preserved. No retry or additional prediction POST occurred.