### PR TITLE
Fix Operator UI R3 prediction bundle root

### DIFF
--- a/docs/operator_ui_v1/CONTRACTS.md
+++ b/docs/operator_ui_v1/CONTRACTS.md
@@ -518,10 +518,13 @@ evidence deletion, and matching deployed commit/tree/unit/config hashes.
 The finite `repository-v1` composition is default-off. Its checked-in profile
 defines exact relative locators and the one fixed generated-binding location;
 the later repository-owned deployment generator must bind the deployed source,
-pinned regular Python, authoritative collector DB/evidence/current-index,
-producer bundle/protocol root, and separate writable Operator UI operations
-root. A missing, malformed, symlinked, permission-unsafe, overlapping, or
-incomplete binding/source fails startup. The application accepts no binding
+pinned regular Python, authoritative collector DB/evidence/current-index and
+protocol root, a read-only historical producer preservation root, and the
+separate writable Operator UI operations root containing the current private
+prediction-bundle root. Current bundle production and catalog reads never use
+the historical producer root. A missing, malformed, symlinked,
+permission-unsafe, overlapping, or incomplete binding/source fails startup.
+The application accepts no binding
 path or arbitrary path, root, executable, command, lock, time, or model
 location from environment, operator, API, or browser input.
 

--- a/docs/operator_ui_v1/DEPLOYMENT.md
+++ b/docs/operator_ui_v1/DEPLOYMENT.md
@@ -15,12 +15,15 @@ copy. Regenerate it from the exact reviewed source instead.
 The generator requires exact source commit/tree/version/profile identities; a
 pinned regular owner-executable Python; the checked-in repository-v1 profile
 and five fixed prediction artifacts; the authoritative canonical database,
-evidence/current-index and collector-protocol roots; the authoritative
-prediction-bundle producer root; and a separate writable Operator UI operations
-root. Missing, symlinked, unsafe, overlapping, malformed, or public inputs fail
-before package output is written. The service namespace mounts source,
-collector evidence, producer evidence, and the canonical database read-only;
-only the separate operations root is writable.
+evidence/current-index and collector-protocol root; the historical producer
+evidence root retained solely as an explicit read-only preservation boundary;
+and a separate writable Operator UI operations root containing the current
+prediction-bundle root. The current worker and bundle catalog do not consume
+the historical producer root. Missing, symlinked, unsafe, overlapping,
+malformed, or public inputs fail before package output is written. The service
+namespace mounts source, collector evidence, historical producer evidence, and
+the canonical database read-only; only the separate operations root is
+writable.
 
 An enabled package additionally requires `--live-authority` pointing to one
 server-owned `operator_ui_live_authority_v1` observation. It names the exact

--- a/src/operator_ui/bootstrap.py
+++ b/src/operator_ui/bootstrap.py
@@ -183,7 +183,7 @@ def _repository_layout()->dict[str,Any]:
     operations=roots["operations_root"].resolve()
     if any(operations==root or operations.is_relative_to(root) or root.is_relative_to(operations) for root in read_roots) or roots["canonical_db"].resolve().is_relative_to(operations):raise RuntimeError("fixed R3 paths overlap")
     paths={"audit.sqlite3":operations/locators["audit_store"],"jobs.sqlite3":operations/locators["job_store"],"canonical.sqlite3":roots["canonical_db"],"current_index.json":roots["evidence_root"]/locators["current_index"]}
-    dirs={"current_evidence":roots["evidence_root"],"prediction_bundles":roots["producer_root"]/locators["prediction_bundles"],"collector_requests":roots["evidence_root"]/locators["collector_protocol"],"capture_evidence_a":roots["evidence_root"]}
+    dirs={"current_evidence":roots["evidence_root"],"prediction_bundles":operations/locators["prediction_bundles"],"collector_requests":roots["evidence_root"]/locators["collector_protocol"],"capture_evidence_a":roots["evidence_root"]}
     artifacts={"script":roots["source_root"]/locators["prediction_script"],"config":roots["source_root"]/locators["prediction_config"],"model":roots["source_root"]/locators["model_artifact"],"manifest":roots["source_root"]/locators["model_manifest"],"schema":roots["source_root"]/locators["model_schema"]}
     if roots["source_root"]!=_REPOSITORY_ROOT:raise RuntimeError("generated repository-v1 source identity mismatch")
     _regular(paths["current_index.json"])

--- a/src/operator_ui/deployment.py
+++ b/src/operator_ui/deployment.py
@@ -714,7 +714,7 @@ def generate_package(*, source_root: Path, pinned_python: Path, evidence_root: P
     app_path = _safe_existing(source / "app.py", directory=False)
     index = _safe_existing(evidence / "shadow_autopilot_daemon_runtime/manual_prediction_current_race_index.json", directory=False)
     protocol = _safe_existing(evidence / "manual_prediction_collector_requests_v1", directory=True)
-    bundles = _safe_existing(producer / "artifacts/on_demand_prediction_runs", directory=True)
+    bundles = _safe_existing(operations / "artifacts/on_demand_prediction_runs", directory=True)
     artifact_paths = {name: _safe_existing(source / relative, directory=False) for name, relative in _ARTIFACTS.items()}
     _validate_secrets_file(secrets)
 
@@ -757,8 +757,9 @@ def generate_package(*, source_root: Path, pinned_python: Path, evidence_root: P
 
 Regenerate this package without `--enable`, stop/disable only
 `greyhound-operator-ui-r3.service`, and verify the existing UI remains available.
-Do not delete `{operations}`: it contains Operator UI audit/job evidence. Do not
-delete `{producer}` or `{evidence}`: prediction and collector evidence is retained.
+Do not delete `{operations}`: it contains Operator UI audit/job and prediction
+bundle evidence. Do not delete `{producer}` or `{evidence}`: producer and collector
+evidence is retained.
 Rollback changes the feature gate only; it does not edit installed/generated files
 by hand and does not alter the canonical database `{database}`.
 """

--- a/tests/operator_ui/test_bootstrap.py
+++ b/tests/operator_ui/test_bootstrap.py
@@ -122,8 +122,8 @@ def repository_binding_fixture(tmp_path,monkeypatch):
     copies={profile_source:repo/"configs/operator_ui/repository-v1.toml",source_root/"configs/prediction/manual-default.json":repo/"configs/prediction/manual-default.json",source_root/"scripts/predict_race_now.py":repo/"scripts/predict_race_now.py",model.model_path:repo/model.model_path.relative_to(source_root),model.manifest_path:repo/model.manifest_path.relative_to(source_root),model.schema_path:repo/model.schema_path.relative_to(source_root)}
     for source,target in copies.items():target.parent.mkdir(parents=True,exist_ok=True);shutil.copy2(source,target)
     evidence=tmp_path/"authoritative-evidence"; producer=tmp_path/"producer"; operations=tmp_path/"operator-ui-operations"
-    (evidence/"shadow_autopilot_daemon_runtime").mkdir(parents=True);(evidence/"manual_prediction_collector_requests_v1").mkdir();(producer/"artifacts/on_demand_prediction_runs").mkdir(parents=True);operations.mkdir()
-    for directory in (repo,evidence,producer,operations,evidence/"manual_prediction_collector_requests_v1",producer/"artifacts/on_demand_prediction_runs"):directory.chmod(0o700)
+    (evidence/"shadow_autopilot_daemon_runtime").mkdir(parents=True);(evidence/"manual_prediction_collector_requests_v1").mkdir();producer.mkdir();operations.mkdir();(operations/"artifacts/on_demand_prediction_runs").mkdir(parents=True)
+    for directory in (repo,evidence,producer,operations,evidence/"manual_prediction_collector_requests_v1",operations/"artifacts/on_demand_prediction_runs"):directory.chmod(0o700)
     (evidence/"shadow_autopilot_daemon_runtime/manual_prediction_current_race_index.json").write_bytes(b"{}")
     python=tmp_path/"pinned-python";python.write_bytes(b"runtime");python.chmod(0o700)
     canonical=tmp_path/"canonical.sqlite3";canonical.write_bytes(b"canonical-read-only");canonical.chmod(0o400)
@@ -167,15 +167,15 @@ def repository_binding_fixture(tmp_path,monkeypatch):
 
 
 def test_repository_profile_binds_authoritative_sources_and_separate_operations_without_canonical_write(tmp_path,monkeypatch):
-    repo,evidence,producer,operations,canonical=repository_binding_fixture(tmp_path,monkeypatch);before=canonical.read_bytes()
+    repo,evidence,producer,operations,canonical=repository_binding_fixture(tmp_path,monkeypatch);before=canonical.read_bytes();legacy=(producer/"legacy-producer-evidence");legacy.write_bytes(b"preserve");legacy_before=legacy.read_bytes()
     app=Flask(__name__);app.config.update(TESTING=True,OPERATOR_UI_CONNECTED_MODE=True,OPERATOR_UI_SECRET_KEY="repository-secret-"+"x"*40,OPERATOR_UI_USERNAME="operator",OPERATOR_UI_PASSWORD_HASH=generate_password_hash("correct horse"),OPERATOR_UI_LEVEL=2,OPERATOR_UI_DEPLOYED_COMMIT="21e7b02e60e82da9c4dbbb796ea435bc120e9862",OPERATOR_UI_DEPLOYED_TREE="2cfc75cd8a2af1a9e5da4986c969cb668b93af62",OPERATOR_UI_DEPLOYED_VERSION="operator-ui-v1",OPERATOR_UI_DEPLOYED_PROFILE="repository-v1")
     app.config[R3_PROFILE_KEY]="repository-v1";assert bootstrap_module.configure_r3_startup(app) is True
     assert Path(app.config["OPERATOR_UI_AUDIT_DB_PATH"]).parent==operations and Path(app.config["DATABASE_PATH"])==canonical
     install_connected_mode(app);assert bind_configured_r3(app) is True
     worker=app.extensions["operator_ui_r3_services"].launch_once._worker
-    assert worker.repository_root==repo and worker.current_index_evidence_root==evidence and worker.output_root==producer/"artifacts/on_demand_prediction_runs"
+    assert worker.repository_root==repo and worker.current_index_evidence_root==evidence and worker.output_root==operations/"artifacts/on_demand_prediction_runs"
     assert worker.canonical_db==canonical and worker.collector_request_root==evidence/"manual_prediction_collector_requests_v1"
-    assert canonical.read_bytes()==before and not (operations/"canonical.sqlite3").exists()
+    assert canonical.read_bytes()==before and legacy.read_bytes()==legacy_before and not (operations/"canonical.sqlite3").exists()
     live=app.config[bootstrap_module.CONFIG_KEY]
     source_limits={key:config.max_bytes for key,config in live._reader._sources.items()}
     assert source_limits=={

--- a/tests/operator_ui/test_deployment_generator.py
+++ b/tests/operator_ui/test_deployment_generator.py
@@ -72,7 +72,7 @@ def deployment_inputs(tmp_path: Path) -> dict[str, object]:
     (evidence / "shadow_autopilot_daemon_runtime").mkdir(mode=0o700)
     (evidence / "manual_prediction_collector_requests_v1").mkdir(mode=0o700)
     (evidence / "shadow_autopilot_daemon_runtime/manual_prediction_current_race_index.json").write_text("{}")
-    (producer / "artifacts/on_demand_prediction_runs").mkdir(parents=True, mode=0o700)
+    (operations / "artifacts/on_demand_prediction_runs").mkdir(parents=True, mode=0o700)
     python = tmp_path / "python"
     python.write_text("python")
     python.chmod(0o700)


### PR DESCRIPTION
## Summary
- bind current prediction bundle production and catalog reads to the dedicated writable operations root
- retain the historical producer root only as an explicit read-only preservation boundary
- align deployment/contract documentation and regression fixtures

## Live defect reproduced
The generated UI unit mounts the source, evidence, historical producer tree, and canonical DB read-only, with only the operations root writable. Bootstrap nevertheless passed the producer-tree bundle directory to the predictor, so live bundle creation failed with `PermissionError` and surfaced as `PROCESS_OUTPUT_INVALID`.

## Validation
- `160 passed` — `tests/operator_ui/test_bootstrap.py tests/operator_ui/test_deployment_generator.py`
- focused connected mapping/preservation regression passed
- `py_compile` passed
- `git diff --check` passed

No prediction POST is part of this PR or its validation.