### PR TITLE
Bound CI apt dependency installs

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -106,9 +106,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     
     - name: Install system dependencies
+      timeout-minutes: 5
       run: |
-        sudo apt-get update
-        sudo apt-get install -y postgresql-client
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y postgresql-client
     
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,10 @@ jobs:
           ${{ runner.os }}-pip-
 
     - name: Install system dependencies
+      timeout-minutes: 5
       run: |
-        sudo apt-get update
-        sudo apt-get install -y postgresql-client
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y postgresql-client
 
     - name: Install Python dependencies
       run: |


### PR DESCRIPTION
## Summary

- bound GitHub-hosted apt setup to five minutes per affected workflow
- add three apt retries with 30-second HTTP/HTTPS transport timeouts
- force noninteractive package installation

## Root cause

PR #152's backend lane stalled twice on separate GitHub-hosted runners in the system-dependency step. The identical step normally completed in eight seconds, but the workflow had no step or apt transport timeout, so an external package-network stall remained in progress indefinitely.

## Impact

Package infrastructure failures now retry briefly and then terminate with a concrete failed check instead of occupying a runner for the six-hour job default. Test and prediction semantics are unchanged.

## Validation

- both workflow files parse successfully with PyYAML
- `git diff --check` passes
- no dependency, application, model, or prediction files changed
