### PR TITLE
Add prospective TheDogs market snapshot adapter

### DIFF
--- a/docs/thedogs_market_history_capture.md
+++ b/docs/thedogs_market_history_capture.md
@@ -1,0 +1,97 @@
+# Prospective TheDogs market-history capture
+
+This path records point-in-time TheDogs `/odds` evidence for future,
+development-only research. It does not train, score, promote, emit EV, or place
+bets. The source class is
+`thedogs_prospective_point_in_time_market_history`; it is not Sportsbet
+evidence and it is separate from historical published OPEN/LOW/HIGH summaries.
+
+## Snapshot contract
+
+Each plan names one exact HTTPS URL of the form:
+
+`https://www.thedogs.com.au/racing/<venue>/<YYYY-MM-DD>/<race-number>/<race-name>/odds`
+
+Queries, fragments, redirects, name-free numeric URLs, other hosts, and other
+paths fail closed. The collector warms the date meeting page and the exact race
+page, requires the plan's declared active native-ID set to match the page,
+requests the exact `/odds` page once, extracts the identified runner IDs and
+active/scratched field (excluding only a source-labelled vacant-box slot), and
+requests TheDogs' native runner-odds JSON once.
+There is no retry, discovery, race substitution, or provider substitution.
+
+An accepted snapshot contains:
+
+- externally recorded UTC request start/end times and strict
+  `capture_end_utc < jump_timestamp`;
+- the exact source/final URLs, status and selected HTTP response metadata;
+- raw `/odds` HTML plus SHA-256;
+- base64-preserved raw jump-page and runner-odds API bytes plus SHA-256;
+- the exact jump-source URL, timestamp, native race identity, and source hash;
+- every identified page runner's native ID, box, scratch state, and every
+  active runner's current point-in-time fixed-WIN price;
+- the provider declared in the source API, or `provider_unknown` if the source
+  does not declare one; and
+- one receipt-core hash and immutable read-only raw/receipt files.
+
+The page's OPEN/LOW/HIGH values are extrema summaries. They are retained only
+in the raw source and never counted as ordered or temporal observations.
+
+## Effective boxes for reserves and replacements
+
+Runner identity remains the numeric native ID from the exact odds page and the
+same ID in the runner-odds API. A name, suffix, price, display order, or nearby
+row never resolves a box.
+
+The collector preserves four distinct box fields in each runner projection:
+
+- `box` and `page_box`: the original page rug from `sprite-svg name="rug_N"`;
+- `page_effective_box`: the optional explicit
+  `race-runners__name__box` text `(from box N)`;
+- `api_run_box`: the unchanged `run_box` value from the native runner's sole
+  fixed-win API quote; and
+- `effective_box`: the resolved active starting box, or `null` for an inactive
+  runner.
+
+For a normal active runner, page rug and API `run_box` must match. For a
+replacement, the page must explicitly say `(from box N)` and that value must
+match the same native runner's API `run_box`. Effective boxes must be unique
+across active runners. A scratched original may retain the same API `run_box`
+as its active replacement, but it has no active `effective_box`.
+
+Missing or malformed explicit box text, multiple mappings, non-unique native
+IDs, page/API disagreement, invalid API boxes, active/scratch price conflicts,
+or duplicate active effective boxes fail closed. Raw HTML and the full native
+API body remain receipt-bound, so the independent auditor recomputes the rule
+instead of trusting the stored projection.
+
+Existing raw/receipt pairs are validated and returned as an idempotent skip.
+A partial pair, changed raw bytes, mismatched plan identity, or changed receipt
+fails as conflicting evidence. The collector never overwrites a snapshot.
+
+## Fixed windows and audit semantics
+
+The only nominal windows are `T-120`, `T-60`, `T-30`, `T-10`, and `T-2`.
+The default due interval is 30 seconds early through 90 seconds late. Actual
+request and capture times are always recorded. A run outside that interval is
+missed; it is not reassigned or interpolated.
+
+The auditor counts one accepted complete snapshot as one temporal observation,
+not one observation per runner. Duplicate references to identical evidence do
+not increase depth. A race becomes trajectory-ready only when all five windows
+have distinct, complete, strictly pre-jump snapshots with no conflict or
+rejection.
+
+Capture one due item:
+
+```bash
+python3 scripts/capture_thedogs_market_history.py plan.json \
+  --output-dir reports/agent_jobs/<job>/capture/<race>/T-120
+```
+
+Audit an immutable manifest:
+
+```bash
+python3 scripts/audit_thedogs_market_history_snapshots.py manifest.json \
+  --output-dir reports/agent_jobs/<job>/audit
+```

--- a/scripts/audit_thedogs_market_history_snapshots.py
+++ b/scripts/audit_thedogs_market_history_snapshots.py
@@ -29,6 +29,8 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from scripts.capture_thedogs_market_history import (
+    DEFAULT_EARLY_TOLERANCE_SECONDS,
+    DEFAULT_LATE_TOLERANCE_SECONDS,
     NOMINAL_WINDOWS,
     RECEIPT_SCHEMA_VERSIONS,
     SERVER_DATE_TOLERANCE_SECONDS,
@@ -322,6 +324,32 @@ def _audit_entry(
     )
     if request_end != api_request_end:
         raise AuditError("request_end_odds_api_end_mismatch")
+    meeting_end = parse_timestamp(
+        warm_meeting.get("request_end_utc"), field="warm_meeting_end"
+    )
+    if not isinstance(jump_source, Mapping):
+        raise AuditError("jump_source_receipt_missing")
+    jump_request_start = parse_timestamp(
+        jump_source.get("request_start_utc"), field="jump_source_start"
+    )
+    jump_request_end = parse_timestamp(
+        jump_source.get("request_end_utc"), field="jump_source_end"
+    )
+    odds_request_end = parse_timestamp(
+        odds_http.get("request_end_utc"), field="odds_page_end"
+    )
+    api_request_start = parse_timestamp(
+        api_http.get("request_start_utc"), field="odds_api_start"
+    )
+    if not (
+        meeting_end <= jump_request_start
+        <= jump_request_end
+        <= odds_request_start
+        <= odds_request_end
+        <= api_request_start
+        <= api_request_end
+    ):
+        raise AuditError("request_chain_time_order_invalid")
     _verify_api_url(str(api_http.get("requested_url") or ""), source_all_ids)
     try:
         api_payload = json.loads(api_body.decode("utf-8"))
@@ -380,9 +408,11 @@ def _audit_entry(
         not isinstance(early_tolerance, int)
         or isinstance(early_tolerance, bool)
         or early_tolerance < 0
+        or early_tolerance > DEFAULT_EARLY_TOLERANCE_SECONDS
         or not isinstance(late_tolerance, int)
         or isinstance(late_tolerance, bool)
         or late_tolerance < 0
+        or late_tolerance > DEFAULT_LATE_TOLERANCE_SECONDS
     ):
         raise AuditError("window_tolerance_invalid")
     if capture_end < nominal_capture - timedelta(seconds=early_tolerance):

--- a/scripts/audit_thedogs_market_history_snapshots.py
+++ b/scripts/audit_thedogs_market_history_snapshots.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python3
+"""Audit immutable prospective TheDogs ``/odds`` snapshot receipts.
+
+Each accepted snapshot is one temporal observation, irrespective of runner
+count or the page's OPEN/LOW/HIGH extrema.  A race is trajectory-ready only
+when all five prescribed windows contain complete, independently timed,
+strictly pre-jump snapshots.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import math
+import re
+import sys
+from collections import Counter
+from collections.abc import Mapping
+from datetime import date, timedelta, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.capture_thedogs_market_history import (
+    NOMINAL_WINDOWS,
+    RECEIPT_SCHEMA_VERSIONS,
+    SERVER_DATE_TOLERANCE_SECONDS,
+    SOURCE_CLASS,
+    CaptureError,
+    canonical_json_bytes,
+    exact_odds_identity,
+    normalize_api_snapshot,
+    parse_jump_from_source,
+    parse_source_runners,
+    parse_timestamp,
+    planned_time,
+    sha256_bytes,
+)
+
+SCHEMA_VERSION = "thedogs_market_history_audit_v2"
+READY = "THEDOGS_MARKET_HISTORY_CAPTURE_READY"
+PARTIAL = "THEDOGS_MARKET_HISTORY_CAPTURE_PARTIAL"
+BLOCKED = "BLOCKED_LIVE_CAPTURE_OR_PROVENANCE"
+
+
+class AuditError(ValueError):
+    """Raised when a snapshot or manifest cannot be verified safely."""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _decode_embedded_body(payload: Mapping[str, Any], *, field: str) -> bytes:
+    encoded = payload.get("body_base64")
+    if not isinstance(encoded, str) or not encoded:
+        raise AuditError(f"{field}_raw_bytes_missing")
+    try:
+        body = base64.b64decode(encoded, validate=True)
+    except ValueError as exc:
+        raise AuditError(f"{field}_raw_bytes_invalid") from exc
+    if sha256_bytes(body) != payload.get("body_sha256"):
+        raise AuditError(f"{field}_raw_hash_mismatch")
+    if len(body) != payload.get("body_bytes"):
+        raise AuditError(f"{field}_raw_size_mismatch")
+    return body
+
+
+def _verify_http_receipt(
+    payload: Any,
+    *,
+    field: str,
+    expected_url: str | None = None,
+    content_type: str,
+    require_body: bool,
+) -> bytes | None:
+    if not isinstance(payload, Mapping):
+        raise AuditError(f"{field}_receipt_missing")
+    requested_url = str(payload.get("requested_url") or "")
+    final_url = str(payload.get("final_url") or "")
+    if not requested_url or requested_url != final_url:
+        raise AuditError(f"{field}_redirect_or_url_mismatch")
+    if expected_url is not None and requested_url != expected_url:
+        raise AuditError(f"{field}_url_mismatch")
+    if payload.get("status_code") != 200:
+        raise AuditError(f"{field}_http_status_invalid")
+    headers = payload.get("headers")
+    if not isinstance(headers, Mapping):
+        raise AuditError(f"{field}_http_headers_missing")
+    observed_type = str(headers.get("content-type") or "").lower()
+    if not observed_type.startswith(content_type):
+        raise AuditError(f"{field}_content_type_invalid")
+    observed_encoding = str(headers.get("content-encoding") or "").lower()
+    if observed_encoding not in {"", "identity"}:
+        raise AuditError(f"{field}_content_encoding_not_identity")
+    start = parse_timestamp(payload.get("request_start_utc"), field=f"{field}_start")
+    end = parse_timestamp(payload.get("request_end_utc"), field=f"{field}_end")
+    if end < start:
+        raise AuditError(f"{field}_receipt_time_order_invalid")
+    server_date_text = str(headers.get("date") or "")
+    if not server_date_text:
+        raise AuditError(f"{field}_server_date_missing")
+    try:
+        server_date = parsedate_to_datetime(server_date_text).astimezone(timezone.utc)
+    except (TypeError, ValueError) as exc:
+        raise AuditError(f"{field}_server_date_invalid") from exc
+    age_text = str(headers.get("age") or "0").strip()
+    try:
+        age_seconds = int(age_text)
+    except ValueError as exc:
+        raise AuditError(f"{field}_server_age_invalid") from exc
+    if age_seconds < 0 or age_seconds > 300:
+        raise AuditError(f"{field}_server_age_invalid")
+    latest_server_date = server_date + timedelta(seconds=age_seconds)
+    tolerance = timedelta(seconds=SERVER_DATE_TOLERANCE_SECONDS)
+    if not (server_date <= end + tolerance and latest_server_date >= start - tolerance):
+        raise AuditError(f"{field}_server_date_outside_request_interval")
+    expected_hash = str(payload.get("body_sha256") or "")
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_hash):
+        raise AuditError(f"{field}_body_hash_invalid")
+    return _decode_embedded_body(payload, field=field) if require_body else None
+
+
+def _verify_api_url(url: str, expected_runner_ids: set[str]) -> None:
+    parsed = urlparse(url)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "www.thedogs.com.au"
+        or parsed.netloc != "www.thedogs.com.au"
+        or parsed.path != "/api/runners/odds"
+        or parsed.params
+        or parsed.fragment
+    ):
+        raise AuditError("odds_api_url_invalid")
+    query = parse_qs(parsed.query)
+    observed_values = [str(value) for value in query.get("runner_ids[]", [])]
+    observed_ids = set(observed_values)
+    if (
+        set(query) != {"runner_ids[]"}
+        or len(observed_values) != len(observed_ids)
+        or observed_ids != expected_runner_ids
+    ):
+        raise AuditError("odds_api_native_runner_query_mismatch")
+
+
+def _finite_current_price(value: Any) -> bool:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return False
+    return math.isfinite(parsed) and parsed > 1.0
+
+
+def _race_date_from_url(odds_url: str) -> date:
+    identity = exact_odds_identity(odds_url)
+    return date.fromisoformat(str(identity["race_date"]))
+
+
+def _resolve_manifest_file(entry: Mapping[str, Any], key: str) -> Path:
+    value = str(entry.get(key) or "").strip()
+    if not value:
+        raise AuditError(f"{key}_required")
+    path = Path(value)
+    if not path.is_file():
+        raise AuditError(f"{key}_missing:{path}")
+    return path.resolve()
+
+
+def _audit_entry(
+    entry: Mapping[str, Any], max_race_date: date | None
+) -> dict[str, Any]:
+    race_id = str(entry.get("race_id") or "").strip()
+    if not race_id:
+        raise AuditError("race_id_required")
+    raw_path = _resolve_manifest_file(entry, "raw_html_path")
+    receipt_path = _resolve_manifest_file(entry, "receipt_path")
+    raw = raw_path.read_bytes()
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise AuditError("receipt_json_invalid") from exc
+    if not isinstance(receipt, Mapping):
+        raise AuditError("receipt_json_invalid")
+    receipt_schema_version = receipt.get("schema_version")
+    if receipt_schema_version not in RECEIPT_SCHEMA_VERSIONS:
+        raise AuditError("receipt_schema_version_invalid")
+    if receipt.get("source_class") != SOURCE_CLASS:
+        raise AuditError("receipt_source_class_invalid")
+    if receipt.get("race_id") != race_id:
+        raise AuditError("receipt_race_id_mismatch")
+    core_hash = str(receipt.get("receipt_core_sha256") or "")
+    core = {key: value for key, value in receipt.items() if key != "receipt_core_sha256"}
+    if core_hash != sha256_bytes(canonical_json_bytes(core)):
+        raise AuditError("receipt_core_hash_mismatch")
+    odds_url = str(entry.get("odds_url") or "").strip()
+    if not odds_url:
+        raise AuditError("manifest_exact_odds_url_required")
+    try:
+        identity = exact_odds_identity(odds_url)
+    except CaptureError as exc:
+        raise AuditError(str(exc)) from exc
+    if receipt.get("race_identity") != identity:
+        raise AuditError("receipt_race_identity_mismatch")
+    if receipt.get("odds_url") != odds_url:
+        raise AuditError("receipt_odds_url_mismatch")
+    if receipt.get("race_url") != identity["race_url"]:
+        raise AuditError("receipt_race_url_mismatch")
+    if max_race_date is not None and _race_date_from_url(odds_url) > max_race_date:
+        raise AuditError("race_outside_development_cutoff")
+    raw_hash = sha256_bytes(raw)
+    if raw_hash != receipt.get("raw_html_sha256"):
+        raise AuditError("raw_html_hash_mismatch")
+    if len(raw) != receipt.get("raw_html_bytes"):
+        raise AuditError("raw_html_size_mismatch")
+    odds_http = receipt.get("odds_page_http")
+    _verify_http_receipt(
+        odds_http,
+        field="odds_page",
+        expected_url=odds_url,
+        content_type="text/html",
+        require_body=False,
+    )
+    if not isinstance(odds_http, Mapping) or odds_http.get("body_sha256") != raw_hash:
+        raise AuditError("odds_page_raw_hash_mismatch")
+    request_start = parse_timestamp(
+        receipt.get("request_start_utc"), field="request_start_utc"
+    )
+    request_end = parse_timestamp(
+        receipt.get("request_end_utc"), field="request_end_utc"
+    )
+    capture_end = parse_timestamp(
+        receipt.get("capture_end_utc"), field="capture_end_utc"
+    )
+    odds_request_start = parse_timestamp(
+        odds_http.get("request_start_utc"), field="odds_page_start"
+    )
+    jump = parse_timestamp(receipt.get("jump_timestamp"), field="jump_timestamp")
+    if request_end != capture_end:
+        raise AuditError("request_end_capture_end_mismatch")
+    if request_start != odds_request_start:
+        raise AuditError("request_start_odds_page_start_mismatch")
+    if request_end < request_start:
+        raise AuditError("request_receipt_time_order_invalid")
+    if capture_end >= jump:
+        raise AuditError("capture_not_strictly_prejump")
+    warm_meeting = receipt.get("warm_meeting_http")
+    _verify_http_receipt(
+        warm_meeting,
+        field="warm_meeting",
+        expected_url=str(identity["meeting_url"]),
+        content_type="text/html",
+        require_body=False,
+    )
+    if not isinstance(warm_meeting, Mapping):
+        raise AuditError("warm_meeting_receipt_missing")
+    capture_start = parse_timestamp(
+        receipt.get("capture_start_utc"), field="capture_start_utc"
+    )
+    meeting_start = parse_timestamp(
+        warm_meeting.get("request_start_utc"), field="warm_meeting_start"
+    )
+    if capture_start != meeting_start:
+        raise AuditError("capture_start_warm_meeting_start_mismatch")
+    jump_source = receipt.get("jump_source")
+    jump_body = _verify_http_receipt(
+        jump_source,
+        field="jump_source",
+        expected_url=str(identity["race_url"]),
+        content_type="text/html",
+        require_body=True,
+    )
+    assert jump_body is not None
+    try:
+        source_jump = parse_jump_from_source(jump_body)
+    except CaptureError as exc:
+        raise AuditError(str(exc)) from exc
+    if source_jump != jump:
+        raise AuditError("jump_source_timestamp_mismatch")
+    try:
+        source_runners = parse_source_runners(raw)
+    except CaptureError as exc:
+        raise AuditError(str(exc)) from exc
+    source_all_ids = {runner.native_runner_id for runner in source_runners}
+    source_active_ids = {
+        runner.native_runner_id for runner in source_runners if runner.active
+    }
+    expected_values = entry.get("expected_active_runner_ids")
+    if not isinstance(expected_values, list) or not expected_values:
+        raise AuditError("expected_active_runner_ids_required")
+    expected_ids = {str(value).strip() for value in expected_values}
+    if "" in expected_ids or len(expected_ids) != len(expected_values):
+        raise AuditError("expected_active_runner_ids_invalid")
+    if expected_ids != source_active_ids:
+        raise AuditError("expected_native_runner_set_mismatch")
+    if set(receipt.get("active_native_runner_ids") or []) != source_active_ids:
+        raise AuditError("receipt_active_native_runner_set_mismatch")
+    if set(receipt.get("all_native_runner_ids") or []) != source_all_ids:
+        raise AuditError("receipt_all_native_runner_set_mismatch")
+    api_http = receipt.get("odds_api_http")
+    api_body = _verify_http_receipt(
+        api_http,
+        field="odds_api",
+        content_type="application/json",
+        require_body=True,
+    )
+    assert api_body is not None
+    if not isinstance(api_http, Mapping):
+        raise AuditError("odds_api_receipt_missing")
+    api_request_end = parse_timestamp(
+        api_http.get("request_end_utc"), field="odds_api_end"
+    )
+    if request_end != api_request_end:
+        raise AuditError("request_end_odds_api_end_mismatch")
+    _verify_api_url(str(api_http.get("requested_url") or ""), source_all_ids)
+    try:
+        api_payload = json.loads(api_body.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise AuditError("odds_api_json_invalid") from exc
+    if not isinstance(api_payload, Mapping):
+        raise AuditError("odds_api_json_invalid")
+    try:
+        normalized_rows, normalized_provider, native_race_id = normalize_api_snapshot(
+            api_payload, source_runners
+        )
+    except CaptureError as exc:
+        raise AuditError(str(exc)) from exc
+    if receipt_schema_version == "thedogs_market_snapshot_receipt_v1":
+        projected_rows = [
+            {
+                key: row[key]
+                for key in (
+                    "native_runner_id",
+                    "runner_name",
+                    "box",
+                    "active",
+                    "current_price",
+                    "provider",
+                )
+            }
+            for row in normalized_rows
+        ]
+    else:
+        projected_rows = normalized_rows
+    if receipt.get("runners") != projected_rows:
+        raise AuditError("receipt_runner_projection_mismatch")
+    if receipt.get("provider") != normalized_provider:
+        raise AuditError("receipt_provider_projection_mismatch")
+    if receipt.get("source_native_race_id") != native_race_id:
+        raise AuditError("receipt_native_race_id_mismatch")
+    if receipt.get("field_complete") is not True:
+        raise AuditError("snapshot_not_marked_complete")
+    active_rows = [row for row in normalized_rows if row["active"]]
+    if len(active_rows) != len(source_active_ids):
+        raise AuditError("active_field_incomplete")
+    if any(not _finite_current_price(row.get("current_price")) for row in active_rows):
+        raise AuditError("active_runner_current_price_invalid")
+    nominal_window = str(receipt.get("nominal_window") or "").upper()
+    if nominal_window not in NOMINAL_WINDOWS:
+        raise AuditError("unsupported_nominal_window")
+    expected_nominal = planned_time(jump, nominal_window)
+    nominal_capture = parse_timestamp(
+        receipt.get("nominal_capture_utc"), field="nominal_capture_utc"
+    )
+    if nominal_capture != expected_nominal:
+        raise AuditError("nominal_capture_timestamp_mismatch")
+    early_tolerance = receipt.get("early_tolerance_seconds")
+    late_tolerance = receipt.get("late_tolerance_seconds")
+    if (
+        not isinstance(early_tolerance, int)
+        or isinstance(early_tolerance, bool)
+        or early_tolerance < 0
+        or not isinstance(late_tolerance, int)
+        or isinstance(late_tolerance, bool)
+        or late_tolerance < 0
+    ):
+        raise AuditError("window_tolerance_invalid")
+    if capture_end < nominal_capture - timedelta(seconds=early_tolerance):
+        raise AuditError("capture_completed_before_nominal_window")
+    if capture_end > nominal_capture + timedelta(seconds=late_tolerance):
+        raise AuditError("capture_completed_after_nominal_window")
+    if entry.get("nominal_window") not in (None, nominal_window):
+        raise AuditError("manifest_nominal_window_mismatch")
+    if receipt.get("open_low_high_are_temporal_observations") is not False:
+        raise AuditError("open_low_high_temporal_semantics_invalid")
+    provider = receipt["provider"]
+    provider_classification = str(provider.get("classification") or "")
+    if provider_classification not in {"provider_explicit", "provider_unknown"}:
+        raise AuditError("provider_classification_invalid")
+    return {
+        "race_id": race_id,
+        "race_identity": identity,
+        "source_native_race_id": native_race_id,
+        "odds_url": odds_url,
+        "raw_html_path": str(raw_path),
+        "receipt_path": str(receipt_path),
+        "raw_html_sha256": raw_hash,
+        "receipt_sha256": _sha256(receipt_path),
+        "receipt_core_sha256": core_hash,
+        "jump_source_sha256": sha256_bytes(jump_body),
+        "odds_api_sha256": sha256_bytes(api_body),
+        "nominal_window": nominal_window,
+        "nominal_capture_utc": receipt.get("nominal_capture_utc"),
+        "request_start_utc": receipt.get("request_start_utc"),
+        "request_end_utc": receipt.get("request_end_utc"),
+        "capture_end_utc": receipt.get("capture_end_utc"),
+        "jump_timestamp": receipt.get("jump_timestamp"),
+        "temporal_observation_count": 1,
+        "snapshot_complete": True,
+        "provider_classification": provider_classification,
+        "provider": provider,
+        "active_runner_count": len(active_rows),
+        "all_runner_count": len(normalized_rows),
+        "active_native_runner_ids": sorted(source_active_ids),
+        "all_native_runner_ids": sorted(source_all_ids),
+        "runners": projected_rows,
+        "open_low_high_are_temporal_observations": False,
+        "status": "ACCEPTED",
+        "blockers": [],
+    }
+
+
+def _race_summary(race_id: str, snapshots: list[dict[str, Any]]) -> dict[str, Any]:
+    accepted = [row for row in snapshots if row.get("status") == "ACCEPTED"]
+    rejected = [row for row in snapshots if row.get("status") != "ACCEPTED"]
+    by_window: dict[str, list[dict[str, Any]]] = {}
+    for row in accepted:
+        by_window.setdefault(str(row["nominal_window"]), []).append(row)
+    conflicts = [
+        window
+        for window, rows in by_window.items()
+        if len({row["receipt_sha256"] for row in rows}) > 1
+    ]
+    unique_by_window = {
+        window: rows[0]
+        for window, rows in by_window.items()
+        if len({row["receipt_sha256"] for row in rows}) == 1
+    }
+    distinct_times = {
+        str(row["request_end_utc"]) for row in unique_by_window.values()
+    }
+    source_native_race_ids = {
+        str(row["source_native_race_id"]) for row in unique_by_window.values()
+    }
+    source_race_identities = {
+        canonical_json_bytes(row["race_identity"]) for row in unique_by_window.values()
+    }
+    source_identity_conflict = (
+        len(source_native_race_ids) > 1 or len(source_race_identities) > 1
+    )
+    runner_depth = Counter(
+        runner_id
+        for row in unique_by_window.values()
+        for runner_id in row["active_native_runner_ids"]
+    )
+    accepted_windows = [
+        window for window in NOMINAL_WINDOWS if window in unique_by_window
+    ]
+    missing_windows = [
+        window for window in NOMINAL_WINDOWS if window not in unique_by_window
+    ]
+    trajectory_ready = (
+        not conflicts
+        and not rejected
+        and not missing_windows
+        and not source_identity_conflict
+        and len(distinct_times) == len(NOMINAL_WINDOWS)
+    )
+    return {
+        "race_id": race_id,
+        "snapshot_entries": len(snapshots),
+        "accepted_snapshot_entries": len(accepted),
+        "rejected_snapshot_entries": len(rejected),
+        "temporal_observation_count": len(distinct_times),
+        "accepted_windows": accepted_windows,
+        "missing_windows": missing_windows,
+        "conflicting_windows": sorted(conflicts),
+        "source_identity_conflict": source_identity_conflict,
+        "source_native_race_ids": sorted(source_native_race_ids),
+        "runner_temporal_depth": dict(sorted(runner_depth.items())),
+        "trajectory_ready": trajectory_ready,
+    }
+
+
+def _write_report_idempotent(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        if path.read_bytes() != payload:
+            raise AuditError(f"conflicting_audit_report:{path}")
+        return
+    with path.open("xb") as handle:
+        handle.write(payload)
+
+
+def audit_manifest(
+    manifest_path: Path,
+    output_dir: Path | None = None,
+    *,
+    max_race_date: date | None = None,
+) -> dict[str, Any]:
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list) or not payload:
+        raise AuditError("manifest_must_be_nonempty_json_list")
+    snapshots: list[dict[str, Any]] = []
+    for entry in payload:
+        if not isinstance(entry, Mapping):
+            raise AuditError("manifest_entries_must_be_objects")
+        try:
+            snapshots.append(_audit_entry(entry, max_race_date))
+        except (AuditError, CaptureError, OSError, UnicodeError, ValueError) as exc:
+            snapshots.append(
+                {
+                    "race_id": str(entry.get("race_id") or ""),
+                    "nominal_window": entry.get("nominal_window"),
+                    "temporal_observation_count": 0,
+                    "snapshot_complete": False,
+                    "status": "REJECTED",
+                    "blockers": [str(exc)],
+                }
+            )
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for snapshot in snapshots:
+        groups.setdefault(str(snapshot.get("race_id") or ""), []).append(snapshot)
+    race_summary = [
+        _race_summary(race_id, rows) for race_id, rows in sorted(groups.items())
+    ]
+    accepted_count = sum(row.get("status") == "ACCEPTED" for row in snapshots)
+    rejected_count = len(snapshots) - accepted_count
+    ready_count = sum(row["trajectory_ready"] for row in race_summary)
+    if ready_count and ready_count == len(race_summary) and not rejected_count:
+        final_status = READY
+    elif accepted_count:
+        final_status = PARTIAL
+    else:
+        final_status = BLOCKED
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "source_class": SOURCE_CLASS,
+        "manifest_path": str(manifest_path.resolve()),
+        "max_race_date_inclusive": (
+            max_race_date.isoformat() if max_race_date is not None else None
+        ),
+        "final_status": final_status,
+        "snapshot_entry_count": len(snapshots),
+        "accepted_snapshot_count": accepted_count,
+        "rejected_snapshot_count": rejected_count,
+        "unique_race_count": len(groups),
+        "trajectory_ready_race_count": ready_count,
+        "required_nominal_windows": list(NOMINAL_WINDOWS),
+        "temporal_observation_semantics": (
+            "one complete receipt-bound point-in-time snapshot at one fixed window"
+        ),
+        "open_low_high_are_temporal_observations": False,
+        "race_summary": race_summary,
+        "snapshots": snapshots,
+        "no_write_guarantees": {
+            "network_acquisition": False,
+            "database_write": False,
+            "model_write": False,
+            "training": False,
+            "scoring": False,
+            "promotion": False,
+            "betting": False,
+        },
+    }
+    if output_dir is not None:
+        encoded = (
+            json.dumps(report, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+        ).encode("utf-8")
+        _write_report_idempotent(
+            output_dir / "thedogs_market_history_audit.json", encoded
+        )
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--max-race-date", type=date.fromisoformat)
+    args = parser.parse_args()
+    report = audit_manifest(
+        args.manifest,
+        args.output_dir,
+        max_race_date=args.max_race_date,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["final_status"] != BLOCKED else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/capture_thedogs_market_history.py
+++ b/scripts/capture_thedogs_market_history.py
@@ -178,6 +178,24 @@ def planned_time(jump_utc: datetime, nominal_window: str) -> datetime:
     return jump_utc - timedelta(minutes=nominal_window_minutes(nominal_window))
 
 
+def validate_window_tolerances(
+    early_value: Any, late_value: Any
+) -> tuple[int, int]:
+    values = (
+        (early_value, DEFAULT_EARLY_TOLERANCE_SECONDS),
+        (late_value, DEFAULT_LATE_TOLERANCE_SECONDS),
+    )
+    if any(
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or value < 0
+        or value > maximum
+        for value, maximum in values
+    ):
+        raise CaptureError("window_tolerance_invalid")
+    return early_value, late_value
+
+
 def validate_due_window(
     *,
     now: datetime,
@@ -479,6 +497,19 @@ def _quote_for_runner(
 def normalize_api_snapshot(
     payload: Mapping[str, Any], source_runners: tuple[SourceRunner, ...]
 ) -> tuple[list[dict[str, Any]], dict[str, Any], str]:
+    runner_odds = payload.get("runner_odds")
+    if not isinstance(runner_odds, Mapping):
+        raise CaptureError("odds_api_runner_odds_missing")
+    expected_runner_ids = {runner.native_runner_id for runner in source_runners}
+    observed_runner_ids = set(runner_odds)
+    if (
+        any(
+            not isinstance(runner_id, str) or runner_id.strip() != runner_id
+            for runner_id in observed_runner_ids
+        )
+        or observed_runner_ids - expected_runner_ids
+    ):
+        raise CaptureError("odds_api_native_runner_set_mismatch")
     rows: list[dict[str, Any]] = []
     active_effective_boxes: list[int] = []
     provider_values: set[tuple[str, str, str]] = set()
@@ -731,6 +762,12 @@ def _validate_existing(
         "race_id": str(plan.get("race_id") or "").strip(),
         "odds_url": str(plan.get("odds_url") or "").strip(),
         "nominal_window": str(plan.get("nominal_window") or "").strip().upper(),
+        "early_tolerance_seconds": plan.get(
+            "early_tolerance_seconds", DEFAULT_EARLY_TOLERANCE_SECONDS
+        ),
+        "late_tolerance_seconds": plan.get(
+            "late_tolerance_seconds", DEFAULT_LATE_TOLERANCE_SECONDS
+        ),
         "raw_html_sha256": observed_raw_hash,
     }
     if any(receipt.get(key) != value for key, value in expected.items()):
@@ -859,12 +896,16 @@ def _validate_existing(
             planned_time(plan_jump, nominal_window)
         ):
             raise CaptureError("nominal_capture_timestamp_mismatch")
+        early_tolerance_seconds, late_tolerance_seconds = validate_window_tolerances(
+            receipt.get("early_tolerance_seconds"),
+            receipt.get("late_tolerance_seconds"),
+        )
         validate_due_window(
             now=capture_end,
             jump_utc=plan_jump,
             nominal_window=nominal_window,
-            early_tolerance_seconds=int(receipt.get("early_tolerance_seconds")),
-            late_tolerance_seconds=int(receipt.get("late_tolerance_seconds")),
+            early_tolerance_seconds=early_tolerance_seconds,
+            late_tolerance_seconds=late_tolerance_seconds,
         )
     except (CaptureError, KeyError, TypeError, ValueError, UnicodeError, json.JSONDecodeError) as exc:
         raise CaptureError("conflicting_snapshot") from exc
@@ -906,6 +947,10 @@ def capture_snapshot(
     expected_ids = {str(value).strip() for value in expected_values}
     if "" in expected_ids or len(expected_ids) != len(expected_values):
         raise CaptureError("expected_active_runner_ids_invalid")
+    early_tolerance_seconds, late_tolerance_seconds = validate_window_tolerances(
+        plan.get("early_tolerance_seconds", DEFAULT_EARLY_TOLERANCE_SECONDS),
+        plan.get("late_tolerance_seconds", DEFAULT_LATE_TOLERANCE_SECONDS),
+    )
     safe_output_dir = assert_output_dir_safe(output_dir, repo_root=repo_root)
     raw_path = safe_output_dir / "raw.html"
     receipt_path = safe_output_dir / "receipt.json"
@@ -917,12 +962,6 @@ def capture_snapshot(
     if existing is not None:
         return existing
     now = (current_time or clock()).astimezone(timezone.utc)
-    early_tolerance_seconds = int(
-        plan.get("early_tolerance_seconds", DEFAULT_EARLY_TOLERANCE_SECONDS)
-    )
-    late_tolerance_seconds = int(
-        plan.get("late_tolerance_seconds", DEFAULT_LATE_TOLERANCE_SECONDS)
-    )
     nominal_at = validate_due_window(
         now=now,
         jump_utc=jump_utc,
@@ -990,6 +1029,15 @@ def capture_snapshot(
         exact_url=api_url,
         content_type_prefix="application/json",
     )
+    if not (
+        meeting.request_end_utc <= race.request_start_utc
+        <= race.request_end_utc
+        <= odds.request_start_utc
+        <= odds.request_end_utc
+        <= api.request_start_utc
+        <= api.request_end_utc
+    ):
+        raise CaptureError("request_chain_time_order_invalid")
     try:
         api_payload = json.loads(api.body.decode("utf-8"))
     except (UnicodeError, json.JSONDecodeError) as exc:

--- a/scripts/capture_thedogs_market_history.py
+++ b/scripts/capture_thedogs_market_history.py
@@ -1,0 +1,1111 @@
+#!/usr/bin/env python3
+"""Capture one immutable prospective TheDogs market snapshot.
+
+The collector accepts one exact race plan, warms the current TheDogs meeting
+and race pages, fetches the exact ``/odds`` page once, then fetches the native
+runner-odds JSON used by that page once.  It writes only an immutable raw HTML
+file and its receipt.  It never retries, discovers a substitute race, writes a
+database, or performs training/scoring.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import math
+import os
+import re
+import stat
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode, urlparse
+
+import requests
+from requests.adapters import HTTPAdapter
+
+ROOT = Path(__file__).resolve().parents[1]
+LEGACY_SCHEMA_VERSION = "thedogs_market_snapshot_receipt_v1"
+SCHEMA_VERSION = "thedogs_market_snapshot_receipt_v2"
+RECEIPT_SCHEMA_VERSIONS = frozenset({LEGACY_SCHEMA_VERSION, SCHEMA_VERSION})
+PLAN_SCHEMA_VERSION = "thedogs_market_snapshot_plan_v1"
+SOURCE_CLASS = "thedogs_prospective_point_in_time_market_history"
+NOMINAL_WINDOWS_MINUTES = (120, 60, 30, 10, 2)
+NOMINAL_WINDOWS = tuple(f"T-{minutes}" for minutes in NOMINAL_WINDOWS_MINUTES)
+DEFAULT_EARLY_TOLERANCE_SECONDS = 30
+DEFAULT_LATE_TOLERANCE_SECONDS = 90
+SERVER_DATE_TOLERANCE_SECONDS = 5
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/91.0.4472.124 Safari/537.36"
+)
+PAGE_HEADERS = {
+    "User-Agent": USER_AGENT,
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "identity",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+RECEIPT_HTTP_HEADERS = (
+    "age",
+    "cache-control",
+    "content-encoding",
+    "content-length",
+    "content-type",
+    "date",
+    "etag",
+    "last-modified",
+    "server",
+    "via",
+    "x-request-id",
+    "x-runtime",
+    "x-varnish-cache",
+)
+EXACT_ODDS_PATH = re.compile(
+    r"^/racing/([a-z0-9-]+)/([0-9]{4}-[0-9]{2}-[0-9]{2})/"
+    r"([1-9][0-9]*)/([a-z0-9-]+)/odds$"
+)
+
+
+class CaptureError(ValueError):
+    """Raised when capture evidence cannot satisfy the prospective contract."""
+
+
+@dataclass(frozen=True)
+class SourceRunner:
+    native_runner_id: str
+    runner_name: str
+    box: int
+    page_effective_box: int | None
+    active: bool
+
+
+@dataclass(frozen=True)
+class TimedResponse:
+    requested_url: str
+    request_start_utc: datetime
+    request_end_utc: datetime
+    final_url: str
+    status_code: int
+    headers: dict[str, str]
+    body: bytes
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_timestamp(value: Any, *, field: str) -> datetime:
+    text = str(value or "").strip().replace("Z", "+00:00")
+    if not text:
+        raise CaptureError(f"{field}_required")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise CaptureError(f"{field}_invalid") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CaptureError(f"{field}_timezone_required")
+    return parsed.astimezone(timezone.utc)
+
+
+def iso_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def canonical_json_bytes(payload: object) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+
+
+def serialized_json_bytes(payload: object) -> bytes:
+    return (
+        json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+    ).encode("utf-8")
+
+
+def exact_odds_identity(value: Any) -> dict[str, str | int]:
+    url = str(value or "").strip()
+    parsed = urlparse(url)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "www.thedogs.com.au"
+        or parsed.port is not None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise CaptureError("exact_thedogs_odds_url_required")
+    match = EXACT_ODDS_PATH.fullmatch(parsed.path)
+    if match is None:
+        raise CaptureError("exact_thedogs_odds_url_required")
+    venue_slug, race_date, race_number, race_slug = match.groups()
+    return {
+        "odds_url": url,
+        "race_url": url[: -len("/odds")],
+        "meeting_url": f"https://www.thedogs.com.au/racing/{race_date}",
+        "venue_slug": venue_slug,
+        "race_date": race_date,
+        "race_number": int(race_number),
+        "race_slug": race_slug,
+    }
+
+
+def nominal_window_minutes(value: Any) -> int:
+    text = str(value or "").strip().upper()
+    if text not in NOMINAL_WINDOWS:
+        raise CaptureError("unsupported_nominal_window")
+    return int(text.removeprefix("T-"))
+
+
+def planned_time(jump_utc: datetime, nominal_window: str) -> datetime:
+    return jump_utc - timedelta(minutes=nominal_window_minutes(nominal_window))
+
+
+def validate_due_window(
+    *,
+    now: datetime,
+    jump_utc: datetime,
+    nominal_window: str,
+    early_tolerance_seconds: int,
+    late_tolerance_seconds: int,
+) -> datetime:
+    nominal = planned_time(jump_utc, nominal_window)
+    if now < nominal - timedelta(seconds=early_tolerance_seconds):
+        raise CaptureError("nominal_window_not_due")
+    if now > nominal + timedelta(seconds=late_tolerance_seconds):
+        raise CaptureError("nominal_window_missed")
+    return nominal
+
+
+class _RunnerParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.runners: list[SourceRunner] = []
+        self._tbody_runner_id: str | None = None
+        self._row: dict[str, Any] | None = None
+        self._collect_name = False
+        self._collect_effective_box = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        lowered = tag.lower()
+        classes = set(str(attributes.get("class") or "").split())
+        if lowered == "tbody":
+            match = re.fullmatch(
+                r"/dogs/runner/([0-9]+)/odds",
+                str(attributes.get("data-content-url") or ""),
+            )
+            self._tbody_runner_id = match.group(1) if match else None
+        elif lowered == "tr" and "race-runner" in classes:
+            self._row = {
+                "native_runner_id": self._tbody_runner_id,
+                "runner_name": "",
+                "box": None,
+                "effective_box_texts": [],
+                "active": "race-runner--scratched" not in classes,
+                "element_runner_ids": set(),
+            }
+        elif self._row is not None and lowered == "sprite-svg":
+            match = re.fullmatch(r"rug_([1-9][0-9]*)", str(attributes.get("name") or ""))
+            if match:
+                self._row["box"] = int(match.group(1))
+        elif self._row is not None and lowered in {
+            "runner-odd",
+            "runner-odd-fluctuation-low",
+            "runner-odd-fluctuation-high",
+            "runner-odd-fluctuation-sparkline",
+        }:
+            runner_id = str(attributes.get("data-runner-id") or "").strip()
+            if runner_id:
+                self._row["element_runner_ids"].add(runner_id)
+        elif self._row is not None and lowered == "div" and (
+            "race-runners__name__dog" in classes
+        ):
+            self._collect_name = True
+        elif (
+            self._row is not None
+            and lowered == "span"
+            and "race-runners__name__box" in classes
+        ):
+            self._row["effective_box_texts"].append("")
+            self._collect_effective_box = True
+        elif self._collect_name and lowered == "span":
+            self._collect_name = False
+
+    def handle_data(self, data: str) -> None:
+        if self._row is not None and self._collect_effective_box:
+            self._row["effective_box_texts"][-1] += data
+        elif self._row is not None and self._collect_name and data.strip():
+            self._row["runner_name"] += data.strip()
+
+    def handle_endtag(self, tag: str) -> None:
+        lowered = tag.lower()
+        if lowered == "span" and self._collect_effective_box:
+            self._collect_effective_box = False
+        if lowered == "div" and self._collect_name:
+            self._collect_name = False
+        if lowered == "tr" and self._row is not None:
+            row = self._row
+            self._row = None
+            runner_id = str(row["native_runner_id"] or "").strip()
+            if not runner_id:
+                if (
+                    row["active"]
+                    or row["element_runner_ids"]
+                    or row["runner_name"].strip().lower() != "vacant box"
+                ):
+                    raise CaptureError("native_runner_identity_missing_from_odds_page")
+                return
+            element_ids = row["element_runner_ids"]
+            if element_ids and element_ids != {runner_id}:
+                raise CaptureError("native_runner_identity_mismatch_in_odds_page")
+            if not row["runner_name"] or row["box"] is None:
+                raise CaptureError("runner_structure_incomplete_in_odds_page")
+            page_effective_box = None
+            effective_box_texts = [
+                value.strip()
+                for value in row["effective_box_texts"]
+                if value.strip()
+            ]
+            if effective_box_texts:
+                if len(effective_box_texts) != 1:
+                    raise CaptureError("effective_box_source_ambiguous_in_odds_page")
+                match = re.fullmatch(
+                    r"\(\s*from\s+box\s+([1-8])\s*\)",
+                    effective_box_texts[0],
+                    flags=re.IGNORECASE,
+                )
+                if match is None:
+                    raise CaptureError("effective_box_source_invalid_in_odds_page")
+                page_effective_box = int(match.group(1))
+            self.runners.append(
+                SourceRunner(
+                    native_runner_id=runner_id,
+                    runner_name=row["runner_name"],
+                    box=row["box"],
+                    page_effective_box=page_effective_box,
+                    active=bool(row["active"]),
+                )
+            )
+        elif lowered == "tbody":
+            self._tbody_runner_id = None
+
+
+def parse_source_runners(source_html: bytes) -> tuple[SourceRunner, ...]:
+    try:
+        text = source_html.decode("utf-8")
+    except UnicodeError as exc:
+        raise CaptureError("odds_page_utf8_invalid") from exc
+    parser = _RunnerParser()
+    parser.feed(text)
+    if not parser.runners:
+        raise CaptureError("odds_page_runner_set_missing")
+    ids = [runner.native_runner_id for runner in parser.runners]
+    boxes = [runner.box for runner in parser.runners]
+    if len(ids) != len(set(ids)):
+        raise CaptureError("duplicate_native_runner_id")
+    if len(boxes) != len(set(boxes)):
+        raise CaptureError("duplicate_runner_box")
+    if not any(runner.active for runner in parser.runners):
+        raise CaptureError("active_runner_set_empty")
+    return tuple(parser.runners)
+
+
+def parse_jump_from_source(source_html: bytes) -> datetime:
+    try:
+        text = source_html.decode("utf-8")
+    except UnicodeError as exc:
+        raise CaptureError("jump_source_utf8_invalid") from exc
+    matches = re.findall(
+        r"<formatted-time\b(?=[^>]*\bdata-format=[\"']datetime_short[\"'])"
+        r"(?=[^>]*\bdata-timestamp=[\"']([0-9]+)[\"'])[^>]*>",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if len(set(matches)) != 1:
+        raise CaptureError("jump_source_timestamp_not_unique")
+    return datetime.fromtimestamp(int(matches[0]), tz=timezone.utc)
+
+
+def make_session() -> requests.Session:
+    session = requests.Session()
+    session.headers.update(PAGE_HEADERS)
+    adapter = HTTPAdapter(max_retries=0)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+def _receipt_headers(headers: Mapping[str, Any]) -> dict[str, str]:
+    lowered = {str(key).lower(): str(value) for key, value in headers.items()}
+    return {key: lowered[key] for key in RECEIPT_HTTP_HEADERS if key in lowered}
+
+
+def timed_get(
+    session: Any,
+    url: str,
+    *,
+    referer: str | None,
+    accept: str,
+    clock: Callable[[], datetime],
+    xhr: bool = False,
+) -> TimedResponse:
+    headers = {"Accept": accept}
+    if referer:
+        headers.update(
+            {
+                "Referer": referer,
+                "Sec-Fetch-Site": "same-origin",
+            }
+        )
+    if xhr:
+        headers["X-Requested-With"] = "XMLHttpRequest"
+    start = clock().astimezone(timezone.utc)
+    response = session.get(url, timeout=30, headers=headers, allow_redirects=False)
+    end = clock().astimezone(timezone.utc)
+    body = bytes(response.content)
+    return TimedResponse(
+        requested_url=url,
+        request_start_utc=start,
+        request_end_utc=end,
+        final_url=str(response.url),
+        status_code=int(response.status_code),
+        headers=_receipt_headers(response.headers),
+        body=body,
+    )
+
+
+def validate_response(
+    response: TimedResponse,
+    *,
+    exact_url: str,
+    content_type_prefix: str,
+) -> None:
+    if response.status_code != 200:
+        raise CaptureError(f"source_http_status_{response.status_code}")
+    if response.final_url != exact_url or response.requested_url != exact_url:
+        raise CaptureError("source_redirect_or_url_mismatch")
+    content_type = response.headers.get("content-type", "").lower()
+    if not content_type.startswith(content_type_prefix):
+        raise CaptureError("source_content_type_invalid")
+    content_encoding = response.headers.get("content-encoding", "").lower()
+    if content_encoding not in {"", "identity"}:
+        raise CaptureError("source_content_encoding_not_identity")
+    if not response.body:
+        raise CaptureError("source_body_empty")
+    if response.request_end_utc < response.request_start_utc:
+        raise CaptureError("request_receipt_time_order_invalid")
+    server_date_text = response.headers.get("date")
+    if not server_date_text:
+        raise CaptureError("source_server_date_missing")
+    try:
+        server_date = parsedate_to_datetime(server_date_text).astimezone(timezone.utc)
+    except (TypeError, ValueError) as exc:
+        raise CaptureError("source_server_date_invalid") from exc
+    age_text = response.headers.get("age", "0").strip()
+    try:
+        age_seconds = int(age_text)
+    except ValueError as exc:
+        raise CaptureError("source_server_age_invalid") from exc
+    if age_seconds < 0 or age_seconds > 300:
+        raise CaptureError("source_server_age_invalid")
+    latest_server_date = server_date + timedelta(seconds=age_seconds)
+    tolerance = timedelta(seconds=SERVER_DATE_TOLERANCE_SECONDS)
+    if not (
+        server_date <= response.request_end_utc + tolerance
+        and latest_server_date >= response.request_start_utc - tolerance
+    ):
+        raise CaptureError("source_server_date_outside_request_interval")
+
+
+def _api_url(runners: tuple[SourceRunner, ...]) -> str:
+    query = urlencode(
+        [("runner_ids[]", runner.native_runner_id) for runner in runners]
+    )
+    return f"https://www.thedogs.com.au/api/runners/odds?{query}"
+
+
+def _safe_price(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) and parsed > 1.0 else None
+
+
+def _quote_for_runner(
+    payload: Mapping[str, Any], runner: SourceRunner
+) -> Mapping[str, Any] | None:
+    runner_odds = payload.get("runner_odds")
+    if not isinstance(runner_odds, Mapping):
+        raise CaptureError("odds_api_runner_odds_missing")
+    quotes = runner_odds.get(runner.native_runner_id)
+    if not isinstance(quotes, list) or not quotes:
+        if runner.active:
+            raise CaptureError("active_runner_current_price_missing")
+        return None
+    fixed_quotes = [
+        quote
+        for quote in quotes
+        if isinstance(quote, Mapping)
+        and isinstance(quote.get("market"), Mapping)
+        and quote["market"].get("code") == "fixed_win"
+    ]
+    if len(fixed_quotes) != 1:
+        raise CaptureError("runner_fixed_win_quote_not_unique")
+    quote = fixed_quotes[0]
+    if str(quote.get("runner_id") or "").strip() != runner.native_runner_id:
+        raise CaptureError("native_runner_quote_id_mismatch")
+    return quote
+
+
+def normalize_api_snapshot(
+    payload: Mapping[str, Any], source_runners: tuple[SourceRunner, ...]
+) -> tuple[list[dict[str, Any]], dict[str, Any], str]:
+    rows: list[dict[str, Any]] = []
+    active_effective_boxes: list[int] = []
+    provider_values: set[tuple[str, str, str]] = set()
+    active_provider_unknown = 0
+    native_race_ids: set[str] = set()
+    for runner in source_runners:
+        quote = _quote_for_runner(payload, runner)
+        price = _safe_price(quote.get("price")) if quote is not None else None
+        if runner.active and price is None:
+            raise CaptureError("active_runner_current_price_invalid")
+        if not runner.active and price is not None:
+            raise CaptureError("scratched_runner_has_active_price")
+        bookmaker = quote.get("bookmaker") if quote is not None else None
+        provider = None
+        if isinstance(bookmaker, Mapping):
+            provider = {
+                "id": str(bookmaker.get("id") or ""),
+                "code": str(bookmaker.get("code") or "").strip(),
+                "name": str(bookmaker.get("name") or "").strip(),
+            }
+            if any(provider.values()):
+                if runner.active:
+                    provider_values.add(
+                        (provider["id"], provider["code"], provider["name"])
+                    )
+            else:
+                provider = None
+        if runner.active and provider is None:
+            active_provider_unknown += 1
+        market = quote.get("market") if quote is not None else None
+        native_race_id = ""
+        if isinstance(market, Mapping):
+            native_race_id = str(market.get("race_id") or "").strip()
+            if native_race_id:
+                native_race_ids.add(native_race_id)
+        api_run_box = quote.get("run_box") if quote is not None else None
+        parsed_api_run_box = None
+        if api_run_box is not None:
+            if isinstance(api_run_box, bool) or re.fullmatch(
+                r"[1-8]", str(api_run_box).strip()
+            ) is None:
+                raise CaptureError("effective_box_source_invalid")
+            parsed_api_run_box = int(str(api_run_box).strip())
+        if (
+            runner.page_effective_box is not None
+            and runner.page_effective_box == runner.box
+        ):
+            raise CaptureError("effective_box_source_conflict")
+        expected_api_box = (
+            runner.page_effective_box
+            if runner.page_effective_box is not None
+            else runner.box
+        )
+        if runner.active:
+            if parsed_api_run_box is None:
+                raise CaptureError("effective_box_source_invalid")
+            if parsed_api_run_box != expected_api_box:
+                raise CaptureError("effective_box_source_conflict")
+            effective_box = parsed_api_run_box
+            active_effective_boxes.append(effective_box)
+            if runner.page_effective_box is None:
+                page_source = "thedogs_odds_page_sprite_svg_rug"
+                resolution = "normal_page_and_api_box_match"
+            else:
+                page_source = (
+                    "thedogs_odds_page_race_runners_name_box_from_box"
+                )
+                resolution = "explicit_replacement_box_match"
+        else:
+            if (
+                parsed_api_run_box is not None
+                and parsed_api_run_box != expected_api_box
+            ):
+                raise CaptureError("effective_box_source_conflict")
+            effective_box = None
+            page_source = (
+                "thedogs_odds_page_race_runners_name_box_from_box"
+                if runner.page_effective_box is not None
+                else "thedogs_odds_page_sprite_svg_rug"
+            )
+            resolution = "inactive_runner_no_effective_box"
+        rows.append(
+            {
+                "native_runner_id": runner.native_runner_id,
+                "runner_name": runner.runner_name,
+                "box": runner.box,
+                "page_box": runner.box,
+                "page_effective_box": runner.page_effective_box,
+                "api_run_box": api_run_box,
+                "effective_box": effective_box,
+                "effective_box_provenance": {
+                    "page_source": page_source,
+                    "api_source": (
+                        "thedogs_runner_odds_api_fixed_win_run_box"
+                        if quote is not None
+                        else "thedogs_runner_odds_api_quote_absent_for_inactive_runner"
+                    ),
+                    "resolution": resolution,
+                },
+                "active": runner.active,
+                "current_price": price,
+                "provider": provider,
+            }
+        )
+    if len(active_effective_boxes) != len(set(active_effective_boxes)):
+        raise CaptureError("active_effective_box_not_unique")
+    if len(native_race_ids) != 1:
+        raise CaptureError("native_race_identity_not_unique")
+    if len(provider_values) > 1:
+        raise CaptureError("provider_identity_not_unique")
+    if provider_values and active_provider_unknown:
+        raise CaptureError("provider_identity_incomplete")
+    if provider_values:
+        provider_id, code, name = next(iter(provider_values))
+        provider = {
+            "classification": "provider_explicit",
+            "id": provider_id,
+            "code": code,
+            "name": name,
+            "source": "thedogs_runner_odds_api_bookmaker",
+        }
+    else:
+        provider = {
+            "classification": "provider_unknown",
+            "id": None,
+            "code": None,
+            "name": None,
+            "source": "provider_not_explicit_in_source_payload",
+        }
+    return rows, provider, next(iter(native_race_ids))
+
+
+def _response_receipt(response: TimedResponse, *, include_body: bool) -> dict[str, Any]:
+    payload = {
+        "requested_url": response.requested_url,
+        "final_url": response.final_url,
+        "request_start_utc": iso_utc(response.request_start_utc),
+        "request_end_utc": iso_utc(response.request_end_utc),
+        "status_code": response.status_code,
+        "headers": response.headers,
+        "body_sha256": sha256_bytes(response.body),
+        "body_bytes": len(response.body),
+    }
+    if include_body:
+        payload["body_base64"] = base64.b64encode(response.body).decode("ascii")
+    return payload
+
+
+def _write_new_immutable(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o444)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except Exception:
+        try:
+            path.chmod(stat.S_IWUSR | stat.S_IRUSR)
+            path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _stored_response(
+    payload: Any,
+    *,
+    field: str,
+    exact_url: str,
+    content_type_prefix: str,
+    body: bytes | None = None,
+    require_body: bool = False,
+) -> TimedResponse:
+    if not isinstance(payload, Mapping):
+        raise CaptureError(f"{field}_receipt_missing")
+    observed_body = body
+    if require_body:
+        encoded = payload.get("body_base64")
+        if not isinstance(encoded, str) or not encoded:
+            raise CaptureError(f"{field}_raw_bytes_missing")
+        try:
+            observed_body = base64.b64decode(encoded, validate=True)
+        except (ValueError, binascii.Error) as exc:
+            raise CaptureError(f"{field}_raw_bytes_invalid") from exc
+    if observed_body is not None:
+        if sha256_bytes(observed_body) != payload.get("body_sha256"):
+            raise CaptureError(f"{field}_raw_hash_mismatch")
+        if len(observed_body) != payload.get("body_bytes"):
+            raise CaptureError(f"{field}_raw_size_mismatch")
+    elif re.fullmatch(r"[0-9a-f]{64}", str(payload.get("body_sha256") or "")) is None:
+        raise CaptureError(f"{field}_body_hash_invalid")
+    response = TimedResponse(
+        requested_url=str(payload.get("requested_url") or ""),
+        request_start_utc=parse_timestamp(
+            payload.get("request_start_utc"), field=f"{field}_request_start_utc"
+        ),
+        request_end_utc=parse_timestamp(
+            payload.get("request_end_utc"), field=f"{field}_request_end_utc"
+        ),
+        final_url=str(payload.get("final_url") or ""),
+        status_code=payload.get("status_code"),
+        headers=dict(payload.get("headers") or {}),
+        body=observed_body if observed_body is not None else b"receipt-body-not-embedded",
+    )
+    validate_response(
+        response,
+        exact_url=exact_url,
+        content_type_prefix=content_type_prefix,
+    )
+    return response
+
+
+def assert_output_dir_safe(output_dir: Path, *, repo_root: Path = ROOT) -> Path:
+    logical = output_dir if output_dir.is_absolute() else repo_root / output_dir
+    try:
+        resolved_root = repo_root.resolve(strict=False)
+        resolved = logical.resolve(strict=False)
+        relative = resolved.relative_to(resolved_root)
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        raise CaptureError("output_dir_must_be_inside_repo") from exc
+    if "capture" not in relative.parts and "canary" not in relative.parts:
+        raise CaptureError("output_dir_must_be_capture_or_canary_path")
+    current = logical
+    while current != repo_root and current != current.parent:
+        if current.exists() and current.is_symlink():
+            raise CaptureError("output_dir_symlink_not_allowed")
+        current = current.parent
+    return resolved
+
+
+def _validate_existing(
+    *, plan: Mapping[str, Any], raw_path: Path, receipt_path: Path
+) -> dict[str, Any] | None:
+    if not raw_path.exists() and not receipt_path.exists():
+        return None
+    if not raw_path.is_file() or not receipt_path.is_file():
+        raise CaptureError("conflicting_snapshot_partial")
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise CaptureError("conflicting_snapshot_receipt_invalid") from exc
+    if not isinstance(receipt, dict):
+        raise CaptureError("conflicting_snapshot_receipt_invalid")
+    raw = raw_path.read_bytes()
+    observed_raw_hash = sha256_bytes(raw)
+    if receipt.get("schema_version") not in RECEIPT_SCHEMA_VERSIONS:
+        raise CaptureError("conflicting_snapshot_receipt_schema")
+    expected = {
+        "race_id": str(plan.get("race_id") or "").strip(),
+        "odds_url": str(plan.get("odds_url") or "").strip(),
+        "nominal_window": str(plan.get("nominal_window") or "").strip().upper(),
+        "raw_html_sha256": observed_raw_hash,
+    }
+    if any(receipt.get(key) != value for key, value in expected.items()):
+        raise CaptureError("conflicting_snapshot")
+    core_hash = str(receipt.get("receipt_core_sha256") or "")
+    core = {key: value for key, value in receipt.items() if key != "receipt_core_sha256"}
+    if core_hash != sha256_bytes(canonical_json_bytes(core)):
+        raise CaptureError("conflicting_snapshot_receipt_hash")
+    try:
+        identity = exact_odds_identity(plan.get("odds_url"))
+        plan_jump = parse_timestamp(plan.get("jump_timestamp"), field="jump_timestamp")
+        receipt_jump = parse_timestamp(
+            receipt.get("jump_timestamp"), field="jump_timestamp"
+        )
+        capture_end = parse_timestamp(
+            receipt.get("capture_end_utc"), field="capture_end_utc"
+        )
+    except CaptureError as exc:
+        raise CaptureError("conflicting_snapshot_receipt_invalid") from exc
+    if (
+        plan_jump != receipt_jump
+        or capture_end >= receipt_jump
+        or receipt.get("race_url") != plan.get("race_url")
+        or receipt.get("race_identity") != identity
+        or receipt.get("source_class") != SOURCE_CLASS
+        or receipt.get("field_complete") is not True
+        or receipt.get("raw_html_bytes") != raw_path.stat().st_size
+    ):
+        raise CaptureError("conflicting_snapshot")
+    active_ids = {str(value) for value in receipt.get("active_native_runner_ids") or []}
+    expected_active_ids = {
+        str(value).strip() for value in plan.get("expected_active_runner_ids", [])
+    }
+    if not active_ids or (expected_active_ids and expected_active_ids != active_ids):
+        raise CaptureError("conflicting_snapshot")
+    try:
+        source_runners = parse_source_runners(raw)
+        source_all_ids = {runner.native_runner_id for runner in source_runners}
+        source_active_ids = {
+            runner.native_runner_id for runner in source_runners if runner.active
+        }
+        if source_active_ids != expected_active_ids or active_ids != source_active_ids:
+            raise CaptureError("runner_set_mismatch")
+        if set(receipt.get("all_native_runner_ids") or []) != source_all_ids:
+            raise CaptureError("all_runner_set_mismatch")
+        meeting = _stored_response(
+            receipt.get("warm_meeting_http"),
+            field="warm_meeting",
+            exact_url=str(identity["meeting_url"]),
+            content_type_prefix="text/html",
+        )
+        jump_source = _stored_response(
+            receipt.get("jump_source"),
+            field="jump_source",
+            exact_url=str(identity["race_url"]),
+            content_type_prefix="text/html",
+            require_body=True,
+        )
+        odds = _stored_response(
+            receipt.get("odds_page_http"),
+            field="odds_page",
+            exact_url=str(identity["odds_url"]),
+            content_type_prefix="text/html",
+            body=raw,
+        )
+        api = _stored_response(
+            receipt.get("odds_api_http"),
+            field="odds_api",
+            exact_url=_api_url(source_runners),
+            content_type_prefix="application/json",
+            require_body=True,
+        )
+        if not (
+            meeting.request_end_utc <= jump_source.request_start_utc
+            <= jump_source.request_end_utc
+            <= odds.request_start_utc
+            <= odds.request_end_utc
+            <= api.request_start_utc
+            <= api.request_end_utc
+        ):
+            raise CaptureError("request_chain_time_order_invalid")
+        if (
+            receipt.get("capture_start_utc") != iso_utc(meeting.request_start_utc)
+            or receipt.get("request_start_utc") != iso_utc(odds.request_start_utc)
+            or receipt.get("request_end_utc") != iso_utc(api.request_end_utc)
+            or receipt.get("capture_end_utc") != iso_utc(api.request_end_utc)
+        ):
+            raise CaptureError("request_receipt_time_mismatch")
+        jump_body = base64.b64decode(
+            str(receipt["jump_source"]["body_base64"]), validate=True
+        )
+        if parse_jump_from_source(jump_body) != plan_jump:
+            raise CaptureError("jump_source_timestamp_mismatch")
+        api_body = base64.b64decode(
+            str(receipt["odds_api_http"]["body_base64"]), validate=True
+        )
+        api_payload = json.loads(api_body.decode("utf-8"))
+        if not isinstance(api_payload, Mapping):
+            raise CaptureError("odds_api_json_invalid")
+        normalized_rows, normalized_provider, native_race_id = normalize_api_snapshot(
+            api_payload, source_runners
+        )
+        if receipt.get("schema_version") == LEGACY_SCHEMA_VERSION:
+            legacy_keys = {
+                "native_runner_id",
+                "runner_name",
+                "box",
+                "active",
+                "current_price",
+                "provider",
+            }
+            projected_rows = [
+                {key: value for key, value in row.items() if key in legacy_keys}
+                for row in normalized_rows
+            ]
+        else:
+            projected_rows = normalized_rows
+        if (
+            receipt.get("runners") != projected_rows
+            or receipt.get("provider") != normalized_provider
+            or receipt.get("source_native_race_id") != native_race_id
+        ):
+            raise CaptureError("receipt_projection_mismatch")
+        nominal_window = str(receipt.get("nominal_window") or "")
+        if receipt.get("nominal_capture_utc") != iso_utc(
+            planned_time(plan_jump, nominal_window)
+        ):
+            raise CaptureError("nominal_capture_timestamp_mismatch")
+        validate_due_window(
+            now=capture_end,
+            jump_utc=plan_jump,
+            nominal_window=nominal_window,
+            early_tolerance_seconds=int(receipt.get("early_tolerance_seconds")),
+            late_tolerance_seconds=int(receipt.get("late_tolerance_seconds")),
+        )
+    except (CaptureError, KeyError, TypeError, ValueError, UnicodeError, json.JSONDecodeError) as exc:
+        raise CaptureError("conflicting_snapshot") from exc
+    if receipt.get("open_low_high_are_temporal_observations") is not False:
+        raise CaptureError("conflicting_snapshot")
+    return {
+        "status": "SKIPPED_IDENTICAL_SNAPSHOT",
+        "accepted": True,
+        "raw_html_path": str(raw_path),
+        "receipt_path": str(receipt_path),
+        "raw_html_sha256": observed_raw_hash,
+        "receipt_sha256": sha256_bytes(receipt_path.read_bytes()),
+    }
+
+
+def capture_snapshot(
+    plan: Mapping[str, Any],
+    output_dir: Path,
+    *,
+    session: Any | None = None,
+    current_time: datetime | None = None,
+    clock: Callable[[], datetime] = utc_now,
+    repo_root: Path = ROOT,
+) -> dict[str, Any]:
+    if plan.get("schema_version") != PLAN_SCHEMA_VERSION:
+        raise CaptureError("plan_schema_version_invalid")
+    race_id = str(plan.get("race_id") or "").strip()
+    if not race_id:
+        raise CaptureError("race_id_required")
+    identity = exact_odds_identity(plan.get("odds_url"))
+    if plan.get("race_url") != identity["race_url"]:
+        raise CaptureError("race_url_odds_url_mismatch")
+    jump_utc = parse_timestamp(plan.get("jump_timestamp"), field="jump_timestamp")
+    nominal_window = str(plan.get("nominal_window") or "").strip().upper()
+    nominal_window_minutes(nominal_window)
+    expected_values = plan.get("expected_active_runner_ids")
+    if not isinstance(expected_values, list) or not expected_values:
+        raise CaptureError("expected_active_runner_ids_required")
+    expected_ids = {str(value).strip() for value in expected_values}
+    if "" in expected_ids or len(expected_ids) != len(expected_values):
+        raise CaptureError("expected_active_runner_ids_invalid")
+    safe_output_dir = assert_output_dir_safe(output_dir, repo_root=repo_root)
+    raw_path = safe_output_dir / "raw.html"
+    receipt_path = safe_output_dir / "receipt.json"
+    existing = _validate_existing(
+        plan=plan,
+        raw_path=raw_path,
+        receipt_path=receipt_path,
+    )
+    if existing is not None:
+        return existing
+    now = (current_time or clock()).astimezone(timezone.utc)
+    early_tolerance_seconds = int(
+        plan.get("early_tolerance_seconds", DEFAULT_EARLY_TOLERANCE_SECONDS)
+    )
+    late_tolerance_seconds = int(
+        plan.get("late_tolerance_seconds", DEFAULT_LATE_TOLERANCE_SECONDS)
+    )
+    nominal_at = validate_due_window(
+        now=now,
+        jump_utc=jump_utc,
+        nominal_window=nominal_window,
+        early_tolerance_seconds=early_tolerance_seconds,
+        late_tolerance_seconds=late_tolerance_seconds,
+    )
+    active_session = session or make_session()
+    meeting = timed_get(
+        active_session,
+        str(identity["meeting_url"]),
+        referer=None,
+        accept=PAGE_HEADERS["Accept"],
+        clock=clock,
+    )
+    validate_response(
+        meeting,
+        exact_url=str(identity["meeting_url"]),
+        content_type_prefix="text/html",
+    )
+    race = timed_get(
+        active_session,
+        str(identity["race_url"]),
+        referer=str(identity["meeting_url"]),
+        accept=PAGE_HEADERS["Accept"],
+        clock=clock,
+    )
+    validate_response(
+        race,
+        exact_url=str(identity["race_url"]),
+        content_type_prefix="text/html",
+    )
+    source_jump = parse_jump_from_source(race.body)
+    if source_jump != jump_utc:
+        raise CaptureError("jump_source_timestamp_mismatch")
+    odds = timed_get(
+        active_session,
+        str(identity["odds_url"]),
+        referer=str(identity["race_url"]),
+        accept=PAGE_HEADERS["Accept"],
+        clock=clock,
+    )
+    validate_response(
+        odds,
+        exact_url=str(identity["odds_url"]),
+        content_type_prefix="text/html",
+    )
+    source_runners = parse_source_runners(odds.body)
+    observed_active_ids = {
+        runner.native_runner_id for runner in source_runners if runner.active
+    }
+    if expected_ids != observed_active_ids:
+        raise CaptureError("expected_native_runner_set_mismatch")
+    api_url = _api_url(source_runners)
+    api = timed_get(
+        active_session,
+        api_url,
+        referer=str(identity["odds_url"]),
+        accept="application/json",
+        clock=clock,
+        xhr=True,
+    )
+    validate_response(
+        api,
+        exact_url=api_url,
+        content_type_prefix="application/json",
+    )
+    try:
+        api_payload = json.loads(api.body.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise CaptureError("odds_api_json_invalid") from exc
+    if not isinstance(api_payload, Mapping):
+        raise CaptureError("odds_api_json_invalid")
+    rows, provider, native_race_id = normalize_api_snapshot(
+        api_payload, source_runners
+    )
+    expected_native_race_id = str(plan.get("expected_native_race_id") or "").strip()
+    if expected_native_race_id and expected_native_race_id != native_race_id:
+        raise CaptureError("expected_native_race_id_mismatch")
+    capture_end = api.request_end_utc
+    if capture_end >= jump_utc:
+        raise CaptureError("capture_not_strictly_prejump")
+    if capture_end < nominal_at - timedelta(seconds=early_tolerance_seconds):
+        raise CaptureError("capture_completed_before_nominal_window")
+    if capture_end > nominal_at + timedelta(seconds=late_tolerance_seconds):
+        raise CaptureError("capture_completed_after_nominal_window")
+    receipt: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "source_class": SOURCE_CLASS,
+        "race_id": race_id,
+        "source_native_race_id": native_race_id,
+        "race_identity": identity,
+        "race_url": identity["race_url"],
+        "odds_url": identity["odds_url"],
+        "nominal_window": nominal_window,
+        "nominal_capture_utc": iso_utc(nominal_at),
+        "early_tolerance_seconds": early_tolerance_seconds,
+        "late_tolerance_seconds": late_tolerance_seconds,
+        "jump_timestamp": iso_utc(jump_utc),
+        "capture_start_utc": iso_utc(meeting.request_start_utc),
+        "capture_end_utc": iso_utc(capture_end),
+        "request_start_utc": iso_utc(odds.request_start_utc),
+        "request_end_utc": iso_utc(capture_end),
+        "raw_html_sha256": sha256_bytes(odds.body),
+        "raw_html_bytes": len(odds.body),
+        "jump_source": _response_receipt(race, include_body=True),
+        "odds_page_http": _response_receipt(odds, include_body=False),
+        "odds_api_http": _response_receipt(api, include_body=True),
+        "warm_meeting_http": _response_receipt(meeting, include_body=False),
+        "provider": provider,
+        "field_complete": True,
+        "active_runner_count": len(observed_active_ids),
+        "all_runner_count": len(source_runners),
+        "active_native_runner_ids": sorted(observed_active_ids),
+        "all_native_runner_ids": sorted(
+            runner.native_runner_id for runner in source_runners
+        ),
+        "runners": rows,
+        "open_low_high_are_temporal_observations": False,
+        "request_attempts": {
+            "meeting_page": 1,
+            "jump_source_race_page": 1,
+            "exact_odds_page": 1,
+            "native_runner_odds_api": 1,
+        },
+        "no_write_guarantees": {
+            "canonical_db_write": False,
+            "runtime_write": False,
+            "service_or_timer_change": False,
+            "training": False,
+            "scoring": False,
+            "promotion": False,
+            "betting": False,
+            "august_cohort_use": False,
+        },
+    }
+    receipt["receipt_core_sha256"] = sha256_bytes(canonical_json_bytes(receipt))
+    raw_bytes = odds.body
+    receipt_bytes = serialized_json_bytes(receipt)
+    _write_new_immutable(raw_path, raw_bytes)
+    _write_new_immutable(receipt_path, receipt_bytes)
+    return {
+        "status": "CAPTURE_ACCEPTED",
+        "accepted": True,
+        "race_id": race_id,
+        "nominal_window": nominal_window,
+        "capture_end_utc": iso_utc(capture_end),
+        "raw_html_path": str(raw_path),
+        "receipt_path": str(receipt_path),
+        "raw_html_sha256": sha256_bytes(raw_bytes),
+        "receipt_sha256": sha256_bytes(receipt_bytes),
+        "active_runner_count": len(observed_active_ids),
+        "provider": provider,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("plan", type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--current-time", help="Test/canary clock override with timezone")
+    args = parser.parse_args()
+    try:
+        plan = json.loads(args.plan.read_text(encoding="utf-8"))
+        if not isinstance(plan, Mapping):
+            raise CaptureError("plan_must_be_json_object")
+        current_time = (
+            parse_timestamp(args.current_time, field="current_time")
+            if args.current_time
+            else None
+        )
+        result = capture_snapshot(
+            plan,
+            args.output_dir,
+            current_time=current_time,
+        )
+    except (CaptureError, OSError, json.JSONDecodeError, requests.RequestException) as exc:
+        result = {"status": "CAPTURE_REJECTED", "accepted": False, "blocker": str(exc)}
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_thedogs_market_history_snapshots.py
+++ b/tests/test_audit_thedogs_market_history_snapshots.py
@@ -1,0 +1,354 @@
+import json
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+from pathlib import Path
+
+from scripts.audit_thedogs_market_history_snapshots import audit_manifest
+from scripts.capture_thedogs_market_history import (
+    canonical_json_bytes,
+    capture_snapshot,
+    sha256_bytes,
+)
+
+RACE_ID = "race-immutable-0001"
+RACE_URL = "https://www.thedogs.com.au/racing/meadows/2026-06-01/1/test-race"
+ODDS_URL = f"{RACE_URL}/odds"
+JUMP = datetime(2026, 6, 1, 1, 0, tzinfo=timezone.utc)
+
+
+def source_html() -> bytes:
+    return f"""
+    <html><body>
+      <formatted-time data-format="datetime_short" data-timestamp="{int(JUMP.timestamp())}">11:00</formatted-time>
+      <table class="race-runners"><tbody data-content-url="/dogs/runner/101/odds">
+        <tr class="race-runner"><td><sprite-svg name="rug_1"></sprite-svg></td>
+        <td><div class="race-runners__name__dog">Alpha<span>29.1</span></div></td>
+        <td class="runner-odds-fluctuation--price">2.60</td>
+        <td><runner-odd data-runner-id="101"></runner-odd></td></tr>
+      </tbody><tbody data-content-url="/dogs/runner/102/odds">
+        <tr class="race-runner"><td><sprite-svg name="rug_2"></sprite-svg></td>
+        <td><div class="race-runners__name__dog">Beta<span>29.2</span></div></td>
+        <td class="runner-odds-fluctuation--price">3.60</td>
+        <td><runner-odd data-runner-id="102"></runner-odd></td></tr>
+      </tbody></table>
+    </body></html>
+    """.encode()
+
+
+def api_payload(*, provider: bool = True, native_race_id: int = 9001) -> bytes:
+    def quote(runner_id: int, box: int, price: float):
+        return {
+            "runner_id": runner_id,
+            "run_box": box,
+            "price": price,
+            "bookmaker": (
+                {"id": 63, "code": "ladbrokes", "name": "Ladbrokes"}
+                if provider
+                else None
+            ),
+            "market": {"code": "fixed_win", "race_id": native_race_id},
+        }
+
+    return json.dumps(
+        {"runner_odds": {"101": [quote(101, 1, 2.5)], "102": [quote(102, 2, 3.5)]}}
+    ).encode()
+
+
+class FakeResponse:
+    def __init__(
+        self, url: str, content: bytes, content_type: str, server_time: datetime
+    ):
+        self.url = url
+        self.content = content
+        self.status_code = 200
+        self.headers = {
+            "Content-Type": content_type,
+            "Date": format_datetime(server_time, usegmt=True),
+            "X-Request-Id": "fixture-request",
+        }
+
+
+class FakeSession:
+    def __init__(
+        self, *, provider: bool = True, server_time: datetime, native_race_id: int = 9001
+    ):
+        self.provider = provider
+        self.server_time = server_time
+        self.native_race_id = native_race_id
+
+    def get(self, url, **_kwargs):
+        if url.endswith("/racing/2026-06-01"):
+            return FakeResponse(
+                url,
+                b"<html>meeting</html>",
+                "text/html; charset=utf-8",
+                self.server_time,
+            )
+        if url in {RACE_URL, ODDS_URL}:
+            return FakeResponse(
+                url, source_html(), "text/html; charset=utf-8", self.server_time
+            )
+        if "/api/runners/odds?" in url:
+            return FakeResponse(
+                url,
+                api_payload(
+                    provider=self.provider, native_race_id=self.native_race_id
+                ),
+                "application/json; charset=utf-8",
+                self.server_time,
+            )
+        raise AssertionError(url)
+
+
+class FakeClock:
+    def __init__(self, start: datetime):
+        self.value = start
+
+    def __call__(self):
+        value = self.value
+        self.value += timedelta(milliseconds=100)
+        return value
+
+
+def plan(window: str):
+    return {
+        "schema_version": "thedogs_market_snapshot_plan_v1",
+        "race_id": RACE_ID,
+        "race_url": RACE_URL,
+        "odds_url": ODDS_URL,
+        "jump_timestamp": JUMP.isoformat(),
+        "nominal_window": window,
+        "expected_active_runner_ids": ["101", "102"],
+    }
+
+
+def make_snapshot(
+    tmp_path: Path,
+    window: str = "T-120",
+    *,
+    provider: bool = True,
+    native_race_id: int = 9001,
+):
+    minutes = int(window.removeprefix("T-"))
+    current = JUMP - timedelta(minutes=minutes)
+    output = tmp_path / "capture" / window
+    result = capture_snapshot(
+        plan(window),
+        output,
+        session=FakeSession(
+            provider=provider,
+            server_time=current,
+            native_race_id=native_race_id,
+        ),
+        current_time=current,
+        clock=FakeClock(current),
+        repo_root=tmp_path,
+    )
+    return {
+        "race_id": RACE_ID,
+        "odds_url": ODDS_URL,
+        "nominal_window": window,
+        "expected_active_runner_ids": ["101", "102"],
+        "raw_html_path": result["raw_html_path"],
+        "receipt_path": result["receipt_path"],
+    }
+
+
+def write_manifest(tmp_path: Path, entries) -> Path:
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(entries), encoding="utf-8")
+    return path
+
+
+def mutate_receipt(path: Path, mutate) -> None:
+    path.chmod(0o644)
+    receipt = json.loads(path.read_text())
+    mutate(receipt)
+    core = {key: value for key, value in receipt.items() if key != "receipt_core_sha256"}
+    receipt["receipt_core_sha256"] = sha256_bytes(canonical_json_bytes(core))
+    path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+    path.chmod(0o444)
+
+
+def test_one_complete_field_snapshot_counts_as_one_temporal_observation(tmp_path):
+    entry = make_snapshot(tmp_path)
+    report = audit_manifest(write_manifest(tmp_path, [entry]))
+
+    assert report["final_status"] == "THEDOGS_MARKET_HISTORY_CAPTURE_PARTIAL"
+    assert report["accepted_snapshot_count"] == 1
+    assert report["race_summary"][0]["temporal_observation_count"] == 1
+    assert report["race_summary"][0]["runner_temporal_depth"] == {"101": 1, "102": 1}
+    assert report["snapshots"][0]["active_runner_count"] == 2
+    assert report["snapshots"][0]["runners"][0]["current_price"] == 2.5
+    assert report["open_low_high_are_temporal_observations"] is False
+
+
+def test_missing_receipt_is_rejected(tmp_path):
+    entry = make_snapshot(tmp_path)
+    Path(entry["receipt_path"]).unlink()
+
+    report = audit_manifest(write_manifest(tmp_path, [entry]))
+
+    assert report["final_status"] == "BLOCKED_LIVE_CAPTURE_OR_PROVENANCE"
+    assert report["accepted_snapshot_count"] == 0
+    assert "receipt_path_missing" in report["snapshots"][0]["blockers"][0]
+
+
+def test_manifest_must_bind_exact_odds_url(tmp_path):
+    entry = make_snapshot(tmp_path)
+    entry.pop("odds_url")
+
+    report = audit_manifest(write_manifest(tmp_path, [entry]))
+
+    assert report["accepted_snapshot_count"] == 0
+    assert "manifest_exact_odds_url_required" in report["snapshots"][0]["blockers"]
+
+
+def test_receipt_source_alias_identity_tamper_is_rejected(tmp_path):
+    entry = make_snapshot(tmp_path)
+    receipt_path = Path(entry["receipt_path"])
+    mutate_receipt(
+        receipt_path,
+        lambda receipt: receipt["race_identity"].update({"race_number": 2}),
+    )
+
+    report = audit_manifest(write_manifest(tmp_path, [entry]))
+
+    assert "receipt_race_identity_mismatch" in report["snapshots"][0]["blockers"]
+
+
+def test_capture_at_jump_is_rejected(tmp_path):
+    entry = make_snapshot(tmp_path)
+    receipt_path = Path(entry["receipt_path"])
+    jump = JUMP.isoformat().replace("+00:00", "Z")
+    mutate_receipt(
+        receipt_path,
+        lambda receipt: receipt.update(
+            {"request_end_utc": jump, "capture_end_utc": jump}
+        ),
+    )
+
+    report = audit_manifest(write_manifest(tmp_path, [entry]))
+
+    assert "capture_not_strictly_prejump" in report["snapshots"][0]["blockers"]
+
+
+def test_post_jump_capture_is_rejected(tmp_path):
+    entry = make_snapshot(tmp_path)
+    receipt_path = Path(entry["receipt_path"])
+    after = (JUMP + timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
+    mutate_receipt(
+        receipt_path,
+        lambda receipt: receipt.update(
+            {"request_end_utc": after, "capture_end_utc": after}
+        ),
+    )
+
+    report = audit_manifest(write_manifest(tmp_path, [entry]))
+
+    assert "capture_not_strictly_prejump" in report["snapshots"][0]["blockers"]
+
+
+def test_receipt_native_id_mismatch_is_rejected(tmp_path):
+    entry = make_snapshot(tmp_path)
+    receipt_path = Path(entry["receipt_path"])
+    mutate_receipt(
+        receipt_path,
+        lambda receipt: receipt.update(
+            {"active_native_runner_ids": ["101", "999"]}
+        ),
+    )
+
+    report = audit_manifest(write_manifest(tmp_path, [entry]))
+
+    assert "receipt_active_native_runner_set_mismatch" in report["snapshots"][0]["blockers"]
+
+
+def test_receipt_effective_box_projection_tamper_is_rejected(tmp_path):
+    entry = make_snapshot(tmp_path)
+    receipt_path = Path(entry["receipt_path"])
+
+    def tamper(receipt):
+        receipt["runners"][0]["effective_box"] = 8
+
+    mutate_receipt(receipt_path, tamper)
+    report = audit_manifest(write_manifest(tmp_path, [entry]))
+
+    assert "receipt_runner_projection_mismatch" in report["snapshots"][0]["blockers"]
+
+
+def test_legacy_v1_runner_projection_remains_auditable(tmp_path):
+    entry = make_snapshot(tmp_path)
+    receipt_path = Path(entry["receipt_path"])
+
+    def downgrade(receipt):
+        receipt["schema_version"] = "thedogs_market_snapshot_receipt_v1"
+        legacy_keys = {
+            "native_runner_id",
+            "runner_name",
+            "box",
+            "active",
+            "current_price",
+            "provider",
+        }
+        receipt["runners"] = [
+            {key: value for key, value in row.items() if key in legacy_keys}
+            for row in receipt["runners"]
+        ]
+
+    mutate_receipt(receipt_path, downgrade)
+    report = audit_manifest(write_manifest(tmp_path, [entry]))
+
+    assert report["accepted_snapshot_count"] == 1
+    assert "effective_box" not in report["snapshots"][0]["runners"][0]
+
+
+def test_provider_unknown_is_a_valid_source_classification(tmp_path):
+    entry = make_snapshot(tmp_path, provider=False)
+
+    report = audit_manifest(write_manifest(tmp_path, [entry]))
+
+    assert report["accepted_snapshot_count"] == 1
+    assert report["snapshots"][0]["provider_classification"] == "provider_unknown"
+
+
+def test_all_five_distinct_windows_are_required_for_trajectory_ready(tmp_path):
+    entries = [
+        make_snapshot(tmp_path / f"snapshot-{window}", window)
+        for window in ("T-120", "T-60", "T-30", "T-10", "T-2")
+    ]
+
+    report = audit_manifest(write_manifest(tmp_path, entries))
+
+    assert report["final_status"] == "THEDOGS_MARKET_HISTORY_CAPTURE_READY"
+    assert report["trajectory_ready_race_count"] == 1
+    assert report["race_summary"][0]["temporal_observation_count"] == 5
+    assert report["race_summary"][0]["missing_windows"] == []
+    assert report["race_summary"][0]["runner_temporal_depth"] == {"101": 5, "102": 5}
+
+
+def test_five_windows_with_conflicting_native_race_identity_are_not_ready(tmp_path):
+    entries = [
+        make_snapshot(
+            tmp_path / f"snapshot-{window}",
+            window,
+            native_race_id=9002 if window == "T-2" else 9001,
+        )
+        for window in ("T-120", "T-60", "T-30", "T-10", "T-2")
+    ]
+
+    report = audit_manifest(write_manifest(tmp_path, entries))
+
+    assert report["final_status"] == "THEDOGS_MARKET_HISTORY_CAPTURE_PARTIAL"
+    assert report["trajectory_ready_race_count"] == 0
+    assert report["race_summary"][0]["source_identity_conflict"] is True
+
+
+def test_duplicate_manifest_entry_does_not_inflate_temporal_depth(tmp_path):
+    entry = make_snapshot(tmp_path)
+
+    report = audit_manifest(write_manifest(tmp_path, [entry, dict(entry)]))
+
+    assert report["accepted_snapshot_count"] == 2
+    assert report["race_summary"][0]["temporal_observation_count"] == 1
+    assert report["race_summary"][0]["runner_temporal_depth"] == {"101": 1, "102": 1}

--- a/tests/test_audit_thedogs_market_history_snapshots.py
+++ b/tests/test_audit_thedogs_market_history_snapshots.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from datetime import datetime, timedelta, timezone
 from email.utils import format_datetime
@@ -262,6 +263,60 @@ def test_receipt_native_id_mismatch_is_rejected(tmp_path):
     report = audit_manifest(write_manifest(tmp_path, [entry]))
 
     assert "receipt_active_native_runner_set_mismatch" in report["snapshots"][0]["blockers"]
+
+
+def test_unexpected_api_native_runner_is_rejected(tmp_path):
+    entry = make_snapshot(tmp_path)
+    receipt_path = Path(entry["receipt_path"])
+
+    def add_unexpected_runner(receipt):
+        api_http = receipt["odds_api_http"]
+        payload = json.loads(base64.b64decode(api_http["body_base64"]))
+        payload["runner_odds"]["999"] = [
+            {
+                "runner_id": 999,
+                "run_box": 8,
+                "price": 9.0,
+                "bookmaker": {"id": 63, "code": "ladbrokes", "name": "Ladbrokes"},
+                "market": {"code": "fixed_win", "race_id": 9001},
+            }
+        ]
+        body = json.dumps(payload).encode()
+        api_http["body_base64"] = base64.b64encode(body).decode("ascii")
+        api_http["body_sha256"] = sha256_bytes(body)
+        api_http["body_bytes"] = len(body)
+
+    mutate_receipt(receipt_path, add_unexpected_runner)
+    report = audit_manifest(write_manifest(tmp_path, [entry]))
+
+    assert "odds_api_native_runner_set_mismatch" in report["snapshots"][0]["blockers"]
+
+
+def test_overlapping_warmed_request_chain_is_rejected(tmp_path):
+    entry = make_snapshot(tmp_path)
+    receipt_path = Path(entry["receipt_path"])
+
+    def overlap_meeting_and_race(receipt):
+        meeting_start = receipt["warm_meeting_http"]["request_start_utc"]
+        receipt["jump_source"]["request_start_utc"] = meeting_start
+
+    mutate_receipt(receipt_path, overlap_meeting_and_race)
+    report = audit_manifest(write_manifest(tmp_path, [entry]))
+
+    assert "request_chain_time_order_invalid" in report["snapshots"][0]["blockers"]
+
+
+def test_receipt_window_tolerance_cannot_exceed_prescribed_interval(tmp_path):
+    entry = make_snapshot(tmp_path)
+    receipt_path = Path(entry["receipt_path"])
+    mutate_receipt(
+        receipt_path,
+        lambda receipt: receipt.update({"late_tolerance_seconds": 91}),
+    )
+
+    report = audit_manifest(write_manifest(tmp_path, [entry]))
+
+    assert "window_tolerance_invalid" in report["snapshots"][0]["blockers"]
 
 
 def test_receipt_effective_box_projection_tamper_is_rejected(tmp_path):

--- a/tests/test_capture_thedogs_market_history.py
+++ b/tests/test_capture_thedogs_market_history.py
@@ -330,6 +330,23 @@ def test_incomplete_active_field_is_rejected(tmp_path):
         capture(tmp_path, missing_runner="102")
 
 
+def test_unexpected_api_native_runner_is_rejected(tmp_path):
+    payload = json.loads(api_payload())
+    payload["runner_odds"]["999"] = [
+        {
+            "runner_id": 999,
+            "run_box": 8,
+            "price": 9.0,
+            "preferred_bookmaker_id": 63,
+            "bookmaker": {"id": 63, "code": "ladbrokes", "name": "Ladbrokes"},
+            "market": {"code": "fixed_win", "race_id": 9001},
+        }
+    ]
+
+    with pytest.raises(CaptureError, match="odds_api_native_runner_set_mismatch"):
+        capture(tmp_path, api_body=json.dumps(payload).encode())
+
+
 def test_native_id_expectation_mismatch_is_rejected(tmp_path):
     with pytest.raises(CaptureError, match="expected_native_runner_set_mismatch"):
         capture(
@@ -588,6 +605,30 @@ def test_missed_window_is_rejected_before_network(tmp_path):
             tmp_path / "capture" / "snapshot",
             session=session,
             current_time=JUMP - timedelta(minutes=118),
+            repo_root=tmp_path,
+        )
+
+    assert session.calls == []
+
+
+@pytest.mark.parametrize(
+    "plan_payload",
+    [
+        plan(early_tolerance_seconds=31),
+        plan(late_tolerance_seconds=91),
+        plan(early_tolerance_seconds=-1),
+        plan(late_tolerance_seconds=-1),
+    ],
+)
+def test_window_tolerance_cannot_weaken_prescribed_interval(tmp_path, plan_payload):
+    session = FakeSession()
+
+    with pytest.raises(CaptureError, match="window_tolerance_invalid"):
+        capture_snapshot(
+            plan_payload,
+            tmp_path / "capture" / "snapshot",
+            session=session,
+            current_time=JUMP - timedelta(minutes=120),
             repo_root=tmp_path,
         )
 

--- a/tests/test_capture_thedogs_market_history.py
+++ b/tests/test_capture_thedogs_market_history.py
@@ -1,0 +1,594 @@
+import json
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+from pathlib import Path
+
+import pytest
+
+from scripts.capture_thedogs_market_history import (
+    CaptureError,
+    TimedResponse,
+    canonical_json_bytes,
+    capture_snapshot,
+    parse_source_runners,
+    sha256_bytes,
+    validate_response,
+)
+
+RACE_ID = "race-immutable-0001"
+RACE_URL = "https://www.thedogs.com.au/racing/meadows/2026-06-01/1/test-race"
+ODDS_URL = f"{RACE_URL}/odds"
+JUMP = datetime(2026, 6, 1, 1, 0, tzinfo=timezone.utc)
+
+
+def source_html(jump: datetime = JUMP) -> bytes:
+    return f"""
+    <html><body>
+      <formatted-time data-format="datetime_short" data-timestamp="{int(jump.timestamp())}">11:00</formatted-time>
+      <table class="race-runners"><tbody data-content-url="/dogs/runner/101/odds">
+        <tr class="race-runner"><td><sprite-svg name="rug_1"></sprite-svg></td>
+        <td><div class="race-runners__name__dog">Alpha<span>29.1</span></div></td>
+        <td><runner-odd data-runner-id="101"></runner-odd></td></tr>
+      </tbody><tbody data-content-url="/dogs/runner/102/odds">
+        <tr class="race-runner"><td><sprite-svg name="rug_2"></sprite-svg></td>
+        <td><div class="race-runners__name__dog">Beta<span>29.2</span></div></td>
+        <td><runner-odd data-runner-id="102"></runner-odd></td></tr>
+      </tbody><tbody data-content-url="/dogs/runner/103/odds">
+        <tr class="race-runner race-runner--scratched"><td><sprite-svg name="rug_3"></sprite-svg></td>
+        <td><div class="race-runners__name__dog">Gamma<span>29.3</span></div></td>
+        <td><runner-odd data-runner-id="103"></runner-odd></td><td>SCR</td></tr>
+      </tbody><tbody>
+        <tr class="race-runner race-runner--scratched"><td><sprite-svg name="rug_4"></sprite-svg></td>
+        <td><div class="race-runners__name__dog">Vacant Box</div></td><td>SCR</td></tr>
+      </tbody></table>
+    </body></html>
+    """.encode()
+
+
+def api_payload(
+    *,
+    provider: bool = True,
+    missing_runner: str | None = None,
+    mismatched_quote_id: bool = False,
+) -> bytes:
+    def quote(runner_id: str, box: int | None, price: float):
+        return {
+            "runner_id": int(runner_id),
+            "run_box": box,
+            "price": price,
+            "preferred_bookmaker_id": 63 if provider else None,
+            "bookmaker": (
+                {"id": 63, "code": "ladbrokes", "name": "Ladbrokes"}
+                if provider
+                else None
+            ),
+            "market": {"code": "fixed_win", "race_id": 9001},
+        }
+
+    rows = {
+        "101": [quote("101", 1, 2.5)],
+        "102": [quote("102", 2, 3.5)],
+        "103": [quote("103", None, 0.0)],
+    }
+    if missing_runner:
+        rows.pop(missing_runner)
+    if mismatched_quote_id:
+        rows["102"][0]["runner_id"] = 999
+    return json.dumps({"runner_odds": rows}).encode()
+
+
+def replacement_source_html(
+    *,
+    from_box_text: str = "(from box 2)",
+    replacement_active: bool = True,
+) -> bytes:
+    replacement_classes = "race-runner" if replacement_active else (
+        "race-runner race-runner--scratched"
+    )
+    return f"""
+    <html><body>
+      <formatted-time data-format="datetime_short" data-timestamp="{int(JUMP.timestamp())}">11:00</formatted-time>
+      <table class="race-runners"><tbody data-content-url="/dogs/runner/101/odds">
+        <tr class="race-runner"><td><sprite-svg name="rug_1"></sprite-svg></td>
+        <td><div class="race-runners__name__dog">Alpha<span>29.1</span></div></td>
+        <td><runner-odd data-runner-id="101"></runner-odd></td></tr>
+      </tbody><tbody data-content-url="/dogs/runner/102/odds">
+        <tr class="race-runner race-runner--scratched"><td><sprite-svg name="rug_2"></sprite-svg></td>
+        <td><div class="race-runners__name__dog">Beta<span>29.2</span></div></td>
+        <td><runner-odd data-runner-id="102"></runner-odd></td><td>SCR</td></tr>
+      </tbody><tbody data-content-url="/dogs/runner/104/odds">
+        <tr class="{replacement_classes}"><td><sprite-svg name="rug_9"></sprite-svg></td>
+        <td><div class="race-runners__name__dog">Reserve<span>29.4</span>
+        <span class="race-runners__name__box">{from_box_text}</span></div></td>
+        <td><runner-odd data-runner-id="104"></runner-odd></td></tr>
+      </tbody></table>
+    </body></html>
+    """.encode()
+
+
+def replacement_api_payload(
+    *,
+    replacement_run_box: int | None = 2,
+    original_price: float = 0.0,
+) -> bytes:
+    def quote(runner_id: str, box: int | None, price: float):
+        return {
+            "runner_id": int(runner_id),
+            "run_box": box,
+            "price": price,
+            "preferred_bookmaker_id": 63,
+            "bookmaker": {"id": 63, "code": "ladbrokes", "name": "Ladbrokes"},
+            "market": {"code": "fixed_win", "race_id": 9001},
+        }
+
+    return json.dumps(
+        {
+            "runner_odds": {
+                "101": [quote("101", 1, 2.5)],
+                "102": [quote("102", 2, original_price)],
+                "104": [quote("104", replacement_run_box, 3.5)],
+            }
+        }
+    ).encode()
+
+
+def mismatched_normal_api_payload() -> bytes:
+    payload = json.loads(api_payload())
+    payload["runner_odds"]["102"][0]["run_box"] = 3
+    return json.dumps(payload).encode()
+
+
+class FakeResponse:
+    def __init__(
+        self, url: str, content: bytes, content_type: str, server_time: datetime
+    ):
+        self.url = url
+        self.content = content
+        self.status_code = 200
+        self.headers = {
+            "Content-Type": content_type,
+            "Date": format_datetime(server_time, usegmt=True),
+            "X-Request-Id": "fixture-request",
+        }
+
+
+class FakeSession:
+    def __init__(
+        self,
+        *,
+        provider: bool = True,
+        missing_runner: str | None = None,
+        mismatched_quote_id: bool = False,
+        server_time: datetime | None = None,
+        source_body: bytes | None = None,
+        api_body: bytes | None = None,
+    ):
+        self.provider = provider
+        self.missing_runner = missing_runner
+        self.server_time = server_time or (JUMP - timedelta(minutes=120))
+        self.mismatched_quote_id = mismatched_quote_id
+        self.source_body = source_body or source_html()
+        self.api_body = api_body
+        self.calls: list[str] = []
+        self.request_headers: list[dict[str, str]] = []
+
+    def get(self, url, **kwargs):
+        assert kwargs["allow_redirects"] is False
+        self.calls.append(url)
+        self.request_headers.append(dict(kwargs["headers"]))
+        if url.endswith("/racing/2026-06-01"):
+            return FakeResponse(
+                url,
+                b"<html>meeting</html>",
+                "text/html; charset=utf-8",
+                self.server_time,
+            )
+        if url == RACE_URL:
+            return FakeResponse(
+                url, self.source_body, "text/html; charset=utf-8", self.server_time
+            )
+        if url == ODDS_URL:
+            return FakeResponse(
+                url, self.source_body, "text/html; charset=utf-8", self.server_time
+            )
+        if "/api/runners/odds?" in url:
+            return FakeResponse(
+                url,
+                self.api_body
+                or api_payload(
+                        provider=self.provider,
+                        missing_runner=self.missing_runner,
+                        mismatched_quote_id=self.mismatched_quote_id,
+                    ),
+                "application/json; charset=utf-8",
+                self.server_time,
+            )
+        raise AssertionError(url)
+
+
+class FakeClock:
+    def __init__(self, start: datetime):
+        self.value = start
+
+    def __call__(self):
+        value = self.value
+        self.value += timedelta(milliseconds=100)
+        return value
+
+
+def plan(**overrides):
+    payload = {
+        "schema_version": "thedogs_market_snapshot_plan_v1",
+        "race_id": RACE_ID,
+        "race_url": RACE_URL,
+        "odds_url": ODDS_URL,
+        "jump_timestamp": JUMP.isoformat(),
+        "nominal_window": "T-120",
+        "expected_active_runner_ids": ["101", "102"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def capture(
+    tmp_path: Path,
+    *,
+    plan_payload=None,
+    provider: bool = True,
+    missing_runner: str | None = None,
+    mismatched_quote_id: bool = False,
+    source_body: bytes | None = None,
+    api_body: bytes | None = None,
+):
+    current = JUMP - timedelta(minutes=120)
+    session = FakeSession(
+        provider=provider,
+        missing_runner=missing_runner,
+        server_time=current,
+        mismatched_quote_id=mismatched_quote_id,
+        source_body=source_body,
+        api_body=api_body,
+    )
+    result = capture_snapshot(
+        plan_payload or plan(),
+        tmp_path / "capture" / "snapshot",
+        session=session,
+        current_time=current,
+        clock=FakeClock(current),
+        repo_root=tmp_path,
+    )
+    return result, session
+
+
+def test_exact_odds_url_is_required(tmp_path):
+    with pytest.raises(CaptureError, match="exact_thedogs_odds_url_required"):
+        capture(tmp_path, plan_payload=plan(odds_url=RACE_URL))
+
+
+def test_http_date_and_age_interval_binds_cached_response_time():
+    request_time = JUMP - timedelta(minutes=120)
+    response = TimedResponse(
+        requested_url=ODDS_URL,
+        request_start_utc=request_time,
+        request_end_utc=request_time + timedelta(milliseconds=100),
+        final_url=ODDS_URL,
+        status_code=200,
+        headers={
+            "content-type": "text/html; charset=utf-8",
+            "date": format_datetime(request_time - timedelta(seconds=18), usegmt=True),
+            "age": "18",
+        },
+        body=b"source",
+    )
+
+    validate_response(response, exact_url=ODDS_URL, content_type_prefix="text/html")
+
+
+def test_internal_race_id_is_preserved_separately_from_source_alias(tmp_path):
+    result, _session = capture(tmp_path)
+
+    receipt = json.loads(Path(result["receipt_path"]).read_text())
+    assert receipt["race_id"] == RACE_ID
+    assert receipt["race_identity"]["venue_slug"] == "meadows"
+    assert receipt["race_identity"]["race_number"] == 1
+
+
+def test_expected_active_native_runner_set_is_required(tmp_path):
+    with pytest.raises(CaptureError, match="expected_active_runner_ids_required"):
+        capture(tmp_path, plan_payload=plan(expected_active_runner_ids=[]))
+
+
+def test_complete_active_field_and_native_ids_are_captured(tmp_path):
+    result, session = capture(tmp_path)
+
+    receipt = json.loads(Path(result["receipt_path"]).read_text())
+    assert result["status"] == "CAPTURE_ACCEPTED"
+    assert receipt["active_native_runner_ids"] == ["101", "102"]
+    assert receipt["all_native_runner_ids"] == ["101", "102", "103"]
+    assert [row["current_price"] for row in receipt["runners"]] == [2.5, 3.5, None]
+    assert receipt["runners"][0]["page_box"] == 1
+    assert receipt["runners"][0]["page_effective_box"] is None
+    assert receipt["runners"][0]["api_run_box"] == 1
+    assert receipt["runners"][0]["effective_box"] == 1
+    assert receipt["provider"]["classification"] == "provider_explicit"
+    assert receipt["provider"]["code"] == "ladbrokes"
+    assert receipt["open_low_high_are_temporal_observations"] is False
+    assert len(session.calls) == 4
+
+
+def test_native_odds_api_uses_frontend_xhr_request_header(tmp_path):
+    _result, session = capture(tmp_path)
+
+    assert all(
+        "X-Requested-With" not in headers for headers in session.request_headers[:3]
+    )
+    assert session.request_headers[3]["X-Requested-With"] == "XMLHttpRequest"
+
+
+def test_incomplete_active_field_is_rejected(tmp_path):
+    with pytest.raises(CaptureError, match="active_runner_current_price_missing"):
+        capture(tmp_path, missing_runner="102")
+
+
+def test_native_id_expectation_mismatch_is_rejected(tmp_path):
+    with pytest.raises(CaptureError, match="expected_native_runner_set_mismatch"):
+        capture(
+            tmp_path,
+            plan_payload=plan(expected_active_runner_ids=["101", "999"]),
+        )
+
+
+def test_api_native_runner_id_mismatch_is_rejected(tmp_path):
+    with pytest.raises(CaptureError, match="native_runner_quote_id_mismatch"):
+        capture(tmp_path, mismatched_quote_id=True)
+
+
+def test_native_id_replacement_resolves_only_from_explicit_matching_boxes(tmp_path):
+    result, _session = capture(
+        tmp_path,
+        plan_payload=plan(expected_active_runner_ids=["101", "104"]),
+        source_body=replacement_source_html(),
+        api_body=replacement_api_payload(),
+    )
+
+    receipt = json.loads(Path(result["receipt_path"]).read_text())
+    rows = {row["native_runner_id"]: row for row in receipt["runners"]}
+    assert rows["104"] == {
+        "active": True,
+        "api_run_box": 2,
+        "box": 9,
+        "current_price": 3.5,
+        "effective_box": 2,
+        "effective_box_provenance": {
+            "api_source": "thedogs_runner_odds_api_fixed_win_run_box",
+            "page_source": "thedogs_odds_page_race_runners_name_box_from_box",
+            "resolution": "explicit_replacement_box_match",
+        },
+        "native_runner_id": "104",
+        "page_box": 9,
+        "page_effective_box": 2,
+        "provider": {"code": "ladbrokes", "id": "63", "name": "Ladbrokes"},
+        "runner_name": "Reserve",
+    }
+    assert rows["102"]["active"] is False
+    assert rows["102"]["api_run_box"] == 2
+    assert rows["102"]["effective_box"] is None
+
+
+@pytest.mark.parametrize(
+    ("source_body", "api_body"),
+    [
+        (replacement_source_html(), replacement_api_payload(replacement_run_box=3)),
+        (source_html(), mismatched_normal_api_payload()),
+    ],
+)
+def test_contradictory_page_and_api_effective_boxes_fail_closed(
+    tmp_path, source_body, api_body
+):
+    expected_ids = ["101", "104"] if b"runner/104" in source_body else ["101", "102"]
+    with pytest.raises(CaptureError, match="effective_box_source_conflict"):
+        capture(
+            tmp_path,
+            plan_payload=plan(expected_active_runner_ids=expected_ids),
+            source_body=source_body,
+            api_body=api_body,
+        )
+
+
+def test_duplicate_active_effective_box_from_replacement_fails_closed(tmp_path):
+    body = replacement_source_html().replace(
+        b'race-runner race-runner--scratched"><td><sprite-svg name="rug_2"',
+        b'race-runner"><td><sprite-svg name="rug_2"',
+    )
+    payload = json.loads(replacement_api_payload())
+    payload["runner_odds"]["102"][0]["price"] = 4.0
+
+    with pytest.raises(CaptureError, match="active_effective_box_not_unique"):
+        capture(
+            tmp_path,
+            plan_payload=plan(expected_active_runner_ids=["101", "102", "104"]),
+            source_body=body,
+            api_body=json.dumps(payload).encode(),
+        )
+
+
+def test_scratched_runner_with_active_price_fails_closed(tmp_path):
+    with pytest.raises(CaptureError, match="scratched_runner_has_active_price"):
+        capture(
+            tmp_path,
+            plan_payload=plan(expected_active_runner_ids=["101", "104"]),
+            source_body=replacement_source_html(),
+            api_body=replacement_api_payload(original_price=4.0),
+        )
+
+
+def test_missing_native_id_on_active_runner_fails_closed():
+    body = source_html().replace(
+        b'<tbody data-content-url="/dogs/runner/101/odds">', b"<tbody>"
+    )
+    with pytest.raises(
+        CaptureError, match="native_runner_identity_missing_from_odds_page"
+    ):
+        parse_source_runners(body)
+
+
+def test_ambiguous_native_id_mapping_in_page_fails_closed():
+    body = source_html().replace(
+        b'<runner-odd data-runner-id="101">',
+        b'<runner-odd data-runner-id="999">',
+    )
+    with pytest.raises(
+        CaptureError, match="native_runner_identity_mismatch_in_odds_page"
+    ):
+        parse_source_runners(body)
+
+
+def test_malformed_explicit_replacement_box_fails_closed():
+    with pytest.raises(CaptureError, match="effective_box_source_invalid_in_odds_page"):
+        parse_source_runners(replacement_source_html(from_box_text="(box 2)"))
+
+
+def test_provider_unknown_is_preserved_without_rejection(tmp_path):
+    result, _session = capture(tmp_path, provider=False)
+
+    receipt = json.loads(Path(result["receipt_path"]).read_text())
+    assert receipt["provider"] == {
+        "classification": "provider_unknown",
+        "code": None,
+        "id": None,
+        "name": None,
+        "source": "provider_not_explicit_in_source_payload",
+    }
+
+
+def test_identical_rerun_is_idempotent_without_network(tmp_path):
+    first, _session = capture(tmp_path)
+    second_session = FakeSession()
+
+    second = capture_snapshot(
+        plan(),
+        tmp_path / "capture" / "snapshot",
+        session=second_session,
+        current_time=JUMP - timedelta(minutes=120),
+        repo_root=tmp_path,
+    )
+
+    assert first["raw_html_sha256"] == second["raw_html_sha256"]
+    assert second["status"] == "SKIPPED_IDENTICAL_SNAPSHOT"
+    assert second_session.calls == []
+
+
+def test_identical_rerun_still_requires_expected_native_runner_set(tmp_path):
+    capture(tmp_path)
+    replay_plan = plan()
+    replay_plan.pop("expected_active_runner_ids")
+
+    with pytest.raises(CaptureError, match="expected_active_runner_ids_required"):
+        capture_snapshot(
+            replay_plan,
+            tmp_path / "capture" / "snapshot",
+            session=FakeSession(),
+            current_time=JUMP - timedelta(minutes=120),
+            repo_root=tmp_path,
+        )
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda receipt: receipt["runners"][0].update({"effective_box": 8}),
+        lambda receipt: receipt["provider"].update({"code": "altered"}),
+        lambda receipt: receipt["odds_api_http"].update(
+            {"request_end_utc": (JUMP - timedelta(minutes=119)).isoformat()}
+        ),
+        lambda receipt: receipt.update(
+            {"nominal_capture_utc": (JUMP - timedelta(minutes=60)).isoformat()}
+        ),
+    ],
+)
+def test_semantically_conflicting_existing_receipt_fails_closed(tmp_path, mutate):
+    result, _session = capture(tmp_path)
+    receipt_path = Path(result["receipt_path"])
+    receipt_path.chmod(0o644)
+    receipt = json.loads(receipt_path.read_text())
+    mutate(receipt)
+    core = {key: value for key, value in receipt.items() if key != "receipt_core_sha256"}
+    receipt["receipt_core_sha256"] = sha256_bytes(canonical_json_bytes(core))
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+    receipt_path.chmod(0o444)
+
+    with pytest.raises(CaptureError, match="conflicting_snapshot"):
+        capture_snapshot(
+            plan(),
+            tmp_path / "capture" / "snapshot",
+            session=FakeSession(),
+            current_time=JUMP - timedelta(minutes=120),
+            repo_root=tmp_path,
+        )
+
+
+def test_legacy_v1_receipt_remains_idempotent_without_network(tmp_path):
+    first, _session = capture(tmp_path)
+    receipt_path = Path(first["receipt_path"])
+    receipt_path.chmod(0o644)
+    receipt = json.loads(receipt_path.read_text())
+    receipt["schema_version"] = "thedogs_market_snapshot_receipt_v1"
+    legacy_keys = {
+        "native_runner_id",
+        "runner_name",
+        "box",
+        "active",
+        "current_price",
+        "provider",
+    }
+    receipt["runners"] = [
+        {key: value for key, value in row.items() if key in legacy_keys}
+        for row in receipt["runners"]
+    ]
+    core = {key: value for key, value in receipt.items() if key != "receipt_core_sha256"}
+    receipt["receipt_core_sha256"] = sha256_bytes(canonical_json_bytes(core))
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+    receipt_path.chmod(0o444)
+    second_session = FakeSession()
+
+    second = capture_snapshot(
+        plan(),
+        tmp_path / "capture" / "snapshot",
+        session=second_session,
+        current_time=JUMP - timedelta(minutes=120),
+        repo_root=tmp_path,
+    )
+
+    assert second["status"] == "SKIPPED_IDENTICAL_SNAPSHOT"
+    assert second_session.calls == []
+
+
+def test_conflicting_existing_snapshot_fails_closed(tmp_path):
+    result, _session = capture(tmp_path)
+    raw_path = Path(result["raw_html_path"])
+    raw_path.chmod(0o644)
+    raw_path.write_bytes(b"conflict")
+
+    with pytest.raises(CaptureError, match="conflicting_snapshot"):
+        capture_snapshot(
+            plan(),
+            tmp_path / "capture" / "snapshot",
+            session=FakeSession(),
+            current_time=JUMP - timedelta(minutes=120),
+            repo_root=tmp_path,
+        )
+
+
+def test_missed_window_is_rejected_before_network(tmp_path):
+    session = FakeSession()
+
+    with pytest.raises(CaptureError, match="nominal_window_missed"):
+        capture_snapshot(
+            plan(),
+            tmp_path / "capture" / "snapshot",
+            session=session,
+            current_time=JUMP - timedelta(minutes=118),
+            repo_root=tmp_path,
+        )
+
+    assert session.calls == []


### PR DESCRIPTION
## What changed

- add a prospective TheDogs point-in-time market snapshot adapter
- add an independent immutable-receipt auditor under a non-conflicting filename
- preserve the warmed meeting → race → odds page → native odds API request chain
- enforce native runner identity, complete fields, effective-box integrity, provider classification, strict pre-jump timing, and the five prescribed windows
- keep raw and receipt evidence immutable, hash-bound, replay-idempotent, and conflict-failing

## Why

The reconciliation selected the proven prospective TheDogs source seam for a narrow, report-only implementation. The adapter remains disconnected from daemons, systemd, `live_odds`, databases, fitting, scoring, prediction, promotion, EV, and betting.

## Review fixes

The final head also closes three independent review findings:

- bounds capture tolerances to no wider than 30 seconds early and 90 seconds late
- independently verifies meeting → race → odds → API chronology
- rejects unexpected native runner IDs in API payloads

## Validation

```text
48 passed in 0.33s
git diff --check a79f06f6b3a52ab9a01871b726c36e149b886830...HEAD
```

Two-axis exact-head review at `239a3a3ad14299ecc5a161847e8088d0a8e1a294` found no hard Standards violations and no Spec findings. The remaining duplication observations are non-blocking judgement calls caused by intentional independent audit recomputation.