### PR TITLE
Bind UI predictor to deployed current index

### DIFF
--- a/docs/on_demand_race_prediction.md
+++ b/docs/on_demand_race_prediction.md
@@ -23,8 +23,10 @@ overrun, and post-jump requests fail closed.
 
 Race resolution reads one collector-owned
 `shadow_autopilot_daemon_runtime/manual_prediction_current_race_index.json`
-packet beneath the first `--capture-evidence-root` (or the explicit
-`--current-race-index`). A successful scheduled odds-refresh cycle atomically
+packet. Direct CLI runs use the fixed default locator. Operator UI jobs use the
+same fixed relative locator beneath the server-bound primary evidence root;
+the worker rejects any configuration whose separately validated index path or
+evidence root disagrees with that binding. A successful scheduled odds-refresh cycle atomically
 replaces this fixed packet with at most 32 selected races and seals the source
 refresh-report path and SHA-256. Publication occurs immediately after that
 bounded refresh completes, before the slower multi-race odds-capture batch, so

--- a/scripts/predict_race_now.py
+++ b/scripts/predict_race_now.py
@@ -918,6 +918,7 @@ def _run_prediction(
     )
     if current_time.tzinfo is None or current_time.utcoffset() is None:
         raise PredictionBlocked("CURRENT_TIME_TIMEZONE_MISSING")
+    job_id = _job_id(getattr(args, "job_id", None))
     model = resolve_model(args.model)
     config, config_sha, config_raw = load_config(Path(args.config), model)
     from race_collection.synchronous_manual_capture import (
@@ -934,10 +935,10 @@ def _run_prediction(
     )
     primary_evidence_root = evidence_roots[0]
     current_index_path = (
-        DEFAULT_CAPTURE_EVIDENCE_ROOTS[0]
-        / "shadow_autopilot_daemon_runtime"
-        / "manual_prediction_current_race_index.json"
-    )
+        primary_evidence_root
+        if job_id is not None
+        else DEFAULT_CAPTURE_EVIDENCE_ROOTS[0]
+    ) / "shadow_autopilot_daemon_runtime" / "manual_prediction_current_race_index.json"
     discovery_started = dependencies.monotonic()
     try:
         races = dependencies.schedule(
@@ -991,7 +992,7 @@ def _run_prediction(
     state.update(
         bundle=bundle,
         prediction_id=str(uuid.uuid4()),
-        job_id=_job_id(getattr(args, "job_id", None)),
+        job_id=job_id,
         model=model,
         config_sha=config_sha,
         race=race,

--- a/src/operator_ui/bootstrap.py
+++ b/src/operator_ui/bootstrap.py
@@ -299,8 +299,9 @@ def _build_r3_services(app: Flask, profile: str) -> R3Services:
     if layout is not None:
         paths=layout["paths"]; dirs=layout["dirs"]
     else:
-        paths={name:base/name for name in ("audit.sqlite3","canonical.sqlite3","jobs.sqlite3","current_index.json")}
         dirs={name:base/name for name in ("current_evidence","prediction_bundles","collector_requests","capture_evidence_a","capture_evidence_b")}
+        paths={name:base/name for name in ("audit.sqlite3","canonical.sqlite3","jobs.sqlite3")}
+        paths["current_index.json"]=dirs["current_evidence"]/"shadow_autopilot_daemon_runtime"/"manual_prediction_current_race_index.json"
     for name,path in paths.items():
         if name!="jobs.sqlite3":_regular(path)
         else:
@@ -330,7 +331,7 @@ def _build_r3_services(app: Flask, profile: str) -> R3Services:
     config=json.loads(config_path.read_text(encoding="utf-8"))
     if config.get("schema_version")!="on_demand_prediction_config_v1" or config.get("model")!=resolved_model:raise RuntimeError("fixed R3 config divergent")
     choice=ServerChoice(config_path,"manual-default",_sha(config_path),resolved_model,model_sha,manifest_sha,schema_sha,model_path,manifest_path,schema_path)
-    captures=(dirs["capture_evidence_a"],) if profile=="repository-v1" else (dirs["capture_evidence_a"],dirs["capture_evidence_b"])
+    captures=(dirs["current_evidence"],) if profile=="repository-v1" else (dirs["current_evidence"],dirs["capture_evidence_a"],dirs["capture_evidence_b"])
     worker=WorkerConfig(layout["pinned_python"] if layout is not None else Path(sys.executable),product_root,{"latest-research":choice},paths["canonical.sqlite3"],dirs["prediction_bundles"],captures,dirs["collector_requests"],paths["current_index.json"],dirs["current_evidence"],1.0,45.0,90.0,2.0)
     store=JobStore(paths["jobs.sqlite3"],separate_from=(paths["audit.sqlite3"],paths["canonical.sqlite3"]))
 

--- a/src/operator_ui/prediction_worker.py
+++ b/src/operator_ui/prediction_worker.py
@@ -40,6 +40,9 @@ class WorkerConfig:
     _runtime:tuple[tuple[Path,tuple[int,int],str],...]=field(init=False,repr=False,compare=False)
     def __post_init__(self):
         if not self.capture_evidence_roots or not self.choices: raise ValueError("worker allowlists must be non-empty")
+        expected_index=self.capture_evidence_roots[0]/"shadow_autopilot_daemon_runtime"/"manual_prediction_current_race_index.json"
+        if self.current_index_path.absolute()!=expected_index.absolute(): raise ValueError("current index binding disagrees with evidence root")
+        if self.current_index_evidence_root.absolute()!=self.capture_evidence_roots[0].absolute(): raise ValueError("current index evidence root disagrees with capture root")
         for v in (self.current_index_timeout_seconds,self.fetch_timeout_seconds,self.process_timeout_seconds,self.cancellation_grace_seconds):
             if not isinstance(v,(int,float)) or isinstance(v,bool) or v<=0: raise ValueError("worker timeouts must be positive")
         executable=self.python_executable.resolve(strict=True); script=(self.repository_root/"scripts/predict_race_now.py").absolute()

--- a/tests/operator_ui/test_bootstrap.py
+++ b/tests/operator_ui/test_bootstrap.py
@@ -360,7 +360,9 @@ def test_finite_testing_fixture_profile_builds_real_repository_composition(tmp_p
     base = repo / "tests/operator_ui/fixtures/r3_runtime"; base.mkdir(parents=True); base.chmod(0o700)
     for directory in ("current_evidence","prediction_bundles","collector_requests","capture_evidence_a","capture_evidence_b"):
         (base / directory).mkdir(mode=0o700)
-    for filename in ("canonical.sqlite3","current_index.json"):(base / filename).write_bytes(b"{}")
+    (base / "canonical.sqlite3").write_bytes(b"{}")
+    index=base/"current_evidence/shadow_autopilot_daemon_runtime/manual_prediction_current_race_index.json"
+    index.parent.mkdir(parents=True); index.write_bytes(b"{}")
     monkeypatch.setattr(bootstrap_module, "_REPOSITORY_ROOT", repo)
     digest=hashlib.sha256(b"fixture-runners").hexdigest()
     race={"race_id":"race-fixture","jump_datetime":"2026-08-01T01:00:00+00:00","runner_set_sha256":digest,
@@ -412,7 +414,9 @@ def test_finite_profile_rejects_unsafe_preexisting_job_store(tmp_path, monkeypat
         target=repo/relative; target.parent.mkdir(parents=True,exist_ok=True); shutil.copy2(source,target)
     base=repo/"tests/operator_ui/fixtures/r3_runtime"; base.mkdir(parents=True); base.chmod(0o700)
     for directory in ("current_evidence","prediction_bundles","collector_requests","capture_evidence_a","capture_evidence_b"):(base/directory).mkdir(mode=0o700)
-    for filename in ("audit.sqlite3","canonical.sqlite3","current_index.json"):(base/filename).write_bytes(b"{}")
+    for filename in ("audit.sqlite3","canonical.sqlite3"):(base/filename).write_bytes(b"{}")
+    index=base/"current_evidence/shadow_autopilot_daemon_runtime/manual_prediction_current_race_index.json"
+    index.parent.mkdir(parents=True); index.write_bytes(b"{}")
     if unsafe_kind=="symlink":(base/"jobs.sqlite3").symlink_to(base/"canonical.sqlite3")
     else:(base/"jobs.sqlite3").mkdir()
     monkeypatch.setattr(bootstrap_module,"_REPOSITORY_ROOT",repo)

--- a/tests/operator_ui/test_prediction_worker.py
+++ b/tests/operator_ui/test_prediction_worker.py
@@ -20,7 +20,9 @@ def setup(tmp_path):
     choice=ServerChoice(paths[0],"manual-default",H,"market_form_residual_v1",H,H,H,*paths[1:])
     python=Path("/tmp/ghu010-validation-73f1e5d/bin/python")
     if not python.is_file(): python=Path("/usr/bin/python3")
-    cfg=WorkerConfig(python,Path(__file__).parents[2],{"latest-research":choice},tmp_path/"canonical.db",tmp_path/"output",(tmp_path/"evidence-a",tmp_path/"evidence-b"),tmp_path/"requests",tmp_path/"index.json",tmp_path/"evidence",1,45.0,90.0,2)
+    evidence_a=tmp_path/"evidence-a"
+    current_index=evidence_a/"shadow_autopilot_daemon_runtime"/"manual_prediction_current_race_index.json"
+    cfg=WorkerConfig(python,Path(__file__).parents[2],{"latest-research":choice},tmp_path/"canonical.db",tmp_path/"output",(evidence_a,tmp_path/"evidence-b"),tmp_path/"requests",current_index,evidence_a,1,45.0,90.0,2)
     value=JobStore(tmp_path/"jobs.db",separate_from=(tmp_path/"canonical.db",tmp_path/"audit.db"))
     inp=JobInput(RACE_ID,"2026-08-01T01:00:00+00:00",H,"latest-research","market_form_residual_v1",H,H,H,"manual-default",H,"auto",({"box":1,"name":"ALPHA","identity":"ALPHA"},))
     job=value.create(actor_identity="op",actor_level=2,operation="manual_prediction",idempotency_key="idempotency-key-1234",job_input=inp,now=NOW,confirm_audit=CONFIRM)
@@ -56,7 +58,17 @@ class Process:
 def test_exact_argv_and_forbidden_surface(tmp_path):
     cfg,_,job=setup(tmp_path); argv=fixed_argv(job,cfg)
     assert argv[0:6]==(str(cfg.pinned_python),str(cfg.script),"--race-id",RACE_ID,"--model","latest-research")
-    assert {"--race","--race-url","--replay-bundle","--list-configs","--current-time","--lock-path"}.isdisjoint(argv)
+    assert {"--race","--race-url","--replay-bundle","--list-configs","--current-time","--lock-path","--current-index-path"}.isdisjoint(argv)
+
+def test_worker_rejects_current_index_outside_primary_evidence_root(tmp_path):
+    cfg,_,_=setup(tmp_path)
+    with pytest.raises(ValueError,match="current index binding disagrees"):
+        replace(cfg,current_index_path=tmp_path/"other"/"index.json")
+
+def test_worker_rejects_divergent_current_index_evidence_root(tmp_path):
+    cfg,_,_=setup(tmp_path)
+    with pytest.raises(ValueError,match="current index evidence root disagrees"):
+        replace(cfg,current_index_evidence_root=tmp_path/"other-evidence")
 
 def test_launch_uses_only_retained_runtime_descriptors(tmp_path):
     cfg,store,job=setup(tmp_path); calls=[]

--- a/tests/operator_ui/test_r3_e2e_safety.py
+++ b/tests/operator_ui/test_r3_e2e_safety.py
@@ -96,7 +96,9 @@ def test_one_authenticated_submission_reaches_real_worker_once_without_false_rea
         path.write_bytes(b"ghu-035c1")
         files.append(path)
     choice = ServerChoice(files[0], "manual-default", DIGEST, "market_form_residual_v1", DIGEST, DIGEST, DIGEST, *files[1:])
-    config = WorkerConfig(Path("/usr/bin/python3"), ROOT, {"latest-research": choice}, tmp_path / "canonical.db", tmp_path / "output", (tmp_path / "evidence-a",), tmp_path / "requests", tmp_path / "index.json", tmp_path / "evidence", 1, 45.0, 90.0, 2)
+    evidence = tmp_path / "evidence-a"
+    index = evidence / "shadow_autopilot_daemon_runtime" / "manual_prediction_current_race_index.json"
+    config = WorkerConfig(Path("/usr/bin/python3"), ROOT, {"latest-research": choice}, tmp_path / "canonical.db", tmp_path / "output", (evidence,), tmp_path / "requests", index, evidence, 1, 45.0, 90.0, 2)
 
     app = Flask(__name__)
     app.config.update(TESTING=True, OPERATOR_UI_CONNECTED_MODE=True, OPERATOR_UI_SECRET_KEY="s" * 48,

--- a/tests/test_predict_race_now.py
+++ b/tests/test_predict_race_now.py
@@ -358,6 +358,7 @@ def args(tmp_path: Path, **overrides: Any) -> argparse.Namespace:
         "fetch_timeout_seconds": 1.0,
         "capture_evidence_root": [tmp_path / "evidence"],
         "collector_request_root": tmp_path / "collector-requests",
+        "job_id": None,
     }
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -1242,6 +1243,43 @@ def test_prediction_discovery_uses_only_fixed_current_index_locator(tmp_path: Pa
         / "shadow_autopilot_daemon_runtime"
         / "manual_prediction_current_race_index.json"
     ]
+
+
+def test_prediction_discovery_uses_worker_bound_evidence_root_index_locator(tmp_path: Path):
+    observed: list[Path] = []
+    deps = dependencies()
+    bound_root = tmp_path / "bound-evidence"
+
+    def schedule(*values: Any) -> list[dict[str, Any]]:
+        observed.append(values[2])
+        return [race()]
+
+    deps.schedule = schedule
+    run_prediction(
+        args(
+            tmp_path,
+            job_id="job_" + "a" * 32,
+            capture_evidence_root=[bound_root],
+        ),
+        deps,
+    )
+    assert observed == [
+        bound_root
+        / "shadow_autopilot_daemon_runtime"
+        / "manual_prediction_current_race_index.json"
+    ]
+
+
+def test_invalid_worker_job_id_fails_before_discovery_or_bundle_creation(tmp_path: Path):
+    calls = {"schedule": 0}
+    deps = dependencies()
+    deps.schedule = lambda *values: calls.__setitem__("schedule", calls["schedule"] + 1)
+
+    with pytest.raises(PredictionBlocked,match="PREDICTION_BUNDLE_INVALID"):
+        run_prediction(args(tmp_path,job_id="not-a-worker-job"),deps)
+
+    assert calls["schedule"] == 0
+    assert not (tmp_path / "bundles").exists()
 
 
 def test_request_race_failure_preserves_original_pre_bundle_blocker(


### PR DESCRIPTION
## Summary

- make Operator UI predictor jobs resolve the current-index packet beneath the server-bound primary evidence root
- reject parent/child current-index path or evidence-root divergence before launch
- validate worker job IDs before discovery or bundle creation
- align fixture/E2E topology and document the direct-CLI versus Operator UI binding

## Live defect reproduced

The UI worker successfully revalidated the binding-derived live index, then launched `predict_race_now.py`. The child ignored that binding and used the source-checkout default index path. Exact deployed source has no live packet there, so the child emitted an early legacy blocker and the V2-only worker correctly recorded `PROCESS_OUTPUT_INVALID`.

## Validation

- `py_compile` for changed Python files
- focused binding/security checks: 6 passed
- adjacent Operator UI/predictor suite: 156 passed, with one unrelated descriptor-snapshot timing race passing immediately in isolation; five unrelated slow fault-injection matrix cases excluded from that adjacent aggregate after prior execution
- `git diff --check`
- independent Standards/Spec re-review: CLEAR

No prediction retry, model change, canonical DB write, collector restart, or betting/ROI action is included.
