### PR TITLE
Fix read-only WAL history sealing

### DIFF
--- a/docs/on_demand_race_prediction.md
+++ b/docs/on_demand_race_prediction.md
@@ -130,14 +130,16 @@ lock implementation.
 
 ## Feature cutoff
 
-For the residual model, the source database is opened with SQLite URI
-`mode=ro` and `PRAGMA query_only=ON`. Before feature materialization, the command
-creates a private SQLite database containing only uniquely identified history
-whose `race_date` is strictly before the target jump date. The exact target
-race, every same-day row, every future row, and ambiguous dates are excluded.
-Relevant runner history without a unique dated race identity is a hard blocker.
-The reviewed feature builder then reads only this sealed database. Its
-target-row and post-outcome provenance counters must remain zero.
+For the residual model, the canonical source database is copied as verified
+bytes without asking SQLite to open it. SQLite opens that private copy with URI
+`mode=ro&immutable=1` and `PRAGMA query_only=ON`. Before feature
+materialization, the command creates a second private SQLite database containing
+only uniquely identified history whose `race_date` is strictly before the
+target jump date. The exact target race, every same-day row, every future row,
+and ambiguous dates are excluded. Relevant runner history without a unique
+dated race identity is a hard blocker. The reviewed feature builder then reads
+only this sealed database. Its target-row and post-outcome provenance counters
+must remain zero.
 
 This deliberately excludes same-day history when the source schema cannot
 prove a precise pre-jump timestamp. It trades some feature coverage for a
@@ -183,6 +185,13 @@ stable blocker in `blockers`; the CLI exits 2.
 The bundle contains the request, canonical config, model schema, copied frozen
 artifacts when applicable, receipt/capture provenance, source form and sidecar,
 sealed history database and audit, sealed features, result, and a hash manifest.
+The history sealer never opens SQLite against the canonical database inside the
+read-only service namespace. It requires an empty WAL/rollback journal, copies
+the main image into private bundle workspace, and verifies stable source
+identity plus equal source/copy hashes before opening the copy. A concurrent or
+uncheckpointed writer fails closed as `HISTORY_DATABASE_BUSY` or
+`HISTORY_DATABASE_CHANGED`; operators should wait for a later qualified race,
+not make the canonical database writable to the UI.
 Replay is offline and rejects changed, missing, or added file bytes:
 
 ```bash

--- a/src/predictor/on_demand.py
+++ b/src/predictor/on_demand.py
@@ -10,6 +10,8 @@ import re
 import shutil
 import sqlite3
 import stat
+import sys
+import tempfile
 import time
 import uuid
 from collections.abc import Callable, Mapping, Sequence
@@ -111,7 +113,7 @@ BLOCKER_STAGE_BY_CODE = {
     **{code: "VALIDATION" for code in {
         "AMBIGUOUS_RACE", "BUNDLE_SOURCE_UNSAFE", "CONFIG_INVALID_JSON", "CONFIG_NOT_CANONICAL",
         "CONFIG_SCHEMA_MISMATCH", "CURRENT_TIME_TIMEZONE_MISSING", "EXACT_RACE_IDENTITY_UNAVAILABLE",
-        "HISTORY_CUTOFF_AMBIGUOUS", "HISTORY_DATABASE_INTEGRITY_FAILED", "HISTORY_DATABASE_UNAVAILABLE", "HISTORY_IDENTITY_AMBIGUOUS",
+        "HISTORY_CUTOFF_AMBIGUOUS", "HISTORY_DATABASE_BUSY", "HISTORY_DATABASE_CHANGED", "HISTORY_DATABASE_INTEGRITY_FAILED", "HISTORY_DATABASE_UNAVAILABLE", "HISTORY_IDENTITY_AMBIGUOUS", "HISTORY_SEAL_WRITE_FAILED",
         "HISTORY_SCHEMA_AMBIGUOUS", "HISTORY_SCHEMA_MISSING", "MODEL_ARTIFACT_MISSING",
         "MODEL_CONFIG_MISMATCH", "MODEL_SCHEMA_INVALID", "MODEL_SCHEMA_MISSING", "MODEL_UNSUPPORTED", "NO_MATCH",
         "ODDS_TIMESTAMP_AMBIGUOUS", "OUTPUT_ROOT_UNSAFE", "OUTPUT_ROOT_WRITABLE_BY_OTHERS",
@@ -1199,6 +1201,161 @@ def _table_columns(connection: sqlite3.Connection, table: str) -> list[str]:
     return [str(row[1]) for row in connection.execute(f'PRAGMA table_info("{table}")')]
 
 
+def _history_sidecars_clear(source: Path) -> bool:
+    for suffix in ("-wal", "-journal"):
+        path = Path(f"{source}{suffix}")
+        try:
+            metadata = path.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            return False
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink() or metadata.st_size:
+            return False
+    return True
+
+
+def _remove_history_work_file(path: Path | None) -> str | None:
+    if path is None:
+        return None
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as exc:
+        return type(exc).__name__
+    return None
+
+
+def _verified_history_snapshot(source: Path, directory: Path) -> tuple[Path, str]:
+    """Copy one checkpointed SQLite image without writing beside the source."""
+
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise PredictionBlocked("HISTORY_SEAL_WRITE_FAILED") from exc
+    if not _history_sidecars_clear(source):
+        raise PredictionBlocked("HISTORY_DATABASE_BUSY")
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        source_fd = os.open(source, flags)
+    except OSError as exc:
+        raise PredictionBlocked("HISTORY_DATABASE_UNAVAILABLE") from exc
+    snapshot_fd = -1
+    snapshot_path: Path | None = None
+    try:
+        try:
+            before = os.fstat(source_fd)
+        except OSError as exc:
+            raise PredictionBlocked("HISTORY_DATABASE_UNAVAILABLE") from exc
+        if not stat.S_ISREG(before.st_mode):
+            raise PredictionBlocked("HISTORY_DATABASE_UNAVAILABLE")
+        try:
+            snapshot_fd, raw_path = tempfile.mkstemp(
+                prefix=".history-source-", suffix=".db", dir=directory
+            )
+            snapshot_path = Path(raw_path)
+            os.fchmod(snapshot_fd, 0o600)
+        except OSError as exc:
+            raise PredictionBlocked("HISTORY_SEAL_WRITE_FAILED") from exc
+        copied = hashlib.sha256()
+        while True:
+            try:
+                chunk = os.read(source_fd, 1024 * 1024)
+            except OSError as exc:
+                raise PredictionBlocked("HISTORY_DATABASE_UNAVAILABLE") from exc
+            if not chunk:
+                break
+            copied.update(chunk)
+            view = memoryview(chunk)
+            while view:
+                try:
+                    written = os.write(snapshot_fd, view)
+                except OSError as exc:
+                    raise PredictionBlocked("HISTORY_SEAL_WRITE_FAILED") from exc
+                if written <= 0:
+                    raise PredictionBlocked("HISTORY_SEAL_WRITE_FAILED")
+                view = view[written:]
+        try:
+            os.fsync(snapshot_fd)
+        except OSError as exc:
+            raise PredictionBlocked("HISTORY_SEAL_WRITE_FAILED") from exc
+        try:
+            os.lseek(source_fd, 0, os.SEEK_SET)
+        except OSError as exc:
+            raise PredictionBlocked("HISTORY_DATABASE_UNAVAILABLE") from exc
+        current = hashlib.sha256()
+        while True:
+            try:
+                chunk = os.read(source_fd, 1024 * 1024)
+            except OSError as exc:
+                raise PredictionBlocked("HISTORY_DATABASE_UNAVAILABLE") from exc
+            if not chunk:
+                break
+            current.update(chunk)
+        try:
+            after = os.fstat(source_fd)
+        except OSError as exc:
+            raise PredictionBlocked("HISTORY_DATABASE_CHANGED") from exc
+        stable_identity = (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+            before.st_mtime_ns,
+            before.st_ctime_ns,
+        ) == (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+            after.st_mtime_ns,
+            after.st_ctime_ns,
+        )
+        sidecars_clear = _history_sidecars_clear(source)
+        try:
+            named = source.lstat()
+        except OSError as exc:
+            raise PredictionBlocked("HISTORY_DATABASE_CHANGED") from exc
+        if (
+            not stable_identity
+            or copied.digest() != current.digest()
+            or not sidecars_clear
+            or not stat.S_ISREG(named.st_mode)
+            or (named.st_dev, named.st_ino) != (after.st_dev, after.st_ino)
+        ):
+            raise PredictionBlocked("HISTORY_DATABASE_CHANGED")
+        return snapshot_path, copied.hexdigest()
+    except PredictionBlocked as exc:
+        cleanup_error = _remove_history_work_file(snapshot_path)
+        if cleanup_error is not None:
+            exc.details["snapshot_cleanup_error"] = cleanup_error
+        raise
+    finally:
+        active_error = sys.exc_info()[1]
+        close_errors: dict[str, str] = {}
+        if snapshot_fd >= 0:
+            try:
+                os.close(snapshot_fd)
+            except OSError as exc:
+                close_errors["snapshot_descriptor_close_error"] = type(exc).__name__
+        try:
+            os.close(source_fd)
+        except OSError as exc:
+            close_errors["source_descriptor_close_error"] = type(exc).__name__
+        if close_errors:
+            if isinstance(active_error, PredictionBlocked):
+                active_error.details.update(close_errors)
+            elif active_error is None:
+                cleanup_error = _remove_history_work_file(snapshot_path)
+                if cleanup_error is not None:
+                    close_errors["snapshot_cleanup_error"] = cleanup_error
+                code = (
+                    "HISTORY_SEAL_WRITE_FAILED"
+                    if "snapshot_descriptor_close_error" in close_errors
+                    else "HISTORY_DATABASE_UNAVAILABLE"
+                )
+                raise PredictionBlocked(code, **close_errors)
+
+
 def seal_history_database(
     *,
     source: Path,
@@ -1207,16 +1364,27 @@ def seal_history_database(
     cutoff: datetime,
     runner_names: Sequence[str],
 ) -> dict[str, Any]:
-    if not source.is_file() or target.exists():
+    if not source.is_file() or source.is_symlink() or target.exists():
         raise PredictionBlocked("HISTORY_DATABASE_UNAVAILABLE")
-    source_uri = f"file:{source.resolve()}?mode=ro"
-    source_db = sqlite3.connect(source_uri, uri=True)
-    source_db.row_factory = sqlite3.Row
-    source_db.execute("PRAGMA query_only=ON")
-    source_db.execute("BEGIN")
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target_db = sqlite3.connect(target)
+    snapshot, source_sha256 = _verified_history_snapshot(source, target.parent)
+    source_db: sqlite3.Connection | None = None
+    target_db: sqlite3.Connection | None = None
+    sqlite_phase = "source"
+    completed = False
+    failure: Exception | None = None
     try:
+        source_uri = f"file:{snapshot.resolve()}?mode=ro&immutable=1"
+        source_db = sqlite3.connect(source_uri, uri=True)
+        source_db.row_factory = sqlite3.Row
+        source_db.execute("PRAGMA query_only=ON")
+        source_db.execute("BEGIN")
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise PredictionBlocked("HISTORY_SEAL_WRITE_FAILED") from exc
+        sqlite_phase = "target"
+        target_db = sqlite3.connect(target)
+        sqlite_phase = "source"
         if source_db.execute("PRAGMA quick_check").fetchone()[0] != "ok":
             raise PredictionBlocked("HISTORY_DATABASE_INTEGRITY_FAILED")
         schemas: dict[str, str] = {}
@@ -1227,7 +1395,9 @@ def seal_history_database(
             if row is None or not row[0]:
                 raise PredictionBlocked("HISTORY_SCHEMA_MISSING", table=table)
             schemas[table] = str(row[0])
+            sqlite_phase = "target"
             target_db.execute(schemas[table])
+            sqlite_phase = "source"
         race_columns = _table_columns(source_db, "race_metadata")
         dog_columns = _table_columns(source_db, "dog_race_data")
         if (
@@ -1335,17 +1505,74 @@ def seal_history_database(
                 [tuple(row.get(column) for column in columns) for row in rows],
             )
 
-        insert_rows("race_metadata", race_columns, safe_metadata)
         dog_rows = rows_for_safe_ids("dog_race_data")
+        sqlite_phase = "target"
+        insert_rows("race_metadata", race_columns, safe_metadata)
         insert_rows("dog_race_data", dog_columns, dog_rows)
         target_db.commit()
         target_db.execute("PRAGMA optimize")
+    except sqlite3.Error as exc:
+        code = (
+            "HISTORY_SEAL_WRITE_FAILED"
+            if sqlite_phase == "target"
+            else "HISTORY_DATABASE_INTEGRITY_FAILED"
+        )
+        failure = PredictionBlocked(code, error=type(exc).__name__)
+        failure.__cause__ = exc
+    except Exception as exc:
+        failure = exc
     finally:
-        target_db.close()
-        source_db.close()
+        if target_db is not None:
+            try:
+                target_db.close()
+            except sqlite3.Error as exc:
+                detail = {"target_connection_close_error": type(exc).__name__}
+                if failure is None:
+                    failure = PredictionBlocked(
+                        "HISTORY_SEAL_WRITE_FAILED", **detail
+                    )
+                elif isinstance(failure, PredictionBlocked):
+                    failure.details.update(detail)
+        if source_db is not None:
+            try:
+                source_db.close()
+            except sqlite3.Error as exc:
+                detail = {"source_connection_close_error": type(exc).__name__}
+                if failure is None:
+                    failure = PredictionBlocked(
+                        "HISTORY_DATABASE_INTEGRITY_FAILED",
+                        **detail,
+                    )
+                elif isinstance(failure, PredictionBlocked):
+                    failure.details.update(detail)
+        snapshot_cleanup_error = _remove_history_work_file(snapshot)
+        if snapshot_cleanup_error is not None and failure is None:
+            failure = PredictionBlocked(
+                "HISTORY_SEAL_WRITE_FAILED",
+                snapshot_cleanup_error=snapshot_cleanup_error,
+            )
+        completed = failure is None
+        cleanup_errors = {
+            "snapshot_cleanup_error": snapshot_cleanup_error,
+            "target_cleanup_error": _remove_history_work_file(target)
+            if not completed
+            else None,
+        }
+        cleanup_errors = {
+            key: value for key, value in cleanup_errors.items() if value is not None
+        }
+        if cleanup_errors:
+            if isinstance(failure, PredictionBlocked):
+                failure.details.update(cleanup_errors)
+            elif failure is None:
+                failure = PredictionBlocked(
+                    "HISTORY_SEAL_WRITE_FAILED", **cleanup_errors
+                )
+    if failure is not None:
+        raise failure
     return {
         "schema_version": "sealed_prediction_history_v1",
-        "source_sha256": sha256_file(source),
+        "source_sha256": source_sha256,
         "sealed_sha256": sha256_file(target),
         "target_race_id": target_race_id,
         "cutoff_timestamp": cutoff.isoformat(),

--- a/tests/test_predict_race_now.py
+++ b/tests/test_predict_race_now.py
@@ -1619,6 +1619,311 @@ def test_history_seal_excludes_target_and_all_same_or_future_dates(tmp_path: Pat
     assert audit["at_or_after_cutoff_rows_materialized"] == 0
 
 
+def test_history_seal_never_opens_canonical_database_through_sqlite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = tmp_path / "source.db"
+    create_db(source)
+    target = tmp_path / "sealed.db"
+    original_connect = on_demand.sqlite3.connect
+    opened: list[str] = []
+
+    def reject_canonical_open(database: Any, *values: Any, **kwargs: Any):
+        location = str(database)
+        opened.append(location)
+        if location.startswith(f"file:{source.resolve()}"):
+            raise sqlite3.OperationalError("read-only WAL sidecars unavailable")
+        return original_connect(database, *values, **kwargs)
+
+    monkeypatch.setattr(on_demand.sqlite3, "connect", reject_canonical_open)
+    audit = seal_history_database(
+        source=source,
+        target=target,
+        target_race_id=RACE_ID,
+        cutoff=NOW + timedelta(hours=1),
+        runner_names=["Alpha", "Beta"],
+    )
+
+    assert target.is_file()
+    assert audit["source_sha256"] == hashlib.sha256(source.read_bytes()).hexdigest()
+    assert any("immutable=1" in location for location in opened)
+    assert not list(tmp_path.glob(".history-source-*.db"))
+
+
+def test_history_seal_fails_closed_while_wal_has_uncheckpointed_bytes(
+    tmp_path: Path,
+):
+    source = tmp_path / "source.db"
+    create_db(source)
+    Path(f"{source}-wal").write_bytes(b"uncheckpointed")
+    target = tmp_path / "sealed.db"
+
+    with pytest.raises(PredictionBlocked) as captured:
+        seal_history_database(
+            source=source,
+            target=target,
+            target_race_id=RACE_ID,
+            cutoff=NOW + timedelta(hours=1),
+            runner_names=["Alpha", "Beta"],
+        )
+
+    assert captured.value.code == "HISTORY_DATABASE_BUSY"
+    assert not target.exists()
+    assert not list(tmp_path.glob(".history-source-*.db"))
+
+
+def test_history_seal_rejects_atomic_source_replacement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = tmp_path / "source.db"
+    replacement = tmp_path / "replacement.db"
+    create_db(source)
+    create_db(replacement)
+    target = tmp_path / "sealed.db"
+    original_check = on_demand._history_sidecars_clear
+    calls = 0
+
+    def replace_before_named_revalidation(path: Path) -> bool:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            os.replace(replacement, source)
+        return original_check(path)
+
+    monkeypatch.setattr(
+        on_demand, "_history_sidecars_clear", replace_before_named_revalidation
+    )
+    with pytest.raises(PredictionBlocked) as captured:
+        seal_history_database(
+            source=source,
+            target=target,
+            target_race_id=RACE_ID,
+            cutoff=NOW + timedelta(hours=1),
+            runner_names=["Alpha", "Beta"],
+        )
+
+    assert captured.value.code == "HISTORY_DATABASE_CHANGED"
+    assert not target.exists()
+    assert not list(tmp_path.glob(".history-source-*.db"))
+
+
+def test_history_seal_normalizes_copy_failure_and_removes_temporary_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = tmp_path / "source.db"
+    create_db(source)
+    target = tmp_path / "sealed.db"
+
+    def fail_read(*values: Any, **kwargs: Any) -> bytes:
+        del values, kwargs
+        raise OSError("simulated source read failure")
+
+    monkeypatch.setattr(on_demand.os, "read", fail_read)
+    with pytest.raises(PredictionBlocked) as captured:
+        seal_history_database(
+            source=source,
+            target=target,
+            target_race_id=RACE_ID,
+            cutoff=NOW + timedelta(hours=1),
+            runner_names=["Alpha", "Beta"],
+        )
+
+    assert captured.value.code == "HISTORY_DATABASE_UNAVAILABLE"
+    assert not target.exists()
+    assert not list(tmp_path.glob(".history-source-*.db"))
+
+
+def test_history_seal_normalizes_snapshot_sqlite_open_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = tmp_path / "source.db"
+    create_db(source)
+    target = tmp_path / "sealed.db"
+    original_connect = on_demand.sqlite3.connect
+
+    def fail_snapshot_open(database: Any, *values: Any, **kwargs: Any):
+        if "immutable=1" in str(database):
+            raise sqlite3.OperationalError("simulated snapshot open failure")
+        return original_connect(database, *values, **kwargs)
+
+    monkeypatch.setattr(on_demand.sqlite3, "connect", fail_snapshot_open)
+    with pytest.raises(PredictionBlocked) as captured:
+        seal_history_database(
+            source=source,
+            target=target,
+            target_race_id=RACE_ID,
+            cutoff=NOW + timedelta(hours=1),
+            runner_names=["Alpha", "Beta"],
+        )
+
+    assert captured.value.code == "HISTORY_DATABASE_INTEGRITY_FAILED"
+    assert not target.exists()
+    assert not list(tmp_path.glob(".history-source-*.db"))
+
+
+def test_history_seal_normalizes_workspace_creation_failure(tmp_path: Path):
+    source = tmp_path / "source.db"
+    create_db(source)
+    blocked_parent = tmp_path / "not-a-directory"
+    blocked_parent.write_text("occupied", encoding="utf-8")
+
+    with pytest.raises(PredictionBlocked) as captured:
+        seal_history_database(
+            source=source,
+            target=blocked_parent / "sealed.db",
+            target_race_id=RACE_ID,
+            cutoff=NOW + timedelta(hours=1),
+            runner_names=["Alpha", "Beta"],
+        )
+
+    assert captured.value.code == "HISTORY_SEAL_WRITE_FAILED"
+
+
+def test_history_seal_removes_partial_target_after_target_sqlite_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = tmp_path / "source.db"
+    create_db(source)
+    target = tmp_path / "sealed.db"
+    original_connect = on_demand.sqlite3.connect
+
+    class FailingTarget:
+        def __init__(self, connection: sqlite3.Connection) -> None:
+            self.connection = connection
+
+        def execute(self, sql: str, parameters: Any = ()):
+            if sql.startswith("CREATE TABLE"):
+                raise sqlite3.OperationalError("simulated target write failure")
+            return self.connection.execute(sql, parameters)
+
+        def close(self) -> None:
+            self.connection.close()
+
+        def __getattr__(self, name: str):
+            return getattr(self.connection, name)
+
+    def fail_target(database: Any, *values: Any, **kwargs: Any):
+        connection = original_connect(database, *values, **kwargs)
+        return FailingTarget(connection) if Path(str(database)) == target else connection
+
+    monkeypatch.setattr(on_demand.sqlite3, "connect", fail_target)
+    with pytest.raises(PredictionBlocked) as captured:
+        seal_history_database(
+            source=source,
+            target=target,
+            target_race_id=RACE_ID,
+            cutoff=NOW + timedelta(hours=1),
+            runner_names=["Alpha", "Beta"],
+        )
+
+    assert captured.value.code == "HISTORY_SEAL_WRITE_FAILED"
+    assert not target.exists()
+    assert not list(tmp_path.glob(".history-source-*.db"))
+
+
+def test_history_seal_cleanup_failure_does_not_mask_primary_blocker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = tmp_path / "source.db"
+    create_db(source)
+    target = tmp_path / "sealed.db"
+    original_unlink = Path.unlink
+
+    def fail_read(*values: Any, **kwargs: Any) -> bytes:
+        del values, kwargs
+        raise OSError("simulated source read failure")
+
+    def fail_snapshot_unlink(path: Path, *values: Any, **kwargs: Any) -> None:
+        if path.name.startswith(".history-source-"):
+            raise OSError("simulated cleanup failure")
+        original_unlink(path, *values, **kwargs)
+
+    monkeypatch.setattr(on_demand.os, "read", fail_read)
+    monkeypatch.setattr(Path, "unlink", fail_snapshot_unlink)
+    with pytest.raises(PredictionBlocked) as captured:
+        seal_history_database(
+            source=source,
+            target=target,
+            target_race_id=RACE_ID,
+            cutoff=NOW + timedelta(hours=1),
+            runner_names=["Alpha", "Beta"],
+        )
+
+    assert captured.value.code == "HISTORY_DATABASE_UNAVAILABLE"
+    assert captured.value.details["snapshot_cleanup_error"] == "OSError"
+
+
+def test_history_seal_descriptor_close_failure_fails_closed_and_cleans_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = tmp_path / "source.db"
+    create_db(source)
+    target = tmp_path / "sealed.db"
+    original_close = on_demand.os.close
+    calls = 0
+
+    def fail_first_close(descriptor: int) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("simulated snapshot descriptor close failure")
+        original_close(descriptor)
+
+    monkeypatch.setattr(on_demand.os, "close", fail_first_close)
+    with pytest.raises(PredictionBlocked) as captured:
+        seal_history_database(
+            source=source,
+            target=target,
+            target_race_id=RACE_ID,
+            cutoff=NOW + timedelta(hours=1),
+            runner_names=["Alpha", "Beta"],
+        )
+
+    assert captured.value.code == "HISTORY_SEAL_WRITE_FAILED"
+    assert captured.value.details["snapshot_descriptor_close_error"] == "OSError"
+    assert not target.exists()
+    assert not list(tmp_path.glob(".history-source-*.db"))
+
+
+def test_history_seal_target_connection_close_failure_removes_complete_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    source = tmp_path / "source.db"
+    create_db(source)
+    target = tmp_path / "sealed.db"
+    original_connect = on_demand.sqlite3.connect
+
+    class CloseFailTarget:
+        def __init__(self, connection: sqlite3.Connection) -> None:
+            self.connection = connection
+
+        def close(self) -> None:
+            self.connection.close()
+            raise sqlite3.OperationalError("simulated target close failure")
+
+        def __getattr__(self, name: str):
+            return getattr(self.connection, name)
+
+    def fail_target_close(database: Any, *values: Any, **kwargs: Any):
+        connection = original_connect(database, *values, **kwargs)
+        return CloseFailTarget(connection) if Path(str(database)) == target else connection
+
+    monkeypatch.setattr(on_demand.sqlite3, "connect", fail_target_close)
+    with pytest.raises(PredictionBlocked) as captured:
+        seal_history_database(
+            source=source,
+            target=target,
+            target_race_id=RACE_ID,
+            cutoff=NOW + timedelta(hours=1),
+            runner_names=["Alpha", "Beta"],
+        )
+
+    assert captured.value.code == "HISTORY_SEAL_WRITE_FAILED"
+    assert captured.value.details["target_connection_close_error"] == "OperationalError"
+    assert not target.exists()
+    assert not list(tmp_path.glob(".history-source-*.db"))
+
+
 def test_history_seal_never_selects_target_or_future_outcome_columns(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
## Summary
- seal history from a verified private copy instead of opening SQLite beside the read-only canonical WAL database
- fail closed on active WAL/journal, source identity drift, output failures, and cleanup/close failures
- remove partial targets and document the operational boundary

## Live reproduction
- exact hardened namespace before fix: sqlite3.OperationalError: unable to open database file
- same namespace after fix: sealed_prediction_history_v1 with zero target/post-cutoff rows

## Validation
- 13 focused history-seal tests pass
- 10 worker/output-adjacent tests pass
- py_compile and git diff --check pass
- independent Standards and Spec review: clear

No additional live prediction POST is included; the authorized retry was already consumed.