### PR TITLE
Isolate forward observer source rejections

### DIFF
--- a/scripts/observe_forward_official_results.py
+++ b/scripts/observe_forward_official_results.py
@@ -28,6 +28,7 @@ from race_collection.forward_sealed_corpus import (  # noqa: E402
     STATUS_SCHEMA,
     ForwardCorpusRejected,
     ForwardSealedCorpus,
+    _normalize_official_result,
     canonical_json,
 )
 from scripts.ingest_results_for_date import (  # noqa: E402
@@ -44,10 +45,19 @@ KNOWN_STATES = {
     *TERMINAL_STATES,
 }
 MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+SOURCE_REJECTION_BACKOFF = timedelta(hours=1)
 OFFICIAL_RESULT_REQUEST_HEADERS = {
     **THEDOGS_PUBLIC_HEADERS,
     "Accept-Encoding": "identity",
 }
+
+
+class SourceEnvelopeRejected(ValueError):
+    """Fetched bytes cannot enter the official-result normalization stage."""
+
+    def __init__(self, reason: str, *, response_hash: str | None = None) -> None:
+        super().__init__(reason)
+        self.response_hash = response_hash
 
 
 def _aware_now(clock: Callable[[], datetime]) -> datetime:
@@ -187,14 +197,226 @@ def _release_lock(path: Path, owned: _LockOwnership) -> bool:
 
 
 def _raw_response_body(response: Any) -> bytes:
-    encoding = response.headers.get("Content-Encoding")
-    if encoding is not None and encoding.strip().lower() not in {"", "identity"}:
-        raise ForwardCorpusRejected(f"unsupported Content-Encoding: {encoding}")
     response.raw.decode_content = False
     body = response.raw.read(MAX_RESPONSE_BYTES + 1, decode_content=False)
     if len(body) > MAX_RESPONSE_BYTES:
-        raise ForwardCorpusRejected("official response exceeds maximum byte size")
+        raise RuntimeError("official response exceeds maximum byte size")
     return body
+
+
+def _fetch_source_response(session: Any, url: str, timeout_seconds: float) -> dict[str, Any]:
+    response = session.get(
+        url,
+        headers=dict(OFFICIAL_RESULT_REQUEST_HEADERS),
+        timeout=timeout_seconds,
+        allow_redirects=False,
+        stream=True,
+    )
+    try:
+        body = _raw_response_body(response)
+        response_hash = hashlib.sha256(body).hexdigest()
+        if response.url != url:
+            raise SourceEnvelopeRejected(
+                "official response final URL changed source identity",
+                response_hash=response_hash,
+            )
+        if not 200 <= response.status_code < 300:
+            reason = (
+                "official response redirected"
+                if 300 <= response.status_code < 400
+                else "official response HTTP status is unsupported"
+            )
+            raise SourceEnvelopeRejected(reason, response_hash=response_hash)
+        encoding = response.headers.get("Content-Encoding")
+        if encoding is not None and encoding.strip().lower() not in {"", "identity"}:
+            raise SourceEnvelopeRejected(
+                f"unsupported Content-Encoding: {encoding}",
+                response_hash=response_hash,
+            )
+        content_type = response.headers.get("Content-Type")
+        if type(content_type) is not str or not content_type.strip():
+            raise SourceEnvelopeRejected(
+                "official response content type is missing",
+                response_hash=response_hash,
+            )
+        media_type, separator, parameters = content_type.partition(";")
+        if media_type.strip().casefold() != "text/html" or (
+            separator and parameters.strip().casefold().replace(" ", "") != "charset=utf-8"
+        ):
+            raise SourceEnvelopeRejected(
+                "official response content type is unsupported",
+                response_hash=response_hash,
+            )
+        return {
+            "body": body,
+            "status_code": response.status_code,
+            "content_type": content_type,
+            "final_url": response.url,
+            "source_document_last_modified": response.headers.get("Last-Modified"),
+        }
+    finally:
+        response.close()
+
+
+def _verify_retained_rejected_response(
+    corpus: ForwardSealedCorpus,
+    *,
+    race_id: str,
+    collector_id: str,
+    session_id: str,
+    run_id: str,
+    request_id: str,
+    request_url: str,
+    response_hash: str,
+) -> None:
+    """Prove normalization, not persistence or identity validation, rejected the stage."""
+    pre = corpus._load_receipt(race_id, "prejump")
+    if pre is None:
+        raise ForwardCorpusRejected("rejected response lost its pre-jump receipt")
+    request_directory = corpus._request_directory(corpus.root, race_id, request_id)
+    stage = corpus._load_request_receipt(
+        request_directory / "response-stage.json", "response-stage"
+    )
+    if stage is None:
+        raise ForwardCorpusRejected("rejected response-stage receipt was not persisted")
+    body = corpus._verify_response_stage(pre, stage)
+    expected = {
+        "race_id": race_id,
+        "collector_id": collector_id,
+        "session_id": session_id,
+        "run_id": run_id,
+        "request_id": request_id,
+        "request_url": request_url,
+    }
+    if any(stage.get(key) != value for key, value in expected.items()):
+        raise ForwardCorpusRejected("rejected response-stage identity drift")
+    if hashlib.sha256(body).hexdigest() != response_hash:
+        raise ForwardCorpusRejected("rejected response-stage raw-byte hash drift")
+
+
+def _validated_rejection_deferrals(
+    value: Sequence[Mapping[str, Any]],
+) -> dict[str, dict[str, str]]:
+    if type(value) not in {list, tuple}:
+        raise ForwardCorpusRejected("source rejection deferral metadata is invalid")
+    result: dict[str, dict[str, str]] = {}
+    for item in value:
+        if type(item) is not dict or set(item) != {
+            "race_id",
+            "response_hash",
+            "reason",
+            "rejected_at",
+            "next_eligible_at",
+        }:
+            raise ForwardCorpusRejected("source rejection deferral metadata is invalid")
+        race_id = item["race_id"]
+        response_hash = item["response_hash"]
+        reason = item["reason"]
+        if (
+            type(race_id) is not str
+            or not race_id
+            or len(race_id.encode()) > 128
+            or race_id in result
+            or type(response_hash) is not str
+            or len(response_hash) != 64
+            or any(character not in "0123456789abcdef" for character in response_hash)
+            or type(reason) is not str
+            or not reason
+        ):
+            raise ForwardCorpusRejected("source rejection deferral metadata is invalid")
+        try:
+            rejected_at = datetime.fromisoformat(item["rejected_at"])
+            next_eligible_at = datetime.fromisoformat(item["next_eligible_at"])
+        except (TypeError, ValueError) as error:
+            raise ForwardCorpusRejected(
+                "source rejection deferral metadata is invalid"
+            ) from error
+        if (
+            rejected_at.tzinfo is None
+            or rejected_at.utcoffset() is None
+            or next_eligible_at.tzinfo is None
+            or next_eligible_at.utcoffset() is None
+            or next_eligible_at - rejected_at != SOURCE_REJECTION_BACKOFF
+        ):
+            raise ForwardCorpusRejected("source rejection deferral metadata is invalid")
+        result[race_id] = dict(item)
+    return result
+
+
+def _rejection_deferral(
+    *, race_id: str, response_hash: str, reason: str, rejected_at: datetime
+) -> dict[str, str]:
+    return {
+        "race_id": race_id,
+        "response_hash": response_hash,
+        "reason": reason,
+        "rejected_at": rejected_at.isoformat(timespec="microseconds"),
+        "next_eligible_at": (rejected_at + SOURCE_REJECTION_BACKOFF).isoformat(
+            timespec="microseconds"
+        ),
+    }
+
+
+def _record_source_rejection(
+    race_report: dict[str, Any],
+    error: Exception,
+    corpus: ForwardSealedCorpus,
+    race_id: str,
+) -> None:
+    race_report["decision"] = "SOURCE_REJECTED"
+    race_report["source_rejection"] = f"{type(error).__name__}: {error}"
+    try:
+        race_report["after_state"] = _race_state(corpus.status(), race_id)
+    except Exception as status_error:
+        race_report["decision"] = "ERROR"
+        race_report["error"] = (
+            "source rejection status check failed: "
+            f"{type(status_error).__name__}: {status_error}"
+        )
+
+
+def _deferral_applies(
+    deferral: Mapping[str, str] | None,
+    *,
+    response_hash: str | None,
+    observed_at: datetime,
+) -> bool:
+    return bool(
+        response_hash
+        and deferral is not None
+        and deferral["response_hash"] == response_hash
+        and observed_at < datetime.fromisoformat(deferral["next_eligible_at"])
+    )
+
+
+def _record_deferred_rejection(
+    race_report: dict[str, Any], deferral: Mapping[str, str]
+) -> None:
+    race_report["decision"] = "SOURCE_REJECTION_DEFERRED"
+    race_report["source_rejection"] = "DeferredSourceRejection: " + deferral["reason"]
+    race_report["deferral_reason"] = "identical_source_response_before_next_eligibility"
+    race_report["rejection_deferral"] = dict(deferral)
+
+
+def _attach_new_deferral(
+    race_report: dict[str, Any],
+    active_deferrals: dict[str, dict[str, str]],
+    *,
+    race_id: str,
+    response_hash: str | None,
+    reason: str,
+    rejected_at: datetime,
+) -> None:
+    if race_report["decision"] != "SOURCE_REJECTED" or response_hash is None:
+        return
+    deferral = _rejection_deferral(
+        race_id=race_id,
+        response_hash=response_hash,
+        reason=reason,
+        rejected_at=rejected_at,
+    )
+    race_report["rejection_deferral"] = deferral
+    active_deferrals[race_id] = deferral
 
 
 def observe_once(
@@ -205,6 +427,7 @@ def observe_once(
     clock: Callable[[], datetime] | None = None,
     session_factory: Callable[[], Any] = requests.Session,
     corpus_factory: Callable[..., ForwardSealedCorpus] = ForwardSealedCorpus,
+    previous_rejection_deferrals: Sequence[Mapping[str, Any]] = (),
 ) -> dict[str, Any]:
     """Observe each eligible nonterminal validated race at most once."""
     if not cycle_id or len(cycle_id.encode()) > 96:
@@ -225,6 +448,10 @@ def observe_once(
         "attempted_race_ids": [],
         "races": [],
         "package_hashes": [],
+        "source_rejection_count": 0,
+        "source_rejected_race_ids": [],
+        "deferred_rejection_count": 0,
+        "source_rejection_deferrals": [],
     }
     owned: _LockOwnership | None = None
     try:
@@ -245,6 +472,10 @@ def observe_once(
         before = corpus.status()
         if before.get("schema_version") != STATUS_SCHEMA:
             raise ForwardCorpusRejected("corpus status is not the accepted prospective schema")
+        active_deferrals = _validated_rejection_deferrals(previous_rejection_deferrals)
+        race_ids = {row.get("race_id") for row in before["races"]}
+        if not set(active_deferrals) <= race_ids:
+            raise ForwardCorpusRejected("source rejection deferral race identity is unknown")
         session = session_factory()
         try:
             for index, row in enumerate(before["races"]):
@@ -257,10 +488,15 @@ def observe_once(
                     "decision": "SKIPPED",
                     "receipt_hash": None,
                     "raw_response_hash": None,
+                    "normalization_attempted": False,
+                    "source_rejection": None,
+                    "deferral_reason": None,
+                    "rejection_deferral": None,
                     "error": None,
                 }
                 report["races"].append(race_report)
                 if row["state"] in TERMINAL_STATES:
+                    active_deferrals.pop(race_id, None)
                     race_report["decision"] = "SKIPPED_TERMINAL"
                     continue
                 try:
@@ -268,7 +504,8 @@ def observe_once(
                     jump = datetime.fromisoformat(source["scheduled_jump_at"])
                     if jump.tzinfo is None or jump.utcoffset() is None:
                         raise ForwardCorpusRejected("scheduled jump is not timezone-aware")
-                    if row["state"] == "RESULT_PENDING" and _aware_now(observer_clock) < (
+                    eligibility_time = _aware_now(observer_clock)
+                    if row["state"] == "RESULT_PENDING" and eligibility_time < (
                         jump + timedelta(minutes=5)
                     ):
                         race_report["decision"] = "SKIPPED_PRE_BOUNDARY"
@@ -277,48 +514,89 @@ def observe_once(
                     request_id = _identity("request", cycle_id, str(index), race_id)
                     race_report["request_id"] = request_id
                     report["attempted_race_ids"].append(race_id)
-
-                    def transport(url: str) -> dict[str, Any]:
-                        response = session.get(
-                            url,
-                            headers=dict(OFFICIAL_RESULT_REQUEST_HEADERS),
-                            timeout=timeout_seconds,
-                            allow_redirects=False,
-                            stream=True,
-                        )
-                        try:
-                            if response.url != url:
-                                raise ForwardCorpusRejected(
-                                    "official response final URL changed source identity"
-                                )
-                            if 300 <= response.status_code < 400:
-                                raise ForwardCorpusRejected("official response redirected")
-                            body = _raw_response_body(response)
-                            race_report["raw_response_hash"] = hashlib.sha256(body).hexdigest()
-                            return {
-                                "body": body,
-                                "status_code": response.status_code,
-                                "content_type": response.headers.get("Content-Type"),
-                                "final_url": response.url,
-                                "source_document_last_modified": response.headers.get(
-                                    "Last-Modified"
-                                ),
-                            }
-                        finally:
-                            response.close()
-
-                    receipt = corpus.capture_result(
-                        race_id=race_id,
-                        collector_id=COLLECTOR_ID,
-                        session_id=report["session_id"],
-                        run_id=report["run_id"],
-                        request_id=request_id,
-                        request_url=request_url,
-                        transport=transport,
+                    prior_deferral = active_deferrals.get(race_id)
+                    source_response = _fetch_source_response(
+                        session, request_url, timeout_seconds
                     )
+                    response_hash = hashlib.sha256(source_response["body"]).hexdigest()
+                    race_report["raw_response_hash"] = response_hash
+                    if _deferral_applies(
+                        prior_deferral,
+                        response_hash=response_hash,
+                        observed_at=eligibility_time,
+                    ):
+                        _record_deferred_rejection(race_report, prior_deferral)
+                        continue
+                    normalization_rejection: ForwardCorpusRejected | None = None
+                    race_report["normalization_attempted"] = True
+                    try:
+                        _normalize_official_result(
+                            source_response["body"],
+                            race_id=race_id,
+                            frozen_runners=source["runners"],
+                        )
+                    except ForwardCorpusRejected as error:
+                        normalization_rejection = error
+                    if normalization_rejection is not None and not source_response["body"]:
+                        _record_source_rejection(
+                            race_report, normalization_rejection, corpus, race_id
+                        )
+                        _attach_new_deferral(
+                            race_report,
+                            active_deferrals,
+                            race_id=race_id,
+                            response_hash=response_hash,
+                            reason=str(normalization_rejection),
+                            rejected_at=eligibility_time,
+                        )
+                        continue
+
+                    try:
+                        receipt = corpus.capture_result(
+                            race_id=race_id,
+                            collector_id=COLLECTOR_ID,
+                            session_id=report["session_id"],
+                            run_id=report["run_id"],
+                            request_id=request_id,
+                            request_url=request_url,
+                            transport=lambda _url: source_response,
+                        )
+                    except ForwardCorpusRejected as error:
+                        if normalization_rejection is None:
+                            raise
+                        try:
+                            _verify_retained_rejected_response(
+                                corpus,
+                                race_id=race_id,
+                                collector_id=COLLECTOR_ID,
+                                session_id=report["session_id"],
+                                run_id=report["run_id"],
+                                request_id=request_id,
+                                request_url=request_url,
+                                response_hash=response_hash,
+                            )
+                        except ForwardCorpusRejected as verification_error:
+                            raise verification_error from error
+                        _record_source_rejection(
+                            race_report, normalization_rejection, corpus, race_id
+                        )
+                        _attach_new_deferral(
+                            race_report,
+                            active_deferrals,
+                            race_id=race_id,
+                            response_hash=response_hash,
+                            reason=str(normalization_rejection),
+                            rejected_at=eligibility_time,
+                        )
+                        continue
+                    if normalization_rejection is not None:
+                        raise ForwardCorpusRejected(
+                            "corpus accepted source bytes rejected by observer normalization"
+                        )
                     race_report["receipt_hash"] = hashlib.sha256(
                         canonical_json(receipt)
                     ).hexdigest()
+                    active_deferrals.pop(race_id, None)
                     race_report["after_state"] = _race_state(corpus.status(), race_id)
                     race_report["decision"] = race_report["after_state"]
                     if race_report["after_state"] == "RESULT_STABILITY_CONFIRMED":
@@ -333,7 +611,35 @@ def observe_once(
                                 "manifest_checksum": str(package.manifest_checksum),
                             }
                         )
-                except Exception as error:  # isolate malformed races
+                except SourceEnvelopeRejected as error:
+                    race_report["raw_response_hash"] = error.response_hash
+                    if _deferral_applies(
+                        prior_deferral,
+                        response_hash=error.response_hash,
+                        observed_at=eligibility_time,
+                    ):
+                        _record_deferred_rejection(race_report, prior_deferral)
+                    else:
+                        _record_source_rejection(race_report, error, corpus, race_id)
+                    _attach_new_deferral(
+                        race_report,
+                        active_deferrals,
+                        race_id=race_id,
+                        response_hash=error.response_hash,
+                        reason=str(error),
+                        rejected_at=eligibility_time,
+                    )
+                except ForwardCorpusRejected as error:
+                    race_report["decision"] = "ERROR"
+                    race_report["error"] = f"{type(error).__name__}: {error}"
+                    try:
+                        race_report["after_state"] = _race_state(corpus.status(), race_id)
+                    except Exception as status_error:
+                        race_report["error"] = (
+                            f"{race_report['error']}; status error: "
+                            f"{type(status_error).__name__}: {status_error}"
+                        )
+                except Exception as error:  # isolate operational race failures
                     race_report["decision"] = "ERROR"
                     race_report["error"] = f"{type(error).__name__}: {error}"
                     try:
@@ -348,11 +654,25 @@ def observe_once(
                 close()
         final_status = corpus.status()
         report["counts"] = _counts(final_status, 0)
-        report["status"] = (
-            "COMPLETED_WITH_ERRORS"
-            if any(row["error"] for row in report["races"])
-            else "COMPLETED"
+        source_rejected = [
+            row
+            for row in report["races"]
+            if row["decision"] in {"SOURCE_REJECTED", "SOURCE_REJECTION_DEFERRED"}
+        ]
+        report["deferred_rejection_count"] = sum(
+            row["decision"] == "SOURCE_REJECTION_DEFERRED" for row in report["races"]
         )
+        report["source_rejection_count"] = len(source_rejected)
+        report["source_rejected_race_ids"] = [row["race_id"] for row in source_rejected]
+        report["source_rejection_deferrals"] = [
+            active_deferrals[race_id] for race_id in sorted(active_deferrals)
+        ]
+        if any(row["error"] for row in report["races"]):
+            report["status"] = "COMPLETED_WITH_ERRORS"
+        elif source_rejected:
+            report["status"] = "COMPLETED_WITH_REJECTIONS"
+        else:
+            report["status"] = "COMPLETED"
     except Exception as error:
         report["status"] = "FAILED"
         report["error"] = f"{type(error).__name__}: {error}"
@@ -384,7 +704,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         timeout_seconds=args.timeout_seconds,
     )
     print(canonical_json(report).decode())
-    return 0 if report["status"] == "COMPLETED" else 2
+    return 0 if report["status"] in {"COMPLETED", "COMPLETED_WITH_REJECTIONS"} else 2
 
 
 if __name__ == "__main__":

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -93,6 +93,9 @@ SERVICE_NAME = "shadow-autopilot.service"
 TIMER_NAME = "shadow-autopilot.timer"
 ODDS_CAPTURE_SERVICE_NAME = "shadow-autopilot-odds-capture.service"
 ODDS_CAPTURE_TIMER_NAME = "shadow-autopilot-odds-capture.timer"
+FORWARD_OBSERVER_CONTINUABLE_STATUSES = frozenset(
+    {"COMPLETED", "COMPLETED_WITH_REJECTIONS"}
+)
 NO_WRITE_GUARANTEES = {
     "training": False,
     "production_promotion": False,
@@ -1472,16 +1475,70 @@ def write_service_files(
     }
 
 
-def run_forward_official_result_observer(args: argparse.Namespace, run_id: str) -> dict[str, Any]:
+def _load_forward_observer_rejection_deferrals(state_path: Path) -> list[dict[str, str]]:
+    if not state_path.exists():
+        return []
+    state = load_json(state_path)
+    if state is None:
+        raise ValueError("forward observer durable state is unreadable")
+    observer = state.get("forward_official_result_observer")
+    if observer is None:
+        return []
+    if not isinstance(observer, Mapping):
+        raise ValueError("source rejection deferral metadata is invalid")
+    value = observer.get("source_rejection_deferrals", [])
+    from scripts.observe_forward_official_results import _validated_rejection_deferrals
+
+    try:
+        validated = _validated_rejection_deferrals(value)
+    except ValueError as error:
+        raise ValueError(str(error)) from error
+    return [validated[race_id] for race_id in sorted(validated)]
+
+
+def run_forward_official_result_observer(
+    args: argparse.Namespace,
+    run_id: str,
+    *,
+    state_path: Path | None = None,
+) -> dict[str, Any]:
     if not args.enable_forward_official_result_observer:
         return {"status": "DISABLED", "attempted_race_ids": []}
     from scripts.observe_forward_official_results import observe_once
 
+    previous_rejection_deferrals = _load_forward_observer_rejection_deferrals(
+        state_path or args.state_path or DEFAULT_STATE_PATH
+    )
     return observe_once(
         corpus_root=args.forward_corpus_root,
         cycle_id=run_id,
         timeout_seconds=min(float(args.timeout_seconds), 120.0),
+        previous_rejection_deferrals=previous_rejection_deferrals,
     )
+
+
+def persist_forward_observer_progress(
+    *,
+    state_path: Path,
+    run_id: str,
+    generated_at: datetime,
+    observer: Mapping[str, Any],
+) -> None:
+    """Durably carry bounded source-rejection state across early service returns."""
+    previous = load_json(state_path)
+    if state_path.exists() and previous is None:
+        raise ValueError("forward observer durable state is unreadable")
+    payload = dict(previous or {})
+    payload.update(
+        {
+            "schema_version": "shadow_autopilot_daemon_state_v1",
+            "last_run_id": run_id,
+            "updated_at": generated_at.isoformat(),
+            "forward_official_result_observer": dict(observer),
+        }
+    )
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    write_json(state_path, payload)
 
 
 def persist_forward_observer_failure(
@@ -9327,7 +9384,7 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
         if args.enable_forward_official_result_observer:
             try:
                 forward_official_result_observer = run_forward_official_result_observer(
-                    args, run_id
+                    args, run_id, state_path=state_path
                 )
             except Exception as exc:
                 forward_official_result_observer = {
@@ -9374,7 +9431,10 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
             output_dir / "forward_official_result_observer.json",
             forward_official_result_observer,
         )
-        if forward_official_result_observer.get("status") != "COMPLETED":
+        if (
+            forward_official_result_observer.get("status")
+            not in FORWARD_OBSERVER_CONTINUABLE_STATUSES
+        ):
             persist_forward_observer_failure(
                 output_dir=output_dir,
                 state_path=state_path,
@@ -9403,6 +9463,12 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
             write_json(output_dir / "daemon_run_report.json", result)
             write_json(output_dir / "output_manifest.json", output_manifest(output_dir))
             return result
+        persist_forward_observer_progress(
+            state_path=state_path,
+            run_id=run_id,
+            generated_at=generated_at,
+            observer=forward_official_result_observer,
+        )
 
         if args.current_time is None:
             current_time = wall_clock_now().isoformat()
@@ -13414,7 +13480,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(json.dumps(result, indent=2, sort_keys=True))
     if args.enable_forward_official_result_observer and result.get(
         "forward_official_result_observer", {}
-    ).get("status") != "COMPLETED":
+    ).get("status") not in FORWARD_OBSERVER_CONTINUABLE_STATUSES:
         return 2
     return 0 if result.get("final_verdict") != "NEEDS_MORE_AUTOMATION" else 2
 

--- a/tests/race_collection/test_forward_official_result_observer.py
+++ b/tests/race_collection/test_forward_official_result_observer.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from race_collection.domain import ArtifactChecksum
-from race_collection.forward_sealed_corpus import ForwardSealedCorpus
+from race_collection.forward_sealed_corpus import ForwardCorpusRejected, ForwardSealedCorpus
 from scripts import observe_forward_official_results as observer
 
 
@@ -95,13 +95,14 @@ def _seed(root, *, race_id="race-1", url=None):
     ForwardSealedCorpus(root, clock=lambda: _dt("09:45")).capture_prejump(**value)
 
 
-def _run(root, cycle, times, responses):
+def _run(root, cycle, times, responses, **observer_kwargs):
     session = Session(responses)
     report = observer.observe_once(
         corpus_root=root,
         cycle_id=cycle,
         clock=Clock(*times),
         session_factory=lambda: session,
+        **observer_kwargs,
     )
     return report, session
 
@@ -183,9 +184,320 @@ def test_pre_boundary_skip_malformed_retention_and_terminal_skip(tmp_path):
         [_dt("10:06")] * 4,
         [Response(b"<html>not a result</html>", url)],
     )
-    assert malformed["status"] == "COMPLETED_WITH_ERRORS"
+    assert malformed["status"] == "COMPLETED_WITH_REJECTIONS"
+    assert malformed["source_rejection_count"] == 1
+    assert malformed["source_rejected_race_ids"] == ["race-1"]
+    assert malformed["races"][0]["decision"] == "SOURCE_REJECTED"
+    assert malformed["races"][0]["error"] is None
+    assert malformed["races"][0]["source_rejection"] == (
+        "ForwardCorpusRejected: official result HTML contains no result rows"
+    )
     assert malformed["races"][0]["raw_response_hash"]
     assert len(list((tmp_path / "races").glob("*/official-requests/*/response-stage.json"))) == 1
+
+
+def test_partial_official_order_is_source_rejected_without_failing_observer(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    partial = T1._html().replace(b"2nd", b"-")
+
+    report, _ = _run(
+        tmp_path,
+        "partial-order",
+        [_dt("10:06")] * 4,
+        [Response(partial, url)],
+    )
+
+    assert report["status"] == "COMPLETED_WITH_REJECTIONS"
+    assert report["source_rejected_race_ids"] == ["race-1"]
+    assert report["races"][0]["after_state"] == "RESULT_PENDING"
+    assert report["races"][0]["decision"] == "SOURCE_REJECTED"
+    assert report["races"][0]["error"] is None
+    assert report["races"][0]["source_rejection"] == (
+        "ForwardCorpusRejected: official finish/status combination is inconsistent"
+    )
+
+
+def test_identical_rejection_is_deferred_and_changed_bytes_can_close(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    partial = T1._html().replace(b"2nd", b"-")
+
+    first, _ = _run(
+        tmp_path,
+        "rejected-first",
+        [_dt("10:06")] * 4,
+        [Response(partial, url)],
+    )
+
+    response_hash = first["races"][0]["raw_response_hash"]
+    assert first["races"][0]["normalization_attempted"] is True
+    assert first["races"][0]["rejection_deferral"] == {
+        "race_id": "race-1",
+        "response_hash": response_hash,
+        "reason": "official finish/status combination is inconsistent",
+        "rejected_at": "2026-07-29T10:06:00.000000+10:00",
+        "next_eligible_at": "2026-07-29T11:06:00.000000+10:00",
+    }
+    assert first["source_rejection_deferrals"] == [
+        first["races"][0]["rejection_deferral"]
+    ]
+
+    identical, session = _run(
+        tmp_path,
+        "rejected-identical",
+        [_dt("10:21")],
+        [Response(partial, url)],
+        previous_rejection_deferrals=first["source_rejection_deferrals"],
+    )
+
+    assert identical["status"] == "COMPLETED_WITH_REJECTIONS"
+    assert identical["races"][0]["decision"] == "SOURCE_REJECTION_DEFERRED"
+    assert identical["races"][0]["after_state"] == "RESULT_PENDING"
+    assert identical["races"][0]["normalization_attempted"] is False
+    assert identical["races"][0]["raw_response_hash"] == response_hash
+    assert identical["races"][0]["rejection_deferral"] == first["races"][0][
+        "rejection_deferral"
+    ]
+    assert identical["races"][0]["deferral_reason"] == (
+        "identical_source_response_before_next_eligibility"
+    )
+    assert len(session.calls) == 1
+    assert len(list((tmp_path / "races").glob("*/official-requests/*/response-stage.json"))) == 1
+
+    changed, _ = _run(
+        tmp_path,
+        "rejected-changed",
+        [_dt("10:22")] * 4,
+        [Response(T1._html(), url)],
+        previous_rejection_deferrals=identical["source_rejection_deferrals"],
+    )
+    assert changed["status"] == "COMPLETED"
+    assert changed["races"][0]["after_state"] == "RESULT_FIRST_OBSERVED"
+    assert changed["source_rejection_deferrals"] == []
+
+    closed, _ = _run(
+        tmp_path,
+        "valid-second",
+        [_dt("10:38")] * 5,
+        [Response(T1._html(), url)],
+        previous_rejection_deferrals=changed["source_rejection_deferrals"],
+    )
+    assert closed["status"] == "COMPLETED"
+    assert closed["races"][0]["after_state"] == "EXAMPLE_CLOSED"
+
+
+@pytest.mark.parametrize(
+    "deferrals",
+    [
+        [{"race_id": "race-1"}],
+        [
+            {
+                "race_id": "race-1",
+                "response_hash": "a" * 64,
+                "reason": "official result is unresolved",
+                "rejected_at": "2026-07-29T10:06:00.000000+10:00",
+                "next_eligible_at": "9999-07-29T11:06:00.000000+10:00",
+            }
+        ],
+    ],
+)
+def test_rejection_deferral_metadata_corruption_fails_closed(tmp_path, deferrals):
+    _seed(tmp_path)
+
+    report, session = _run(
+        tmp_path,
+        "corrupt-deferral",
+        [],
+        [],
+        previous_rejection_deferrals=deferrals,
+    )
+
+    assert report["status"] == "FAILED"
+    assert report["error"] == (
+        "ForwardCorpusRejected: source rejection deferral metadata is invalid"
+    )
+    assert session.calls == []
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_exit"),
+    [
+        ("COMPLETED", 0),
+        ("COMPLETED_WITH_REJECTIONS", 0),
+        ("COMPLETED_WITH_ERRORS", 2),
+        ("FAILED", 2),
+    ],
+)
+def test_observer_cli_exit_preserves_continuable_and_fatal_statuses(
+    monkeypatch, status, expected_exit
+):
+    monkeypatch.setattr(
+        observer,
+        "parse_args",
+        lambda argv=None: observer.argparse.Namespace(
+            corpus_root=Path("/corpus"), cycle_id="cli-cycle", timeout_seconds=30.0
+        ),
+    )
+    monkeypatch.setattr(
+        observer,
+        "observe_once",
+        lambda **kwargs: {"status": status},
+    )
+
+    assert observer.main([]) == expected_exit
+
+
+def test_identical_rejection_is_reprocessed_after_bounded_deferral(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    partial = T1._html().replace(b"2nd", b"-")
+    first, _ = _run(
+        tmp_path,
+        "bounded-first",
+        [_dt("10:06")] * 4,
+        [Response(partial, url)],
+    )
+
+    retried, session = _run(
+        tmp_path,
+        "bounded-retry",
+        [_dt("11:07")] * 4,
+        [Response(partial, url)],
+        previous_rejection_deferrals=first["source_rejection_deferrals"],
+    )
+
+    assert retried["status"] == "COMPLETED_WITH_REJECTIONS"
+    assert retried["races"][0]["decision"] == "SOURCE_REJECTED"
+    assert retried["races"][0]["normalization_attempted"] is True
+    assert retried["races"][0]["rejection_deferral"]["next_eligible_at"] == (
+        "2026-07-29T12:07:00.000000+10:00"
+    )
+    assert len(session.calls) == 1
+    assert len(list((tmp_path / "races").glob("*/official-requests/*/response-stage.json"))) == 2
+
+
+def test_deferred_rejection_does_not_block_unrelated_race(tmp_path):
+    first_url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-one"
+    second_url = "https://www.thedogs.com.au/racing/venue/2026-07-29/2/race-two"
+    _seed(tmp_path, race_id="race-1", url=first_url)
+    _seed(tmp_path, race_id="race-2", url=second_url)
+    partial = T1._html().replace(b"2nd", b"-")
+    first, _ = _run(
+        tmp_path,
+        "multi-first",
+        [_dt("10:06")] * 8,
+        [
+            Response(partial, first_url + "?trial=false"),
+            Response(T1._html(), second_url + "?trial=false"),
+        ],
+    )
+    assert first["source_rejected_race_ids"] == ["race-1"]
+    assert first["races"][1]["after_state"] == "RESULT_FIRST_OBSERVED"
+
+    second, session = _run(
+        tmp_path,
+        "multi-second",
+        [_dt("10:22")] * 8,
+        [
+            Response(partial, first_url + "?trial=false"),
+            Response(T1._html(), second_url + "?trial=false"),
+        ],
+        previous_rejection_deferrals=first["source_rejection_deferrals"],
+    )
+
+    assert second["status"] == "COMPLETED_WITH_REJECTIONS"
+    assert second["races"][0]["decision"] == "SOURCE_REJECTION_DEFERRED"
+    assert second["races"][1]["after_state"] == "EXAMPLE_CLOSED"
+    assert len(session.calls) == 2
+    assert len(list((tmp_path / "races").glob("*/official-requests/*/response-stage.json"))) == 3
+
+
+def test_operational_race_failure_remains_an_error(tmp_path):
+    _seed(tmp_path)
+
+    report, _ = _run(tmp_path, "transport-failed", [_dt("10:06")] * 2, [])
+
+    assert report["status"] == "COMPLETED_WITH_ERRORS"
+    assert report["source_rejection_count"] == 0
+    assert report["source_rejected_race_ids"] == []
+    assert report["races"][0]["decision"] == "ERROR"
+    assert report["races"][0]["source_rejection"] is None
+    assert report["races"][0]["error"] == "StopIteration: "
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_error"),
+    [
+        ("identity", "rejected response-stage identity drift"),
+        ("raw_hash", "rejected response-stage raw-byte hash drift"),
+    ],
+)
+def test_retained_rejection_stage_drift_remains_an_error(
+    tmp_path, mutation, expected_error
+):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    malformed = b"<html>not a result</html>"
+    first, _ = _run(
+        tmp_path,
+        "retained-stage-drift",
+        [_dt("10:06")] * 4,
+        [Response(malformed, url)],
+    )
+    assert first["races"][0]["decision"] == "SOURCE_REJECTED"
+    stage_path = next(
+        (tmp_path / "races").glob("*/official-requests/*/response-stage.json")
+    )
+    stage = json.loads(stage_path.read_text())
+    if mutation == "identity":
+        stage["collector_id"] = "different-collector"
+    else:
+        replacement = ForwardSealedCorpus(tmp_path).artifacts.put(
+            b"<html>different rejected response</html>",
+            media_type="application/octet-stream",
+        )
+        stage["raw_response_checksum"] = str(replacement.checksum)
+    stage_path.write_bytes(observer.canonical_json(stage))
+
+    report, _ = _run(
+        tmp_path,
+        "retained-stage-drift",
+        [_dt("10:21")],
+        [Response(malformed, url)],
+    )
+
+    assert report["status"] == "COMPLETED_WITH_ERRORS"
+    assert report["source_rejection_count"] == 0
+    assert report["races"][0]["decision"] == "ERROR"
+    assert report["races"][0]["source_rejection"] is None
+    assert report["races"][0]["error"] == f"ForwardCorpusRejected: {expected_error}"
+
+
+def test_source_rejection_cannot_mask_missing_persistence_receipt(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    partial = T1._html().replace(b"2nd", b"-")
+
+    class NonPersistingCorpus(ForwardSealedCorpus):
+        def capture_result(self, **kwargs):
+            raise ForwardCorpusRejected("synthetic persistence rejection")
+
+    report, _ = _run(
+        tmp_path,
+        "source-and-persistence-rejected",
+        [_dt("10:06")],
+        [Response(partial, url)],
+        corpus_factory=NonPersistingCorpus,
+    )
+
+    assert report["status"] == "COMPLETED_WITH_ERRORS"
+    assert report["source_rejection_count"] == 0
+    assert report["races"][0]["decision"] == "ERROR"
+    assert report["races"][0]["source_rejection"] is None
+    assert report["races"][0]["error"] == (
+        "ForwardCorpusRejected: rejected response-stage receipt was not persisted"
+    )
 
 
 @pytest.mark.parametrize(
@@ -218,14 +530,14 @@ def test_final_url_rejection_empty_response_and_lock_contention(tmp_path):
         [_dt("10:06")] * 2,
         [Response(T1._html(), expected + "/other")],
     )
-    assert redirected["status"] == "COMPLETED_WITH_ERRORS"
+    assert redirected["status"] == "COMPLETED_WITH_REJECTIONS"
     empty, _ = _run(
         tmp_path,
         "empty",
         [_dt("10:06")] * 4,
         [Response(b"", expected)],
     )
-    assert empty["status"] == "COMPLETED_WITH_ERRORS"
+    assert empty["status"] == "COMPLETED_WITH_REJECTIONS"
 
     lock = tmp_path / "forward-sealed-corpus.lock"
     lock.write_text('{"owner":"other"}')
@@ -269,7 +581,7 @@ def test_redirect_is_not_followed_and_response_is_closed(tmp_path):
     )
     response = Response(b"redirect", url, status=302, headers={"Location": url + "/other"})
     report, session = _run(tmp_path, "redirect", [_dt("10:06")] * 2, [response])
-    assert report["status"] == "COMPLETED_WITH_ERRORS"
+    assert report["status"] == "COMPLETED_WITH_REJECTIONS"
     assert len(session.calls) == 1
     assert session.calls[0]["headers"] == {
         **observer.THEDOGS_PUBLIC_HEADERS,
@@ -288,14 +600,26 @@ def test_wire_exact_body_encoding_and_bound_are_enforced(tmp_path, monkeypatch):
     )
     encoded = Response(T1._html(), url, headers={"Content-Encoding": "gzip"})
     report, _ = _run(tmp_path, "encoded", [_dt("10:06")] * 2, [encoded])
-    assert report["status"] == "COMPLETED_WITH_ERRORS"
-    assert "unsupported Content-Encoding" in report["races"][0]["error"]
+    assert report["status"] == "COMPLETED_WITH_REJECTIONS"
+    assert "unsupported Content-Encoding" in report["races"][0]["source_rejection"]
     assert encoded.closed
+    repeated = Response(T1._html(), url, headers={"Content-Encoding": "gzip"})
+    deferred, _ = _run(
+        tmp_path,
+        "encoded-repeated",
+        [_dt("10:21")],
+        [repeated],
+        previous_rejection_deferrals=report["source_rejection_deferrals"],
+    )
+    assert deferred["races"][0]["decision"] == "SOURCE_REJECTION_DEFERRED"
+    assert deferred["races"][0]["normalization_attempted"] is False
+    assert not list((tmp_path / "races").glob("*/official-requests/*/response-stage.json"))
 
     monkeypatch.setattr(observer, "MAX_RESPONSE_BYTES", 8)
     oversized = Response(b"123456789", url)
     report, _ = _run(tmp_path, "oversized", [_dt("10:06")] * 2, [oversized])
     assert report["status"] == "COMPLETED_WITH_ERRORS"
+    assert report["races"][0]["source_rejection"] is None
     assert "maximum byte size" in report["races"][0]["error"]
     assert oversized.closed
 

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -1131,18 +1131,30 @@ def test_run_once_non_deferred_validates_run_owned_service_files(
         daemon.run_once(args)
 
 
-def test_run_once_defer_observes_result_before_odds_priority_return(
+def test_run_once_defer_continues_after_source_rejection_before_odds_priority_return(
     tmp_path, monkeypatch
 ):
     evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
     output_dir = evidence_root / "shadow_autopilot_daemonization_v1_observer_defer"
     odds_state_path = tmp_path / "runtime" / "odds_capture_state.json"
+    state_path = tmp_path / "runtime" / "state.json"
     lock_path = tmp_path / "runtime" / "shadow_autopilot.lock"
     corpus_root = tmp_path / "forward-corpus"
     observed = {
-        "status": "COMPLETED",
+        "status": "COMPLETED_WITH_REJECTIONS",
         "attempted_race_ids": ["race-1"],
-        "counts": {"observed": 1},
+        "counts": {"pending": 1},
+        "source_rejection_count": 1,
+        "source_rejected_race_ids": ["race-1"],
+        "source_rejection_deferrals": [
+            {
+                "race_id": "race-1",
+                "response_hash": "a" * 64,
+                "reason": "official result is unresolved",
+                "rejected_at": "2026-06-13T15:17:11.000000+10:00",
+                "next_eligible_at": "2026-06-13T16:17:11.000000+10:00",
+            }
+        ],
     }
     defer_times = []
 
@@ -1159,7 +1171,7 @@ def test_run_once_defer_observes_result_before_odds_priority_return(
     monkeypatch.setattr(
         daemon,
         "run_forward_official_result_observer",
-        lambda args, run_id: observed | {"run_id": run_id},
+        lambda args, run_id, state_path: observed | {"run_id": run_id},
     )
     monkeypatch.setattr(
         daemon,
@@ -1196,6 +1208,8 @@ def test_run_once_defer_observes_result_before_odds_priority_return(
             "--enable-autonomous-odds-capture",
             "--odds-capture-state-path",
             str(odds_state_path),
+            "--state-path",
+            str(state_path),
         ]
     )
 
@@ -1219,6 +1233,9 @@ def test_run_once_defer_observes_result_before_odds_priority_return(
     assert json.loads(
         (output_dir / "forward_official_result_observer.json").read_text()
     ) == report["forward_official_result_observer"]
+    assert json.loads(state_path.read_text())["forward_official_result_observer"] == report[
+        "forward_official_result_observer"
+    ]
 
 
 def test_run_once_observer_waits_for_natural_odds_release_then_continues(
@@ -1272,7 +1289,7 @@ def test_run_once_observer_waits_for_natural_odds_release_then_continues(
         assert lock_path.read_bytes() == lock_bytes
         lock_path.unlink()
 
-    def observe(args, run_id):
+    def observe(args, run_id, state_path):
         lock = json.loads(lock_path.read_text())
         assert lock["run_id"] == run_id
         assert lock["phase"] == "forward_official_result_observer"
@@ -1359,7 +1376,7 @@ def test_run_once_observer_failure_stops_before_odds_defer_and_full_lock(
     monkeypatch.setattr(
         daemon,
         "run_forward_official_result_observer",
-        lambda args, run_id: failed | {"run_id": run_id},
+        lambda args, run_id, state_path: failed | {"run_id": run_id},
     )
     monkeypatch.setattr(
         daemon,
@@ -1522,7 +1539,10 @@ def test_observer_completion_refreshes_wall_time_before_odds_defer(
     monkeypatch.setattr(
         daemon,
         "run_forward_official_result_observer",
-        lambda args, run_id: {"status": "COMPLETED", "attempted_race_ids": []},
+        lambda args, run_id, state_path: {
+            "status": "COMPLETED",
+            "attempted_race_ids": [],
+        },
     )
 
     def decide(_odds_state, current_time):
@@ -10467,6 +10487,27 @@ def test_forward_corpus_root_is_required_in_installed_service_identity():
 
 def test_forward_observer_opt_in_invokes_owned_cycle(monkeypatch, tmp_path):
     expected = {"status": "COMPLETED", "attempted_race_ids": ["race-1"]}
+    state_path = tmp_path / "runtime" / "state.json"
+    deferrals = [
+        {
+            "race_id": "race-1",
+            "response_hash": "b" * 64,
+            "reason": "official result is unresolved",
+            "rejected_at": "2026-07-29T10:06:00.000000+10:00",
+            "next_eligible_at": "2026-07-29T11:06:00.000000+10:00",
+        }
+    ]
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "shadow_autopilot_daemon_state_v1",
+                "forward_official_result_observer": {
+                    "source_rejection_deferrals": deferrals
+                },
+            }
+        )
+    )
     monkeypatch.setattr(
         "scripts.observe_forward_official_results.observe_once",
         lambda **kwargs: expected | {"arguments": kwargs},
@@ -10481,13 +10522,44 @@ def test_forward_observer_opt_in_invokes_owned_cycle(monkeypatch, tmp_path):
             "840",
         ]
     )
-    result = daemon.run_forward_official_result_observer(args, "daemon-cycle")
+    result = daemon.run_forward_official_result_observer(
+        args, "daemon-cycle", state_path=state_path
+    )
     assert result["status"] == "COMPLETED"
     assert result["arguments"] == {
         "corpus_root": tmp_path,
         "cycle_id": "daemon-cycle",
         "timeout_seconds": 120.0,
+        "previous_rejection_deferrals": deferrals,
     }
+
+
+def test_forward_observer_corrupt_durable_deferral_state_fails_closed(tmp_path):
+    state_path = tmp_path / "runtime" / "state.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "shadow_autopilot_daemon_state_v1",
+                "forward_official_result_observer": {
+                    "source_rejection_deferrals": [{"race_id": "race-1"}]
+                },
+            }
+        )
+    )
+    args = daemon.parse_args(
+        [
+            "run-once",
+            "--enable-forward-official-result-observer",
+            "--forward-corpus-root",
+            str(tmp_path / "corpus"),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="source rejection deferral metadata is invalid"):
+        daemon.run_forward_official_result_observer(
+            args, "corrupt-deferral", state_path=state_path
+        )
 
 
 def test_full_service_generator_emits_forward_opt_in_only_when_declared(tmp_path):
@@ -10548,6 +10620,30 @@ def test_forward_observer_nonclean_daemon_cli_exit_is_nonzero(monkeypatch, statu
         },
     )
     assert daemon.main([]) == 2
+
+
+def test_forward_observer_source_rejection_service_cli_exit_is_zero(monkeypatch):
+    args = daemon.parse_args(
+        [
+            "run-once",
+            "--enable-forward-official-result-observer",
+            "--forward-corpus-root",
+            "/corpus",
+        ]
+    )
+    monkeypatch.setattr(daemon, "parse_args", lambda argv=None: args)
+    monkeypatch.setattr(
+        daemon,
+        "run_once",
+        lambda _args: {
+            "final_verdict": "PARTIAL_DAEMONIZATION",
+            "forward_official_result_observer": {
+                "status": "COMPLETED_WITH_REJECTIONS",
+                "cycle_id": "current-cycle",
+            },
+        },
+    )
+    assert daemon.main([]) == 0
 
 
 def test_forward_observer_failure_replaces_durable_success(tmp_path):


### PR DESCRIPTION
## Summary

- keep source-invalid official-result responses visible and unresolved without failing the full daemon
- defer an identical rejected response for one hour using validated durable metadata
- preserve fatal handling for operational, persistence, identity, lock-release, and integrity failures
- allow unrelated full-daemon work to continue after a bounded source rejection

## Validation

- `uv run --no-project --with-requirements requirements/all.in pytest -q tests/race_collection/test_forward_official_result_observer.py tests/test_shadow_autopilot_daemon.py -k "forward_observer or official_result_observer"` (35 passed, 154 deselected)
- `uv run --no-project --with-requirements requirements/all.in python -m py_compile scripts/observe_forward_official_results.py scripts/shadow_autopilot_daemon.py`
- `git diff --check`

## Runtime boundary

This PR contains repository code and tests only. It does not deploy the runtime or claim a natural-cycle proof. Merge remains approval-gated.