### PR TITLE
Fix semantic fingerprinting for rejected official results

### DIFF
--- a/scripts/observe_forward_official_results.py
+++ b/scripts/observe_forward_official_results.py
@@ -331,6 +331,7 @@ def _semantic_deferral_fingerprint(
     if len(frozen_by_box) != len(frozen_runners):
         return None
     projected_rows = []
+    parsed_boxes = []
     for row, displayed_result_text in zip(parsed, displayed_result_texts, strict=True):
         if type(row) is not dict or set(row) != {
             "box_number",
@@ -350,6 +351,7 @@ def _semantic_deferral_fingerprint(
             or (status is not None and type(status) is not str)
         ):
             return None
+        parsed_boxes.append(box_number)
         frozen = frozen_by_box.get(box_number)
         projected_rows.append(
             {
@@ -364,6 +366,8 @@ def _semantic_deferral_fingerprint(
                 ),
             }
         )
+    if len(set(parsed_boxes)) != len(parsed_boxes) or set(parsed_boxes) != set(frozen_by_box):
+        return None
     projected_rows.sort(key=lambda row: canonical_json(row))
     projection = {
         "fingerprint_algorithm_version": SEMANTIC_FINGERPRINT_ALGORITHM,

--- a/scripts/observe_forward_official_results.py
+++ b/scripts/observe_forward_official_results.py
@@ -18,7 +18,6 @@ from typing import Any
 from urllib.parse import urlsplit
 
 import requests
-from bs4 import BeautifulSoup
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -310,9 +309,11 @@ def _semantic_deferral_fingerprint(
 ) -> str | None:
     """Fingerprint a complete parsed result projection, never page scaffolding."""
     try:
+        from bs4 import BeautifulSoup
+
         markup = body.decode("utf-8")
         parsed = parse_thedogs_result_html_runner_rows(markup)
-    except (UnicodeDecodeError, TypeError, ValueError):
+    except (ImportError, UnicodeDecodeError, TypeError, ValueError):
         return None
     if not parsed or len(parsed) != len(frozen_runners):
         return None

--- a/scripts/observe_forward_official_results.py
+++ b/scripts/observe_forward_official_results.py
@@ -410,7 +410,10 @@ def _semantic_deferral_fingerprint(
 
 
 def _verify_retained_deferral_response(
-    corpus: ForwardSealedCorpus, deferral: Mapping[str, Any]
+    corpus: ForwardSealedCorpus,
+    deferral: Mapping[str, Any],
+    *,
+    frozen_runners: Sequence[Mapping[str, Any]],
 ) -> None:
     pre = corpus._load_receipt(deferral["race_id"], "prejump")
     if pre is None:
@@ -435,6 +438,15 @@ def _verify_retained_deferral_response(
         raise ForwardCorpusRejected("retained rejection response-stage identity drift")
     if hashlib.sha256(body).hexdigest() != deferral["retained_raw_response_hash"]:
         raise ForwardCorpusRejected("retained rejection raw-byte hash drift")
+    semantic_fingerprint = _semantic_deferral_fingerprint(
+        body,
+        race_id=deferral["race_id"],
+        source_native_race_id=deferral["source_native_race_id"],
+        request_url=deferral["request_url"],
+        frozen_runners=frozen_runners,
+    )
+    if semantic_fingerprint != deferral["semantic_fingerprint"]:
+        raise ForwardCorpusRejected("retained rejection semantic fingerprint drift")
 
 
 def _validated_rejection_deferrals(
@@ -721,7 +733,9 @@ def observe_once(
                 raise ForwardCorpusRejected(
                     "source rejection deferral race identity is inconsistent"
                 )
-            _verify_retained_deferral_response(corpus, deferral)
+            _verify_retained_deferral_response(
+                corpus, deferral, frozen_runners=source["runners"]
+            )
         session = session_factory()
         try:
             for index, row in enumerate(before["races"]):

--- a/scripts/observe_forward_official_results.py
+++ b/scripts/observe_forward_official_results.py
@@ -18,6 +18,7 @@ from typing import Any
 from urllib.parse import urlsplit
 
 import requests
+from bs4 import BeautifulSoup
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -33,6 +34,7 @@ from race_collection.forward_sealed_corpus import (  # noqa: E402
 )
 from scripts.ingest_results_for_date import (  # noqa: E402
     THEDOGS_PUBLIC_HEADERS,
+    parse_thedogs_result_html_runner_rows,
     thedogs_result_urls_from_race_url,
 )
 
@@ -46,6 +48,10 @@ KNOWN_STATES = {
 }
 MAX_RESPONSE_BYTES = 4 * 1024 * 1024
 SOURCE_REJECTION_BACKOFF = timedelta(hours=1)
+SEMANTIC_FINGERPRINT_ALGORITHM = (
+    "thedogs-official-result-semantic-projection-sha256-v1"
+)
+REJECTION_DEFERRAL_SCHEMA = "forward-official-result-rejection-deferral-v2"
 OFFICIAL_RESULT_REQUEST_HEADERS = {
     **THEDOGS_PUBLIC_HEADERS,
     "Accept-Encoding": "identity",
@@ -294,23 +300,145 @@ def _verify_retained_rejected_response(
         raise ForwardCorpusRejected("rejected response-stage raw-byte hash drift")
 
 
+def _semantic_deferral_fingerprint(
+    body: bytes,
+    *,
+    race_id: str,
+    source_native_race_id: str,
+    request_url: str,
+    frozen_runners: Sequence[Mapping[str, Any]],
+) -> str | None:
+    """Fingerprint a complete parsed result projection, never page scaffolding."""
+    try:
+        markup = body.decode("utf-8")
+        parsed = parse_thedogs_result_html_runner_rows(markup)
+    except (UnicodeDecodeError, TypeError, ValueError):
+        return None
+    if not parsed or len(parsed) != len(frozen_runners):
+        return None
+    soup = BeautifulSoup(markup, "html.parser")
+    displayed_result_texts = [
+        cell.get_text(" ", strip=True)
+        for cell in soup.select(
+            "table.race-runners--result tr.race-runner "
+            "td.race-runners__finish-position"
+        )
+    ]
+    if len(displayed_result_texts) != len(parsed):
+        return None
+    frozen_by_box = {runner.get("box_number"): runner for runner in frozen_runners}
+    if len(frozen_by_box) != len(frozen_runners):
+        return None
+    projected_rows = []
+    for row, displayed_result_text in zip(parsed, displayed_result_texts, strict=True):
+        if type(row) is not dict or set(row) != {
+            "box_number",
+            "finish_position",
+            "dog_name",
+            "status",
+        }:
+            return None
+        box_number = row["box_number"]
+        finish_position = row["finish_position"]
+        dog_name = row["dog_name"]
+        status = row["status"]
+        if (
+            type(box_number) is not int
+            or (finish_position is not None and type(finish_position) is not int)
+            or (dog_name is not None and type(dog_name) is not str)
+            or (status is not None and type(status) is not str)
+        ):
+            return None
+        frozen = frozen_by_box.get(box_number)
+        projected_rows.append(
+            {
+                "box_number": box_number,
+                "displayed_finish_position": finish_position,
+                "displayed_finish_or_status_text": displayed_result_text,
+                "displayed_runner_name": dog_name,
+                "frozen_runner_name": frozen.get("name") if frozen else None,
+                "source_declared_terminal_status": status,
+                "source_native_runner_id": (
+                    frozen.get("source_native_runner_id") if frozen else None
+                ),
+            }
+        )
+    projected_rows.sort(key=lambda row: canonical_json(row))
+    projection = {
+        "fingerprint_algorithm_version": SEMANTIC_FINGERPRINT_ALGORITHM,
+        "race_id": race_id,
+        "request_url": request_url,
+        "source_native_race_id": source_native_race_id,
+        "runners": projected_rows,
+    }
+    return hashlib.sha256(canonical_json(projection)).hexdigest()
+
+
+def _verify_retained_deferral_response(
+    corpus: ForwardSealedCorpus, deferral: Mapping[str, Any]
+) -> None:
+    pre = corpus._load_receipt(deferral["race_id"], "prejump")
+    if pre is None:
+        raise ForwardCorpusRejected("retained rejection lost its pre-jump receipt")
+    request_directory = corpus._request_directory(
+        corpus.root, deferral["race_id"], deferral["retained_request_id"]
+    )
+    stage = corpus._load_request_receipt(
+        request_directory / "response-stage.json", "response-stage"
+    )
+    if stage is None:
+        raise ForwardCorpusRejected("retained rejection response-stage receipt is missing")
+    body = corpus._verify_response_stage(pre, stage)
+    if any(
+        stage.get(field) != deferral[expected]
+        for field, expected in (
+            ("race_id", "race_id"),
+            ("request_id", "retained_request_id"),
+            ("request_url", "request_url"),
+        )
+    ):
+        raise ForwardCorpusRejected("retained rejection response-stage identity drift")
+    if hashlib.sha256(body).hexdigest() != deferral["retained_raw_response_hash"]:
+        raise ForwardCorpusRejected("retained rejection raw-byte hash drift")
+
+
 def _validated_rejection_deferrals(
     value: Sequence[Mapping[str, Any]],
-) -> dict[str, dict[str, str]]:
+) -> dict[str, dict[str, Any]]:
     if type(value) not in {list, tuple}:
         raise ForwardCorpusRejected("source rejection deferral metadata is invalid")
-    result: dict[str, dict[str, str]] = {}
+    result: dict[str, dict[str, Any]] = {}
     for item in value:
-        if type(item) is not dict or set(item) != {
+        if type(item) is not dict:
+            raise ForwardCorpusRejected("source rejection deferral metadata is invalid")
+        legacy = set(item) == {
             "race_id",
             "response_hash",
             "reason",
             "rejected_at",
             "next_eligible_at",
-        }:
+        }
+        versioned = set(item) == {
+            "schema_version",
+            "race_id",
+            "source_native_race_id",
+            "request_url",
+            "retained_request_id",
+            "retained_raw_response_hash",
+            "semantic_fingerprint",
+            "fingerprint_algorithm_version",
+            "reason",
+            "rejected_at",
+            "next_eligible_at",
+            "deferral_decision",
+            "pending_state",
+        }
+        if not legacy and not versioned:
             raise ForwardCorpusRejected("source rejection deferral metadata is invalid")
         race_id = item["race_id"]
-        response_hash = item["response_hash"]
+        response_hash = (
+            item["response_hash"] if legacy else item["retained_raw_response_hash"]
+        )
         reason = item["reason"]
         if (
             type(race_id) is not str
@@ -324,6 +452,35 @@ def _validated_rejection_deferrals(
             or not reason
         ):
             raise ForwardCorpusRejected("source rejection deferral metadata is invalid")
+        if versioned:
+            semantic_fingerprint = item["semantic_fingerprint"]
+            algorithm = item["fingerprint_algorithm_version"]
+            if (
+                item["schema_version"] != REJECTION_DEFERRAL_SCHEMA
+                or algorithm != SEMANTIC_FINGERPRINT_ALGORITHM
+                or type(semantic_fingerprint) is not str
+                or len(semantic_fingerprint) != 64
+                or any(
+                    character not in "0123456789abcdef"
+                    for character in semantic_fingerprint
+                )
+                or any(
+                    type(item[field]) is not str
+                    or not item[field]
+                    or len(item[field].encode()) > 512
+                    for field in (
+                        "source_native_race_id",
+                        "request_url",
+                        "retained_request_id",
+                    )
+                )
+                or item["deferral_decision"]
+                not in {"SOURCE_REJECTED", "SOURCE_REJECTION_DEFERRED"}
+                or item["pending_state"] != "RESULT_PENDING"
+            ):
+                raise ForwardCorpusRejected(
+                    "source rejection deferral metadata is invalid"
+                )
         try:
             rejected_at = datetime.fromisoformat(item["rejected_at"])
             next_eligible_at = datetime.fromisoformat(item["next_eligible_at"])
@@ -337,6 +494,8 @@ def _validated_rejection_deferrals(
             or next_eligible_at.tzinfo is None
             or next_eligible_at.utcoffset() is None
             or next_eligible_at - rejected_at != SOURCE_REJECTION_BACKOFF
+            or next_eligible_at
+            > datetime.now().astimezone() + SOURCE_REJECTION_BACKOFF
         ):
             raise ForwardCorpusRejected("source rejection deferral metadata is invalid")
         result[race_id] = dict(item)
@@ -344,16 +503,32 @@ def _validated_rejection_deferrals(
 
 
 def _rejection_deferral(
-    *, race_id: str, response_hash: str, reason: str, rejected_at: datetime
-) -> dict[str, str]:
+    *,
+    race_id: str,
+    source_native_race_id: str,
+    request_url: str,
+    retained_request_id: str,
+    response_hash: str,
+    semantic_fingerprint: str,
+    reason: str,
+    rejected_at: datetime,
+) -> dict[str, Any]:
     return {
+        "schema_version": REJECTION_DEFERRAL_SCHEMA,
         "race_id": race_id,
-        "response_hash": response_hash,
+        "source_native_race_id": source_native_race_id,
+        "request_url": request_url,
+        "retained_request_id": retained_request_id,
+        "retained_raw_response_hash": response_hash,
+        "semantic_fingerprint": semantic_fingerprint,
+        "fingerprint_algorithm_version": SEMANTIC_FINGERPRINT_ALGORITHM,
         "reason": reason,
         "rejected_at": rejected_at.isoformat(timespec="microseconds"),
         "next_eligible_at": (rejected_at + SOURCE_REJECTION_BACKOFF).isoformat(
             timespec="microseconds"
         ),
+        "deferral_decision": "SOURCE_REJECTED",
+        "pending_state": "RESULT_PENDING",
     }
 
 
@@ -376,42 +551,62 @@ def _record_source_rejection(
 
 
 def _deferral_applies(
-    deferral: Mapping[str, str] | None,
+    deferral: Mapping[str, Any] | None,
     *,
-    response_hash: str | None,
+    semantic_fingerprint: str | None,
     observed_at: datetime,
 ) -> bool:
+    if deferral is None or observed_at >= datetime.fromisoformat(
+        deferral["next_eligible_at"]
+    ):
+        return False
+    if "schema_version" not in deferral:
+        return False
     return bool(
-        response_hash
-        and deferral is not None
-        and deferral["response_hash"] == response_hash
-        and observed_at < datetime.fromisoformat(deferral["next_eligible_at"])
+        semantic_fingerprint
+        and deferral["semantic_fingerprint"] == semantic_fingerprint
     )
 
 
 def _record_deferred_rejection(
-    race_report: dict[str, Any], deferral: Mapping[str, str]
+    race_report: dict[str, Any],
+    deferral: Mapping[str, Any],
 ) -> None:
+    recorded = dict(deferral)
+    if "schema_version" in recorded:
+        recorded["deferral_decision"] = "SOURCE_REJECTION_DEFERRED"
     race_report["decision"] = "SOURCE_REJECTION_DEFERRED"
     race_report["source_rejection"] = "DeferredSourceRejection: " + deferral["reason"]
-    race_report["deferral_reason"] = "identical_source_response_before_next_eligibility"
-    race_report["rejection_deferral"] = dict(deferral)
+    race_report["deferral_reason"] = "identical_result_semantics_before_next_eligibility"
+    race_report["rejection_deferral"] = recorded
 
 
 def _attach_new_deferral(
     race_report: dict[str, Any],
-    active_deferrals: dict[str, dict[str, str]],
+    active_deferrals: dict[str, dict[str, Any]],
     *,
     race_id: str,
+    source_native_race_id: str,
+    request_url: str,
+    request_id: str,
     response_hash: str | None,
+    semantic_fingerprint: str | None,
     reason: str,
     rejected_at: datetime,
 ) -> None:
-    if race_report["decision"] != "SOURCE_REJECTED" or response_hash is None:
+    if (
+        race_report["decision"] != "SOURCE_REJECTED"
+        or response_hash is None
+        or semantic_fingerprint is None
+    ):
         return
     deferral = _rejection_deferral(
         race_id=race_id,
+        source_native_race_id=source_native_race_id,
+        request_url=request_url,
+        retained_request_id=request_id,
         response_hash=response_hash,
+        semantic_fingerprint=semantic_fingerprint,
         reason=reason,
         rejected_at=rejected_at,
     )
@@ -476,6 +671,22 @@ def observe_once(
         race_ids = {row.get("race_id") for row in before["races"]}
         if not set(active_deferrals) <= race_ids:
             raise ForwardCorpusRejected("source rejection deferral race identity is unknown")
+        state_by_race = {row["race_id"]: row["state"] for row in before["races"]}
+        for deferred_race_id, deferral in active_deferrals.items():
+            if "schema_version" not in deferral:
+                continue
+            source = _source_capture(corpus, deferred_race_id)
+            if (
+                state_by_race[deferred_race_id] != deferral["pending_state"]
+                or source["source_native_race_id"]
+                != deferral["source_native_race_id"]
+                or canonical_result_url(source["canonical_source_url"])
+                != deferral["request_url"]
+            ):
+                raise ForwardCorpusRejected(
+                    "source rejection deferral race identity is inconsistent"
+                )
+            _verify_retained_deferral_response(corpus, deferral)
         session = session_factory()
         try:
             for index, row in enumerate(before["races"]):
@@ -488,6 +699,8 @@ def observe_once(
                     "decision": "SKIPPED",
                     "receipt_hash": None,
                     "raw_response_hash": None,
+                    "semantic_fingerprint": None,
+                    "fingerprint_algorithm_version": None,
                     "normalization_attempted": False,
                     "source_rejection": None,
                     "deferral_reason": None,
@@ -520,13 +733,27 @@ def observe_once(
                     )
                     response_hash = hashlib.sha256(source_response["body"]).hexdigest()
                     race_report["raw_response_hash"] = response_hash
+                    semantic_fingerprint = _semantic_deferral_fingerprint(
+                        source_response["body"],
+                        race_id=race_id,
+                        source_native_race_id=source["source_native_race_id"],
+                        request_url=request_url,
+                        frozen_runners=source["runners"],
+                    )
+                    race_report["semantic_fingerprint"] = semantic_fingerprint
+                    if semantic_fingerprint is not None:
+                        race_report["fingerprint_algorithm_version"] = (
+                            SEMANTIC_FINGERPRINT_ALGORITHM
+                        )
                     if _deferral_applies(
                         prior_deferral,
-                        response_hash=response_hash,
+                        semantic_fingerprint=semantic_fingerprint,
                         observed_at=eligibility_time,
                     ):
                         _record_deferred_rejection(race_report, prior_deferral)
+                        active_deferrals[race_id] = race_report["rejection_deferral"]
                         continue
+                    active_deferrals.pop(race_id, None)
                     normalization_rejection: ForwardCorpusRejected | None = None
                     race_report["normalization_attempted"] = True
                     try:
@@ -545,7 +772,11 @@ def observe_once(
                             race_report,
                             active_deferrals,
                             race_id=race_id,
+                            source_native_race_id=source["source_native_race_id"],
+                            request_url=request_url,
+                            request_id=request_id,
                             response_hash=response_hash,
+                            semantic_fingerprint=semantic_fingerprint,
                             reason=str(normalization_rejection),
                             rejected_at=eligibility_time,
                         )
@@ -584,7 +815,11 @@ def observe_once(
                             race_report,
                             active_deferrals,
                             race_id=race_id,
+                            source_native_race_id=source["source_native_race_id"],
+                            request_url=request_url,
+                            request_id=request_id,
                             response_hash=response_hash,
+                            semantic_fingerprint=semantic_fingerprint,
                             reason=str(normalization_rejection),
                             rejected_at=eligibility_time,
                         )
@@ -615,17 +850,23 @@ def observe_once(
                     race_report["raw_response_hash"] = error.response_hash
                     if _deferral_applies(
                         prior_deferral,
-                        response_hash=error.response_hash,
+                        semantic_fingerprint=None,
                         observed_at=eligibility_time,
                     ):
                         _record_deferred_rejection(race_report, prior_deferral)
+                        active_deferrals[race_id] = race_report["rejection_deferral"]
                     else:
+                        active_deferrals.pop(race_id, None)
                         _record_source_rejection(race_report, error, corpus, race_id)
                     _attach_new_deferral(
                         race_report,
                         active_deferrals,
                         race_id=race_id,
+                        source_native_race_id=source["source_native_race_id"],
+                        request_url=request_url,
+                        request_id=request_id,
                         response_hash=error.response_hash,
+                        semantic_fingerprint=None,
                         reason=str(error),
                         rejected_at=eligibility_time,
                     )

--- a/scripts/observe_forward_official_results.py
+++ b/scripts/observe_forward_official_results.py
@@ -318,21 +318,50 @@ def _semantic_deferral_fingerprint(
     if not parsed or len(parsed) != len(frozen_runners):
         return None
     soup = BeautifulSoup(markup, "html.parser")
-    displayed_result_texts = [
-        cell.get_text(" ", strip=True)
-        for cell in soup.select(
-            "table.race-runners--result tr.race-runner "
-            "td.race-runners__finish-position"
-        )
-    ]
-    if len(displayed_result_texts) != len(parsed):
+    result_rows = soup.select("table.race-runners--result tr.race-runner")
+    if len(result_rows) != len(parsed):
+        return None
+    displayed_result_texts = []
+    response_native_runner_ids = []
+    for result_row in result_rows:
+        position_cell = result_row.select_one("td.race-runners__finish-position")
+        name_cell = result_row.select_one("td.race-runners__name")
+        if position_cell is None or name_cell is None:
+            return None
+        displayed_result_texts.append(position_cell.get_text(" ", strip=True))
+        native_runner_ids = {
+            str(element.get("data-dog-id"))
+            for element in name_cell.select("blackbook-dog[data-dog-id]")
+            if str(element.get("data-dog-id") or "").strip()
+        }
+        for link in name_cell.select("a[href]"):
+            parsed_link = urlsplit(str(link.get("href") or ""))
+            parts = parsed_link.path.split("/")
+            if (
+                not parsed_link.scheme
+                and not parsed_link.netloc
+                and not parsed_link.query
+                and not parsed_link.fragment
+                and len(parts) == 4
+                and parts[0] == ""
+                and parts[1] == "dogs"
+                and parts[2]
+                and parts[3]
+            ):
+                native_runner_ids.add(parts[2])
+        if len(native_runner_ids) != 1:
+            return None
+        response_native_runner_ids.append(native_runner_ids.pop())
+    if len(set(response_native_runner_ids)) != len(response_native_runner_ids):
         return None
     frozen_by_box = {runner.get("box_number"): runner for runner in frozen_runners}
     if len(frozen_by_box) != len(frozen_runners):
         return None
     projected_rows = []
     parsed_boxes = []
-    for row, displayed_result_text in zip(parsed, displayed_result_texts, strict=True):
+    for row, displayed_result_text, response_native_runner_id in zip(
+        parsed, displayed_result_texts, response_native_runner_ids, strict=True
+    ):
         if type(row) is not dict or set(row) != {
             "box_number",
             "finish_position",
@@ -361,7 +390,8 @@ def _semantic_deferral_fingerprint(
                 "displayed_runner_name": dog_name,
                 "frozen_runner_name": frozen.get("name") if frozen else None,
                 "source_declared_terminal_status": status,
-                "source_native_runner_id": (
+                "response_source_native_runner_id": response_native_runner_id,
+                "frozen_source_native_runner_id": (
                     frozen.get("source_native_runner_id") if frozen else None
                 ),
             }

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -1475,7 +1475,8 @@ def write_service_files(
     }
 
 
-def _load_forward_observer_rejection_deferrals(state_path: Path) -> list[dict[str, str]]:
+def _load_forward_observer_rejection_deferrals(state_path: Path) -> list[dict[str, Any]]:
+    """Load only exact legacy or versioned, one-hour observer deferral state."""
     if not state_path.exists():
         return []
     state = load_json(state_path)

--- a/tests/race_collection/test_forward_official_result_observer.py
+++ b/tests/race_collection/test_forward_official_result_observer.py
@@ -1,3 +1,4 @@
+import hashlib
 import importlib.util
 import json
 from datetime import datetime
@@ -193,6 +194,8 @@ def test_pre_boundary_skip_malformed_retention_and_terminal_skip(tmp_path):
         "ForwardCorpusRejected: official result HTML contains no result rows"
     )
     assert malformed["races"][0]["raw_response_hash"]
+    assert malformed["races"][0]["semantic_fingerprint"] is None
+    assert malformed["source_rejection_deferrals"] == []
     assert len(list((tmp_path / "races").glob("*/official-requests/*/response-stage.json"))) == 1
 
 
@@ -232,13 +235,20 @@ def test_identical_rejection_is_deferred_and_changed_bytes_can_close(tmp_path):
 
     response_hash = first["races"][0]["raw_response_hash"]
     assert first["races"][0]["normalization_attempted"] is True
-    assert first["races"][0]["rejection_deferral"] == {
-        "race_id": "race-1",
-        "response_hash": response_hash,
-        "reason": "official finish/status combination is inconsistent",
-        "rejected_at": "2026-07-29T10:06:00.000000+10:00",
-        "next_eligible_at": "2026-07-29T11:06:00.000000+10:00",
-    }
+    deferral = first["races"][0]["rejection_deferral"]
+    assert deferral["schema_version"] == observer.REJECTION_DEFERRAL_SCHEMA
+    assert deferral["race_id"] == "race-1"
+    assert deferral["source_native_race_id"] == "thedogs-2026-07-29-1"
+    assert deferral["retained_request_id"] == first["races"][0]["request_id"]
+    assert deferral["retained_raw_response_hash"] == response_hash
+    assert deferral["semantic_fingerprint"] == first["races"][0][
+        "semantic_fingerprint"
+    ]
+    assert deferral["reason"] == "official finish/status combination is inconsistent"
+    assert deferral["rejected_at"] == "2026-07-29T10:06:00.000000+10:00"
+    assert deferral["next_eligible_at"] == "2026-07-29T11:06:00.000000+10:00"
+    assert deferral["deferral_decision"] == "SOURCE_REJECTED"
+    assert deferral["pending_state"] == "RESULT_PENDING"
     assert first["source_rejection_deferrals"] == [
         first["races"][0]["rejection_deferral"]
     ]
@@ -256,11 +266,11 @@ def test_identical_rejection_is_deferred_and_changed_bytes_can_close(tmp_path):
     assert identical["races"][0]["after_state"] == "RESULT_PENDING"
     assert identical["races"][0]["normalization_attempted"] is False
     assert identical["races"][0]["raw_response_hash"] == response_hash
-    assert identical["races"][0]["rejection_deferral"] == first["races"][0][
-        "rejection_deferral"
-    ]
+    assert identical["races"][0]["rejection_deferral"] == deferral | {
+        "deferral_decision": "SOURCE_REJECTION_DEFERRED"
+    }
     assert identical["races"][0]["deferral_reason"] == (
-        "identical_source_response_before_next_eligibility"
+        "identical_result_semantics_before_next_eligibility"
     )
     assert len(session.calls) == 1
     assert len(list((tmp_path / "races").glob("*/official-requests/*/response-stage.json"))) == 1
@@ -285,6 +295,252 @@ def test_identical_rejection_is_deferred_and_changed_bytes_can_close(tmp_path):
     )
     assert closed["status"] == "COMPLETED"
     assert closed["races"][0]["after_state"] == "EXAMPLE_CLOSED"
+
+
+def test_csrf_only_change_uses_semantic_deferral_without_conflating_raw_hash(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    partial = T1._html().replace(b"2nd", b"-")
+    first_body = b'<meta name="csrf-token" content="first">' + partial
+    second_body = b'<meta name="csrf-token" content="second">' + partial
+
+    first, _ = _run(
+        tmp_path,
+        "semantic-first",
+        [_dt("10:06")] * 4,
+        [Response(first_body, url)],
+    )
+    deferred, _ = _run(
+        tmp_path,
+        "semantic-second",
+        [_dt("10:21")],
+        [Response(second_body, url)],
+        previous_rejection_deferrals=first["source_rejection_deferrals"],
+    )
+
+    first_race = first["races"][0]
+    deferred_race = deferred["races"][0]
+    assert first_race["raw_response_hash"] != deferred_race["raw_response_hash"]
+    assert first_race["semantic_fingerprint"] == deferred_race["semantic_fingerprint"]
+    assert first_race["fingerprint_algorithm_version"] == (
+        "thedogs-official-result-semantic-projection-sha256-v1"
+    )
+    assert deferred_race["decision"] == "SOURCE_REJECTION_DEFERRED"
+    assert deferred_race["normalization_attempted"] is False
+    assert deferred_race["rejection_deferral"]["retained_raw_response_hash"] == (
+        first_race["raw_response_hash"]
+    )
+    stages = list((tmp_path / "races").glob("*/official-requests/*/response-stage.json"))
+    assert len(stages) == 1
+    retained = json.loads(stages[0].read_text())
+    assert ForwardSealedCorpus(tmp_path).artifacts.read(
+        ArtifactChecksum(retained["raw_response_checksum"])
+    ) == first_body
+
+
+@pytest.mark.parametrize(
+    "changed_body",
+    [
+        T1._html(),
+        T1._html().replace(b"2nd", b"DNF"),
+        T1._html().replace(b"2nd", b"-").replace(b">-<", b">VOID<"),
+        T1._html().replace(b"2nd", b"-").replace(b"Dog 1 A", b"Dog 1 A csrf_deadbeef"),
+        T1._html().replace(b"2nd", b"-").replace(b"rug_1", b"rug_3"),
+    ],
+    ids=[
+        "finish",
+        "recognized-status",
+        "unrecognized-status",
+        "runner-identity-token-text",
+        "box-rug",
+    ],
+)
+def test_material_result_change_bypasses_semantic_deferral(tmp_path, changed_body):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    partial = T1._html().replace(b"2nd", b"-")
+    first, _ = _run(
+        tmp_path,
+        "material-first",
+        [_dt("10:06")] * 4,
+        [Response(partial, url)],
+    )
+
+    changed, _ = _run(
+        tmp_path,
+        "material-changed",
+        [_dt("10:21")] * 4,
+        [Response(changed_body, url)],
+        previous_rejection_deferrals=first["source_rejection_deferrals"],
+    )
+
+    assert changed["races"][0]["semantic_fingerprint"] != first["races"][0][
+        "semantic_fingerprint"
+    ]
+    assert changed["races"][0]["decision"] != "SOURCE_REJECTION_DEFERRED"
+    assert changed["races"][0]["normalization_attempted"] is True
+
+
+def test_semantic_deferral_still_verifies_retained_exact_raw_bytes(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    partial = T1._html().replace(b"2nd", b"-")
+    first, _ = _run(
+        tmp_path,
+        "retained-semantic-first",
+        [_dt("10:06")] * 4,
+        [Response(partial, url)],
+    )
+    deferral = dict(first["source_rejection_deferrals"][0])
+    deferral["retained_raw_response_hash"] = deferral["semantic_fingerprint"]
+
+    repeated, _ = _run(
+        tmp_path,
+        "retained-semantic-second",
+        [_dt("10:21")],
+        [Response(partial, url)],
+        previous_rejection_deferrals=[deferral],
+    )
+
+    assert repeated["status"] == "FAILED"
+    assert repeated["races"] == []
+    assert "retained rejection raw-byte hash drift" in repeated["error"]
+
+
+def test_race_and_native_runner_identity_are_part_of_semantic_fingerprint(tmp_path):
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    partial = T1._html().replace(b"2nd", b"-")
+    _seed(tmp_path / "base")
+    base, _ = _run(
+        tmp_path / "base", "identity-base", [_dt("10:06")] * 4, [Response(partial, url)]
+    )
+
+    _seed(tmp_path / "other-race", race_id="race-other")
+    other_race, _ = _run(
+        tmp_path / "other-race",
+        "identity-race",
+        [_dt("10:06")] * 4,
+        [Response(partial, url)],
+    )
+
+    native_value = T1.fixture(2)
+    native_value["race_id"] = "race-1"
+    native_value["sealed_evidence_bytes"] = native_value["sealed_evidence_bytes"].replace(
+        b'"race_id":"race-2"', b'"race_id":"race-1"'
+    )
+    native_value["canonical_source_url"] = url.removesuffix("?trial=false")
+    native_value["source_native_race_id"] = "thedogs-2026-07-29-1"
+    ForwardSealedCorpus(tmp_path / "other-native", clock=lambda: _dt("09:45")).capture_prejump(
+        **native_value
+    )
+    native_partial = T1._html(2).replace(b"2nd", b"-")
+    other_native, _ = _run(
+        tmp_path / "other-native",
+        "identity-native",
+        [_dt("10:06")] * 4,
+        [Response(native_partial, url)],
+    )
+
+    fingerprint = base["races"][0]["semantic_fingerprint"]
+    assert other_race["races"][0]["semantic_fingerprint"] != fingerprint
+    assert other_native["races"][0]["semantic_fingerprint"] != fingerprint
+
+
+def test_known_legacy_deferral_is_reprocessed_once_into_versioned_state(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    partial = T1._html().replace(b"2nd", b"-")
+    legacy = {
+        "race_id": "race-1",
+        "response_hash": hashlib.sha256(partial).hexdigest(),
+        "reason": "official finish/status combination is inconsistent",
+        "rejected_at": "2026-07-29T10:06:00.000000+10:00",
+        "next_eligible_at": "2026-07-29T11:06:00.000000+10:00",
+    }
+
+    transitioned, _ = _run(
+        tmp_path,
+        "legacy-transition",
+        [_dt("10:21")] * 4,
+        [Response(partial, url)],
+        previous_rejection_deferrals=[legacy],
+    )
+
+    race = transitioned["races"][0]
+    assert race["decision"] == "SOURCE_REJECTED"
+    assert race["normalization_attempted"] is True
+    assert race["rejection_deferral"]["schema_version"] == (
+        observer.REJECTION_DEFERRAL_SCHEMA
+    )
+    assert race["rejection_deferral"]["rejected_at"] == (
+        "2026-07-29T10:21:00.000000+10:00"
+    )
+    assert race["rejection_deferral"]["next_eligible_at"] == (
+        "2026-07-29T11:21:00.000000+10:00"
+    )
+
+
+def test_unprojectable_response_consumes_prior_deferral_instead_of_carrying_it(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    partial = T1._html().replace(b"2nd", b"-")
+    first, _ = _run(
+        tmp_path,
+        "unprojectable-first",
+        [_dt("10:06")] * 4,
+        [Response(partial, url)],
+    )
+
+    unprojectable, _ = _run(
+        tmp_path,
+        "unprojectable-second",
+        [_dt("10:21")] * 4,
+        [Response(b"<html>not a result</html>", url)],
+        previous_rejection_deferrals=first["source_rejection_deferrals"],
+    )
+
+    assert unprojectable["races"][0]["decision"] == "SOURCE_REJECTED"
+    assert unprojectable["races"][0]["semantic_fingerprint"] is None
+    assert unprojectable["source_rejection_deferrals"] == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema_version", "unknown-deferral-v99"),
+        ("source_native_race_id", "wrong-source-race"),
+        ("pending_state", "RESULT_FIRST_OBSERVED"),
+        ("deferral_decision", "UNKNOWN"),
+        ("fingerprint_algorithm_version", "unknown-fingerprint-v99"),
+        ("next_eligible_at", "9999-07-29T11:06:00.000000+10:00"),
+    ],
+)
+def test_versioned_deferral_corruption_and_inconsistency_are_fatal(
+    tmp_path, field, value
+):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    partial = T1._html().replace(b"2nd", b"-")
+    first, _ = _run(
+        tmp_path,
+        "versioned-corruption-first",
+        [_dt("10:06")] * 4,
+        [Response(partial, url)],
+    )
+    corrupted = dict(first["source_rejection_deferrals"][0])
+    corrupted[field] = value
+
+    report, session = _run(
+        tmp_path,
+        "versioned-corruption-second",
+        [],
+        [],
+        previous_rejection_deferrals=[corrupted],
+    )
+
+    assert report["status"] == "FAILED"
+    assert "source rejection deferral" in report["error"]
+    assert session.calls == []
 
 
 @pytest.mark.parametrize(
@@ -611,8 +867,9 @@ def test_wire_exact_body_encoding_and_bound_are_enforced(tmp_path, monkeypatch):
         [repeated],
         previous_rejection_deferrals=report["source_rejection_deferrals"],
     )
-    assert deferred["races"][0]["decision"] == "SOURCE_REJECTION_DEFERRED"
+    assert deferred["races"][0]["decision"] == "SOURCE_REJECTED"
     assert deferred["races"][0]["normalization_attempted"] is False
+    assert deferred["source_rejection_deferrals"] == []
     assert not list((tmp_path / "races").glob("*/official-requests/*/response-stage.json"))
 
     monkeypatch.setattr(observer, "MAX_RESPONSE_BYTES", 8)

--- a/tests/race_collection/test_forward_official_result_observer.py
+++ b/tests/race_collection/test_forward_official_result_observer.py
@@ -221,6 +221,69 @@ def test_partial_official_order_is_source_rejected_without_failing_observer(tmp_
     )
 
 
+def test_duplicate_result_box_is_not_eligible_for_semantic_deferral(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    duplicate_box = T1._html().replace(b"rug_2", b"rug_1")
+
+    report, _ = _run(
+        tmp_path,
+        "duplicate-result-box",
+        [_dt("10:06")] * 4,
+        [Response(duplicate_box, url)],
+    )
+
+    race = report["races"][0]
+    assert race["decision"] == "SOURCE_REJECTED"
+    assert race["source_rejection"] == (
+        "ForwardCorpusRejected: official result runner box/rug identity mismatch"
+    )
+    assert race["semantic_fingerprint"] is None
+    assert report["source_rejection_deferrals"] == []
+
+
+def test_missing_result_box_is_not_eligible_for_semantic_deferral(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    missing_box = T1._html().replace(b'<tr class="race-runner">', b"<tr>", 1)
+
+    report, _ = _run(
+        tmp_path,
+        "missing-result-box",
+        [_dt("10:06")] * 4,
+        [Response(missing_box, url)],
+    )
+
+    race = report["races"][0]
+    assert race["decision"] == "SOURCE_REJECTED"
+    assert race["source_rejection"] == (
+        "ForwardCorpusRejected: official result runner box/rug identity mismatch"
+    )
+    assert race["semantic_fingerprint"] is None
+    assert report["source_rejection_deferrals"] == []
+
+
+def test_unknown_result_box_is_not_eligible_for_semantic_deferral(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    unknown_box = T1._html().replace(b"rug_2", b"rug_3")
+
+    report, _ = _run(
+        tmp_path,
+        "unknown-result-box",
+        [_dt("10:06")] * 4,
+        [Response(unknown_box, url)],
+    )
+
+    race = report["races"][0]
+    assert race["decision"] == "SOURCE_REJECTED"
+    assert race["source_rejection"] == (
+        "ForwardCorpusRejected: official result runner box/rug identity mismatch"
+    )
+    assert race["semantic_fingerprint"] is None
+    assert report["source_rejection_deferrals"] == []
+
+
 def test_identical_rejection_is_deferred_and_changed_bytes_can_close(tmp_path):
     _seed(tmp_path)
     url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"

--- a/tests/race_collection/test_forward_official_result_observer.py
+++ b/tests/race_collection/test_forward_official_result_observer.py
@@ -578,6 +578,49 @@ def test_semantic_deferral_still_verifies_retained_exact_raw_bytes(tmp_path):
     assert "retained rejection raw-byte hash drift" in repeated["error"]
 
 
+def test_forged_semantic_fingerprint_for_changed_native_identity_fails_before_fetch(
+    tmp_path,
+):
+    _seed(tmp_path / "retained")
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    partial = T1._html().replace(b"2nd", b"-")
+    first, _ = _run(
+        tmp_path / "retained",
+        "forged-semantic-first",
+        [_dt("10:06")] * 4,
+        [Response(partial, url)],
+    )
+
+    changed_native_id = partial.replace(
+        b'/dogs/dog-1-a/dog-1-a', b'/dogs/dog-other/dog-1-a'
+    )
+    _seed(tmp_path / "changed")
+    changed, _ = _run(
+        tmp_path / "changed",
+        "forged-semantic-changed",
+        [_dt("10:06")] * 4,
+        [Response(changed_native_id, url)],
+    )
+    assert changed["races"][0]["semantic_fingerprint"] != first["races"][0][
+        "semantic_fingerprint"
+    ]
+
+    forged = dict(first["source_rejection_deferrals"][0])
+    forged["semantic_fingerprint"] = changed["races"][0]["semantic_fingerprint"]
+    repeated, session = _run(
+        tmp_path / "retained",
+        "forged-semantic-second",
+        [_dt("10:21")] * 4,
+        [Response(changed_native_id, url)],
+        previous_rejection_deferrals=[forged],
+    )
+
+    assert repeated["status"] == "FAILED"
+    assert repeated["races"] == []
+    assert "retained rejection semantic fingerprint drift" in repeated["error"]
+    assert session.calls == []
+
+
 def test_race_and_native_runner_identity_are_part_of_semantic_fingerprint(tmp_path):
     url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
     partial = T1._html().replace(b"2nd", b"-")

--- a/tests/race_collection/test_forward_official_result_observer.py
+++ b/tests/race_collection/test_forward_official_result_observer.py
@@ -21,6 +21,23 @@ def _accepted_helpers():
 
 
 T1 = _accepted_helpers()
+_fixture_html = T1._html
+
+
+def _result_html(index=1, *, whitespace=""):
+    body = _fixture_html(index, whitespace=whitespace)
+    for suffix in ("a", "b"):
+        name = f"Dog {index} {suffix.upper()}".encode()
+        link = (
+            f'<a href="/dogs/dog-{index}-{suffix}/dog-{index}-{suffix}">'.encode()
+            + name
+            + b"</a>"
+        )
+        body = body.replace(name, link)
+    return body
+
+
+T1._html = _result_html
 
 
 def _dt(value):
@@ -442,6 +459,97 @@ def test_material_result_change_bypasses_semantic_deferral(tmp_path, changed_bod
     ]
     assert changed["races"][0]["decision"] != "SOURCE_REJECTION_DEFERRED"
     assert changed["races"][0]["normalization_attempted"] is True
+
+
+def test_current_response_native_runner_identity_change_bypasses_deferral(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    partial = T1._html().replace(b"2nd", b"-")
+    first, _ = _run(
+        tmp_path,
+        "native-response-first",
+        [_dt("10:06")] * 4,
+        [Response(partial, url)],
+    )
+    changed_native_id = partial.replace(
+        b'/dogs/dog-1-a/dog-1-a', b'/dogs/dog-other/dog-1-a'
+    )
+
+    changed, _ = _run(
+        tmp_path,
+        "native-response-changed",
+        [_dt("10:21")] * 4,
+        [Response(changed_native_id, url)],
+        previous_rejection_deferrals=first["source_rejection_deferrals"],
+    )
+
+    assert changed["races"][0]["semantic_fingerprint"] != first["races"][0][
+        "semantic_fingerprint"
+    ]
+    assert changed["races"][0]["decision"] != "SOURCE_REJECTION_DEFERRED"
+    assert changed["races"][0]["normalization_attempted"] is True
+
+
+def test_duplicate_current_response_native_runner_identity_cannot_defer(tmp_path):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    duplicate_native_id = (
+        T1._html()
+        .replace(b"2nd", b"-")
+        .replace(b'/dogs/dog-1-b/dog-1-b', b'/dogs/dog-1-a/dog-1-b')
+    )
+
+    first, _ = _run(
+        tmp_path,
+        "duplicate-native-first",
+        [_dt("10:06")] * 4,
+        [Response(duplicate_native_id, url)],
+    )
+    repeated, _ = _run(
+        tmp_path,
+        "duplicate-native-repeated",
+        [_dt("10:21")] * 4,
+        [Response(duplicate_native_id, url)],
+        previous_rejection_deferrals=first["source_rejection_deferrals"],
+    )
+
+    assert first["races"][0]["semantic_fingerprint"] is None
+    assert first["source_rejection_deferrals"] == []
+    assert repeated["races"][0]["decision"] == "SOURCE_REJECTED"
+    assert repeated["races"][0]["normalization_attempted"] is True
+
+
+@pytest.mark.parametrize(
+    "identity_mutation",
+    [
+        lambda body: body.replace(
+            b'<a href="/dogs/dog-1-a/dog-1-a">Dog 1 A</a>', b"Dog 1 A"
+        ),
+        lambda body: body.replace(
+            b'<a href="/dogs/dog-1-a/dog-1-a">',
+            b'<blackbook-dog data-dog-id="dog-conflict"></blackbook-dog>'
+            b'<a href="/dogs/dog-1-a/dog-1-a">',
+        ),
+    ],
+    ids=["missing", "conflicting-within-row"],
+)
+def test_incomplete_current_response_native_runner_identity_cannot_defer(
+    tmp_path, identity_mutation
+):
+    _seed(tmp_path)
+    url = "https://www.thedogs.com.au/racing/venue/2026-07-29/1/race-name?trial=false"
+    incomplete_identity = identity_mutation(T1._html().replace(b"2nd", b"-"))
+
+    report, _ = _run(
+        tmp_path,
+        "incomplete-native-identity",
+        [_dt("10:06")] * 4,
+        [Response(incomplete_identity, url)],
+    )
+
+    assert report["races"][0]["decision"] == "SOURCE_REJECTED"
+    assert report["races"][0]["semantic_fingerprint"] is None
+    assert report["source_rejection_deferrals"] == []
 
 
 def test_semantic_deferral_still_verifies_retained_exact_raw_bytes(tmp_path):

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -10562,6 +10562,61 @@ def test_forward_observer_corrupt_durable_deferral_state_fails_closed(tmp_path):
         )
 
 
+def test_forward_observer_reloads_versioned_semantic_deferral_with_exact_hour(
+    monkeypatch, tmp_path
+):
+    state_path = tmp_path / "runtime" / "state.json"
+    state_path.parent.mkdir(parents=True)
+    deferral = {
+        "schema_version": "forward-official-result-rejection-deferral-v2",
+        "race_id": "race-1",
+        "source_native_race_id": "thedogs-2026-07-29-1",
+        "request_url": "https://www.thedogs.com.au/racing/venue/2026-07-29/1?trial=false",
+        "retained_request_id": "request-retained",
+        "retained_raw_response_hash": "a" * 64,
+        "semantic_fingerprint": "b" * 64,
+        "fingerprint_algorithm_version": (
+            "thedogs-official-result-semantic-projection-sha256-v1"
+        ),
+        "reason": "official finish/status combination is inconsistent",
+        "rejected_at": "2026-07-29T10:06:00.000000+10:00",
+        "next_eligible_at": "2026-07-29T11:06:00.000000+10:00",
+        "deferral_decision": "SOURCE_REJECTION_DEFERRED",
+        "pending_state": "RESULT_PENDING",
+    }
+    state_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "shadow_autopilot_daemon_state_v1",
+                "forward_official_result_observer": {
+                    "source_rejection_deferrals": [deferral]
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(
+        "scripts.observe_forward_official_results.observe_once",
+        lambda **kwargs: {"status": "COMPLETED", "arguments": kwargs},
+    )
+    args = daemon.parse_args(
+        [
+            "run-once",
+            "--enable-forward-official-result-observer",
+            "--forward-corpus-root",
+            str(tmp_path / "corpus"),
+        ]
+    )
+
+    result = daemon.run_forward_official_result_observer(
+        args, "semantic-reload", state_path=state_path
+    )
+
+    assert result["arguments"]["previous_rejection_deferrals"] == [deferral]
+    rejected_at = datetime.fromisoformat(deferral["rejected_at"])
+    next_eligible_at = datetime.fromisoformat(deferral["next_eligible_at"])
+    assert (next_eligible_at - rejected_at).total_seconds() == 3600
+
+
 def test_full_service_generator_emits_forward_opt_in_only_when_declared(tmp_path):
     lock_path = Path("/runtime/shared-shadow-autopilot.lock")
     default = daemon.service_file_text(repo_path=tmp_path, timeout_seconds=840)


### PR DESCRIPTION
## Problem

Volatile CSRF tokens changed the exact raw response hash for otherwise identical rejected official-result pages, defeating the bounded one-hour rejection deferral.

## Solution

Separate the immutable exact raw-response integrity identity from the versioned semantic deferral identity. The semantic projection binds race and source identity, request URL, frozen native runner identity, box or rug, runner name, displayed finish or status text, and parsed finish or status while excluding CSRF page scaffolding.

## Safety and legacy behavior

- Meaningful result changes bypass deferral immediately.
- Exact raw bytes, receipts, hashes, persistence, identity, lock, closure, and operational failures remain fatal.
- Known legacy raw-hash records are reprocessed once into the versioned semantic state; malformed or inconsistent state fails closed.
- Continuable source rejection remains COMPLETED_WITH_REJECTIONS, while COMPLETED_WITH_ERRORS and FAILED remain fatal.

## Validation

- Forward observer module: 43 passed.
- Shadow daemon module: 163 passed.
- Fatal Flake8 on the four changed files: 0.
- Python compilation: passed.
- git diff --check: passed.

Repository-wide Flake8 is not required for this patch. Its ten established failures are in untouched baseline files and remain a non-blocking observation.

## Explicit exclusions

No deployment, live or natural-cycle proof, result invention, TheDogs scheduler work, database or corpus mutation, runtime or service change, prediction, model promotion, or betting action was performed.