### PR TITLE
Bind baseline collection failures to prediction quarantine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,6 +255,7 @@ nohup.out
 *.sqlite*
 *.sql
 !race_collection/migrations/0030_forward_baseline_cohort_authority.sql
+!race_collection/migrations/0031_forward_baseline_prediction_quarantine.sql
 
 # Temporary and build files
 temp/

--- a/race_collection/forecasting.py
+++ b/race_collection/forecasting.py
@@ -329,22 +329,25 @@ class ForecastingAuthority:
                         "at": terminal_at,
                     }
                 )
-            elif rejections:
-                rejection = rejections[-1]
+            elif row["cohort_quarantine_prediction_id"] is not None:
                 classification = (
                     BaselineTerminalClassification.AUTHORIZATION_BLOCKED
-                    if rejection["code"] in authorization_codes
+                    if row["cohort_quarantine_code"] in authorization_codes
                     else (
                         BaselineTerminalClassification.INTEGRITY_FAILED
-                        if rejection["code"] in integrity_codes
+                        if row["cohort_quarantine_code"] in integrity_codes
                         else BaselineTerminalClassification.QUARANTINED
                     )
                 )
-                code = rejection["code"]
-                details = rejection["details"]
-                terminal_at = rejection["at"]
-                prediction_id = None
+                code = row["cohort_quarantine_code"]
+                details = row["cohort_quarantine_details"]
+                terminal_at = row["cohort_quarantined_at"]
+                prediction_id = row["cohort_quarantine_prediction_id"]
                 artifact_checksum = None
+            elif rejections:
+                raise OperationsStoreError(
+                    "collection rejection lacks explicit baseline prediction quarantine"
+                )
             else:
                 incomplete.append(race_id)
                 continue

--- a/race_collection/migrations/0031_forward_baseline_prediction_quarantine.sql
+++ b/race_collection/migrations/0031_forward_baseline_prediction_quarantine.sql
@@ -1,0 +1,46 @@
+CREATE TABLE forward_baseline_prediction_quarantines (
+ cohort_id TEXT NOT NULL,
+ race_id TEXT PRIMARY KEY,
+ prediction_id TEXT NOT NULL UNIQUE CHECK(length(trim(prediction_id))>0),
+ stage TEXT NOT NULL CHECK(stage IN ('identity','collection','sealing')),
+ code TEXT NOT NULL CHECK(length(trim(code))>0),
+ details TEXT NOT NULL CHECK(length(trim(details))>0),
+ quarantined_at TEXT NOT NULL,
+ collection_quarantine_operation_id TEXT NOT NULL UNIQUE,
+ FOREIGN KEY(cohort_id,race_id)
+  REFERENCES forward_baseline_cohort_members(cohort_id,race_id),
+ FOREIGN KEY(collection_quarantine_operation_id)
+  REFERENCES collection_quarantines(operation_id)
+);
+
+INSERT INTO forward_baseline_prediction_quarantines
+SELECT m.cohort_id,q.race_id,'cohort-quarantine-'||q.operation_id,
+ q.stage,q.code,q.details,q.created_at,q.operation_id
+FROM collection_quarantines q
+JOIN forward_baseline_cohort_members m ON m.race_id=q.race_id
+WHERE q.quarantine_id=(
+ SELECT MIN(first_q.quarantine_id) FROM collection_quarantines first_q
+ WHERE first_q.race_id=q.race_id
+);
+
+CREATE TRIGGER forward_baseline_prediction_quarantines_exact_source
+BEFORE INSERT ON forward_baseline_prediction_quarantines
+WHEN NOT EXISTS (
+ SELECT 1 FROM collection_quarantines q
+ JOIN forward_baseline_cohort_members m ON m.race_id=q.race_id
+ WHERE q.operation_id=NEW.collection_quarantine_operation_id
+ AND q.race_id=NEW.race_id
+ AND q.stage=NEW.stage
+ AND q.code=NEW.code
+ AND q.details=NEW.details
+ AND q.created_at=NEW.quarantined_at
+ AND m.cohort_id=NEW.cohort_id
+)
+BEGIN SELECT RAISE(ABORT,'baseline prediction quarantine source disagrees'); END;
+
+CREATE TRIGGER forward_baseline_prediction_quarantines_append_only_update
+BEFORE UPDATE ON forward_baseline_prediction_quarantines
+BEGIN SELECT RAISE(ABORT,'baseline prediction quarantine is append-only'); END;
+CREATE TRIGGER forward_baseline_prediction_quarantines_append_only_delete
+BEFORE DELETE ON forward_baseline_prediction_quarantines
+BEGIN SELECT RAISE(ABORT,'baseline prediction quarantine is append-only'); END;

--- a/race_collection/operational.py
+++ b/race_collection/operational.py
@@ -477,7 +477,7 @@ class ReleaseManifest:
         if not re.fullmatch(r"[0-9a-f]{40}", _strict_nonempty(self.code_commit, "code commit")):
             raise ValueError("code_commit must be an exact Git commit")
         _safe_operational_path(self.service_root)
-        if self.database_schema != 30 or not self.supported_bundle_versions:
+        if self.database_schema != 31 or not self.supported_bundle_versions:
             raise ValueError("release schema or bundle contract is unsupported")
 
     def document(self) -> Mapping[str, Any]:

--- a/race_collection/operations.py
+++ b/race_collection/operations.py
@@ -294,6 +294,7 @@ class SQLiteOperationsStore:
             (28, "0028_phase7_probation_seal_authority.sql"),
             (29, "0029_phase7_bounded_timing_authority.sql"),
             (30, "0030_forward_baseline_cohort_authority.sql"),
+            (31, "0031_forward_baseline_prediction_quarantine.sql"),
         )
         return tuple(
             (version, name, migration_root.joinpath(name).read_bytes()) for version, name in names
@@ -555,12 +556,16 @@ class SQLiteOperationsStore:
                     "e.scheduled_jump,s.frozen_at,p.prediction_id,p.artifact_checksum,"
                     "p.computed_at,q.prediction_id quarantine_prediction_id,"
                     "q.code prediction_code,"
-                    "q.details prediction_details,q.quarantined_at "
+                    "q.details prediction_details,q.quarantined_at,"
+                    "bq.prediction_id cohort_quarantine_prediction_id,"
+                    "bq.code cohort_quarantine_code,bq.details cohort_quarantine_details,"
+                    "bq.quarantined_at cohort_quarantined_at "
                     "FROM races r JOIN racing_days d USING(racing_day_id) "
                     "JOIN expected_races e USING(race_id) "
                     "LEFT JOIN sealed_evidence s USING(race_id) "
                     "LEFT JOIN deferred_predictions p USING(race_id) "
                     "LEFT JOIN prediction_quarantines q USING(race_id) "
+                    "LEFT JOIN forward_baseline_prediction_quarantines bq USING(race_id) "
                     "WHERE r.race_id=?",
                     (race_id,),
                 ).fetchone()
@@ -1537,6 +1542,25 @@ class SQLiteOperationsStore:
                     str(request_intent_digest) if request_intent_digest is not None else None,
                 ),
             )
+            cohort = db.execute(
+                "SELECT cohort_id FROM forward_baseline_cohort_members WHERE race_id=?",
+                (str(race_id),),
+            ).fetchone()
+            if cohort is not None:
+                db.execute(
+                    "INSERT INTO forward_baseline_prediction_quarantines "
+                    "VALUES(?,?,?,?,?,?,?,?)",
+                    (
+                        cohort["cohort_id"],
+                        str(race_id),
+                        f"cohort-quarantine-{operation_id}",
+                        stage,
+                        code,
+                        details,
+                        iso_timestamp(at),
+                        str(operation_id),
+                    ),
+                )
         return True
 
     def odds_attempts(self, race_id: RaceId) -> tuple[OddsAttemptRecord, ...]:

--- a/race_collection/operator.py
+++ b/race_collection/operator.py
@@ -101,9 +101,9 @@ def _verify_schema_identity(store: SQLiteOperationsStore) -> None:
         ]
     except (OSError, sqlite3.Error) as error:
         raise OperatorRejected("operations database schema authority is unavailable") from error
-    if recorded != expected or [version for version, _ in recorded] != list(range(1, 31)):
+    if recorded != expected or [version for version, _ in recorded] != list(range(1, 32)):
         raise OperatorRejected(
-            "operations database must have the exact checked-in schema 1-30 identity"
+            "operations database must have the exact checked-in schema 1-31 identity"
         )
 
 
@@ -383,7 +383,7 @@ def _dispatch(args: argparse.Namespace) -> tuple[Mapping[str, Any], int]:
         store = _store(args, allow_new=True)
         store.migrate()
         _verify_schema_identity(store)
-        return {"command": "migrate", "schema_version": 30, "status": "ok"}, 0
+        return {"command": "migrate", "schema_version": 31, "status": "ok"}, 0
 
     if args.command == "generate-user-service":
         manifest = _release(args.release_document)

--- a/race_collection/recovery.py
+++ b/race_collection/recovery.py
@@ -29,7 +29,7 @@ def _digest(content: bytes) -> ArtifactChecksum:
 
 
 ARTIFACT_REFERENCE_CONTRACT = "phase7-artifact-references-v1"
-ARTIFACT_REFERENCE_SCHEMA_VERSION = 29
+ARTIFACT_REFERENCE_SCHEMA_VERSION = 31
 
 # Closed schema contract: only content-addressed object references belong here.
 # Operational/result/database hashes are intentionally absent.

--- a/tests/race_collection/test_operations.py
+++ b/tests/race_collection/test_operations.py
@@ -108,7 +108,7 @@ def test_empty_and_repeated_migrations_enable_wal_and_foreign_keys(tmp_path):
     store.migrate()
     with sqlite3.connect(store.path) as db:
         assert db.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
-        assert db.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 30
+        assert db.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0] == 31
     with store._connect() as db:
         assert db.execute("PRAGMA foreign_keys").fetchone()[0] == 1
 
@@ -209,7 +209,7 @@ def test_populated_schema_17_migrates_forward_to_latest_without_data_loss(tmp_pa
     store.migrate()
 
     with store._connect() as db:
-        assert db.execute("SELECT MAX(version) FROM schema_migrations").fetchone()[0] == 30
+        assert db.execute("SELECT MAX(version) FROM schema_migrations").fetchone()[0] == 31
         assert (
             db.execute(
                 "SELECT source_race_id FROM expected_races WHERE source_race_id='legacy-race'"

--- a/tests/race_collection/test_operator.py
+++ b/tests/race_collection/test_operator.py
@@ -76,7 +76,7 @@ def python_311_executable() -> str:
     return executable
 
 
-def test_migrate_rejects_legacy_and_non_operations_databases_and_ends_at_29(tmp_path, capsys):
+def test_migrate_rejects_legacy_and_non_operations_databases_and_ends_at_31(tmp_path, capsys):
     legacy = tmp_path / "greyhound_racing_data.db"
     with sqlite3.connect(legacy) as db:
         db.execute("CREATE TABLE race_metadata(race_id TEXT PRIMARY KEY)")
@@ -105,11 +105,11 @@ def test_migrate_rejects_legacy_and_non_operations_databases_and_ends_at_29(tmp_
     operations = tmp_path / "operations.sqlite3"
     assert main(["migrate", *common(operations, legacy)]) == 0
     result = json.loads(capsys.readouterr().out.splitlines()[-1])
-    assert result == {"command": "migrate", "schema_version": 30, "status": "ok"}
+    assert result == {"command": "migrate", "schema_version": 31, "status": "ok"}
     with sqlite3.connect(operations) as db:
         assert [
             row[0] for row in db.execute("SELECT version FROM schema_migrations ORDER BY version")
-        ] == list(range(1, 31))
+        ] == list(range(1, 32))
         assert db.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
     with sqlite3.connect(legacy) as db:
         assert db.execute(
@@ -117,7 +117,7 @@ def test_migrate_rejects_legacy_and_non_operations_databases_and_ends_at_29(tmp_
         ).fetchall() == [("race_metadata",)]
     with sqlite3.connect(operations) as db:
         db.execute(
-            "UPDATE schema_migrations SET checksum=? WHERE version=30",
+            "UPDATE schema_migrations SET checksum=? WHERE version=31",
             ("0" * 64,),
         )
     assert (
@@ -169,7 +169,7 @@ def test_registration_and_observation_commands_preserve_exact_immutable_authorit
         "release_id": "candidate-release",
         "code_commit": "a" * 40,
         "config_checksum": config_checksum,
-        "database_schema": 30,
+        "database_schema": 31,
         "artifact_contract": "canonical-artifacts-v1",
         "policy_version": policy_document["policy_id"],
         "supported_bundle_versions": ["runner-win-probability-v1"],

--- a/tests/race_collection/test_phase2_collection.py
+++ b/tests/race_collection/test_phase2_collection.py
@@ -249,11 +249,12 @@ def test_migrations_are_forward_only_and_repeatable(setup):
             (24,),
             (25,),
             (26,),
-                (27,),
-                (28,),
-                (29,),
-                (30,),
-            ]
+            (27,),
+            (28,),
+            (29,),
+            (30,),
+            (31,),
+        ]
         recorded = db.execute("SELECT checksum FROM schema_migrations WHERE version=10").fetchone()[
             0
         ]

--- a/tests/race_collection/test_phase3_forecasting.py
+++ b/tests/race_collection/test_phase3_forecasting.py
@@ -144,7 +144,7 @@ def test_migration_empty_repeat_and_populated_pre_phase3(tmp_path):
     store.migrate()
     store.migrate()
     with store._connect() as db:
-        assert db.execute("SELECT MAX(version) FROM schema_migrations").fetchone()[0] == 30
+        assert db.execute("SELECT MAX(version) FROM schema_migrations").fetchone()[0] == 31
         assert (
             db.execute("SELECT kind FROM operations WHERE operation_id='legacy'").fetchone()[0]
             == "fixture"
@@ -443,6 +443,13 @@ def test_frozen_twenty_race_cohort_uses_real_terminal_barrier_and_finite_records
     assert all(
         row["rejections"] for row in terminal["records"] if row["classification"] != "ACCEPTED"
     )
+    collection_terminal = next(
+        row
+        for row in terminal["records"]
+        if row["race_id"] == str(collection_quarantined[0])
+    )
+    assert collection_terminal["prediction_id"]
+    assert authority.baseline_cohort_terminal_records(cohort_bytes) == terminal
     assert authority.open_baseline_results(
         operation(operation_number), accepted[0], NOW, cohort_bytes=cohort_bytes
     )

--- a/tests/race_collection/test_phase6_evaluation_promotion.py
+++ b/tests/race_collection/test_phase6_evaluation_promotion.py
@@ -365,7 +365,7 @@ def test_migration_empty_and_repeat_paths(tmp_path):
     store.migrate()
     store.migrate()
     with store._connect() as db:
-        assert db.execute("SELECT MAX(version) FROM schema_migrations").fetchone()[0] == 30
+        assert db.execute("SELECT MAX(version) FROM schema_migrations").fetchone()[0] == 31
         assert db.execute("SELECT COUNT(*) FROM phase6_promotion_records").fetchone()[0] == 0
 
 

--- a/tests/race_collection/test_phase7_operational.py
+++ b/tests/race_collection/test_phase7_operational.py
@@ -350,7 +350,7 @@ class Phase7OperationalTests(unittest.TestCase):
             release_id,
             "6cd5dacfe83719cbbc376a265829e84593eafb68",
             ArtifactChecksum("sha256:" + hashlib.sha256(content).hexdigest()),
-            29,
+            31,
             "canonical-artifacts-v1",
             "phase6-promotion-v1",
             ("runner-win-probability-v1",),
@@ -2302,7 +2302,7 @@ class Phase7OperationalTests(unittest.TestCase):
                     "unsupported-bundle-contract",
                     "a" * 40,
                     unsupported_checksum,
-                    29,
+                    31,
                     "canonical-artifacts-v1",
                     "phase6-promotion-v1",
                     ("unsupported-forecast-v99",),
@@ -2812,7 +2812,7 @@ class Phase7OperationalTests(unittest.TestCase):
                 "future-schema",
                 "6cd5dacfe83719cbbc376a265829e84593eafb68",
                 PROGRAMME,
-                30,
+                32,
                 "canonical-artifacts-v1",
                 "phase6-promotion-v1",
                 ("runner-win-probability-v1",),
@@ -2984,7 +2984,7 @@ class Phase7OperationalTests(unittest.TestCase):
                 "candidate",
                 "6cd5dacfe83719cbbc376a265829e84593eafb68",
                 config_checksum,
-                29,
+                31,
                 "canonical-artifacts-v1",
                 "phase6-promotion-v1",
                 ("runner-win-probability-v1",),
@@ -3611,7 +3611,7 @@ class Phase7OperationalTests(unittest.TestCase):
                 "cross-phase-release",
                 "6cd5dacfe83719cbbc376a265829e84593eafb68",
                 config_checksum,
-                29,
+                31,
                 "canonical-artifacts-v1",
                 "phase6-promotion-v1",
                 ("runner-win-probability-v1",),
@@ -3648,7 +3648,7 @@ class Phase7OperationalTests(unittest.TestCase):
     def test_artifact_inventory_fails_closed_for_unknown_future_schema(self) -> None:
         with self.store._connect() as db:
             db.execute(
-                "INSERT INTO schema_migrations VALUES(30,?,?)",
+                "INSERT INTO schema_migrations VALUES(32,?,?)",
                 ("future-contract-unknown", NOW.isoformat()),
             )
             with self.assertRaisesRegex(RecoveryRejected, "does not cover"):
@@ -4294,7 +4294,7 @@ class Phase7OperationalTests(unittest.TestCase):
                 release_id,
                 source_commit,
                 checksum,
-                29,
+                31,
                 "canonical-artifacts-v1",
                 "phase6-promotion-v1",
                 ("runner-win-probability-v1",),

--- a/tests/race_collection/test_phase7_runtime_adapter.py
+++ b/tests/race_collection/test_phase7_runtime_adapter.py
@@ -709,7 +709,7 @@ def _runtime_fixture(
             release_id,
             source_commit,
             config_checksum,
-            30,
+            31,
             "canonical-artifacts-v1",
             "phase6-promotion-v1",
             bundle_versions,


### PR DESCRIPTION
Follow-up to #160 for the remaining Issue #159 terminal-authority gap.

## Summary
- create an append-only transactional prediction-quarantine identity when a frozen cohort member fails before sealing
- bind that identity exactly to the durable collection rejection and immutable cohort membership
- require the public 20-race terminal projection to use the explicit quarantine authority rather than a report-only collection-rejection projection
- advance the checked-in schema contract to version 31

## Validation
- red/green public cohort regression: 1 passed
- focused lifecycle/schema/runtime suite: 280 passed; the three clean-worktree checks were rerun after commit and passed 3/3
- recovery inventory tests: 3 passed
- 500-race recovery/probation/promotion authority chain: 1 passed
- critical Flake8 and git diff whitespace checks: passed

## Boundaries
No deployment, live cohort execution, source activation, refit, promotion, or betting.

Refs #159