### PR TITLE
Fix PR #160 deployment argument compatibility

### DIFF
--- a/race_collection/service.py
+++ b/race_collection/service.py
@@ -215,7 +215,7 @@ class ForwardBaselineCaptureService:
         ):
             return {
                 "schema_version": self.REPORT_SCHEMA,
-                "status": "INTEGRITY_FAILED",
+                "status": "AWAITING_COHORT_CANDIDATES",
                 "reason": "CURRENT_RACE_INDEX_NOT_READY_NOW",
             }
         races = tuple(verified_index.races)

--- a/scripts/autonomous_live_odds_capture.py
+++ b/scripts/autonomous_live_odds_capture.py
@@ -3024,6 +3024,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--collector-receipt-root", type=Path)
     parser.add_argument("--collector-run-id")
     parser.add_argument("--forward-corpus-root", type=Path)
+    parser.add_argument("--forward-current-race-index-path", type=Path)
     parser.add_argument("--forward-baseline-config", type=Path)
     return parser.parse_args(argv)
 
@@ -3091,45 +3092,75 @@ def main(
 
     forward_corpus_admitter = None
     if args.forward_corpus_root is not None:
-        if (
-            receipt_protocol is None
-            or not args.collector_run_id
-            or args.forward_baseline_config is None
-        ):
+        if receipt_protocol is None or not args.collector_run_id:
             raise ValueError("forward_corpus_scheduled_receipt_authority_missing")
-        if forward_baseline_loader is None:
-            from race_collection.service import load_forward_baseline_capture_binding
-
-            forward_baseline_loader = load_forward_baseline_capture_binding
-        binding = forward_baseline_loader(args.forward_baseline_config)
-        if (
-            binding.service.configuration.corpus_root != args.forward_corpus_root
-            or binding.evidence_root != evidence_root
-        ):
-            raise ValueError("forward_baseline_runtime_binding_mismatch")
-        if current_index_reader is None:
-            from race_collection.synchronous_manual_capture import (
-                bounded_current_race_index,
+        if args.forward_baseline_config is None:
+            if args.forward_current_race_index_path is None:
+                raise ValueError("forward_corpus_current_index_authority_missing")
+            from race_collection.scheduled_forward_corpus import (
+                admit_scheduled_capture,
             )
+            if current_index_reader is None:
+                from race_collection.synchronous_manual_capture import (
+                    bounded_current_race_index,
+                )
 
-            current_index_reader = bounded_current_race_index
-        verified_current_index = current_index_reader(
-            current_time=current_time,
-            timeout_seconds=binding.current_index_timeout_seconds,
-            index_path=binding.current_index_path,
-            evidence_root=binding.evidence_root,
-            max_age_seconds=binding.current_index_max_age_seconds,
-            return_verified_view=True,
-        )
-
-        def forward_corpus_admitter(**values: Any) -> Mapping[str, Any]:
-            return binding.service.capture_scheduled(
-                protocol=receipt_protocol,
+                current_index_reader = bounded_current_race_index
+            verified_current_index = current_index_reader(
+                current_time=current_time,
+                timeout_seconds=min(args.fetch_timeout_seconds, 5.0),
+                index_path=args.forward_current_race_index_path,
                 evidence_root=evidence_root,
-                collector_run_id=args.collector_run_id,
-                verified_index=verified_current_index,
-                **values,
+                max_age_seconds=15 * 60,
+                return_verified_view=True,
             )
+
+            def forward_corpus_admitter(**values: Any) -> Mapping[str, Any]:
+                return admit_scheduled_capture(
+                    protocol=receipt_protocol,
+                    evidence_root=evidence_root,
+                    corpus_root=args.forward_corpus_root,
+                    collector_run_id=args.collector_run_id,
+                    verified_index=verified_current_index,
+                    **values,
+                )
+        else:
+            if forward_baseline_loader is None:
+                from race_collection.service import (
+                    load_forward_baseline_capture_binding,
+                )
+
+                forward_baseline_loader = load_forward_baseline_capture_binding
+            binding = forward_baseline_loader(args.forward_baseline_config)
+            if (
+                binding.service.configuration.corpus_root
+                != args.forward_corpus_root
+                or binding.evidence_root != evidence_root
+            ):
+                raise ValueError("forward_baseline_runtime_binding_mismatch")
+            if current_index_reader is None:
+                from race_collection.synchronous_manual_capture import (
+                    bounded_current_race_index,
+                )
+
+                current_index_reader = bounded_current_race_index
+            verified_current_index = current_index_reader(
+                current_time=current_time,
+                timeout_seconds=binding.current_index_timeout_seconds,
+                index_path=binding.current_index_path,
+                evidence_root=binding.evidence_root,
+                max_age_seconds=binding.current_index_max_age_seconds,
+                return_verified_view=True,
+            )
+
+            def forward_corpus_admitter(**values: Any) -> Mapping[str, Any]:
+                return binding.service.capture_scheduled(
+                    protocol=receipt_protocol,
+                    evidence_root=evidence_root,
+                    collector_run_id=args.collector_run_id,
+                    verified_index=verified_current_index,
+                    **values,
+                )
     elif args.forward_baseline_config is not None:
         raise ValueError("forward_baseline_config_requires_forward_corpus")
 

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -1240,10 +1240,8 @@ def require_forward_baseline_binding(
     forward_corpus_root: Path | None,
     forward_baseline_config: Path | None,
 ) -> None:
-    if (forward_corpus_root is None) != (forward_baseline_config is None):
-        raise ValueError(
-            "forward_corpus_root and forward_baseline_config must be supplied together"
-        )
+    if forward_baseline_config is not None and forward_corpus_root is None:
+        raise ValueError("forward_baseline_config requires forward_corpus_root")
 
 
 def service_file_text(
@@ -1277,10 +1275,16 @@ def service_file_text(
                 "--enable-forward-official-result-observer",
                 "--forward-corpus-root",
                 systemd_exec_argument(str(forward_corpus_root)),
+            ]
+            if forward_corpus_root is not None
+            else []
+        ),
+        *(
+            [
                 "--forward-baseline-config",
                 systemd_exec_argument(str(forward_baseline_config)),
             ]
-            if forward_corpus_root is not None and forward_baseline_config is not None
+            if forward_baseline_config is not None
             else []
         ),
     ]
@@ -1373,10 +1377,16 @@ def odds_capture_service_file_text(
             [
                 "--forward-corpus-root",
                 systemd_exec_argument(str(forward_corpus_root)),
+            ]
+            if forward_corpus_root is not None
+            else []
+        ),
+        *(
+            [
                 "--forward-baseline-config",
                 systemd_exec_argument(str(forward_baseline_config)),
             ]
-            if forward_corpus_root is not None and forward_baseline_config is not None
+            if forward_baseline_config is not None
             else []
         ),
     ]
@@ -1952,18 +1962,18 @@ def odds_capture_only_autopilot_command(
     if state_path is not None:
         command.extend(["--current-race-index-state-path", str(state_path)])
     if forward_corpus_root is not None:
-        if forward_baseline_config is None:
-            raise ValueError("forward_baseline_config_missing")
         command.extend(
             [
                 "--forward-corpus-root",
                 str(forward_corpus_root),
-                "--forward-baseline-config",
-                str(forward_baseline_config),
             ]
         )
-    elif forward_baseline_config is not None:
-        raise ValueError("forward_corpus_root_missing")
+    if forward_baseline_config is not None:
+        if forward_corpus_root is None:
+            raise ValueError("forward_corpus_root_missing")
+        command.extend(
+            ["--forward-baseline-config", str(forward_baseline_config)]
+        )
     return command
 
 
@@ -9695,11 +9705,27 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
             autopilot_command.append("--allow-auto-scrape-odds")
         if args.enable_autonomous_result_capture:
             autopilot_command.append("--enable-autonomous-result-capture")
+        if (
+            args.forward_corpus_root is not None
+            and args.forward_baseline_config is None
+            and args.odds_capture_state_path is not None
+        ):
+            autopilot_command.extend(
+                [
+                    "--current-race-index-state-path",
+                    str(args.odds_capture_state_path),
+                ]
+            )
         if args.forward_corpus_root is not None:
             autopilot_command.extend(
                 [
                     "--forward-corpus-root",
                     str(args.forward_corpus_root),
+                ]
+            )
+        if args.forward_baseline_config is not None:
+            autopilot_command.extend(
+                [
                     "--forward-baseline-config",
                     str(args.forward_baseline_config),
                 ]
@@ -13470,11 +13496,12 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "--forward-corpus-root is required with "
             "--enable-forward-official-result-observer"
         )
-    if bool(getattr(args, "forward_corpus_root", None)) != bool(
-        getattr(args, "forward_baseline_config", None)
+    if (
+        getattr(args, "forward_baseline_config", None) is not None
+        and getattr(args, "forward_corpus_root", None) is None
     ):
         parser.error(
-            "--forward-corpus-root and --forward-baseline-config must be supplied together"
+            "--forward-baseline-config requires --forward-corpus-root"
         )
     return args
 

--- a/scripts/shadow_autopilot_v1.py
+++ b/scripts/shadow_autopilot_v1.py
@@ -43,6 +43,7 @@ from race_collection.manual_prediction_collector_request import (  # noqa: E402
 )
 from race_collection.synchronous_manual_capture import (  # noqa: E402
     CURRENT_RACE_INDEX_PUBLISH_REPORT_FILENAME,
+    current_race_index_path as collector_current_race_index_path,
     publish_current_race_index,
     publish_current_race_index_lifecycle,
 )
@@ -629,6 +630,7 @@ def autonomous_live_odds_capture_command(
     collector_receipt_root: Path | None = None,
     collector_run_id: str | None = None,
     forward_corpus_root: Path | None = None,
+    forward_current_race_index_path: Path | None = None,
     forward_baseline_config: Path | None = None,
     command_prefix: Sequence[str] | None = None,
 ) -> list[str]:
@@ -670,18 +672,30 @@ def autonomous_live_odds_capture_command(
     if forward_corpus_root is not None:
         if collector_receipt_root is None or collector_run_id is None:
             raise ValueError("forward_corpus_scheduled_receipt_authority_missing")
-        if forward_baseline_config is None:
-            raise ValueError("forward_baseline_config_missing")
+        if (
+            forward_baseline_config is None
+            and forward_current_race_index_path is None
+        ):
+            raise ValueError("forward_corpus_current_index_authority_missing")
         command.extend(
             [
                 "--forward-corpus-root",
                 str(forward_corpus_root),
-                "--forward-baseline-config",
-                str(forward_baseline_config),
             ]
         )
-    elif forward_baseline_config is not None:
-        raise ValueError("forward_corpus_root_missing")
+    if forward_current_race_index_path is not None:
+        command.extend(
+            [
+                "--forward-current-race-index-path",
+                str(forward_current_race_index_path),
+            ]
+        )
+    if forward_baseline_config is not None:
+        if forward_corpus_root is None:
+            raise ValueError("forward_corpus_root_missing")
+        command.extend(
+            ["--forward-baseline-config", str(forward_baseline_config)]
+        )
     if manual_request_id is not None:
         if manual_request_root is None or collector_run_id is None:
             raise ValueError("manual_request_collector_authority_missing")
@@ -6913,6 +6927,15 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
                 else None
             ),
             forward_corpus_root=args.forward_corpus_root,
+            forward_current_race_index_path=(
+                collector_current_race_index_path(
+                    args.current_race_index_state_path
+                )
+                if args.forward_corpus_root is not None
+                and args.forward_baseline_config is None
+                and args.current_race_index_state_path is not None
+                else None
+            ),
             forward_baseline_config=args.forward_baseline_config,
         )
         autonomous_odds_step = step_command(
@@ -8623,9 +8646,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_RESULT_BACKLOG_LOOKBACK_DAYS,
     )
     args = parser.parse_args(argv)
-    if (args.forward_corpus_root is None) != (args.forward_baseline_config is None):
+    if args.forward_baseline_config is not None and args.forward_corpus_root is None:
         parser.error(
-            "--forward-corpus-root and --forward-baseline-config must be supplied together"
+            "--forward-baseline-config requires --forward-corpus-root"
         )
     return args
 

--- a/tests/race_collection/test_forward_baseline_service.py
+++ b/tests/race_collection/test_forward_baseline_service.py
@@ -253,10 +253,11 @@ def test_production_preflight_rejects_malformed_selected_race_before_any_write(
     assert not configuration(tmp_path).corpus_root.exists()
 
 
-def test_production_preflight_rejects_stale_verified_view_before_any_write(tmp_path: Path):
+def test_production_preflight_awaits_fresh_verified_view_before_any_write(tmp_path: Path):
     database = tmp_path / "operations.sqlite3"
     store = SQLiteOperationsStore(database)
     store.migrate()
+    config_path, evidence_root, index_path = production_config(tmp_path, database)
     stale = verified_index(complete_candidates())
     stale = VerifiedCurrentRaceIndex(
         **{
@@ -268,12 +269,19 @@ def test_production_preflight_rejects_stale_verified_view_before_any_write(tmp_p
     )
     before = table_counts(database)
 
-    report = ForwardBaselineCaptureService(store, configuration(tmp_path)).run(
-        stale,
+    report = run_forward_baseline_capture(
+        config_path,
         now=NOW,
+        current_index_reader=lambda **values: (
+            stale
+            if values["index_path"] == index_path
+            and values["evidence_root"] == evidence_root
+            and values["return_verified_view"] is True
+            else None
+        ),
     )
 
-    assert report["status"] == "INTEGRITY_FAILED"
+    assert report["status"] == "AWAITING_COHORT_CANDIDATES"
     assert report["reason"] == "CURRENT_RACE_INDEX_NOT_READY_NOW"
     assert table_counts(database) == before
     assert not configuration(tmp_path).corpus_root.exists()

--- a/tests/test_autonomous_live_odds_capture.py
+++ b/tests/test_autonomous_live_odds_capture.py
@@ -892,6 +892,84 @@ def test_main_routes_forward_corpus_through_durable_baseline_service(
     assert observed[0]["evidence_root"] == evidence_root
 
 
+def test_main_forward_corpus_without_baseline_config_keeps_existing_admission(
+    tmp_path, monkeypatch
+):
+    input_dir = tmp_path / "upcoming"
+    _write_capture_input(input_dir)
+    evidence_root = tmp_path / "evidence"
+    evidence_root.mkdir()
+    output_dir = evidence_root / "autonomous_live_odds_capture_existing_unit"
+    corpus_root = tmp_path / "forward-corpus"
+    index_path = evidence_root / "manual_prediction_current_race_index.json"
+    verified_index = object()
+    observed = []
+    release_root = tmp_path / "release-repo"
+    release_root.mkdir()
+    monkeypatch.setattr(capture, "ROOT", release_root)
+    monkeypatch.setattr(capture, "build_capture_plan", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(
+        "race_collection.scheduled_forward_corpus.admit_scheduled_capture",
+        lambda **values: observed.append(values) or {"status": "PREJUMP_CAPTURED"},
+    )
+
+    def execute(_plan, **values):
+        admission = values["forward_corpus_admitter"](
+            plan_item={"race_id": "race-existing"},
+            attempt={"status": "APPENDED"},
+            receipt_publish={"status": "PUBLISHED"},
+            emitted_at=datetime.fromisoformat("2026-06-10T14:40:00+10:00"),
+        )
+        assert admission == {"status": "PREJUMP_CAPTURED"}
+        return {
+            "attempts": [],
+            "capture_window_coverage": {},
+            "final_status": "NO_ELIGIBLE_WINDOWS",
+        }
+
+    monkeypatch.setattr(capture, "execute_capture_plan", execute)
+
+    assert (
+        capture.main(
+            [
+                "--input-dir",
+                str(input_dir),
+                "--evidence-root",
+                str(evidence_root),
+                "--output-dir",
+                str(output_dir),
+                "--db",
+                str(tmp_path / "odds.db"),
+                "--current-time",
+                "2026-06-10T14:40:00+10:00",
+                "--execute",
+                "--allow-auto-scrape-odds",
+                "--collector-receipt-root",
+                str(tmp_path / "receipts"),
+                "--collector-run-id",
+                "collector-existing",
+                "--forward-corpus-root",
+                str(corpus_root),
+                "--forward-current-race-index-path",
+                str(index_path),
+            ],
+            forward_baseline_loader=lambda _path: pytest.fail(
+                "baseline initialization must remain disabled"
+            ),
+            current_index_reader=lambda **values: (
+                verified_index
+                if values["index_path"] == index_path
+                and values["return_verified_view"] is True
+                else None
+            ),
+        )
+        == 0
+    )
+    assert observed[0]["corpus_root"] == corpus_root
+    assert observed[0]["collector_run_id"] == "collector-existing"
+    assert observed[0]["verified_index"] is verified_index
+
+
 def test_execute_capture_plan_skips_existing_superset_capture_without_retry(
     tmp_path,
 ):

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -1,5 +1,6 @@
 import os
 import json
+import shlex
 import sqlite3
 import subprocess
 import sys
@@ -272,6 +273,13 @@ def test_run_once_exception_writes_terminal_daemon_report(tmp_path, monkeypatch)
         assert command[command.index("--collector-lock-path") + 1] == str(
             launch_dir / "shared-runtime" / "shadow_autopilot.lock"
         )
+        assert command[command.index("--current-race-index-state-path") + 1] == str(
+            Path("runtime/odds-capture-state.json")
+        )
+        assert command[command.index("--forward-corpus-root") + 1] == str(
+            Path("forward-corpus")
+        )
+        assert "--forward-baseline-config" not in command
         raise RuntimeError("synthetic daemon failure")
 
     monkeypatch.setattr(daemon, "run_command", failing_run_command)
@@ -294,6 +302,10 @@ def test_run_once_exception_writes_terminal_daemon_report(tmp_path, monkeypatch)
             str(shadow_model),
             "--lock-path",
             "shared-runtime/shadow_autopilot.lock",
+            "--odds-capture-state-path",
+            "runtime/odds-capture-state.json",
+            "--forward-corpus-root",
+            "forward-corpus",
         ]
     )
 
@@ -1966,6 +1978,25 @@ def test_odds_capture_only_autopilot_command_is_narrow_and_append_only():
         require_safe_refresh_metadata=False,
     )
     assert "--require-safe-refresh-metadata" not in permissive_command
+
+    existing_command = daemon.odds_capture_only_autopilot_command(
+        run_id="odds_only_autopilot",
+        evidence_root=Path("/evidence"),
+        lock_path=Path("/runtime/shared.lock"),
+        current_time="2026-06-12T09:48:00+10:00",
+        db_path=Path("/data/greyhound_racing_data.db"),
+        days_ahead=1,
+        refresh_limit=8,
+        odds_capture_min_minutes=0.0,
+        odds_capture_max_minutes=60.0,
+        odds_capture_refresh_limit=8,
+        timeout_seconds=600,
+        forward_corpus_root=Path("/evidence/forward-corpus"),
+    )
+    assert existing_command[
+        existing_command.index("--forward-corpus-root") + 1
+    ] == "/evidence/forward-corpus"
+    assert "--forward-baseline-config" not in existing_command
 
 
 def test_gated_challenger_commands_use_report_only_packet_builders():
@@ -10683,6 +10714,54 @@ def test_full_service_generator_emits_forward_opt_in_only_when_declared(tmp_path
         timeout_seconds=600,
     )
     assert "--forward-corpus-root" not in odds
+    existing_odds = daemon.odds_capture_service_file_text(
+        repo_path=tmp_path,
+        timeout_seconds=600,
+        forward_corpus_root=Path("/runtime/forward-corpus"),
+    )
+    assert '--forward-corpus-root "/runtime/forward-corpus"' in existing_odds
+    assert "--forward-baseline-config" not in existing_odds
+    with pytest.raises(ValueError, match="requires forward_corpus_root"):
+        daemon.service_file_text(
+            repo_path=tmp_path,
+            timeout_seconds=840,
+            forward_baseline_config=Path("/runtime/forward-baseline.json"),
+        )
+
+
+def test_existing_forward_corpus_service_command_runs_without_baseline_capture(
+    monkeypatch, tmp_path
+):
+    service = daemon.service_file_text(
+        repo_path=tmp_path,
+        python_path=Path(sys.executable),
+        timeout_seconds=840,
+        forward_corpus_root=Path("/runtime/forward-corpus"),
+    )
+    exec_start = next(
+        line.removeprefix("ExecStart=")
+        for line in service.splitlines()
+        if line.startswith("ExecStart=")
+    )
+    command = shlex.split(exec_start)
+    observed = {}
+
+    def run_cycle(args):
+        observed["forward_corpus_root"] = args.forward_corpus_root
+        observed["forward_baseline_config"] = args.forward_baseline_config
+        return {
+            "final_verdict": "PARTIAL_DAEMONIZATION",
+            "forward_official_result_observer": {"status": "COMPLETED"},
+        }
+
+    monkeypatch.setattr(daemon, "run_once", run_cycle)
+
+    assert daemon.main(command[2:]) == 0
+    assert observed == {
+        "forward_corpus_root": Path("/runtime/forward-corpus"),
+        "forward_baseline_config": None,
+    }
+    assert "--forward-baseline-config" not in command
 
 
 @pytest.mark.parametrize("status", ["LOCK_BUSY", "COMPLETED_WITH_ERRORS", "FAILED"])

--- a/tests/test_shadow_autopilot_v1.py
+++ b/tests/test_shadow_autopilot_v1.py
@@ -619,23 +619,37 @@ def test_autonomous_live_odds_capture_command_requires_explicit_execute_flags():
             forward_baseline_config=Path("forward-baseline.json"),
         )
 
-    with pytest.raises(ValueError, match="forward_baseline_config_missing"):
-        autopilot.autonomous_live_odds_capture_command(
-            input_dirs=[Path("upcoming_a")],
-            evidence_root=Path("artifacts/full_evidence_orchestration_20260525"),
-            capture_dir=Path("autonomous_live_odds_capture_x"),
-            db_path=Path("greyhound_racing_data.db"),
-            current_time="2026-06-10T14:00:00+10:00",
-            limit=16,
-            execute=True,
-            allow_auto_scrape_odds=True,
-            collector_receipt_root=Path("collector-requests"),
-            collector_run_id="scheduled-run-1",
-            forward_corpus_root=Path("forward-corpus"),
-        )
+    existing_binding = autopilot.autonomous_live_odds_capture_command(
+        input_dirs=[Path("upcoming_a")],
+        evidence_root=Path("artifacts/full_evidence_orchestration_20260525"),
+        capture_dir=Path("autonomous_live_odds_capture_x"),
+        db_path=Path("greyhound_racing_data.db"),
+        current_time="2026-06-10T14:00:00+10:00",
+        limit=16,
+        execute=True,
+        allow_auto_scrape_odds=True,
+        collector_receipt_root=Path("collector-requests"),
+        collector_run_id="scheduled-run-1",
+        forward_corpus_root=Path("forward-corpus"),
+        forward_current_race_index_path=Path("current-race-index.json"),
+    )
+    assert existing_binding[
+        existing_binding.index("--forward-corpus-root") + 1
+    ] == "forward-corpus"
+    assert "--forward-baseline-config" not in existing_binding
+    assert existing_binding[
+        existing_binding.index("--forward-current-race-index-path") + 1
+    ] == "current-race-index.json"
 
+    existing_args = autopilot.parse_args(
+        ["--forward-corpus-root", "forward-corpus"]
+    )
+    assert existing_args.forward_corpus_root == Path("forward-corpus")
+    assert existing_args.forward_baseline_config is None
     with pytest.raises(SystemExit):
-        autopilot.parse_args(["--forward-corpus-root", "forward-corpus"])
+        autopilot.parse_args(
+            ["--forward-baseline-config", "forward-baseline.json"]
+        )
 
 
 def test_manual_request_command_is_bound_to_claimed_collector_run():


### PR DESCRIPTION
## Summary

- preserve generated Race Collection Service commands that provide `--forward-corpus-root` without baseline configuration
- keep root-only scheduled corpus admission bound to the freshly published, verified collector v2 current index without loading baseline configuration or an operations database
- activate the durable forward-baseline binding only when `--forward-baseline-config` is explicit
- report insufficient or stale baseline candidate indexes as `AWAITING_COHORT_CANDIDATES` with a zero-write, non-error readiness result

## Validation

- deterministic generated-service command regression: pass
- focused compatibility, baseline-service, scheduled-corpus entrypoint, and deployment-generator tests: 313 passed
- CI blocking Flake8 selection on changed files: 0 findings
- independent Standards review: PASS
- independent Spec review: PASS

Two unrelated assertions already fail on exact `origin/master`: they expect the odds refresh limit to be 8 while master defines 16. The same two failures reproduce without this commit.

Refs #159
