### PR TITLE
Restore operational current-race index publication

### DIFF
--- a/docs/adr/0014-require-the-collector-owned-current-race-index.md
+++ b/docs/adr/0014-require-the-collector-owned-current-race-index.md
@@ -1,3 +1,10 @@
 # Require the collector-owned current-race index
 
 A genuine report-only live manual prediction requires a fresh, verified collector v2 current-race index containing the selected pre-jump race. Its race identity, jump timestamp, and runner-set hash must agree with the sealed receipt. The index must not be manually edited, synthesized, copied into place, or bypassed; if publication is unavailable or stale, prediction waits or fails closed.
+
+The operational index is published only by a completed primary collector
+refresh and contains any non-empty bounded set of individually valid races.
+Odds-only refreshes never publish it. Scientific cohort composition is a
+separate downstream freeze gate: the forward baseline still requires exactly
+20 races spanning at least three venues and two racing dates, but those
+thresholds never determine operational-index validity.

--- a/docs/operator_ui_v1/CONTRACTS.md
+++ b/docs/operator_ui_v1/CONTRACTS.md
@@ -146,7 +146,7 @@ These policies are exhaustive; an adapter may not invent or defer a threshold:
   `shadow_autopilot_daemon_runtime/manual_prediction_current_race_index.json`
   at its server-configured locator beneath the server-owned evidence root. The
   packet has schema `collector_current_race_index_v1` or
-  `collector_current_race_index_v2`, canonical bytes, at most 32 races, a
+  `collector_current_race_index_v2`, canonical bytes, one to 32 races, a
   timezone-aware `source_generated_at`, and the sealed refresh-report path and
   SHA-256. Its configured maximum age is exactly 1200 seconds. Every v1 and v2
   row contains validated `date`, timezone-aware `jump_datetime`, stable
@@ -180,8 +180,10 @@ These policies are exhaustive; an adapter may not invent or defer a threshold:
   lock, caller-path resolution, or independent refresh-report interpretation.
   Each runner binds integer box, source display name, protocol-compatible
   normalized uppercase identity, explicit `ACTIVE` scratch state, and a
-  source-native runner ID only when the accepted source supplies it; absence is
-  explicit and IDs are never guessed. Duplicate box/normalized identity,
+  numeric source-native runner ID retained from the accepted source. Every v2
+  race likewise retains its numeric source-native race ID. Missing,
+  non-numeric, conflicting, duplicated, or ambiguous native identity is
+  rejected and IDs are never guessed. Duplicate box/normalized identity,
   empty/partial/ambiguous sets, unknown scratch state, or noncanonical ordering
   is invalid. The deterministic runner-set SHA binds the ordered set to exact
   race URL/date/venue/number/jump identity, pre-race source URL/timestamp,

--- a/race_collection/synchronous_manual_capture.py
+++ b/race_collection/synchronous_manual_capture.py
@@ -835,17 +835,16 @@ def _normalize_current_index_rows(
             "race_url": race_url,
             "venue": venue,
         }
-        if "source_native_race_id" in raw:
-            native_race_id = raw.get("source_native_race_id")
-            if (
-                type(native_race_id) is not str
-                or not native_race_id.isascii()
-                or not native_race_id.isdecimal()
-            ):
-                raise CaptureOneRejected(
-                    "CURRENT_INDEX_INVALID", reason="source_native_race_id_invalid"
-                )
-            row["source_native_race_id"] = native_race_id
+        native_race_id = raw.get("source_native_race_id")
+        if (
+            type(native_race_id) is not str
+            or not native_race_id.isascii()
+            or not native_race_id.isdecimal()
+        ):
+            raise CaptureOneRejected(
+                "CURRENT_INDEX_INVALID", reason="source_native_race_id_invalid"
+            )
+        row["source_native_race_id"] = native_race_id
         alias_set = set(aliases)
         canonical_aliases = sorted(stable_race_id_variants(row))
         if (
@@ -910,6 +909,11 @@ def _v2_runner_rows(
         or not isinstance(shadow.get("venue"), str)
         or normalize_venue(shadow["venue"]) != normalize_venue(race["venue"])
         or shadow.get("race_number") != race["race_number"]
+        or (
+            race.get("source_native_race_id") is not None
+            and shadow.get("source_native_race_id")
+            != race.get("source_native_race_id")
+        )
     ):
         raise CaptureOneRejected("CURRENT_INDEX_SOURCE_INVALID", reason="runner_race_identity_mismatch")
     observed = datetime.fromisoformat(str(shadow.get("metadata_captured_at") or ""))
@@ -942,7 +946,9 @@ def _v2_runner_rows(
     def admitted_native_id(item: Mapping[str, Any]) -> str | None:
         value = item.get("source_native_runner_id", item.get("runner_id"))
         if value is None:
-            return None
+            raise CaptureOneRejected(
+                "CURRENT_INDEX_SOURCE_INVALID", reason="runner_id_unavailable"
+            )
         if isinstance(value, bool) or not isinstance(value, (str, int)):
             raise CaptureOneRejected(
                 "CURRENT_INDEX_SOURCE_INVALID", reason="runner_id_invalid"
@@ -1300,6 +1306,10 @@ def publish_current_race_index(
             ):
                 raise CaptureOneRejected("CURRENT_INDEX_SOURCE_INVALID")
             races = _normalize_current_index_rows(source, max_races=max_races)
+            if not races:
+                raise CaptureOneRejected(
+                    "CURRENT_INDEX_SOURCE_INVALID", reason="no_valid_current_races"
+                )
             sealed_races = []
             for race in races:
                 runners, runner_source, runner_hash = _v2_runner_rows(

--- a/scripts/refresh_prejump_upcoming.py
+++ b/scripts/refresh_prejump_upcoming.py
@@ -465,6 +465,16 @@ def _metadata_record_for_csv(csv_path: Path) -> dict[str, Any]:
         and isinstance(payload.get("prejump_shadow_metadata"), Mapping)
         else {}
     )
+    runner_rows = shadow.get("runner_box_name_list")
+    native_runner_ids = (
+        [
+            row.get("source_native_runner_id")
+            for row in runner_rows
+            if isinstance(row, Mapping)
+        ]
+        if isinstance(runner_rows, list)
+        else []
+    )
     weather_present = bool(weather_track.get("weather"))
     track_present = bool(weather_track.get("track_condition"))
     expert_form_safe = bool(expert_form.get("metadata_is_leakage_safe"))
@@ -482,6 +492,8 @@ def _metadata_record_for_csv(csv_path: Path) -> dict[str, Any]:
             weather_present and track_present and expert_form_safe
         ),
         "runner_source_observed_at": shadow.get("metadata_captured_at"),
+        "source_native_race_id": shadow.get("source_native_race_id"),
+        "source_native_runner_ids": native_runner_ids,
         "weather": weather_track.get("weather"),
         "track_condition": weather_track.get("track_condition"),
         "weather_track_metadata_source": weather_track.get("weather_track_metadata_source"),
@@ -677,8 +689,30 @@ def current_index_metadata_selection(
             and generated < jump
             and observed < jump
         )
-        if aligned and safe_components and safe_runner_timing:
-            eligible.append(dict(selected))
+        native_race_id = (
+            row.get("source_native_race_id") if isinstance(row, Mapping) else None
+        )
+        native_runner_ids = (
+            row.get("source_native_runner_ids") if isinstance(row, Mapping) else None
+        )
+        safe_native_identity = bool(
+            isinstance(native_race_id, str)
+            and native_race_id.isascii()
+            and native_race_id.isdecimal()
+            and isinstance(native_runner_ids, list)
+            and len(native_runner_ids) >= 2
+            and all(
+                isinstance(value, str)
+                and value.isascii()
+                and value.isdecimal()
+                for value in native_runner_ids
+            )
+            and len(native_runner_ids) == len(set(native_runner_ids))
+        )
+        if aligned and safe_components and safe_runner_timing and safe_native_identity:
+            eligible.append(
+                {**dict(selected), "source_native_race_id": native_race_id}
+            )
             continue
         missing = []
         if not aligned:
@@ -694,6 +728,8 @@ def current_index_metadata_selection(
                 missing.append("expert_form")
             if not safe_runner_timing:
                 missing.append("runner_source_timing")
+            if not safe_native_identity:
+                missing.append("native_source_identity")
         exclusions.append(
             {
                 "race_id": selected.get("race_id"),

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -3905,21 +3905,8 @@ def run_odds_capture_once(args: argparse.Namespace) -> dict[str, Any]:
     current_race_index_publish: dict[str, Any] = {
         "schema_version": "collector_current_race_index_publish_v2",
         "status": "SKIPPED",
-        "reason": "refresh_report_unavailable",
+        "reason": "odds_capture_only_does_not_publish_candidate_index",
     }
-    if args.state_path is not None and autopilot_output_dir is not None:
-        from race_collection.synchronous_manual_capture import (
-            publish_current_race_index,
-        )
-
-        current_race_index_publish = publish_current_race_index(
-            state_path=args.state_path,
-            evidence_root=evidence_root,
-            source_refresh_report_path=(
-                autopilot_output_dir / "odds_capture_refresh_report.json"
-            ),
-            run_id=run_id,
-        )
 
     report = {
         "schema_version": "shadow_autopilot_odds_capture_only_daemon_report_v1",

--- a/scripts/shadow_autopilot_v1.py
+++ b/scripts/shadow_autopilot_v1.py
@@ -6662,10 +6662,17 @@ def publish_current_race_index_after_refresh(
     evidence_root: Path,
     output_dir: Path,
     run_id: str,
+    source_refresh_report_path: Path | None,
 ) -> dict[str, Any]:
     """Publish the bounded index before the slower odds-capture batch begins."""
 
-    if state_path is None:
+    if source_refresh_report_path is None:
+        publication = {
+            "schema_version": "collector_current_race_index_publish_v2",
+            "status": "SKIPPED",
+            "reason": "primary_candidate_refresh_not_run",
+        }
+    elif state_path is None:
         publication = {
             "schema_version": "collector_current_race_index_publish_v1",
             "status": "SKIPPED",
@@ -6675,9 +6682,7 @@ def publish_current_race_index_after_refresh(
         publication = publish_current_race_index(
             state_path=state_path,
             evidence_root=evidence_root,
-            source_refresh_report_path=(
-                output_dir / "odds_capture_refresh_report.json"
-            ),
+            source_refresh_report_path=source_refresh_report_path,
             run_id=run_id,
         )
     report_path = output_dir / CURRENT_RACE_INDEX_PUBLISH_REPORT_FILENAME
@@ -6888,6 +6893,11 @@ def run_autopilot(args: argparse.Namespace) -> dict[str, Any]:
         evidence_root=evidence_root,
         output_dir=output_dir,
         run_id=collector_run_id or run_id,
+        source_refresh_report_path=(
+            None
+            if args.skip_refresh or skip_primary_refresh
+            else output_dir / "refresh_prejump_report.json"
+        ),
     )
     if args.enable_autonomous_odds_capture:
         capture_current_time = (

--- a/tests/race_collection/test_forward_baseline_service.py
+++ b/tests/race_collection/test_forward_baseline_service.py
@@ -159,6 +159,37 @@ def test_production_preflight_awaits_complete_candidate_population_without_write
     assert not configuration(tmp_path).corpus_root.exists()
 
 
+def test_forward_cohort_freeze_still_requires_twenty_races_three_venues_two_dates(
+    tmp_path: Path,
+):
+    cases = (
+        [
+            candidate(
+                number,
+                venue=("Sandown", "Richmond")[number % 2],
+                racing_date="2026-08-23" if number <= 10 else "2026-08-24",
+            )
+            for number in range(1, 21)
+        ],
+        [candidate(number, venue=("Sandown", "Richmond", "Albion Park")[number % 3]) for number in range(1, 21)],
+    )
+    for index, races in enumerate(cases):
+        database = tmp_path / f"operations-{index}.sqlite3"
+        store = SQLiteOperationsStore(database)
+        store.migrate()
+        before = table_counts(database)
+
+        report = ForwardBaselineCaptureService(
+            store, configuration(tmp_path / str(index))
+        ).run(verified_index(races), now=NOW)
+
+        assert report["status"] == "AWAITING_COHORT_CANDIDATES"
+        assert report["required_race_count"] == 20
+        assert report["required_venue_count"] == 3
+        assert report["required_race_date_count"] == 2
+        assert table_counts(database) == before
+
+
 def test_checked_in_production_entrypoint_uses_verified_v2_index_and_awaits_without_writes(
     tmp_path: Path,
 ):

--- a/tests/race_collection/test_synchronous_manual_capture.py
+++ b/tests/race_collection/test_synchronous_manual_capture.py
@@ -42,9 +42,16 @@ from race_collection.synchronous_manual_capture import (
 from src.predictor.on_demand import canonical_bytes, sha256_bytes
 
 
-def _runner_coverage(evidence_root: Path, race_url: str, observed_at: datetime | None = None) -> dict:
+def _runner_coverage(
+    evidence_root: Path,
+    race_url: str,
+    observed_at: datetime | None = None,
+    *,
+    race_number: int = 5,
+    native_race_id: str = "15900",
+) -> dict:
     observed_at = observed_at or NOW
-    csv_path = evidence_root / "upcoming/Race 5 - GUNN - 2026-07-19.csv"
+    csv_path = evidence_root / f"upcoming/Race {race_number} - GUNN - 2026-07-19.csv"
     csv_path.parent.mkdir(parents=True, exist_ok=True)
     csv_path.write_bytes(b"box|dog_name\n1|Alpha\n2|Beta\n")
     sidecar = csv_path.with_name(csv_path.name + ".metadata.json")
@@ -52,17 +59,24 @@ def _runner_coverage(evidence_root: Path, race_url: str, observed_at: datetime |
         "runner_completeness_after_canonical_alignment": {
             "status": "COMPLETE", "runner_count": 2,
             "participants": [
-                {"box_number": 1, "dog_name": "Alpha", "scratch_state": "ACTIVE"},
-                {"box_number": 2, "dog_name": "Beta", "scratch_state": "ACTIVE"},
+                {
+                    "box_number": 1, "dog_name": "Alpha", "scratch_state": "ACTIVE",
+                    "source_native_runner_id": "159001",
+                },
+                {
+                    "box_number": 2, "dog_name": "Beta", "scratch_state": "ACTIVE",
+                    "source_native_runner_id": "159002",
+                },
             ],
         },
         "prejump_shadow_metadata": {
             "status": "PASS", "metadata_is_leakage_safe": True,
-            "race_date": "2026-07-19", "venue": "GUNN", "race_number": 5,
+            "race_date": "2026-07-19", "venue": "GUNN", "race_number": race_number,
             "source_url": race_url, "metadata_captured_at": observed_at.isoformat(),
+            "source_native_race_id": native_race_id,
             "runner_box_name_list": [
-                {"box_number": 1, "dog_name": "Alpha"},
-                {"box_number": 2, "dog_name": "Beta"},
+                {"box_number": 1, "dog_name": "Alpha", "source_native_runner_id": "159001"},
+                {"box_number": 2, "dog_name": "Beta", "source_native_runner_id": "159002"},
             ],
             "canonical_final_runner_alignment": {
                 "status": "aligned", "canonical_runner_set_status": "available"
@@ -70,7 +84,9 @@ def _runner_coverage(evidence_root: Path, race_url: str, observed_at: datetime |
         }
     }))
     return {"schema_version": "prejump_sidecar_metadata_coverage_v1", "races": [{
-        "race_url": race_url, "csv_path": str(csv_path), "sidecar_path": str(sidecar)
+        "race_url": race_url, "csv_path": str(csv_path), "sidecar_path": str(sidecar),
+        "source_native_race_id": native_race_id,
+        "source_native_runner_ids": ["159001", "159002"],
     }]}
 
 
@@ -307,7 +323,7 @@ def test_current_race_index_publication_is_atomic_bounded_and_source_sealed(
 ):
     evidence_root = tmp_path / "evidence"
     state = evidence_root / "shadow_autopilot_daemon_runtime/odds_capture_state.json"
-    source = evidence_root / "shadow_autopilot_v1_fixture/odds_capture_refresh_report.json"
+    source = evidence_root / "shadow_autopilot_v1_fixture/refresh_prejump_report.json"
     source.parent.mkdir(parents=True)
     index_now = datetime.fromisoformat("2026-07-19T12:55:00+10:00")
     race_url = "https://www.thedogs.com.au/racing/gunnedah/2026-07-19/5"
@@ -339,9 +355,7 @@ def test_current_race_index_publication_is_atomic_bounded_and_source_sealed(
                         "race_number": 5,
                         "source_native_race_id": "15900",
                         "race_time": "13:00",
-                        "race_url": (
-                            race_url
-                        ),
+                        "race_url": race_url,
                         "venue": "GUNN",
                     }
                 ],
@@ -352,6 +366,7 @@ def test_current_race_index_publication_is_atomic_bounded_and_source_sealed(
     published = autopilot.publish_current_race_index_after_refresh(
         state_path=state, evidence_root=evidence_root,
         output_dir=source.parent, run_id="fixture",
+        source_refresh_report_path=source,
     )
     index_path = current_race_index_path(state)
     original = index_path.read_bytes()
@@ -798,6 +813,142 @@ def test_current_race_index_publishes_explicit_safe_subset_from_mixed_candidates
     assert rejected["reason"] == "CURRENT_INDEX_SOURCE_INVALID"
 
 
+def test_current_race_index_publishes_multiple_safe_races_without_cohort_floor(
+    tmp_path: Path,
+):
+    evidence_root = tmp_path / "evidence"
+    state = evidence_root / "runtime/odds_capture_state.json"
+    source = evidence_root / "run/refresh_prejump_report.json"
+    source.parent.mkdir(parents=True)
+    generated = datetime.fromisoformat("2026-07-19T12:55:00+10:00")
+    races = [
+        {
+            "date": "2026-07-19",
+            "jump_datetime": f"2026-07-19T13:0{number - 5}:00+10:00",
+            "race_id": f"Race {number} - GUNN - 2026-07-19",
+            "race_id_aliases": [
+                f"Race {number} - GUNN - 2026-07-19",
+                f"Race {number} - GUNNEDAH - 2026-07-19",
+            ],
+            "race_number": number,
+            "race_time": f"13:0{number - 5}",
+            "race_url": f"https://www.thedogs.com.au/racing/gunnedah/2026-07-19/{number}",
+            "venue": "GUNN",
+        }
+        for number in (5, 6)
+    ]
+    coverage_rows = []
+    for offset, race in enumerate(races):
+        coverage = _runner_coverage(
+            evidence_root,
+            race["race_url"],
+            generated,
+            race_number=race["race_number"],
+            native_race_id=str(15900 + offset),
+        )
+        coverage["races"][0].update({
+            "race_id": race["race_id"],
+            "safe_weather_present": True,
+            "safe_track_condition_present": True,
+            "safe_expert_form_present": True,
+            "safe_all_weather_track_expert_form_present": True,
+            "runner_source_observed_at": generated.isoformat(),
+        })
+        coverage_rows.extend(coverage["races"])
+    coverage = {
+        "schema_version": "prejump_sidecar_metadata_coverage_v1",
+        "races": coverage_rows,
+    }
+    current_races, selection = current_index_metadata_selection(
+        races, coverage, source_generated_at=generated
+    )
+    source.write_bytes(canonical_bytes({
+        "status": "SUCCESS",
+        "generated_at": generated.isoformat(),
+        "sidecar_metadata_coverage": coverage,
+        "selected_count": 2,
+        "selected_races": races,
+        "current_index_race_count": 2,
+        "current_index_races": current_races,
+        "current_index_metadata_selection": selection,
+    }))
+
+    published = publish_current_race_index(
+        state_path=state,
+        evidence_root=evidence_root,
+        source_refresh_report_path=source,
+        run_id="two-safe-races",
+    )
+
+    assert published["status"] == "PUBLISHED"
+    packet = json.loads(current_race_index_path(state).read_bytes())
+    assert packet["race_count"] == 2
+    assert {race["source_native_race_id"] for race in packet["races"]} == {
+        "15900", "15901"
+    }
+
+
+def test_zero_safe_races_rejects_and_preserves_existing_index(tmp_path: Path):
+    evidence_root = tmp_path / "evidence"
+    state = evidence_root / "runtime/odds_capture_state.json"
+    source = evidence_root / "run/refresh_prejump_report.json"
+    source.parent.mkdir(parents=True)
+    generated = datetime.fromisoformat("2026-07-19T12:55:00+10:00")
+    race_url = "https://www.thedogs.com.au/racing/gunnedah/2026-07-19/5"
+    coverage = _runner_coverage(evidence_root, race_url, generated)
+    race = {
+        "date": "2026-07-19",
+        "jump_datetime": "2026-07-19T13:00:00+10:00",
+        "race_id": "Race 5 - GUNN - 2026-07-19",
+        "race_id_aliases": [
+            "Race 5 - GUNN - 2026-07-19",
+            "Race 5 - GUNNEDAH - 2026-07-19",
+        ],
+        "race_number": 5,
+        "race_time": "13:00",
+        "race_url": race_url,
+        "source_native_race_id": "15900",
+        "venue": "GUNN",
+    }
+    source.write_bytes(canonical_bytes({
+        "status": "SUCCESS",
+        "generated_at": generated.isoformat(),
+        "sidecar_metadata_coverage": coverage,
+        "selected_count": 1,
+        "selected_races": [race],
+    }))
+    first = publish_current_race_index(
+        state_path=state,
+        evidence_root=evidence_root,
+        source_refresh_report_path=source,
+        run_id="one-safe-race",
+    )
+    assert first["status"] == "PUBLISHED"
+    index_path = current_race_index_path(state)
+    existing = index_path.read_bytes()
+
+    source.write_bytes(canonical_bytes({
+        "status": "SUCCESS",
+        "generated_at": generated.isoformat(),
+        "sidecar_metadata_coverage": {
+            "schema_version": "prejump_sidecar_metadata_coverage_v1",
+            "races": [],
+        },
+        "selected_count": 0,
+        "selected_races": [],
+    }))
+    rejected = publish_current_race_index(
+        state_path=state,
+        evidence_root=evidence_root,
+        source_refresh_report_path=source,
+        run_id="zero-safe-races",
+    )
+
+    assert rejected["status"] == "REJECTED"
+    assert rejected["reason"] == "CURRENT_INDEX_SOURCE_INVALID"
+    assert index_path.read_bytes() == existing
+
+
 def test_current_race_index_rejects_contradictory_explicit_subset_report(
     tmp_path: Path,
 ):
@@ -891,9 +1042,8 @@ def test_current_race_index_rejects_stale_or_changed_source(tmp_path: Path):
                         ],
                         "race_number": 5,
                         "race_time": "13:00",
-                        "race_url": (
-                            race_url
-                        ),
+                        "race_url": race_url,
+                        "source_native_race_id": "15900",
                         "venue": "GUNN",
                     }
                 ],
@@ -952,6 +1102,7 @@ def test_final_validation_rejection_never_publishes_new_marker(
                 "Race 5 - GUNNEDAH - 2026-07-19",
             ],
             "race_number": 5, "race_time": "13:00", "race_url": race_url,
+            "source_native_race_id": "15900",
             "venue": "GUNN",
         }],
     }))
@@ -1019,6 +1170,8 @@ def test_v2_runner_seal_rejects_native_id_collisions(
     if case == "duplicate":
         detailed[0]["source_native_runner_id"] = "15901"
         detailed[1]["source_native_runner_id"] = "15901"
+        shadow[0]["source_native_runner_id"] = "15901"
+        shadow[1]["source_native_runner_id"] = "15901"
     else:
         detailed[0]["source_native_runner_id"] = "15901"
         shadow[0]["source_native_runner_id"] = "15902"
@@ -1036,6 +1189,85 @@ def test_v2_runner_seal_rejects_native_id_collisions(
 
     expected = "runner_id_duplicate" if case == "duplicate" else "runner_id_conflict"
     assert rejected.value.details["reason"] == expected
+
+
+def test_v2_runner_seal_rejects_missing_native_ids(tmp_path: Path):
+    evidence_root = tmp_path / "evidence"
+    race_url = "https://www.thedogs.com.au/racing/gunnedah/2026-07-19/5"
+    observed = datetime.fromisoformat("2026-07-19T12:55:00+10:00")
+    coverage = _runner_coverage(evidence_root, race_url, observed)
+    sidecar_path = Path(coverage["races"][0]["sidecar_path"])
+    sidecar = json.loads(sidecar_path.read_bytes())
+    for section in (
+        sidecar["runner_completeness_after_canonical_alignment"]["participants"],
+        sidecar["prejump_shadow_metadata"]["runner_box_name_list"],
+    ):
+        for runner in section:
+            runner.pop("source_native_runner_id", None)
+    sidecar_path.write_bytes(canonical_bytes(sidecar))
+
+    with pytest.raises(CaptureOneRejected) as rejected:
+        capture._v2_runner_rows(
+            {
+                "date": "2026-07-19",
+                "jump_datetime": "2026-07-19T13:00:00+10:00",
+                "race_number": 5,
+                "race_url": race_url,
+                "venue": "GUNN",
+            },
+            {
+                "generated_at": observed.isoformat(),
+                "sidecar_metadata_coverage": coverage,
+            },
+            evidence_root=evidence_root,
+        )
+
+    assert rejected.value.details["reason"] == "runner_id_unavailable"
+
+
+def test_current_index_rejects_sidecar_native_race_id_substitution(tmp_path: Path):
+    evidence_root = tmp_path / "evidence"
+    state = evidence_root / "runtime/odds_capture_state.json"
+    source = evidence_root / "run/refresh_prejump_report.json"
+    source.parent.mkdir(parents=True)
+    observed = datetime.fromisoformat("2026-07-19T12:55:00+10:00")
+    race_url = "https://www.thedogs.com.au/racing/gunnedah/2026-07-19/5"
+    coverage = _runner_coverage(evidence_root, race_url, observed)
+    sidecar_path = Path(coverage["races"][0]["sidecar_path"])
+    sidecar = json.loads(sidecar_path.read_bytes())
+    sidecar["prejump_shadow_metadata"]["source_native_race_id"] = "99999"
+    sidecar_path.write_bytes(canonical_bytes(sidecar))
+    source.write_bytes(canonical_bytes({
+        "status": "SUCCESS",
+        "generated_at": observed.isoformat(),
+        "selected_count": 1,
+        "selected_races": [{
+            "date": "2026-07-19",
+            "jump_datetime": "2026-07-19T13:00:00+10:00",
+            "race_id": "Race 5 - GUNN - 2026-07-19",
+            "race_id_aliases": [
+                "Race 5 - GUNN - 2026-07-19",
+                "Race 5 - GUNNEDAH - 2026-07-19",
+            ],
+            "race_number": 5,
+            "race_time": "13:00",
+            "race_url": race_url,
+            "source_native_race_id": "15900",
+            "venue": "GUNN",
+        }],
+        "sidecar_metadata_coverage": coverage,
+    }))
+
+    publication = publish_current_race_index(
+        state_path=state,
+        evidence_root=evidence_root,
+        source_refresh_report_path=source,
+        run_id="native-race-substitution",
+    )
+
+    assert publication["status"] == "REJECTED"
+    assert publication["reason"] == "CURRENT_INDEX_SOURCE_INVALID"
+    assert not current_race_index_path(state).exists()
 
 
 def test_retained_inputs_survive_expected_atomic_publication(tmp_path: Path):
@@ -1158,6 +1390,7 @@ def test_current_index_requires_time_and_normalizes_producer_time():
         },
         now=datetime.fromisoformat("2026-07-19T12:00:00+10:00"),
     )
+    row["source_native_race_id"] = "15900"
     normalized = capture._normalize_current_index_rows(
         {"selected_count": 1, "selected_races": [row]}, max_races=32
     )[0]
@@ -1170,6 +1403,31 @@ def test_current_index_requires_time_and_normalizes_producer_time():
         capture._normalize_current_index_rows(
             {"selected_count": 1, "selected_races": [row]}, max_races=32
         )
+
+
+@pytest.mark.parametrize("native_race_id", [None, "race-15900", 15900])
+def test_current_index_rejects_missing_or_non_numeric_native_race_id(
+    native_race_id: object,
+):
+    row = race_window_record(
+        {
+            "date": "2026-07-19",
+            "race_number": 5,
+            "race_time": "1:00 PM",
+            "url": "https://www.thedogs.com.au/racing/gunnedah/2026-07-19/5",
+            "venue": "GUNN",
+        },
+        now=datetime.fromisoformat("2026-07-19T12:00:00+10:00"),
+    )
+    row["source_native_race_id"] = native_race_id
+
+    with pytest.raises(CaptureOneRejected) as rejected:
+        capture._normalize_current_index_rows(
+            {"selected_count": 1, "selected_races": [row]}, max_races=32
+        )
+
+    assert rejected.value.code == "CURRENT_INDEX_INVALID"
+    assert rejected.value.details["reason"] == "source_native_race_id_invalid"
 
 
 @pytest.mark.parametrize("mutation", ["arbitrary", "extra", "substitution", "omission"])
@@ -1720,6 +1978,7 @@ def test_v2_requires_matching_successful_retained_publication(tmp_path: Path):
                 "Race 5 - GUNNEDAH - 2026-07-19",
             ],
             "race_number": 5, "race_time": "13:00", "race_url": race_url,
+            "source_native_race_id": "15900",
             "venue": "GUNN",
         }],
     }))

--- a/tests/test_csv_download_hardening.py
+++ b/tests/test_csv_download_hardening.py
@@ -281,7 +281,11 @@ def _synthetic_thedogs_export(runners):
 
 def _canonical_runner_set_for_test(race_url, runners):
     participants = [
-        {"box_number": box_number, "dog_name": dog_name}
+        {
+            "box_number": box_number,
+            "dog_name": dog_name,
+            "source_native_runner_id": str(159000 + box_number),
+        }
         for box_number, dog_name in runners
     ]
     return {
@@ -292,6 +296,8 @@ def _canonical_runner_set_for_test(race_url, runners):
         "final_runner_boxes": [box_number for box_number, _dog_name in runners],
         "final_runner_names": [dog_name for _box_number, dog_name in runners],
         "final_runner_participants": participants,
+        "source_native_race_id": "15900",
+        "native_identity_status": "available",
         "scratched_boxes": [],
         "scratched_participants": [],
         "reserve_boxes": [],
@@ -339,7 +345,7 @@ def test_download_refreshes_existing_csv_with_stale_sidecar_contract(
     monkeypatch.setattr(
         br,
         "extract_detailed_race_info",
-        lambda soup, url: {
+        lambda soup, url, **_kwargs: {
             "race_number": "1",
             "venue": "TEST",
             "date": "2030-06-09",
@@ -351,7 +357,7 @@ def test_download_refreshes_existing_csv_with_stale_sidecar_contract(
     monkeypatch.setattr(
         br,
         "_extract_safe_target_metadata_from_page",
-        lambda soup, url: {
+        lambda soup, url, **_kwargs: {
             "target_distance": "400m",
             "target_distance_source": "canonical_pre_race_page",
             "metadata_source_url": race_url,
@@ -424,11 +430,28 @@ def test_download_refreshes_existing_csv_with_stale_sidecar_contract(
     assert sidecar["prejump_shadow_metadata"]["status"] == "PASS"
     assert sidecar["prejump_shadow_metadata"]["metadata_captured_at"]
     assert sidecar["prejump_shadow_metadata"]["runner_box_name_list"] == [
-        {"box_number": 1, "dog_name": "Alpha Runner"},
-        {"box_number": 2, "dog_name": "Bravo Runner"},
-        {"box_number": 3, "dog_name": "Charlie Runner"},
-        {"box_number": 4, "dog_name": "Delta Runner"},
+        {
+            "box_number": 1, "dog_name": "Alpha Runner",
+            "scratch_state": "ACTIVE",
+            "source_native_runner_id": "159001",
+        },
+        {
+            "box_number": 2, "dog_name": "Bravo Runner",
+            "scratch_state": "ACTIVE",
+            "source_native_runner_id": "159002",
+        },
+        {
+            "box_number": 3, "dog_name": "Charlie Runner",
+            "scratch_state": "ACTIVE",
+            "source_native_runner_id": "159003",
+        },
+        {
+            "box_number": 4, "dog_name": "Delta Runner",
+            "scratch_state": "ACTIVE",
+            "source_native_runner_id": "159004",
+        },
     ]
+    assert sidecar["prejump_shadow_metadata"]["source_native_race_id"] == "15900"
     validation = validate_prejump_sidecar_metadata(existing_path)
     assert validation["status"] == "PASS", validation
     contract = existing_prejump_sidecar_contract_status(existing_path)
@@ -457,7 +480,7 @@ def test_download_fallback_quarantines_csv_without_valid_prejump_sidecar(
     monkeypatch.setattr(
         br,
         "extract_detailed_race_info",
-        lambda soup, url: {
+        lambda soup, url, **_kwargs: {
             "race_number": "1",
             "venue": "TEST",
             "date": "2026-06-09",
@@ -469,7 +492,7 @@ def test_download_fallback_quarantines_csv_without_valid_prejump_sidecar(
     monkeypatch.setattr(
         br,
         "_extract_safe_target_metadata_from_page",
-        lambda soup, url: {
+        lambda soup, url, **_kwargs: {
             "target_distance": "400m",
             "target_distance_source": "canonical_pre_race_page",
             "target_grade": "Maiden",
@@ -549,7 +572,7 @@ def test_download_pdf_masquerading_as_csv_tries_expert_form_fallback(
     monkeypatch.setattr(
         br,
         "extract_detailed_race_info",
-        lambda soup, url: {
+        lambda soup, url, **_kwargs: {
             "race_number": "9",
             "venue": "TAREE",
             "date": "2026-06-13",
@@ -561,7 +584,7 @@ def test_download_pdf_masquerading_as_csv_tries_expert_form_fallback(
     monkeypatch.setattr(
         br,
         "_extract_safe_target_metadata_from_page",
-        lambda soup, url: {
+        lambda soup, url, **_kwargs: {
             "target_distance": "300m",
             "target_distance_source": "canonical_pre_race_page",
             "target_grade": "5th Grade",

--- a/tests/test_form_guide_delimiter_normalization.py
+++ b/tests/test_form_guide_delimiter_normalization.py
@@ -135,7 +135,11 @@ def _synthetic_sidecar() -> dict:
 
 def _canonical_runner_set(runners: list[tuple[int, str]]) -> dict:
     participants = [
-        {"box_number": box_number, "dog_name": dog_name}
+        {
+            "box_number": box_number,
+            "dog_name": dog_name,
+            "source_native_runner_id": str(159000 + box_number),
+        }
         for box_number, dog_name in runners
     ]
     return {
@@ -146,6 +150,8 @@ def _canonical_runner_set(runners: list[tuple[int, str]]) -> dict:
         "final_runner_boxes": [box_number for box_number, _dog_name in runners],
         "final_runner_names": [dog_name for _box_number, dog_name in runners],
         "final_runner_participants": participants,
+        "source_native_race_id": "15900",
+        "native_identity_status": "available",
         "scratched_boxes": [],
         "scratched_participants": [],
         "reserve_boxes": [],
@@ -247,11 +253,24 @@ def test_provenance_payload_writes_flat_prejump_shadow_metadata_block(
     assert shadow_metadata["target_grade_safe"] == "Maiden"
     assert shadow_metadata["source_url"] == SYNTHETIC_RACE_URL
     assert shadow_metadata["runner_box_name_list"] == [
-        {"box_number": 1, "dog_name": "Alpha Runner", "scratch_state": "ACTIVE"},
-        {"box_number": 2, "dog_name": "Bravo Runner", "scratch_state": "ACTIVE"},
-        {"box_number": 3, "dog_name": "Charlie Runner", "scratch_state": "ACTIVE"},
-        {"box_number": 4, "dog_name": "Delta Runner", "scratch_state": "ACTIVE"},
+        {
+            "box_number": 1, "dog_name": "Alpha Runner", "scratch_state": "ACTIVE",
+            "source_native_runner_id": "159001",
+        },
+        {
+            "box_number": 2, "dog_name": "Bravo Runner", "scratch_state": "ACTIVE",
+            "source_native_runner_id": "159002",
+        },
+        {
+            "box_number": 3, "dog_name": "Charlie Runner", "scratch_state": "ACTIVE",
+            "source_native_runner_id": "159003",
+        },
+        {
+            "box_number": 4, "dog_name": "Delta Runner", "scratch_state": "ACTIVE",
+            "source_native_runner_id": "159004",
+        },
     ]
+    assert shadow_metadata["source_native_race_id"] == "15900"
     assert {
         row["scratch_state"]
         for row in final_sidecar[
@@ -277,6 +296,7 @@ def test_provenance_payload_writes_flat_prejump_shadow_metadata_block(
             "jump_datetime": "2026-05-29T11:15:00+10:00",
             "race_number": 1,
             "race_url": SYNTHETIC_RACE_URL,
+            "source_native_race_id": "15900",
             "venue": "TEST",
         },
         {

--- a/tests/test_prejump_prediction_loop.py
+++ b/tests/test_prejump_prediction_loop.py
@@ -800,7 +800,9 @@ def test_refresh_prejump_upcoming_honors_supplied_current_time(tmp_path, monkeyp
 
 
 def _write_safe_collection_sidecar(csv_path: Path, *, expert_form: bool = True):
-    csv_path.write_text("box|dog_name\n1|Alpha Runner\n", encoding="utf-8")
+    csv_path.write_text(
+        "box|dog_name\n1|Alpha Runner\n2|Bravo Runner\n", encoding="utf-8"
+    )
     expert = {
         "schema_version": "thedogs_expert_form_metadata_v1",
         "source": "thedogs_expert_form_page",
@@ -822,6 +824,19 @@ def _write_safe_collection_sidecar(csv_path: Path, *, expert_form: bool = True):
         "metadata_captured_at": "2026-06-17T02:45:00Z",
         "prejump_shadow_metadata": {
             "metadata_captured_at": "2026-06-17T02:45:00Z",
+            "source_native_race_id": "15900",
+            "runner_box_name_list": [
+                {
+                    "box_number": 1,
+                    "dog_name": "Alpha Runner",
+                    "source_native_runner_id": "159001",
+                },
+                {
+                    "box_number": 2,
+                    "dog_name": "Bravo Runner",
+                    "source_native_runner_id": "159002",
+                },
+            ],
         },
         "race_url": "https://www.thedogs.com.au/racing/sale/2026-06-17/9/test?trial=false",
         "race_info": {
@@ -915,6 +930,8 @@ def test_current_index_metadata_selection_requires_complete_consistent_identity(
         "safe_expert_form_present": True,
         "safe_all_weather_track_expert_form_present": True,
         "runner_source_observed_at": "2026-06-17T12:45:00+10:00",
+        "source_native_race_id": "15900",
+        "source_native_runner_ids": ["159001", "159002"],
     }
 
     eligible, selection = current_index_metadata_selection(
@@ -938,6 +955,47 @@ def test_current_index_metadata_selection_requires_complete_consistent_identity(
     assert selection["exclusions"][0]["missing_safe_metadata"] == ["weather"]
 
 
+def test_current_index_metadata_selection_rejects_unsafe_native_identity():
+    race_url = "https://www.thedogs.com.au/racing/sale/2026-06-17/9/test"
+    race = {
+        "race_id": "Race 9 - SAL - 2026-06-17",
+        "race_id_aliases": ["Race 9 - SAL - 2026-06-17"],
+        "race_url": race_url,
+        "jump_datetime": "2026-06-17T13:57:00+10:00",
+    }
+    safe_row = {
+        "race_id": race["race_id"],
+        "race_url": race_url,
+        "csv_path": "/evidence/Race 9 - SAL - 2026-06-17.csv",
+        "safe_weather_present": True,
+        "safe_track_condition_present": True,
+        "safe_expert_form_present": True,
+        "safe_all_weather_track_expert_form_present": True,
+        "runner_source_observed_at": "2026-06-17T12:45:00+10:00",
+    }
+    for race_id, runner_ids in (
+        ("not-numeric", ["159001", "159002"]),
+        ("15900", ["159001", "not-numeric"]),
+        ("15900", ["159001", "159001"]),
+        ("15900", ["159001", []]),
+    ):
+        row = {
+            **safe_row,
+            "source_native_race_id": race_id,
+            "source_native_runner_ids": runner_ids,
+        }
+        eligible, selection = current_index_metadata_selection(
+            [race],
+            {"races": [row]},
+            source_generated_at="2026-06-17T12:30:00+10:00",
+        )
+
+        assert eligible == []
+        assert selection["exclusions"][0]["missing_safe_metadata"] == [
+            "native_source_identity"
+        ]
+
+
 def test_current_index_metadata_selection_excludes_postjump_runner_observation():
     race_url = "https://www.thedogs.com.au/racing/sale/2026-06-17/9/test"
     race = {
@@ -955,6 +1013,8 @@ def test_current_index_metadata_selection_excludes_postjump_runner_observation()
         "safe_expert_form_present": True,
         "safe_all_weather_track_expert_form_present": True,
         "runner_source_observed_at": "2026-06-17T13:00:06+10:00",
+        "source_native_race_id": "15900",
+        "source_native_runner_ids": ["159001", "159002"],
     }
 
     eligible, selection = current_index_metadata_selection(
@@ -999,6 +1059,8 @@ def test_current_index_metadata_selection_enforces_runner_source_age_boundary():
         "safe_track_condition_present": True,
         "safe_expert_form_present": True,
         "safe_all_weather_track_expert_form_present": True,
+        "source_native_race_id": "15900",
+        "source_native_runner_ids": ["159001", "159002"],
     }
     cases = [
         ("2026-06-17T12:50:00+10:00", True),

--- a/tests/test_runner_completeness.py
+++ b/tests/test_runner_completeness.py
@@ -22,17 +22,22 @@ def _source_report(participants):
     }
 
 
-def _runner_row(box, name, *, scratched=False, into_box=None):
+def _runner_row(box, name, *, scratched=False, into_box=None, native_id=None):
     classes = "accordion__anchor race-runner"
     if scratched:
         classes += " race-runner--scratched"
     into = f"(into box {into_box})" if into_box is not None else ""
     odds = "SCR" if scratched else "N/A"
+    native = (
+        f'<blackbook-dog data-dog-id="{native_id}"></blackbook-dog>'
+        if native_id is not None
+        else ""
+    )
     return f"""
     <tr class="{classes}">
       <td class="race-runners__box"><sprite-svg name="rug_{box}"></sprite-svg></td>
       <td class="race-runners__name">
-        <div class="race-runners__name__dog">{name}
+        <div class="race-runners__name__dog">{name}{native}
           <span class="race-runners__name__time">24.00</span>
           <span class="race-runners__name__box">{into}</span>
         </div>
@@ -49,6 +54,82 @@ def _race_page(*rows):
       <table class="race-runners"><tbody>{''.join(rows)}</tbody></table>
     </body></html>
     """
+
+
+def test_canonical_runner_parser_preserves_numeric_native_source_identities():
+    html = _race_page(
+        _runner_row(1, "Alpha Runner", native_id="159001"),
+        _runner_row(2, "Bravo Runner", native_id="159002"),
+    ).replace(
+        '<div class="race-header">',
+        '<div class="race-header" data-race-id="15900">',
+    )
+
+    canonical = extract_canonical_runner_set_from_html(
+        html,
+        source_url="https://www.thedogs.com.au/racing/test/2026-05-27/4/example",
+    )
+
+    assert canonical["source_native_race_id"] == "15900"
+    assert canonical["native_identity_status"] == "available"
+    assert [
+        row["source_native_runner_id"]
+        for row in canonical["final_runner_participants"]
+    ] == ["159001", "159002"]
+
+
+def test_canonical_runner_parser_uses_native_odds_page_runner_identity():
+    html = """
+    <html><body><div data-race-id="15900"></div>
+      <table class="race-runners">
+        <tbody data-content-url="/dogs/runner/159001/odds">
+          <tr class="race-runner">
+            <td class="race-runners__box"><sprite-svg name="rug_1"></sprite-svg></td>
+            <td class="race-runners__name"><div class="race-runners__name__dog">Alpha Runner</div></td>
+            <td><runner-odd data-runner-id="159001"></runner-odd></td>
+          </tr>
+        </tbody>
+        <tbody data-content-url="/dogs/runner/159002/odds">
+          <tr class="race-runner">
+            <td class="race-runners__box"><sprite-svg name="rug_2"></sprite-svg></td>
+            <td class="race-runners__name"><div class="race-runners__name__dog">Bravo Runner</div></td>
+            <td><runner-odd data-runner-id="159002"></runner-odd></td>
+          </tr>
+        </tbody>
+      </table>
+    </body></html>
+    """
+
+    canonical = extract_canonical_runner_set_from_html(
+        html,
+        source_url="https://www.thedogs.com.au/racing/test/2026-05-27/4/example",
+    )
+
+    assert canonical["native_identity_status"] == "available"
+    assert [
+        row["source_native_runner_id"]
+        for row in canonical["final_runner_participants"]
+    ] == ["159001", "159002"]
+
+
+def test_canonical_runner_parser_rejects_ambiguous_native_source_identity():
+    html = _race_page(
+        _runner_row(1, "Alpha Runner", native_id="159001"),
+        _runner_row(2, "Bravo Runner", native_id="not-numeric"),
+    ).replace(
+        '<div class="race-header">',
+        '<div class="race-header" data-race-id="15900">',
+    )
+
+    canonical = extract_canonical_runner_set_from_html(
+        html,
+        source_url="https://www.thedogs.com.au/racing/test/2026-05-27/4/example",
+    )
+
+    assert canonical["native_identity_status"] == "unavailable"
+    assert canonical["native_identity_reasons"] == [
+        "source_native_runner_id_unavailable:box:2"
+    ]
 
 
 def test_runner_completeness_extracts_full_embedded_form_field():

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -3108,15 +3108,13 @@ def test_run_odds_capture_once_uses_lock_and_writes_compact_report(tmp_path, mon
         "AUTONOMOUS_LIVE_ODDS_CAPTURE_NO_ELIGIBLE_WINDOWS"
     )
     assert report["allowed_write_scope"] == "append_only_live_odds_rows_when_validation_passes"
-    assert report["current_race_index_publish"]["status"] == "PUBLISHED"
+    assert report["current_race_index_publish"] == {
+        "schema_version": "collector_current_race_index_publish_v2",
+        "status": "SKIPPED",
+        "reason": "odds_capture_only_does_not_publish_candidate_index",
+    }
     assert not lock_path.exists()
-    current_index = json.loads(
-        (
-            state_path.parent / "manual_prediction_current_race_index.json"
-        ).read_text()
-    )
-    assert current_index["race_count"] == 1
-    assert current_index["races"][0]["race_id"] == "Race 1 - HEA - 2026-06-12"
+    assert not (state_path.parent / "manual_prediction_current_race_index.json").exists()
     written = json.loads((output_dir / "odds_capture_only_daemon_report.json").read_text())
     manifest = json.loads((output_dir / "output_manifest.json").read_text())
     state = json.loads(state_path.read_text())

--- a/tests/test_shadow_autopilot_v1.py
+++ b/tests/test_shadow_autopilot_v1.py
@@ -67,7 +67,7 @@ def test_current_race_index_is_published_from_completed_refresh(
     output_dir = evidence_root / "run"
     output_dir.mkdir(parents=True)
     state_path = evidence_root / "runtime/odds_capture_state.json"
-    source_path = output_dir / "odds_capture_refresh_report.json"
+    source_path = output_dir / "refresh_prejump_report.json"
     observed = {}
     def fake_publish(**kwargs):
         observed.update(kwargs)
@@ -87,6 +87,7 @@ def test_current_race_index_is_published_from_completed_refresh(
         evidence_root=evidence_root,
         output_dir=output_dir,
         run_id="scheduled-run",
+        source_refresh_report_path=source_path,
     )
 
     assert result["status"] == "PUBLISHED"
@@ -5307,6 +5308,13 @@ def test_skip_primary_refresh_still_runs_odds_capture_refresh(tmp_path, monkeypa
         }
 
     monkeypatch.setattr(autopilot, "step_command", fake_step_command)
+    monkeypatch.setattr(
+        autopilot,
+        "publish_current_race_index",
+        lambda **_kwargs: pytest.fail(
+            "odds-only refresh must not replace the shared candidate index"
+        ),
+    )
 
     args = autopilot.parse_args(
         [
@@ -5318,6 +5326,8 @@ def test_skip_primary_refresh_still_runs_odds_capture_refresh(tmp_path, monkeypa
             "2026-06-12T00:35:00+10:00",
             "--db",
             str(db_path),
+            "--current-race-index-state-path",
+            str(evidence_root / "runtime/odds_capture_state.json"),
             "--enable-autonomous-odds-capture",
             "--execute-autonomous-odds-capture",
             "--allow-auto-scrape-odds",
@@ -5348,6 +5358,14 @@ def test_skip_primary_refresh_still_runs_odds_capture_refresh(tmp_path, monkeypa
         "AUTONOMOUS_LIVE_ODDS_CAPTURE_NO_ELIGIBLE_WINDOWS"
     )
     assert (output_dir / "odds_capture_refresh_report.json").exists()
+    publication = json.loads(
+        (output_dir / "current_race_index_publish.json").read_text(encoding="utf-8")
+    )
+    assert publication == {
+        "schema_version": "collector_current_race_index_publish_v2",
+        "status": "SKIPPED",
+        "reason": "primary_candidate_refresh_not_run",
+    }
     assert (output_dir / "rolling_model_comparison_status.json").exists()
     assert (output_dir / "high_accuracy_refinement_status.json").exists()
     rolling_status = json.loads(

--- a/utils/csv_metadata.py
+++ b/utils/csv_metadata.py
@@ -1616,6 +1616,13 @@ def _participant_box_name_list(payload: Mapping[str, Any]) -> list[Dict[str, Any
             if box_number is None or not dog_name:
                 continue
             row = {"box_number": box_number, "dog_name": dog_name}
+            native_id = participant.get("source_native_runner_id")
+            if (
+                isinstance(native_id, str)
+                and native_id.isascii()
+                and native_id.isdecimal()
+            ):
+                row["source_native_runner_id"] = native_id
             if participant.get("scratch_state") == "ACTIVE":
                 row["scratch_state"] = "ACTIVE"
             rows.append(row)
@@ -1727,6 +1734,7 @@ def build_prejump_shadow_metadata_payload(payload: Mapping[str, Any]) -> Dict[st
         "target_grade_safe": target_grade,
         "target_grade_source": str(grade_source) if grade_source not in (None, "") else None,
         "source_url": str(source_url) if source_url not in (None, "") else None,
+        "source_native_race_id": payload.get("source_native_race_id"),
         "runner_box_name_list": participants,
         "canonical_final_runner_alignment": {
             "status": alignment.get("status"),
@@ -1735,6 +1743,7 @@ def build_prejump_shadow_metadata_payload(payload: Mapping[str, Any]) -> Dict[st
             "prediction_runner_count": alignment.get("prediction_runner_count"),
             "source_url": canonical_runner_source_url,
             "reason": alignment.get("reason"),
+            "native_identity_status": alignment.get("native_identity_status"),
         },
     }
 
@@ -1792,6 +1801,10 @@ def normalize_verified_thedogs_export_content(
             source=str(accepted_csv_path),
         )
         base["canonical_runner_alignment"] = canonical_alignment
+        if canonical_runner_set.get("native_identity_status") == "available":
+            base["source_native_race_id"] = canonical_runner_set.get(
+                "source_native_race_id"
+            )
         if canonical_alignment.get("status") == "aligned":
             content_for_normalization = aligned_content
             effective_delimiter = (
@@ -1817,7 +1830,7 @@ def normalize_verified_thedogs_export_content(
                 (
                     _safe_int(participant.get("box_number")),
                     normalise_runner_name(participant.get("dog_name") or ""),
-                )
+                ): participant
                 for participant in canonical_runner_set.get(
                     "final_runner_participants", []
                 )
@@ -1837,6 +1850,15 @@ def normalize_verified_thedogs_export_content(
                     # pre-race producer explicitly excluded scratched and
                     # unpromoted reserve rows before reporting this active set.
                     participant["scratch_state"] = "ACTIVE"
+                    native_id = canonical_active[identity].get(
+                        "source_native_runner_id"
+                    )
+                    if (
+                        isinstance(native_id, str)
+                        and native_id.isascii()
+                        and native_id.isdecimal()
+                    ):
+                        participant["source_native_runner_id"] = native_id
             base["runner_completeness_after_canonical_alignment"] = (
                 dict(effective_runner_completeness)
             )

--- a/utils/runner_completeness.py
+++ b/utils/runner_completeness.py
@@ -297,6 +297,11 @@ def align_csv_text_to_canonical_final_runner_set(
         "source": source,
         "canonical_runner_set_status": canonical.get("canonical_runner_set_status"),
         "canonical_source_url": canonical.get("final_runner_source_url"),
+        "source_native_race_id": canonical.get("source_native_race_id"),
+        "native_identity_status": canonical.get("native_identity_status"),
+        "native_identity_reasons": list(
+            canonical.get("native_identity_reasons") or []
+        ),
         "source_runner_count": 0,
         "canonical_runner_count": len(participants),
         "prediction_runner_count": 0,
@@ -605,6 +610,9 @@ def _canonical_unavailable(
         "reserve_boxes": [],
         "vacant_boxes": [],
         "race_number": _extract_race_number_from_url(source_url),
+        "source_native_race_id": None,
+        "native_identity_status": "unavailable",
+        "native_identity_reasons": [reason],
         "extraction_timestamp": extraction_timestamp or _iso_utc_now(),
         "unavailable_reason": reason,
     }
@@ -662,11 +670,65 @@ def extract_canonical_runner_set_from_html(
     reserve_boxes: set[int] = set()
     vacant_boxes: set[int] = set()
     ambiguous_reasons: list[str] = []
+    native_identity_reasons: list[str] = []
+
+    race_id_values = {
+        str(element.get("data-race-id") or "").strip()
+        for element in soup.select("[data-race-id]")
+        if str(element.get("data-race-id") or "").strip()
+    }
+    numeric_race_ids = {
+        value for value in race_id_values if value.isascii() and value.isdecimal()
+    }
+    source_native_race_id = (
+        next(iter(numeric_race_ids))
+        if len(race_id_values) == 1 and len(numeric_race_ids) == 1
+        else None
+    )
+    if source_native_race_id is None:
+        native_identity_reasons.append(
+            "source_native_race_id_missing"
+            if not race_id_values
+            else "source_native_race_id_invalid_or_ambiguous"
+        )
 
     for row in rows:
         original_box = _runner_row_box(row)
         dog_name = _runner_row_name(row)
         into_box = _runner_row_into_box(row)
+        runner_id_values = {
+            str(element.get("data-dog-id") or "").strip()
+            for element in row.select("[data-dog-id]")
+            if str(element.get("data-dog-id") or "").strip()
+        }
+        runner_id_values.update(
+            str(element.get("data-runner-id") or "").strip()
+            for element in row.select("[data-runner-id]")
+            if str(element.get("data-runner-id") or "").strip()
+        )
+        runner_group = row.find_parent("tbody")
+        if runner_group is not None:
+            match = re.fullmatch(
+                r"/dogs/runner/([0-9]+)/odds",
+                urlparse(str(runner_group.get("data-content-url") or "")).path,
+                flags=re.IGNORECASE,
+            )
+            if match:
+                runner_id_values.add(match.group(1))
+        for anchor in row.select("a[href]"):
+            parts = urlparse(str(anchor.get("href") or "")).path.split("/")
+            if len(parts) >= 3 and parts[1].lower() == "dogs" and parts[2].isdigit():
+                runner_id_values.add(parts[2])
+        numeric_runner_ids = {
+            value
+            for value in runner_id_values
+            if value.isascii() and value.isdecimal()
+        }
+        source_native_runner_id = (
+            next(iter(numeric_runner_ids))
+            if len(runner_id_values) == 1 and len(numeric_runner_ids) == 1
+            else None
+        )
         if original_box is not None and original_box > 8:
             reserve_boxes.add(original_box)
 
@@ -680,6 +742,8 @@ def extract_canonical_runner_set_from_html(
             continue
 
         participant = {"box_number": original_box, "dog_name": dog_name}
+        if source_native_runner_id is not None:
+            participant["source_native_runner_id"] = source_native_runner_id
         if _runner_row_is_scratched(row):
             scratched.append(participant)
             continue
@@ -689,6 +753,12 @@ def extract_canonical_runner_set_from_html(
 
         final_box = into_box or original_box
         active_participant = {"box_number": final_box, "dog_name": dog_name}
+        if source_native_runner_id is not None:
+            active_participant["source_native_runner_id"] = source_native_runner_id
+        else:
+            native_identity_reasons.append(
+                f"source_native_runner_id_unavailable:box:{final_box}"
+            )
         if into_box is not None and into_box != original_box:
             active_participant["original_box_number"] = original_box
         active.append(active_participant)
@@ -724,6 +794,11 @@ def extract_canonical_runner_set_from_html(
         "vacant_boxes": sorted(vacant_boxes),
         "race_number": page_race_number or expected,
         "expected_race_number": expected,
+        "source_native_race_id": source_native_race_id,
+        "native_identity_status": (
+            "available" if not native_identity_reasons else "unavailable"
+        ),
+        "native_identity_reasons": native_identity_reasons,
         "extraction_timestamp": timestamp,
         "ambiguous_reasons": ambiguous_reasons,
     }


### PR DESCRIPTION
## Summary

- publish a non-empty bounded current-race index from the completed primary collector refresh without applying forward-cohort composition floors
- preserve numeric native race and runner identities through extraction, metadata, selection, and sealed publication
- prevent odds-only refresh paths from publishing the shared index and preserve the prior index when no valid races remain
- keep the 20-race / 3-venue / 2-date requirement at forward cohort freeze only

## Safety boundary

- acquisition-call delta: exactly zero
- no refresh-limit, days-ahead, cadence, provider, weather-call, caching, scheduler, endpoint, database, or predictive-feature changes
- no deployment, live acquisition, cohort freeze, result access, model, promotion, or betting actions

## Validation

- 215 passed, 9 skipped: focused runner/index/publisher/forward-baseline suites
- 9 passed, 1 skipped, 2 deselected: CSV hardening without API dependency cases
- 262 passed, 2 deselected: autopilot and odds-only daemon suites
- 43 passed: adjacent autonomous odds-capture suite
- 121 passed: deployment generator and operator safety suites
- 103 passed, 9 skipped: post-review affected fixture rerun
- py_compile, JSON schema parse, fatal Flake8 checks, and git diff --check passed
- two unrelated shadow-autopilot limit assertions fail identically on pristine master and were excluded from the focused run

## Review

Independent Standards review: clean.
Independent Spec review: clean.

Cross-packet cohort accumulation is not present in the existing forward service. This PR does not add that architecture; cohort freeze continues to require a single verified 20/3/2 candidate population.