### PR TITLE
Bound odds deferrals so primary collection progresses

### DIFF
--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -83,6 +83,7 @@ DEFAULT_HEAVY_SCHEDULING_PAUSE_PATH = DEFAULT_RUNTIME_DIR / "pause-heavy-schedul
 DEFAULT_ODDS_CAPTURE_ONLY_PREFLIGHT_MAX_AGE_SECONDS = 30 * 60
 DEFAULT_ODDS_CAPTURE_ONLY_PREFLIGHT_RESUME_BUFFER_SECONDS = 5 * 60
 DEFAULT_FULL_DAEMON_ODDS_DEFER_HORIZON_SECONDS = 8 * 60
+MAX_CONSECUTIVE_ODDS_PRIORITY_FULL_DEFERRALS = 1
 DEFAULT_FULL_DAEMON_ODDS_LOCK_RETRY_SECONDS = DEFAULT_ODDS_CAPTURE_ONLY_TIMEOUT_SECONDS + 60
 DEFAULT_FULL_DAEMON_ODDS_LOCK_RETRY_POLL_SECONDS = 5
 DEFAULT_ODDS_CAPTURE_ONLY_T2_LOCK_RETRY_SECONDS = 90
@@ -3391,6 +3392,105 @@ def full_daemon_odds_window_defer_decision(
         "fresh_open_multi_race_state": fresh_open_multi_race_state,
         "due_capture_window_count": due_count,
     }
+
+
+def bounded_full_primary_defer_decision(
+    defer_decision: Mapping[str, Any],
+    daemon_state: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Bound odds-window priority without weakening the shared-lock handoff."""
+    decision = dict(defer_decision)
+    state = daemon_state if isinstance(daemon_state, Mapping) else {}
+    count = state.get("consecutive_odds_priority_full_deferrals", 0)
+    if type(count) is not int or count < 0:
+        decision.update(
+            {
+                "full_primary_fairness_status": "INVALID_FAIL_CLOSED",
+                "full_primary_fairness_blocker": (
+                    "consecutive_odds_priority_full_deferrals_invalid"
+                ),
+                "consecutive_odds_priority_full_deferrals": None,
+            }
+        )
+        return decision
+
+    decision.update(
+        {
+            "full_primary_fairness_status": "ODDS_PRIORITY_ALLOWED",
+            "full_primary_fairness_blocker": None,
+            "consecutive_odds_priority_full_deferrals": count,
+        }
+    )
+    if (
+        decision.get("should_defer")
+        and count >= MAX_CONSECUTIVE_ODDS_PRIORITY_FULL_DEFERRALS
+    ):
+        decision.update(
+            {
+                "should_defer": False,
+                "original_reason": decision.get("reason"),
+                "reason": "full_primary_fairness_opportunity_due",
+                "full_primary_fairness_status": "FAIRNESS_OVERRIDE",
+            }
+        )
+    return decision
+
+
+def persist_odds_priority_full_deferral(
+    *,
+    state_path: Path,
+    run_id: str,
+    generated_at: datetime,
+    defer_decision: Mapping[str, Any],
+) -> None:
+    """Record the single allowed odds-priority deferral in daemon state."""
+    previous = load_json(state_path)
+    if state_path.exists() and previous is None:
+        raise ValueError("full primary fairness durable state is unreadable")
+    count = defer_decision.get("consecutive_odds_priority_full_deferrals")
+    if type(count) is not int or count < 0:
+        raise ValueError("full primary fairness durable state is invalid")
+    payload = dict(previous or {})
+    payload.update(
+        {
+            "schema_version": "shadow_autopilot_daemon_state_v1",
+            "last_run_id": run_id,
+            "updated_at": generated_at.isoformat(),
+            "consecutive_odds_priority_full_deferrals": min(
+                count + 1,
+                MAX_CONSECUTIVE_ODDS_PRIORITY_FULL_DEFERRALS,
+            ),
+            "last_odds_priority_full_deferral_run_id": run_id,
+            "last_odds_priority_full_deferral_at": generated_at.isoformat(),
+        }
+    )
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    write_json(state_path, payload)
+
+
+def persist_full_primary_opportunity(
+    *,
+    state_path: Path,
+    run_id: str,
+    generated_at: datetime,
+) -> None:
+    """Reset fairness after the existing primary cycle has been invoked."""
+    previous = load_json(state_path)
+    if state_path.exists() and previous is None:
+        raise ValueError("full primary fairness durable state is unreadable")
+    payload = dict(previous or {})
+    payload.update(
+        {
+            "schema_version": "shadow_autopilot_daemon_state_v1",
+            "last_run_id": run_id,
+            "updated_at": generated_at.isoformat(),
+            "consecutive_odds_priority_full_deferrals": 0,
+            "last_full_primary_opportunity_run_id": run_id,
+            "last_full_primary_opportunity_at": generated_at.isoformat(),
+        }
+    )
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    write_json(state_path, payload)
 
 
 def post_primary_odds_capture_release_decision(
@@ -9531,9 +9631,25 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
             odds_state,
             current_time=current_dt,
         )
+        daemon_state = load_json(state_path)
+        if state_path.exists() and daemon_state is None:
+            daemon_state = {"consecutive_odds_priority_full_deferrals": None}
+        defer_decision = bounded_full_primary_defer_decision(
+            defer_decision,
+            daemon_state,
+        )
         defer_decision["odds_capture_state_path"] = relpath(odds_state_path)
         write_json(output_dir / "full_daemon_odds_window_defer.json", defer_decision)
         if defer_decision.get("should_defer"):
+            if defer_decision.get("full_primary_fairness_status") != (
+                "INVALID_FAIL_CLOSED"
+            ):
+                persist_odds_priority_full_deferral(
+                    state_path=state_path,
+                    run_id=run_id,
+                    generated_at=generated_at,
+                    defer_decision=defer_decision,
+                )
             result = {
                 "schema_version": "shadow_autopilot_daemon_run_v1",
                 "run_id": run_id,
@@ -9724,6 +9840,11 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
                 output_dir=output_dir,
                 timeout_seconds=autopilot_cycle_timeout_seconds(args.timeout_seconds),
             )
+        )
+        persist_full_primary_opportunity(
+            state_path=state_path,
+            run_id=run_id,
+            generated_at=generated_at,
         )
         autopilot_stdout = output_dir / "logs" / "autopilot_cycle.stdout.txt"
         autopilot_result = load_json(autopilot_stdout)
@@ -12905,6 +13026,9 @@ def run_once(args: argparse.Namespace) -> dict[str, Any]:
         "last_observability_status": observability["status"].get("status"),
         "last_cycle_activity_status": cycle_activity.get("status"),
         "last_safe_joined_delta": cycle_activity.get("safe_joined_delta_this_cycle"),
+        "consecutive_odds_priority_full_deferrals": 0,
+        "last_full_primary_opportunity_run_id": run_id,
+        "last_full_primary_opportunity_at": generated_at.isoformat(),
         "updated_at": datetime.now().astimezone().isoformat(),
     }
     state_payload.update(autopilot_cycle_state_fields(daily_status))

--- a/scripts/shadow_autopilot_daemon.py
+++ b/scripts/shadow_autopilot_daemon.py
@@ -3402,7 +3402,11 @@ def bounded_full_primary_defer_decision(
     decision = dict(defer_decision)
     state = daemon_state if isinstance(daemon_state, Mapping) else {}
     count = state.get("consecutive_odds_priority_full_deferrals", 0)
-    if type(count) is not int or count < 0:
+    if (
+        type(count) is not int
+        or count < 0
+        or count > MAX_CONSECUTIVE_ODDS_PRIORITY_FULL_DEFERRALS
+    ):
         decision.update(
             {
                 "full_primary_fairness_status": "INVALID_FAIL_CLOSED",
@@ -3448,7 +3452,11 @@ def persist_odds_priority_full_deferral(
     if state_path.exists() and previous is None:
         raise ValueError("full primary fairness durable state is unreadable")
     count = defer_decision.get("consecutive_odds_priority_full_deferrals")
-    if type(count) is not int or count < 0:
+    if (
+        type(count) is not int
+        or count < 0
+        or count > MAX_CONSECUTIVE_ODDS_PRIORITY_FULL_DEFERRALS
+    ):
         raise ValueError("full primary fairness durable state is invalid")
     payload = dict(previous or {})
     payload.update(

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -509,6 +509,8 @@ def test_run_once_releases_after_primary_when_odds_refresh_due(tmp_path, monkeyp
     def fake_run_command(*, name, command, output_dir, timeout_seconds, cwd=daemon.ROOT):
         if name != "autopilot_cycle":
             raise AssertionError(f"post-primary release should not run {name}")
+        assert command[command.index("--days-ahead") + 1] == "1"
+        assert command[command.index("--refresh-limit") + 1] == "6"
         assert command[command.index("--autonomous-odds-capture-limit") + 1] == "16"
         assert command[command.index("--result-backlog-limit") + 1] == "8"
         assert command[command.index("--result-backlog-shadow-run-limit") + 1] == "16"
@@ -543,6 +545,8 @@ def test_run_once_releases_after_primary_when_odds_refresh_due(tmp_path, monkeyp
             "--enable-autonomous-odds-capture",
             "--odds-capture-state-path",
             str(odds_state_path),
+            "--state-path",
+            str(tmp_path / "runtime" / "daemon_state.json"),
         ]
     )
 
@@ -656,6 +660,9 @@ def test_run_once_releases_after_primary_when_odds_refresh_due(tmp_path, monkeyp
     assert written[
         "autopilot_cycle_best_aggregate_unified_evidence_eligible_rows"
     ] == report["autopilot_cycle_best_aggregate_unified_evidence_eligible_rows"]
+    state = json.loads((tmp_path / "runtime" / "daemon_state.json").read_text())
+    assert state["consecutive_odds_priority_full_deferrals"] == 0
+    assert state["last_full_primary_opportunity_run_id"] == "release"
     assert odds_state_path.exists()
 
 
@@ -913,6 +920,7 @@ def test_run_once_defer_writes_startup_output_manifest(tmp_path, monkeypatch):
     evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
     output_dir = evidence_root / "shadow_autopilot_daemonization_v1_defer"
     odds_state_path = tmp_path / "runtime" / "odds_capture_state.json"
+    state_path = tmp_path / "runtime" / "daemon_state.json"
 
     monkeypatch.setattr(daemon, "ROOT", tmp_path)
     monkeypatch.setattr(daemon, "copy_if_exists", lambda source, dest: None)
@@ -954,6 +962,8 @@ def test_run_once_defer_writes_startup_output_manifest(tmp_path, monkeypatch):
             "--enable-autonomous-odds-capture",
             "--odds-capture-state-path",
             str(odds_state_path),
+            "--state-path",
+            str(state_path),
         ]
     )
 
@@ -965,6 +975,81 @@ def test_run_once_defer_writes_startup_output_manifest(tmp_path, monkeypatch):
     assert any(path.endswith("daemon_run_report.json") for path in manifest["files"])
     assert any(path.endswith("final_status.txt") for path in manifest["files"])
     assert any(path.endswith("full_daemon_odds_window_defer.json") for path in manifest["files"])
+    state = json.loads(state_path.read_text())
+    assert state["consecutive_odds_priority_full_deferrals"] == 1
+    assert state["last_odds_priority_full_deferral_run_id"] == "defer"
+
+
+def test_run_once_repeated_odds_priority_cannot_starve_full_primary(
+    tmp_path, monkeypatch
+):
+    evidence_root = tmp_path / "artifacts/full_evidence_orchestration_20260525"
+    output_dir = evidence_root / "shadow_autopilot_daemonization_v1_fairness"
+    odds_state_path = tmp_path / "runtime" / "odds_capture_state.json"
+    state_path = tmp_path / "runtime" / "daemon_state.json"
+    daemon.write_json(
+        state_path,
+        {
+            "schema_version": "shadow_autopilot_daemon_state_v1",
+            "consecutive_odds_priority_full_deferrals": 1,
+            "last_odds_priority_full_deferral_run_id": "previous-full",
+        },
+    )
+
+    monkeypatch.setattr(daemon, "ROOT", tmp_path)
+    monkeypatch.setattr(daemon, "copy_if_exists", lambda source, dest: None)
+    monkeypatch.setattr(
+        daemon,
+        "write_service_files",
+        lambda **kwargs: {
+            "status": "SERVICE_FILES_WRITTEN",
+            "systemd_deployment_ready": True,
+        },
+    )
+    monkeypatch.setattr(
+        daemon,
+        "full_daemon_odds_window_defer_decision",
+        lambda odds_state, current_time: {
+            "should_defer": True,
+            "reason": "test_fixed_window_open",
+        },
+    )
+    monkeypatch.setattr(
+        daemon,
+        "acquire_lock_with_odds_capture_retry",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("full primary lock opportunity reached")
+        ),
+    )
+
+    args = daemon.parse_args(
+        [
+            "run-once",
+            "--run-id",
+            "fairness",
+            "--evidence-root",
+            str(evidence_root),
+            "--output-dir",
+            str(output_dir),
+            "--current-time",
+            "2026-06-13T15:32:11+10:00",
+            "--enable-autonomous-odds-capture",
+            "--odds-capture-state-path",
+            str(odds_state_path),
+            "--state-path",
+            str(state_path),
+        ]
+    )
+
+    report = daemon.run_once(args)
+
+    decision = json.loads(
+        (output_dir / "full_daemon_odds_window_defer.json").read_text()
+    )
+    assert report["runtime_action"] == "CHECK_DAEMON_EXCEPTION"
+    assert report["exception_message"] == "full primary lock opportunity reached"
+    assert decision["should_defer"] is False
+    assert decision["full_primary_fairness_status"] == "FAIRNESS_OVERRIDE"
 
 
 def test_run_once_keeps_source_service_templates_immutable(tmp_path, monkeypatch):
@@ -1018,6 +1103,8 @@ def test_run_once_keeps_source_service_templates_immutable(tmp_path, monkeypatch
             "--enable-autonomous-odds-capture",
             "--odds-capture-state-path",
             str(odds_state_path),
+            "--state-path",
+            str(tmp_path / "runtime" / "daemon_state.json"),
         ]
     )
 
@@ -1347,6 +1434,8 @@ def test_run_once_observer_waits_for_natural_odds_release_then_continues(
             "--enable-autonomous-odds-capture",
             "--odds-capture-state-path",
             str(odds_state_path),
+            "--state-path",
+            str(tmp_path / "runtime" / "daemon_state.json"),
         ]
     )
 
@@ -1596,6 +1685,8 @@ def test_observer_completion_refreshes_wall_time_before_odds_defer(
             "--enable-autonomous-odds-capture",
             "--odds-capture-state-path",
             str(odds_state_path),
+            "--state-path",
+            str(tmp_path / "runtime" / "daemon_state.json"),
         ]
     )
 
@@ -1688,6 +1779,8 @@ def test_run_once_defers_before_lock_when_t2_window_recomputed_due(
             "--enable-autonomous-odds-capture",
             "--odds-capture-state-path",
             str(odds_state_path),
+            "--state-path",
+            str(tmp_path / "runtime" / "daemon_state.json"),
         ]
     )
 
@@ -4209,6 +4302,43 @@ def test_full_daemon_odds_window_defer_decision_defers_fresh_multi_race_open_sta
     assert decision["should_defer"] is True
     assert decision["reason"] == "odds_capture_state_open_with_additional_selected_races"
     assert decision["fresh_open_multi_race_state"] is True
+
+
+def test_full_primary_fairness_allows_only_one_consecutive_odds_priority_deferral():
+    decision = daemon.bounded_full_primary_defer_decision(
+        {
+            "should_defer": True,
+            "reason": "odds_capture_window_open_or_imminent",
+        },
+        {
+            "consecutive_odds_priority_full_deferrals": 1,
+        },
+    )
+
+    assert decision["should_defer"] is False
+    assert decision["reason"] == "full_primary_fairness_opportunity_due"
+    assert decision["original_reason"] == "odds_capture_window_open_or_imminent"
+    assert decision["full_primary_fairness_status"] == "FAIRNESS_OVERRIDE"
+    assert decision["consecutive_odds_priority_full_deferrals"] == 1
+
+
+def test_full_primary_fairness_fails_closed_on_ambiguous_durable_state():
+    decision = daemon.bounded_full_primary_defer_decision(
+        {
+            "should_defer": True,
+            "reason": "odds_capture_window_open_or_imminent",
+        },
+        {
+            "consecutive_odds_priority_full_deferrals": "1",
+        },
+    )
+
+    assert decision["should_defer"] is True
+    assert decision["reason"] == "odds_capture_window_open_or_imminent"
+    assert decision["full_primary_fairness_status"] == "INVALID_FAIL_CLOSED"
+    assert decision["full_primary_fairness_blocker"] == (
+        "consecutive_odds_priority_full_deferrals_invalid"
+    )
 
 
 def test_run_odds_capture_once_preserves_window_state_on_lock_busy(

--- a/tests/test_shadow_autopilot_daemon.py
+++ b/tests/test_shadow_autopilot_daemon.py
@@ -4323,22 +4323,23 @@ def test_full_primary_fairness_allows_only_one_consecutive_odds_priority_deferra
 
 
 def test_full_primary_fairness_fails_closed_on_ambiguous_durable_state():
-    decision = daemon.bounded_full_primary_defer_decision(
-        {
-            "should_defer": True,
-            "reason": "odds_capture_window_open_or_imminent",
-        },
-        {
-            "consecutive_odds_priority_full_deferrals": "1",
-        },
-    )
+    for invalid_count in ("1", 2, -1, True):
+        decision = daemon.bounded_full_primary_defer_decision(
+            {
+                "should_defer": True,
+                "reason": "odds_capture_window_open_or_imminent",
+            },
+            {
+                "consecutive_odds_priority_full_deferrals": invalid_count,
+            },
+        )
 
-    assert decision["should_defer"] is True
-    assert decision["reason"] == "odds_capture_window_open_or_imminent"
-    assert decision["full_primary_fairness_status"] == "INVALID_FAIL_CLOSED"
-    assert decision["full_primary_fairness_blocker"] == (
-        "consecutive_odds_priority_full_deferrals_invalid"
-    )
+        assert decision["should_defer"] is True
+        assert decision["reason"] == "odds_capture_window_open_or_imminent"
+        assert decision["full_primary_fairness_status"] == "INVALID_FAIL_CLOSED"
+        assert decision["full_primary_fairness_blocker"] == (
+            "consecutive_odds_priority_full_deferrals_invalid"
+        )
 
 
 def test_run_odds_capture_once_preserves_window_state_on_lock_busy(


### PR DESCRIPTION
## Summary

- record at most one consecutive odds-priority full-daemon deferral in the existing daemon state
- give the next natural full invocation a primary opportunity through the existing no-steal lock retry and odds-only handoff
- reset fairness only after the existing primary autopilot cycle is invoked
- reject unreadable, non-numeric, boolean, negative, and out-of-range fairness state without overriding odds priority

The full timer remains completion-relative at 15 minutes. Its observed 18:12, 18:29, and 18:45 starts all land in minutes enabled by the odds-only calendar; only minutes 02, 17, 32, and 47 are reserved. That drift makes the prior unbounded early defer recurrent.

No timer cadence, horizon, refresh limit, provider/weather call, endpoint, database, or scheduler is added or changed. Acquisition-call delta versus the existing scheduled workload is exactly zero.

## Safety

The fairness override only suppresses the early return. It does not acquire, steal, or bypass a lock. Full collection still uses the existing shared-lock retry/wait marker; odds-only still yields to that marker and remains unable to publish the shared current index.

## Validation

- 167 passed: full daemon suite
- 4 passed: focused current-index and skip-primary autopilot tests
- 13 passed: current-index publisher/consumer tests
- 54 passed: adjacent collector and forward-baseline tests
- 120 passed: deployment/operator safety tests, with one environment-only test deselected because the existing virtualenv lacks flask_compress
- 350 tracked JSON files parsed
- py_compile passed
- git diff --check passed
- independent Standards review: clean
- independent Spec review: clean

Known unchanged baseline: the full shadow_autopilot_v1 suite has two pre-existing assertions expecting odds refresh limit 8 while exact base code sets 16.

No deployment or live acquisition was performed.