### PR TITLE
Preserve TheDogs native identity in primary refresh

### DIFF
--- a/scripts/capture_thedogs_market_history.py
+++ b/scripts/capture_thedogs_market_history.py
@@ -19,7 +19,7 @@ import math
 import os
 import re
 import stat
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
@@ -371,7 +371,9 @@ def make_session() -> requests.Session:
     return session
 
 
-def _receipt_headers(headers: Mapping[str, Any]) -> dict[str, str]:
+def bounded_receipt_headers(headers: Mapping[str, Any]) -> dict[str, str]:
+    """Retain only source-validation headers, never cookies or credentials."""
+
     lowered = {str(key).lower(): str(value) for key, value in headers.items()}
     return {key: lowered[key] for key in RECEIPT_HTTP_HEADERS if key in lowered}
 
@@ -405,7 +407,7 @@ def timed_get(
         request_end_utc=end,
         final_url=str(response.url),
         status_code=int(response.status_code),
-        headers=_receipt_headers(response.headers),
+        headers=bounded_receipt_headers(response.headers),
         body=body,
     )
 
@@ -540,11 +542,15 @@ def normalize_api_snapshot(
         if runner.active and provider is None:
             active_provider_unknown += 1
         market = quote.get("market") if quote is not None else None
-        native_race_id = ""
-        if isinstance(market, Mapping):
+        if runner.active:
+            if not isinstance(market, Mapping):
+                raise CaptureError("native_race_identity_incomplete")
             native_race_id = str(market.get("race_id") or "").strip()
-            if native_race_id:
-                native_race_ids.add(native_race_id)
+            if not native_race_id:
+                raise CaptureError("native_race_identity_incomplete")
+            if not native_race_id.isascii() or not native_race_id.isdecimal():
+                raise CaptureError("native_race_identity_invalid")
+            native_race_ids.add(native_race_id)
         api_run_box = quote.get("run_box") if quote is not None else None
         parsed_api_run_box = None
         if api_run_box is not None:
@@ -618,6 +624,7 @@ def normalize_api_snapshot(
         raise CaptureError("active_effective_box_not_unique")
     if len(native_race_ids) != 1:
         raise CaptureError("native_race_identity_not_unique")
+    native_race_id = next(iter(native_race_ids))
     if len(provider_values) > 1:
         raise CaptureError("provider_identity_not_unique")
     if provider_values and active_provider_unknown:
@@ -639,7 +646,295 @@ def normalize_api_snapshot(
             "name": None,
             "source": "provider_not_explicit_in_source_payload",
         }
-    return rows, provider, next(iter(native_race_ids))
+    return rows, provider, native_race_id
+
+
+def _expected_native_runner_box_map(value: Any) -> dict[str, int]:
+    try:
+        pairs = list(value)
+    except TypeError as exc:
+        raise CaptureError("expected_active_runner_boxes_invalid") from exc
+    if len(pairs) < 2:
+        raise CaptureError("expected_active_runner_boxes_invalid")
+    normalized: dict[str, int] = {}
+    boxes: set[int] = set()
+    for pair in pairs:
+        if not isinstance(pair, (list, tuple)) or len(pair) != 2:
+            raise CaptureError("expected_active_runner_boxes_invalid")
+        runner_id, effective_box = pair
+        if (
+            not isinstance(runner_id, str)
+            or not runner_id.isascii()
+            or not runner_id.isdecimal()
+            or runner_id in normalized
+            or not isinstance(effective_box, int)
+            or isinstance(effective_box, bool)
+            or effective_box not in range(1, 9)
+            or effective_box in boxes
+        ):
+            raise CaptureError("expected_active_runner_boxes_invalid")
+        normalized[runner_id] = effective_box
+        boxes.add(effective_box)
+    return normalized
+
+
+def capture_native_identity_from_retained_race_page(
+    *,
+    session: Any,
+    race_page: TimedResponse,
+    expected_active_runner_boxes: Sequence[tuple[str, int]],
+    expected_jump_utc: datetime,
+    current_time: datetime,
+    clock: Callable[[], datetime] = utc_now,
+) -> dict[str, Any]:
+    """Bind a retained primary race page to native identity in two requests."""
+
+    expected_boxes = _expected_native_runner_box_map(expected_active_runner_boxes)
+    expected_ids = set(expected_boxes)
+    if expected_jump_utc.tzinfo is None or expected_jump_utc.utcoffset() is None:
+        raise CaptureError("expected_jump_timestamp_timezone_required")
+    if current_time.tzinfo is None or current_time.utcoffset() is None:
+        raise CaptureError("current_time_timezone_required")
+    jump_utc = expected_jump_utc.astimezone(timezone.utc)
+    observed_now = current_time.astimezone(timezone.utc)
+    retained_age_seconds = (
+        observed_now - race_page.request_end_utc.astimezone(timezone.utc)
+    ).total_seconds()
+    if retained_age_seconds < 0 or retained_age_seconds > 1200:
+        raise CaptureError("native_identity_evidence_stale")
+    validate_response(
+        race_page,
+        exact_url=race_page.requested_url,
+        content_type_prefix="text/html",
+    )
+    source_jump = parse_jump_from_source(race_page.body)
+    if source_jump != jump_utc:
+        raise CaptureError("jump_source_timestamp_mismatch")
+    retained_url = urlparse(race_page.requested_url)
+    canonical_race_url = retained_url._replace(query="", fragment="").geturl().rstrip("/")
+    identity = exact_odds_identity(f"{canonical_race_url}/odds")
+
+    odds = timed_get(
+        session,
+        str(identity["odds_url"]),
+        referer=str(identity["race_url"]),
+        accept=PAGE_HEADERS["Accept"],
+        clock=clock,
+    )
+    validate_response(
+        odds,
+        exact_url=str(identity["odds_url"]),
+        content_type_prefix="text/html",
+    )
+    source_runners = parse_source_runners(odds.body)
+    observed_active_ids = {
+        runner.native_runner_id for runner in source_runners if runner.active
+    }
+    if observed_active_ids != expected_ids:
+        raise CaptureError("expected_native_runner_set_mismatch")
+
+    api_url = _api_url(source_runners)
+    api = timed_get(
+        session,
+        api_url,
+        referer=str(identity["odds_url"]),
+        accept="application/json",
+        clock=clock,
+        xhr=True,
+    )
+    validate_response(
+        api,
+        exact_url=api_url,
+        content_type_prefix="application/json",
+    )
+    if not (
+        race_page.request_end_utc
+        <= odds.request_start_utc
+        <= odds.request_end_utc
+        <= api.request_start_utc
+        <= api.request_end_utc
+    ):
+        raise CaptureError("request_chain_time_order_invalid")
+    try:
+        api_payload = json.loads(api.body.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise CaptureError("odds_api_json_invalid") from exc
+    if not isinstance(api_payload, Mapping):
+        raise CaptureError("odds_api_json_invalid")
+    rows, provider, native_race_id = normalize_api_snapshot(
+        api_payload, source_runners
+    )
+    observed_boxes = {
+        row["native_runner_id"]: row["effective_box"]
+        for row in rows
+        if row["active"] is True
+    }
+    if observed_boxes != expected_boxes:
+        raise CaptureError("expected_native_runner_effective_box_mismatch")
+    if api.request_end_utc >= jump_utc:
+        raise CaptureError("capture_not_strictly_prejump")
+    evidence_age_seconds = (
+        api.request_end_utc - race_page.request_end_utc
+    ).total_seconds()
+    if evidence_age_seconds < 0 or evidence_age_seconds > 1200:
+        raise CaptureError("native_identity_evidence_stale")
+    evidence: dict[str, Any] = {
+        "schema_version": "thedogs_primary_native_identity_evidence_v1",
+        "source_class": SOURCE_CLASS,
+        "source_native_race_id": native_race_id,
+        "active_native_runner_ids": sorted(observed_active_ids),
+        "active_native_runner_boxes": dict(sorted(observed_boxes.items())),
+        "all_native_runner_ids": sorted(
+            runner.native_runner_id for runner in source_runners
+        ),
+        "jump_timestamp": iso_utc(jump_utc),
+        "capture_start_utc": iso_utc(odds.request_start_utc),
+        "capture_end_utc": iso_utc(api.request_end_utc),
+        "race_page_http": _response_receipt(race_page, include_body=True),
+        "odds_page_http": _response_receipt(odds, include_body=True),
+        "odds_api_http": _response_receipt(api, include_body=True),
+        "provider": provider,
+        "runners": rows,
+        "request_accounting": {
+            "logical_requests": 2,
+            "shared_session_max_attempts_per_request": 3,
+            "worst_case_wire_attempts": 6,
+        },
+    }
+    evidence["evidence_sha256"] = sha256_bytes(canonical_json_bytes(evidence))
+    return evidence
+
+
+def validate_primary_native_identity_evidence(
+    evidence: Any,
+    *,
+    expected_race_url: str,
+    expected_native_race_id: str,
+    expected_active_runner_boxes: Sequence[tuple[str, int]],
+    metadata_captured_at: str,
+) -> tuple[bool, str | None]:
+    """Revalidate persisted primary identity evidence without network access."""
+
+    try:
+        if not isinstance(evidence, Mapping):
+            raise CaptureError("native_identity_evidence_missing")
+        if evidence.get("schema_version") != "thedogs_primary_native_identity_evidence_v1":
+            raise CaptureError("native_identity_evidence_schema_invalid")
+        if evidence.get("source_class") != SOURCE_CLASS:
+            raise CaptureError("native_identity_evidence_source_class_invalid")
+        if evidence.get("request_accounting") != {
+            "logical_requests": 2,
+            "shared_session_max_attempts_per_request": 3,
+            "worst_case_wire_attempts": 6,
+        }:
+            raise CaptureError("native_identity_request_accounting_invalid")
+        core = {key: value for key, value in evidence.items() if key != "evidence_sha256"}
+        if evidence.get("evidence_sha256") != sha256_bytes(canonical_json_bytes(core)):
+            raise CaptureError("native_identity_evidence_hash_mismatch")
+        expected_boxes = _expected_native_runner_box_map(
+            expected_active_runner_boxes
+        )
+        expected_ids = set(expected_boxes)
+        if (
+            not isinstance(expected_native_race_id, str)
+            or not expected_native_race_id.isascii()
+            or not expected_native_race_id.isdecimal()
+        ):
+            raise CaptureError("expected_native_race_id_invalid")
+
+        race = _stored_response(
+            evidence.get("race_page_http"),
+            field="race_page_http",
+            exact_url=expected_race_url,
+            content_type_prefix="text/html",
+            require_body=True,
+        )
+        retained_url = urlparse(expected_race_url)
+        canonical_race_url = retained_url._replace(query="", fragment="").geturl().rstrip("/")
+        identity = exact_odds_identity(f"{canonical_race_url}/odds")
+        odds = _stored_response(
+            evidence.get("odds_page_http"),
+            field="odds_page_http",
+            exact_url=str(identity["odds_url"]),
+            content_type_prefix="text/html",
+            require_body=True,
+        )
+        source_runners = parse_source_runners(odds.body)
+        active_ids = sorted(
+            runner.native_runner_id for runner in source_runners if runner.active
+        )
+        if active_ids != sorted(expected_ids):
+            raise CaptureError("expected_native_runner_set_mismatch")
+        api_url = _api_url(source_runners)
+        api = _stored_response(
+            evidence.get("odds_api_http"),
+            field="odds_api_http",
+            exact_url=api_url,
+            content_type_prefix="application/json",
+            require_body=True,
+        )
+        try:
+            api_payload = json.loads(api.body.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise CaptureError("odds_api_json_invalid") from exc
+        if not isinstance(api_payload, Mapping):
+            raise CaptureError("odds_api_json_invalid")
+        rows, provider, native_race_id = normalize_api_snapshot(
+            api_payload, source_runners
+        )
+        observed_boxes = {
+            row["native_runner_id"]: row["effective_box"]
+            for row in rows
+            if row["active"] is True
+        }
+        if observed_boxes != expected_boxes:
+            raise CaptureError("expected_native_runner_effective_box_mismatch")
+        if native_race_id != expected_native_race_id:
+            raise CaptureError("expected_native_race_id_mismatch")
+        if evidence.get("source_native_race_id") != native_race_id:
+            raise CaptureError("persisted_native_race_id_mismatch")
+        if evidence.get("active_native_runner_ids") != active_ids:
+            raise CaptureError("persisted_active_runner_ids_mismatch")
+        if evidence.get("active_native_runner_boxes") != dict(
+            sorted(observed_boxes.items())
+        ):
+            raise CaptureError("persisted_active_runner_boxes_mismatch")
+        if evidence.get("all_native_runner_ids") != sorted(
+            runner.native_runner_id for runner in source_runners
+        ):
+            raise CaptureError("persisted_all_runner_ids_mismatch")
+        if evidence.get("runners") != rows:
+            raise CaptureError("persisted_native_runner_projection_mismatch")
+        if evidence.get("provider") != provider:
+            raise CaptureError("persisted_provider_projection_mismatch")
+        if evidence.get("capture_start_utc") != iso_utc(odds.request_start_utc):
+            raise CaptureError("persisted_capture_start_mismatch")
+        if evidence.get("capture_end_utc") != iso_utc(api.request_end_utc):
+            raise CaptureError("persisted_capture_end_mismatch")
+        jump_utc = parse_jump_from_source(race.body)
+        if evidence.get("jump_timestamp") != iso_utc(jump_utc):
+            raise CaptureError("persisted_jump_timestamp_mismatch")
+        if not (
+            race.request_end_utc
+            <= odds.request_start_utc
+            <= odds.request_end_utc
+            <= api.request_start_utc
+            <= api.request_end_utc
+            < jump_utc
+        ):
+            raise CaptureError("request_chain_time_order_invalid")
+        if (api.request_end_utc - race.request_end_utc).total_seconds() > 1200:
+            raise CaptureError("native_identity_evidence_stale")
+        metadata_time = parse_timestamp(
+            metadata_captured_at,
+            field="metadata_captured_at",
+        )
+        metadata_distance = (metadata_time - api.request_end_utc).total_seconds()
+        if metadata_distance < -5 or metadata_distance > 1200 or metadata_time >= jump_utc:
+            raise CaptureError("native_identity_evidence_stale")
+    except (CaptureError, TypeError, ValueError) as exc:
+        return False, str(exc)
+    return True, None
 
 
 def _response_receipt(response: TimedResponse, *, include_body: bool) -> dict[str, Any]:

--- a/scripts/refresh_prejump_upcoming.py
+++ b/scripts/refresh_prejump_upcoming.py
@@ -30,6 +30,9 @@ from utils.csv_metadata import (  # noqa: E402
 )
 from utils.expert_form_metadata import safe_expert_form_metadata_from_payload  # noqa: E402
 from utils.race_lifecycle import melbourne_now  # noqa: E402
+from scripts.capture_thedogs_market_history import (  # noqa: E402
+    validate_primary_native_identity_evidence,
+)
 
 
 def parse_current_time(value: str | None) -> datetime:
@@ -475,6 +478,49 @@ def _metadata_record_for_csv(csv_path: Path) -> dict[str, Any]:
         if isinstance(runner_rows, list)
         else []
     )
+    native_runner_boxes = (
+        [
+            (
+                row.get("source_native_runner_id"),
+                row.get("box_number") or row.get("box"),
+            )
+            for row in runner_rows
+            if isinstance(row, Mapping)
+        ]
+        if isinstance(runner_rows, list)
+        else []
+    )
+    native_race_id = shadow.get("source_native_race_id")
+    native_identity_evidence_status = "not_required_direct_source_identity"
+    native_identity_evidence_reason = None
+    evidence = payload.get("native_identity_evidence") if isinstance(payload, Mapping) else None
+    evidence_required = (
+        shadow.get("source_native_identity_origin")
+        == "thedogs_odds_api_exact_runner_set"
+    )
+    if evidence_required and evidence is None:
+        native_identity_evidence_status = "rejected"
+        native_identity_evidence_reason = "native_identity_evidence_missing"
+        native_race_id = None
+        native_runner_ids = []
+    if evidence is not None:
+        evidence_valid, native_identity_evidence_reason = (
+            validate_primary_native_identity_evidence(
+                evidence,
+                expected_race_url=str(_sidecar_race_url(payload) or ""),
+                expected_native_race_id=str(native_race_id or ""),
+                expected_active_runner_boxes=native_runner_boxes,
+                metadata_captured_at=str(
+                    shadow.get("metadata_captured_at")
+                    or payload.get("metadata_captured_at")
+                    or ""
+                ),
+            )
+        )
+        native_identity_evidence_status = "verified" if evidence_valid else "rejected"
+        if not evidence_valid:
+            native_race_id = None
+            native_runner_ids = []
     weather_present = bool(weather_track.get("weather"))
     track_present = bool(weather_track.get("track_condition"))
     expert_form_safe = bool(expert_form.get("metadata_is_leakage_safe"))
@@ -492,8 +538,10 @@ def _metadata_record_for_csv(csv_path: Path) -> dict[str, Any]:
             weather_present and track_present and expert_form_safe
         ),
         "runner_source_observed_at": shadow.get("metadata_captured_at"),
-        "source_native_race_id": shadow.get("source_native_race_id"),
+        "source_native_race_id": native_race_id,
         "source_native_runner_ids": native_runner_ids,
+        "native_identity_evidence_status": native_identity_evidence_status,
+        "native_identity_evidence_reason": native_identity_evidence_reason,
         "weather": weather_track.get("weather"),
         "track_condition": weather_track.get("track_condition"),
         "weather_track_metadata_source": weather_track.get("weather_track_metadata_source"),
@@ -787,10 +835,20 @@ def refresh_prejump_upcoming(args: argparse.Namespace) -> dict[str, Any]:
 
     downloads: list[dict[str, Any]] = []
     if not args.dry_run:
+        selected_record_by_url = {
+            str(record.get("race_url") or ""): record
+            for record in records
+            if record.get("selected") is True and record.get("race_url")
+        }
         for race in selected:
+            race_url = str(race["url"])
+            selected_record = selected_record_by_url.get(race_url, {})
             result = browser.download_race_csv(
-                str(race["url"]),
-                race_info_hint=race,
+                race_url,
+                race_info_hint={
+                    **dict(race),
+                    "jump_datetime": selected_record.get("jump_datetime"),
+                },
             )
             downloads.append(
                 {

--- a/tests/test_capture_thedogs_market_history.py
+++ b/tests/test_capture_thedogs_market_history.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from scripts import capture_thedogs_market_history as subject
 from scripts.capture_thedogs_market_history import (
     CaptureError,
     TimedResponse,
@@ -315,6 +316,333 @@ def test_complete_active_field_and_native_ids_are_captured(tmp_path):
     assert receipt["open_low_high_are_temporal_observations"] is False
     assert len(session.calls) == 4
 
+
+def test_retained_race_page_identity_binding_uses_exactly_two_requests():
+    observed = JUMP - timedelta(minutes=20)
+    session = FakeSession(server_time=observed)
+    race_page = TimedResponse(
+        requested_url=RACE_URL,
+        request_start_utc=observed - timedelta(milliseconds=100),
+        request_end_utc=observed,
+        final_url=RACE_URL,
+        status_code=200,
+        headers={
+            "content-type": "text/html; charset=utf-8",
+            "date": format_datetime(observed, usegmt=True),
+        },
+        body=source_html(),
+    )
+
+    evidence = subject.capture_native_identity_from_retained_race_page(
+        session=session,
+        race_page=race_page,
+        expected_active_runner_boxes=[("101", 1), ("102", 2)],
+        expected_jump_utc=JUMP,
+        current_time=observed + timedelta(seconds=1),
+        clock=FakeClock(observed + timedelta(milliseconds=100)),
+    )
+
+    assert session.calls == [ODDS_URL, subject._api_url(parse_source_runners(source_html()))]
+    assert evidence["source_native_race_id"] == "9001"
+    assert evidence["active_native_runner_ids"] == ["101", "102"]
+    assert evidence["request_accounting"] == {
+        "logical_requests": 2,
+        "shared_session_max_attempts_per_request": 3,
+        "worst_case_wire_attempts": 6,
+    }
+    assert evidence["evidence_sha256"] == sha256_bytes(
+        canonical_json_bytes(
+            {key: value for key, value in evidence.items() if key != "evidence_sha256"}
+        )
+    )
+
+
+def test_primary_identity_request_accounting_matches_shared_retry_bound():
+    from utils.http_client import get_shared_session
+
+    retries = get_shared_session().get_adapter("https://").max_retries
+    assert retries.total == 2
+    assert 1 + retries.total == 3
+    assert 2 * (1 + retries.total) == 6
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement", "reason"),
+    [
+        (
+            "capture_start_utc",
+            "2026-06-01T08:39:00Z",
+            "persisted_capture_start_mismatch",
+        ),
+        (
+            "capture_end_utc",
+            "2026-06-01T08:41:00Z",
+            "persisted_capture_end_mismatch",
+        ),
+        (
+            "provider",
+            {
+                "classification": "provider_unknown",
+                "id": None,
+                "code": None,
+                "name": None,
+                "source": "provider_not_explicit_in_source_payload",
+            },
+            "persisted_provider_projection_mismatch",
+        ),
+    ],
+)
+def test_primary_identity_revalidation_rejects_rehashed_provenance_tampering(
+    field,
+    replacement,
+    reason,
+):
+    observed = JUMP - timedelta(minutes=20)
+    evidence = subject.capture_native_identity_from_retained_race_page(
+        session=FakeSession(server_time=observed),
+        race_page=TimedResponse(
+            requested_url=RACE_URL,
+            request_start_utc=observed - timedelta(milliseconds=100),
+            request_end_utc=observed,
+            final_url=RACE_URL,
+            status_code=200,
+            headers={
+                "content-type": "text/html; charset=utf-8",
+                "date": format_datetime(observed, usegmt=True),
+            },
+            body=source_html(),
+        ),
+        expected_active_runner_boxes=[("101", 1), ("102", 2)],
+        expected_jump_utc=JUMP,
+        current_time=observed + timedelta(seconds=1),
+        clock=FakeClock(observed + timedelta(milliseconds=100)),
+    )
+    evidence[field] = replacement
+    evidence["evidence_sha256"] = sha256_bytes(
+        canonical_json_bytes(
+            {key: value for key, value in evidence.items() if key != "evidence_sha256"}
+        )
+    )
+
+    valid, observed_reason = subject.validate_primary_native_identity_evidence(
+        evidence,
+        expected_race_url=RACE_URL,
+        expected_native_race_id="9001",
+        expected_active_runner_boxes=[("101", 1), ("102", 2)],
+        metadata_captured_at=evidence["odds_api_http"]["request_end_utc"],
+    )
+
+    assert valid is False
+    assert observed_reason == reason
+
+
+def test_retained_race_page_identity_rejects_non_numeric_native_race_id():
+    observed = JUMP - timedelta(minutes=20)
+    payload = json.loads(api_payload())
+    for quotes in payload["runner_odds"].values():
+        quotes[0]["market"]["race_id"] = "race-nine-thousand-one"
+    session = FakeSession(
+        server_time=observed,
+        api_body=json.dumps(payload).encode(),
+    )
+    race_page = TimedResponse(
+        requested_url=RACE_URL,
+        request_start_utc=observed - timedelta(milliseconds=100),
+        request_end_utc=observed,
+        final_url=RACE_URL,
+        status_code=200,
+        headers={
+            "content-type": "text/html; charset=utf-8",
+            "date": format_datetime(observed, usegmt=True),
+        },
+        body=source_html(),
+    )
+
+    with pytest.raises(CaptureError, match="native_race_identity_invalid"):
+        subject.capture_native_identity_from_retained_race_page(
+            session=session,
+            race_page=race_page,
+            expected_active_runner_boxes=[("101", 1), ("102", 2)],
+            expected_jump_utc=JUMP,
+            current_time=observed + timedelta(seconds=1),
+            clock=FakeClock(observed + timedelta(milliseconds=100)),
+        )
+
+
+def test_retained_race_page_identity_rejects_partial_native_race_id():
+    observed = JUMP - timedelta(minutes=20)
+    payload = json.loads(api_payload())
+    del payload["runner_odds"]["102"][0]["market"]["race_id"]
+    session = FakeSession(
+        server_time=observed,
+        api_body=json.dumps(payload).encode(),
+    )
+    race_page = TimedResponse(
+        requested_url=RACE_URL,
+        request_start_utc=observed - timedelta(milliseconds=100),
+        request_end_utc=observed,
+        final_url=RACE_URL,
+        status_code=200,
+        headers={
+            "content-type": "text/html; charset=utf-8",
+            "date": format_datetime(observed, usegmt=True),
+        },
+        body=source_html(),
+    )
+
+    with pytest.raises(CaptureError, match="native_race_identity_incomplete"):
+        subject.capture_native_identity_from_retained_race_page(
+            session=session,
+            race_page=race_page,
+            expected_active_runner_boxes=[("101", 1), ("102", 2)],
+            expected_jump_utc=JUMP,
+            current_time=observed + timedelta(seconds=1),
+            clock=FakeClock(observed + timedelta(milliseconds=100)),
+        )
+
+
+@pytest.mark.parametrize(
+    ("expected_runner_boxes", "reason"),
+    [
+        ([("101", 1)], "expected_active_runner_boxes_invalid"),
+        (
+            [("101", 1), ("101", 2)],
+            "expected_active_runner_boxes_invalid",
+        ),
+        (
+            [("101", 1), ("runner-two", 2)],
+            "expected_active_runner_boxes_invalid",
+        ),
+        (
+            [("101", 1), ("999", 2)],
+            "expected_native_runner_set_mismatch",
+        ),
+    ],
+)
+def test_retained_race_page_identity_rejects_partial_or_mismatched_runner_ids(
+    expected_runner_boxes,
+    reason,
+):
+    observed = JUMP - timedelta(minutes=20)
+    session = FakeSession(server_time=observed)
+    race_page = TimedResponse(
+        requested_url=RACE_URL,
+        request_start_utc=observed - timedelta(milliseconds=100),
+        request_end_utc=observed,
+        final_url=RACE_URL,
+        status_code=200,
+        headers={
+            "content-type": "text/html; charset=utf-8",
+            "date": format_datetime(observed, usegmt=True),
+        },
+        body=source_html(),
+    )
+
+    with pytest.raises(CaptureError, match=reason):
+        subject.capture_native_identity_from_retained_race_page(
+            session=session,
+            race_page=race_page,
+            expected_active_runner_boxes=expected_runner_boxes,
+            expected_jump_utc=JUMP,
+            current_time=observed + timedelta(seconds=1),
+            clock=FakeClock(observed + timedelta(milliseconds=100)),
+        )
+
+
+def test_retained_race_page_identity_rejects_ambiguous_native_race_id():
+    observed = JUMP - timedelta(minutes=20)
+    payload = json.loads(api_payload())
+    payload["runner_odds"]["102"][0]["market"]["race_id"] = 9002
+    session = FakeSession(
+        server_time=observed,
+        api_body=json.dumps(payload).encode(),
+    )
+    race_page = TimedResponse(
+        requested_url=RACE_URL,
+        request_start_utc=observed - timedelta(milliseconds=100),
+        request_end_utc=observed,
+        final_url=RACE_URL,
+        status_code=200,
+        headers={
+            "content-type": "text/html; charset=utf-8",
+            "date": format_datetime(observed, usegmt=True),
+        },
+        body=source_html(),
+    )
+
+    with pytest.raises(CaptureError, match="native_race_identity_not_unique"):
+        subject.capture_native_identity_from_retained_race_page(
+            session=session,
+            race_page=race_page,
+            expected_active_runner_boxes=[("101", 1), ("102", 2)],
+            expected_jump_utc=JUMP,
+            current_time=observed + timedelta(seconds=1),
+            clock=FakeClock(observed + timedelta(milliseconds=100)),
+        )
+
+
+def test_retained_race_page_identity_rejects_primary_effective_box_mismatch():
+    observed = JUMP - timedelta(minutes=20)
+    race_page = TimedResponse(
+        requested_url=RACE_URL,
+        request_start_utc=observed - timedelta(milliseconds=100),
+        request_end_utc=observed,
+        final_url=RACE_URL,
+        status_code=200,
+        headers={
+            "content-type": "text/html; charset=utf-8",
+            "date": format_datetime(observed, usegmt=True),
+        },
+        body=source_html(),
+    )
+
+    with pytest.raises(
+        CaptureError,
+        match="expected_native_runner_effective_box_mismatch",
+    ):
+        subject.capture_native_identity_from_retained_race_page(
+            session=FakeSession(server_time=observed),
+            race_page=race_page,
+            expected_active_runner_boxes=[("101", 1), ("102", 3)],
+            expected_jump_utc=JUMP,
+            current_time=observed + timedelta(seconds=1),
+            clock=FakeClock(observed + timedelta(milliseconds=100)),
+        )
+
+
+def test_retained_race_page_identity_rejects_stale_or_postjump_evidence():
+    observed = JUMP - timedelta(minutes=20)
+    race_page = TimedResponse(
+        requested_url=RACE_URL,
+        request_start_utc=observed - timedelta(milliseconds=100),
+        request_end_utc=observed,
+        final_url=RACE_URL,
+        status_code=200,
+        headers={
+            "content-type": "text/html; charset=utf-8",
+            "date": format_datetime(observed, usegmt=True),
+        },
+        body=source_html(),
+    )
+    with pytest.raises(CaptureError, match="native_identity_evidence_stale"):
+        subject.capture_native_identity_from_retained_race_page(
+            session=FakeSession(server_time=observed),
+            race_page=race_page,
+            expected_active_runner_boxes=[("101", 1), ("102", 2)],
+            expected_jump_utc=JUMP,
+            current_time=observed + timedelta(seconds=1201),
+            clock=FakeClock(observed + timedelta(milliseconds=100)),
+        )
+
+    with pytest.raises(CaptureError, match="capture_not_strictly_prejump"):
+        subject.capture_native_identity_from_retained_race_page(
+            session=FakeSession(server_time=JUMP),
+            race_page=race_page,
+            expected_active_runner_boxes=[("101", 1), ("102", 2)],
+            expected_jump_utc=JUMP,
+            current_time=observed + timedelta(seconds=1),
+            clock=FakeClock(JUMP),
+        )
 
 def test_native_odds_api_uses_frontend_xhr_request_header(tmp_path):
     _result, session = capture(tmp_path)

--- a/tests/test_csv_download_hardening.py
+++ b/tests/test_csv_download_hardening.py
@@ -1,9 +1,12 @@
+import hashlib
 import io
 import os
 import sys
 import types
 import tempfile
 import json
+from datetime import datetime, timezone
+from email.utils import format_datetime
 from pathlib import Path
 
 import pytest
@@ -165,7 +168,7 @@ def test_download_rejects_html_masquerading_as_csv(monkeypatch, _isolate_upcomin
     br = UpcomingRaceBrowser()
 
     # Patch link finder to return direct CSV content which is actually HTML
-    def _fake_find_csv_download_link(soup, race_url):
+    def _fake_find_csv_download_link(soup, race_url, **_kwargs):
         return {"type": "direct_csv", "data": "<html><body>Not CSV</body></html>"}
 
     monkeypatch.setattr(br, "find_csv_download_link", _fake_find_csv_download_link)
@@ -181,7 +184,7 @@ def test_download_rejects_html_masquerading_as_csv(monkeypatch, _isolate_upcomin
             pass
     
     fake_session = types.SimpleNamespace(
-        get=lambda url, timeout=30: _Resp(200, content=b"<html><title>Race 5</title></html>")
+        get=lambda url, timeout=30, **_kwargs: _Resp(200, content=b"<html><title>Race 5</title></html>")
     )
     monkeypatch.setattr(br, "session", fake_session)
 
@@ -201,7 +204,7 @@ def test_download_accepts_verified_thedogs_export_and_writes_pipe_file(monkeypat
     csv_content = REAL_COMMA_EXPORT.read_text(encoding="utf-8")
     sidecar = json.loads(REAL_COMMA_SIDECAR.read_text(encoding="utf-8"))
 
-    def _fake_find_csv_download_link(soup, race_url):
+    def _fake_find_csv_download_link(soup, race_url, **_kwargs):
         return {"type": "direct_csv", "data": csv_content}
 
     monkeypatch.setattr(br, "find_csv_download_link", _fake_find_csv_download_link)
@@ -234,7 +237,7 @@ def test_download_accepts_verified_thedogs_export_and_writes_pipe_file(monkeypat
             pass
 
     fake_session = types.SimpleNamespace(
-        get=lambda url, timeout=30: _Resp(200, content=b"<html><title>Race 5</title></html>")
+        get=lambda url, timeout=30, **_kwargs: _Resp(200, content=b"<html><title>Race 5</title></html>")
     )
     monkeypatch.setattr(br, "session", fake_session)
 
@@ -277,6 +280,240 @@ def _synthetic_thedogs_export(runners):
             ]
         )
     return "\n".join(",".join(row) for row in rows) + "\n"
+
+
+def test_primary_download_reallocates_duplicate_refetches_to_native_identity(
+    monkeypatch,
+    _isolate_upcoming_dir,
+):
+    from upcoming_race_browser import UpcomingRaceBrowser
+    from scripts.refresh_prejump_upcoming import (
+        current_index_metadata_selection,
+        sidecar_metadata_coverage,
+    )
+
+    jump = datetime(2099, 6, 9, 13, 15, tzinfo=timezone.utc)
+    race_url = "https://www.thedogs.com.au/racing/the-meadows/2099-06-09/1/test-race"
+    odds_url = f"{race_url}/odds"
+    expert_url = f"{race_url}/expert-form"
+    export_url = f"{expert_url}/export.csv"
+    race_html = f"""
+    <html><head><title>Race 1</title></head><body>
+      <formatted-time data-format="datetime_short" data-timestamp="{int(jump.timestamp())}">11:15 PM</formatted-time>
+      <section class="race-card"><dl>
+        <dt>Race Distance</dt><dd>400m</dd><dt>Race Grade</dt><dd>Maiden</dd>
+        <dt>Track Condition</dt><dd>Good</dd><dt>Weather</dt><dd>Fine</dd>
+      </dl></section>
+      <table class="race-runners">
+        <tbody data-content-url="/dogs/runner/159001/odds"><tr class="race-runner">
+          <td class="race-runners__box"><sprite-svg name="rug_1"></sprite-svg></td>
+          <td><div class="race-runners__name__dog">Alpha Runner<span>29.1</span></div></td>
+          <td><runner-odd data-runner-id="159001"></runner-odd></td>
+        </tr></tbody>
+        <tbody data-content-url="/dogs/runner/159002/odds"><tr class="race-runner">
+          <td class="race-runners__box"><sprite-svg name="rug_2"></sprite-svg></td>
+          <td><div class="race-runners__name__dog">Bravo Runner<span>29.2</span></div></td>
+          <td><runner-odd data-runner-id="159002"></runner-odd></td>
+        </tr></tbody>
+        <tbody data-content-url="/dogs/runner/159003/odds"><tr class="race-runner">
+          <td class="race-runners__box"><sprite-svg name="rug_3"></sprite-svg></td>
+          <td><div class="race-runners__name__dog">Charlie Runner<span>29.3</span></div></td>
+          <td><runner-odd data-runner-id="159003"></runner-odd></td>
+        </tr></tbody>
+        <tbody data-content-url="/dogs/runner/159004/odds"><tr class="race-runner">
+          <td class="race-runners__box"><sprite-svg name="rug_4"></sprite-svg></td>
+          <td><div class="race-runners__name__dog">Delta Runner<span>29.4</span></div></td>
+          <td><runner-odd data-runner-id="159004"></runner-odd></td>
+        </tr></tbody>
+      </table>
+    </body></html>
+    """.encode()
+    expert_html = f"""
+    <html><body><a href="{export_url}">Download CSV</a>
+      <div class="layout--sidebar--expert">
+        <div class="expert-form-runner__details__dog__name">Alpha Runner<span>(M)</span></div>
+      </div>
+    </body></html>
+    """.encode()
+    csv_content = _synthetic_thedogs_export(
+        [
+            (1, "Alpha Runner"),
+            (2, "Bravo Runner"),
+            (3, "Charlie Runner"),
+            (4, "Delta Runner"),
+        ]
+    )
+    api_url_prefix = "https://www.thedogs.com.au/api/runners/odds?"
+    api_body = json.dumps(
+        {
+            "runner_odds": {
+                runner_id: [
+                    {
+                        "runner_id": int(runner_id),
+                        "run_box": box,
+                        "price": 2.5 + box,
+                        "bookmaker": {"id": 63, "code": "ladbrokes", "name": "Ladbrokes"},
+                        "market": {"code": "fixed_win", "race_id": 15900},
+                    }
+                ]
+                for box, runner_id in (
+                    (1, "159001"),
+                    (2, "159002"),
+                    (3, "159003"),
+                    (4, "159004"),
+                )
+            }
+        },
+        sort_keys=True,
+    ).encode()
+
+    class Response:
+        def __init__(self, url, body, content_type):
+            self.url = url
+            self.content = body
+            self.text = body.decode()
+            self.status_code = 200
+            self.headers = {
+                "Content-Type": content_type,
+                "Date": format_datetime(datetime.now(timezone.utc), usegmt=True),
+                "Set-Cookie": "session=must-not-be-retained",
+            }
+
+        def close(self):
+            pass
+
+        def json(self):
+            return json.loads(self.text)
+
+    class Session:
+        def __init__(self):
+            self.calls = []
+
+        def get(self, url, **kwargs):
+            self.calls.append(url)
+            if url == race_url:
+                return Response(url, race_html, "text/html; charset=utf-8")
+            if url == expert_url:
+                return Response(url, expert_html, "text/html; charset=utf-8")
+            if url == export_url:
+                return Response(url, csv_content.encode(), "text/csv")
+            if url == odds_url:
+                return Response(url, race_html, "text/html; charset=utf-8")
+            if url.startswith(api_url_prefix):
+                return Response(url, api_body, "application/json; charset=utf-8")
+            if url.startswith("https://api.open-meteo.com/v1/forecast?"):
+                weather = {
+                    "hourly": {
+                        "time": ["2099-06-09T23:00"],
+                        "temperature_2m": [18.0],
+                        "relative_humidity_2m": [70],
+                        "precipitation": [0.0],
+                        "pressure_msl": [1014.0],
+                        "weather_code": [0],
+                        "wind_speed_10m": [12.0],
+                        "wind_direction_10m": [180],
+                        "visibility": [10000],
+                    }
+                }
+                return Response(url, json.dumps(weather).encode(), "application/json")
+            raise AssertionError(f"unexpected request: {url}")
+
+    browser = UpcomingRaceBrowser()
+    session = Session()
+    browser.session = session
+    result = browser.download_race_csv(
+        race_url,
+        race_info_hint={
+            "url": race_url,
+            "date": "2099-06-09",
+            "venue": "MEA",
+            "race_number": 1,
+            "jump_datetime": jump.isoformat(),
+        },
+    )
+
+    assert result["success"] is True, result
+    assert session.calls[0] == race_url
+    assert session.calls[1].startswith("https://api.open-meteo.com/v1/forecast?")
+    assert len(session.calls) == 6
+    assert session.calls[2:5] == [expert_url, export_url, odds_url]
+    assert session.calls[-1].startswith(api_url_prefix)
+    assert session.calls.count(race_url) == 1
+    assert session.calls.count(expert_url) == 1
+    sidecar = json.loads(Path(f"{result['filepath']}.metadata.json").read_text())
+    assert sidecar["source_native_race_id"] == "15900"
+    evidence = sidecar["native_identity_evidence"]
+    assert evidence["active_native_runner_ids"] == [
+        "159001",
+        "159002",
+        "159003",
+        "159004",
+    ]
+    assert evidence["request_accounting"]["logical_requests"] == 2
+    evidence_core = {
+        key: value for key, value in evidence.items() if key != "evidence_sha256"
+    }
+    assert evidence["evidence_sha256"] == hashlib.sha256(
+        json.dumps(
+            evidence_core,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode()
+    ).hexdigest()
+    assert evidence["odds_page_http"]["body_sha256"]
+    assert evidence["odds_api_http"]["body_sha256"]
+    assert "set-cookie" not in evidence["race_page_http"]["headers"]
+    assert sidecar["expert_form_metadata"]["source_final_url"] == expert_url
+    assert sidecar["expert_form_metadata"]["source_sha256"] == hashlib.sha256(
+        expert_html
+    ).hexdigest()
+    assert sidecar["prejump_shadow_metadata"]["source_native_race_id"] == "15900"
+    selected = [
+        {
+            "race_id": "Race 1 - MEA - 2099-06-09",
+            "race_id_aliases": ["Race 1 - MEA - 2099-06-09"],
+            "race_url": race_url,
+            "race_number": 1,
+            "venue": "MEA",
+            "date": "2099-06-09",
+            "jump_datetime": jump.isoformat(),
+        }
+    ]
+    coverage = sidecar_metadata_coverage(Path(browser.upcoming_dir), selected)
+    identity_coverage = json.loads(json.dumps(coverage))
+    identity_coverage["races"][0].update(
+        {
+            "safe_weather_present": True,
+            "safe_track_condition_present": True,
+            "safe_expert_form_present": True,
+            "safe_all_weather_track_expert_form_present": True,
+        }
+    )
+    eligible, selection = current_index_metadata_selection(
+        selected,
+        identity_coverage,
+        source_generated_at=datetime.now(timezone.utc),
+    )
+    assert selection["status"] == "READY", (selection, identity_coverage)
+    assert eligible[0]["source_native_race_id"] == "15900"
+
+    verified_sidecar = json.loads(json.dumps(sidecar))
+    sidecar["native_identity_evidence"]["source_native_race_id"] = "15999"
+    Path(f"{result['filepath']}.metadata.json").write_text(json.dumps(sidecar))
+    tampered = sidecar_metadata_coverage(Path(browser.upcoming_dir), selected)
+    assert tampered["races"][0]["source_native_race_id"] is None
+    assert tampered["races"][0]["source_native_runner_ids"] == []
+
+    del verified_sidecar["native_identity_evidence"]
+    Path(f"{result['filepath']}.metadata.json").write_text(
+        json.dumps(verified_sidecar)
+    )
+    missing = sidecar_metadata_coverage(Path(browser.upcoming_dir), selected)
+    assert missing["races"][0]["source_native_race_id"] is None
+    assert missing["races"][0]["native_identity_evidence_reason"] == (
+        "native_identity_evidence_missing"
+    )
 
 
 def _canonical_runner_set_for_test(race_url, runners):
@@ -340,7 +577,7 @@ def test_download_refreshes_existing_csv_with_stale_sidecar_contract(
     monkeypatch.setattr(
         br,
         "find_csv_download_link",
-        lambda soup, url: {"type": "direct_csv", "data": csv_content},
+        lambda soup, url, **_kwargs: {"type": "direct_csv", "data": csv_content},
     )
     monkeypatch.setattr(
         br,
@@ -365,8 +602,10 @@ def test_download_refreshes_existing_csv_with_stale_sidecar_contract(
     )
     monkeypatch.setattr(
         browser_module,
-        "fetch_canonical_runner_set",
-        lambda url, session=None: _canonical_runner_set_for_test(url, runners),
+        "extract_canonical_runner_set_from_html",
+        lambda html, source_url=None, **_kwargs: _canonical_runner_set_for_test(
+            source_url, runners
+        ),
     )
 
     class _Resp:
@@ -381,7 +620,7 @@ def test_download_refreshes_existing_csv_with_stale_sidecar_contract(
     monkeypatch.setattr(
         br,
         "session",
-        types.SimpleNamespace(get=lambda url, timeout=30: _Resp()),
+        types.SimpleNamespace(get=lambda url, timeout=30, **_kwargs: _Resp()),
     )
 
     result = br.download_race_csv(
@@ -476,7 +715,9 @@ def test_download_fallback_quarantines_csv_without_valid_prejump_sidecar(
     race_url = "https://www.thedogs.com.au/racing/test/2026-06-09/1/test?trial=false"
     filename = "Race 1 - TEST - 2026-06-09.csv"
 
-    monkeypatch.setattr(br, "find_csv_download_link", lambda soup, url: None)
+    monkeypatch.setattr(
+        br, "find_csv_download_link", lambda soup, url, **_kwargs: None
+    )
     monkeypatch.setattr(
         br,
         "extract_detailed_race_info",
@@ -514,7 +755,7 @@ def test_download_fallback_quarantines_csv_without_valid_prejump_sidecar(
     monkeypatch.setattr(
         br,
         "session",
-        types.SimpleNamespace(get=lambda url, timeout=30: _Resp()),
+        types.SimpleNamespace(get=lambda url, timeout=30, **_kwargs: _Resp()),
     )
 
     class _FakeExpertFormCsvScraper:
@@ -567,7 +808,10 @@ def test_download_pdf_masquerading_as_csv_tries_expert_form_fallback(
     monkeypatch.setattr(
         br,
         "find_csv_download_link",
-        lambda soup, url: {"type": "direct_csv", "data": "%PDF-1.5\nnot a csv\n"},
+        lambda soup, url, **_kwargs: {
+            "type": "direct_csv",
+            "data": "%PDF-1.5\nnot a csv\n",
+        },
     )
     monkeypatch.setattr(
         br,
@@ -619,7 +863,7 @@ def test_download_pdf_masquerading_as_csv_tries_expert_form_fallback(
     monkeypatch.setattr(
         br,
         "session",
-        types.SimpleNamespace(get=lambda url, timeout=30: _Resp()),
+        types.SimpleNamespace(get=lambda url, timeout=30, **_kwargs: _Resp()),
     )
 
     calls = []
@@ -724,7 +968,7 @@ def test_download_rejects_partial_runner_set(monkeypatch, _isolate_upcoming_dir)
     br = UpcomingRaceBrowser()
     csv_content = "Dog Name,Box\n2. Shima Lexie,2\n4. Sekiro,4\n"
 
-    def _fake_find_csv_download_link(soup, race_url):
+    def _fake_find_csv_download_link(soup, race_url, **_kwargs):
         return {"type": "direct_csv", "data": csv_content}
 
     monkeypatch.setattr(br, "find_csv_download_link", _fake_find_csv_download_link)
@@ -740,7 +984,7 @@ def test_download_rejects_partial_runner_set(monkeypatch, _isolate_upcoming_dir)
             pass
 
     fake_session = types.SimpleNamespace(
-        get=lambda url, timeout=30: _Resp(200, content=b"<html><title>Race 5</title></html>")
+        get=lambda url, timeout=30, **_kwargs: _Resp(200, content=b"<html><title>Race 5</title></html>")
     )
     monkeypatch.setattr(br, "session", fake_session)
 

--- a/tests/test_prejump_prediction_loop.py
+++ b/tests/test_prejump_prediction_loop.py
@@ -701,6 +701,7 @@ def test_refresh_prejump_upcoming_reports_top_level_artifact_counts(tmp_path, mo
                     "https://www.thedogs.com.au/racing/2026-05-29"
                 ),
                 "target_grade_source_sha256": "c" * 64,
+                "jump_datetime": "2026-05-29T13:45:00+10:00",
             }
             upcoming_dir = tmp_path / "upcoming"
             csv_path = upcoming_dir / "Race 1 - TEST - 2026-05-29.csv"

--- a/upcoming_race_browser.py
+++ b/upcoming_race_browser.py
@@ -16,7 +16,7 @@ import os
 import re
 import sys
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import urljoin, urlsplit
 
@@ -29,9 +29,15 @@ except Exception as _bs4_import_error:
 from utils.http_client import get_shared_session
 from utils.runner_completeness import (
     analyze_csv_text_runner_completeness,
-    fetch_canonical_runner_set,
+    extract_canonical_runner_set_from_html,
     quarantine_csv_content,
     quarantine_existing_file,
+)
+from scripts.capture_thedogs_market_history import (
+    CaptureError as NativeIdentityCaptureError,
+    TimedResponse,
+    bounded_receipt_headers,
+    capture_native_identity_from_retained_race_page,
 )
 from utils.csv_metadata import (
     THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE,
@@ -1951,6 +1957,12 @@ class UpcomingRaceBrowser:
     def _collect_expert_form_metadata(self, race_url, race_info):
         """Collect structured Expert Form page metadata for the CSV sidecar."""
 
+        metadata, _soup = self._fetch_expert_form_artifact(race_url, race_info)
+        return metadata
+
+    def _fetch_expert_form_artifact(self, race_url, race_info):
+        """Fetch one Expert Form response for metadata and export discovery."""
+
         base_race_url, expert_form_url = self._normalize_race_url(race_url)
         response = None
         try:
@@ -1980,12 +1992,38 @@ class UpcomingRaceBrowser:
                     "rejected_reasons": [
                         f"expert_form_source_fetch_failed:{response.status_code}"
                     ],
-                }
-            return build_expert_form_metadata_payload(
+                }, None
+            final_url = str(getattr(response, "url", expert_form_url) or "")
+            if final_url != expert_form_url:
+                return {
+                    "schema_version": "thedogs_expert_form_metadata_v1",
+                    "source": "thedogs_expert_form_page",
+                    "source_url": expert_form_url,
+                    "source_final_url": final_url,
+                    "metadata_is_leakage_safe": False,
+                    "runner_count": 0,
+                    "runners": [],
+                    "rejected_reasons": [
+                        "expert_form_source_redirect_or_url_mismatch"
+                    ],
+                }, None
+            body = bytes(response.content)
+            captured_at = datetime.now(timezone.utc)
+            metadata = build_expert_form_metadata_payload(
                 response.text,
                 race_info=race_info,
                 source_url=expert_form_url,
+                captured_at=captured_at,
             )
+            metadata.update(
+                {
+                    "source_final_url": final_url,
+                    "source_sha256": hashlib.sha256(body).hexdigest(),
+                    "source_bytes": len(body),
+                }
+            )
+            expert_soup = bs4.BeautifulSoup(body, "html.parser") if bs4 else None
+            return metadata, expert_soup
         except Exception as exc:
             return {
                 "schema_version": "thedogs_expert_form_metadata_v1",
@@ -1997,7 +2035,7 @@ class UpcomingRaceBrowser:
                 "rejected_reasons": [
                     f"expert_form_source_fetch_failed:{type(exc).__name__}"
                 ],
-            }
+            }, None
         finally:
             if response is not None:
                 try:
@@ -2012,8 +2050,16 @@ class UpcomingRaceBrowser:
 
             # Get race page
             response = None
+            race_request_start = datetime.now(timezone.utc)
+            retained_race_page = None
             try:
-                response = self.session.get(race_url, timeout=30)
+                response = self.session.get(
+                    race_url,
+                    timeout=30,
+                    headers={"Accept-Encoding": "identity"},
+                    allow_redirects=False,
+                )
+                race_request_end = datetime.now(timezone.utc)
 
                 if response.status_code == 404:
                     return {
@@ -2030,6 +2076,17 @@ class UpcomingRaceBrowser:
                     raise RuntimeError("BeautifulSoup (bs4) is required. Install with 'pip install beautifulsoup4'.")
                 race_page_content = response.content
                 race_page_sha256 = hashlib.sha256(race_page_content).hexdigest()
+                retained_race_page = TimedResponse(
+                    requested_url=race_url,
+                    request_start_utc=race_request_start,
+                    request_end_utc=race_request_end,
+                    final_url=str(getattr(response, "url", race_url) or ""),
+                    status_code=int(response.status_code),
+                    headers=bounded_receipt_headers(
+                        dict(getattr(response, "headers", {}) or {})
+                    ),
+                    body=bytes(race_page_content),
+                )
                 soup = bs4.BeautifulSoup(race_page_content, "html.parser")
             finally:
                 if response is not None:
@@ -2078,10 +2135,11 @@ class UpcomingRaceBrowser:
                 race_info,
                 self._collect_safe_weather_metadata_from_forecast(race_info)
             )
-            race_info["expert_form_metadata"] = self._collect_expert_form_metadata(
+            expert_form_metadata, retained_expert_soup = self._fetch_expert_form_artifact(
                 race_url,
                 {**race_info, "url": race_url},
             )
+            race_info["expert_form_metadata"] = expert_form_metadata
 
             # Generate filename
             filename = f"Race {race_info['race_number']} - {race_info['venue']} - {race_info['date']}.csv"
@@ -2112,7 +2170,11 @@ class UpcomingRaceBrowser:
                 )
 
             # Find CSV download link
-            csv_info = self.find_csv_download_link(soup, race_url)
+            csv_info = self.find_csv_download_link(
+                soup,
+                race_url,
+                retained_expert_soup=retained_expert_soup,
+            )
 
             if not csv_info:
                 fallback = self._try_expert_form_fallback(
@@ -2260,10 +2322,55 @@ class UpcomingRaceBrowser:
                 filename=filename,
                 allow_generic_fields=False,
             )
-            canonical_runner_set = fetch_canonical_runner_set(
-                race_url,
-                session=self.session,
+            canonical_runner_set = extract_canonical_runner_set_from_html(
+                race_page_content.decode("utf-8", errors="strict"),
+                source_url=race_url,
+                expected_race_number=int(race_info["race_number"]),
+                extraction_timestamp=retained_race_page.request_end_utc.isoformat(),
             )
+            expected_native_runner_boxes = [
+                (
+                    participant.get("source_native_runner_id"),
+                    participant.get("box_number"),
+                )
+                for participant in canonical_runner_set.get(
+                    "final_runner_participants", []
+                )
+                if isinstance(participant, dict)
+            ]
+            if (
+                canonical_runner_set.get("canonical_runner_set_status") == "available"
+                and canonical_runner_set.get("native_identity_status") != "available"
+                and expected_native_runner_boxes
+                and race_info_hint
+                and race_info_hint.get("jump_datetime")
+            ):
+                try:
+                    expected_jump = datetime.fromisoformat(
+                        str(race_info_hint["jump_datetime"])
+                    )
+                    identity_evidence = capture_native_identity_from_retained_race_page(
+                        session=self.session,
+                        race_page=retained_race_page,
+                        expected_active_runner_boxes=expected_native_runner_boxes,
+                        expected_jump_utc=expected_jump,
+                        current_time=datetime.now(timezone.utc),
+                    )
+                except (NativeIdentityCaptureError, UnicodeError, ValueError) as exc:
+                    canonical_runner_set["native_identity_reasons"] = [
+                        f"native_identity_evidence_rejected:{exc}"
+                    ]
+                else:
+                    canonical_runner_set.update(
+                        {
+                            "source_native_race_id": identity_evidence[
+                                "source_native_race_id"
+                            ],
+                            "native_identity_status": "available",
+                            "native_identity_reasons": [],
+                            "native_identity_evidence": identity_evidence,
+                        }
+                    )
             normalization = normalize_verified_thedogs_export_content(
                 content,
                 accepted_csv_path=filepath,
@@ -2426,7 +2533,7 @@ class UpcomingRaceBrowser:
             print(f"   ❌ Error extracting race info: {e}")
             return None
 
-    def find_csv_download_link(self, soup, race_url):
+    def find_csv_download_link(self, soup, race_url, *, retained_expert_soup=False):
         """Find CSV download link on the race page"""
         try:
             # Try the expert-form page method first (normalized)
@@ -2434,39 +2541,42 @@ class UpcomingRaceBrowser:
 
             print(f"   🔍 Trying expert-form URL: {expert_form_url}")
             response = None
-            try:
-                # Include Referer and browser-like headers to avoid 403 blocks
-                response = self.session.get(
-                    expert_form_url,
-                    timeout=15,
-                    headers={
-                        "Referer": base_race_url,
-                        "Origin": self.base_url,
-                        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-                        "Accept-Language": "en-US,en;q=0.9",
-                        "Upgrade-Insecure-Requests": "1",
-                        "Sec-Fetch-Site": "same-origin",
-                        "Sec-Fetch-Mode": "navigate",
-                        "Sec-Fetch-Dest": "document",
-                        "DNT": "1",
-                    },
-                )
-
-                if response.status_code == 200:
-                    if bs4 is None:
-                        raise RuntimeError("BeautifulSoup (bs4) is required. Install with 'pip install beautifulsoup4'.")
-                    expert_soup = bs4.BeautifulSoup(response.content, "html.parser")
-                else:
-                    print(
-                        f"   ❌ Expert-form page not accessible: {response.status_code}"
+            if retained_expert_soup is not False:
+                expert_soup = retained_expert_soup
+            else:
+                try:
+                    # Include Referer and browser-like headers to avoid 403 blocks.
+                    response = self.session.get(
+                        expert_form_url,
+                        timeout=15,
+                        headers={
+                            "Referer": base_race_url,
+                            "Origin": self.base_url,
+                            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+                            "Accept-Language": "en-US,en;q=0.9",
+                            "Upgrade-Insecure-Requests": "1",
+                            "Sec-Fetch-Site": "same-origin",
+                            "Sec-Fetch-Mode": "navigate",
+                            "Sec-Fetch-Dest": "document",
+                            "DNT": "1",
+                        },
                     )
-                    expert_soup = None
-            finally:
-                if response is not None:
-                    try:
-                        response.close()
-                    except Exception:
-                        pass
+
+                    if response.status_code == 200:
+                        if bs4 is None:
+                            raise RuntimeError("BeautifulSoup (bs4) is required. Install with 'pip install beautifulsoup4'.")
+                        expert_soup = bs4.BeautifulSoup(response.content, "html.parser")
+                    else:
+                        print(
+                            f"   ❌ Expert-form page not accessible: {response.status_code}"
+                        )
+                        expert_soup = None
+                finally:
+                    if response is not None:
+                        try:
+                            response.close()
+                        except Exception:
+                            pass
 
             if expert_soup:
                 # Method 1: Look for direct CSV download links

--- a/utils/csv_metadata.py
+++ b/utils/csv_metadata.py
@@ -1735,6 +1735,9 @@ def build_prejump_shadow_metadata_payload(payload: Mapping[str, Any]) -> Dict[st
         "target_grade_source": str(grade_source) if grade_source not in (None, "") else None,
         "source_url": str(source_url) if source_url not in (None, "") else None,
         "source_native_race_id": payload.get("source_native_race_id"),
+        "source_native_identity_origin": payload.get(
+            "source_native_identity_origin"
+        ),
         "runner_box_name_list": participants,
         "canonical_final_runner_alignment": {
             "status": alignment.get("status"),
@@ -1805,6 +1808,14 @@ def normalize_verified_thedogs_export_content(
             base["source_native_race_id"] = canonical_runner_set.get(
                 "source_native_race_id"
             )
+            native_identity_evidence = canonical_runner_set.get(
+                "native_identity_evidence"
+            )
+            if isinstance(native_identity_evidence, Mapping):
+                base["native_identity_evidence"] = dict(native_identity_evidence)
+                base["source_native_identity_origin"] = (
+                    "thedogs_odds_api_exact_runner_set"
+                )
         if canonical_alignment.get("status") == "aligned":
             content_for_normalization = aligned_content
             effective_delimiter = (


### PR DESCRIPTION
## Summary

- reuse the retained primary race page and Expert Form response instead of refetching each
- reallocate those two logical requests to the exact TheDogs `/odds` and `/api/runners/odds` identity chain
- bind numeric `market.race_id` only through exact active native runner-ID/effective-box equality and strict pre-jump provenance
- revalidate embedded response bytes, hashes, timestamps, provider, runner projection, and bounded headers before current-index eligibility
- leave primary as the sole current-index publisher; odds-only behavior is unchanged

## Request accounting

The two removed logical GETs and two added logical GETs use the same shared retry policy (`Retry(total=2)`). Fixed per-race requests remain 6 logical / 18 worst-case wire attempts in the covered natural-primary path. Discovery, Sportsbet, weather, export fallbacks, timers, and acquisition horizons are unchanged. Acquisition-call delta: 0.

## Validation

- 293 passed, 1 skipped across focused capture/parser/export/refresh/index/baseline/daemon/deployment tests
- `py_compile` on changed Python paths
- focused Flake8 fatal checks
- all tracked JSON parsed with `jq empty`
- `git diff --check`
- independent Standards review: PASS
- independent Spec review: PASS

No live calls, deployment, prediction, result access, model changes, scheduler changes, or database activation.