### PR TITLE
Persist primary race-page evidence

### DIFF
--- a/scripts/capture_thedogs_market_history.py
+++ b/scripts/capture_thedogs_market_history.py
@@ -37,6 +37,7 @@ SCHEMA_VERSION = "thedogs_market_snapshot_receipt_v2"
 RECEIPT_SCHEMA_VERSIONS = frozenset({LEGACY_SCHEMA_VERSION, SCHEMA_VERSION})
 PLAN_SCHEMA_VERSION = "thedogs_market_snapshot_plan_v1"
 SOURCE_CLASS = "thedogs_prospective_point_in_time_market_history"
+PRIMARY_RACE_PAGE_EVIDENCE_SCHEMA_VERSION = "thedogs_primary_race_page_evidence_v1"
 NOMINAL_WINDOWS_MINUTES = (120, 60, 30, 10, 2)
 NOMINAL_WINDOWS = tuple(f"T-{minutes}" for minutes in NOMINAL_WINDOWS_MINUTES)
 DEFAULT_EARLY_TOLERANCE_SECONDS = 30
@@ -968,6 +969,224 @@ def _write_new_immutable(path: Path, payload: bytes) -> None:
         except OSError:
             pass
         raise
+
+
+def _primary_runner_extraction_summary(
+    canonical_runner_set: Mapping[str, Any],
+) -> dict[str, Any]:
+    participants = [
+        row
+        for row in canonical_runner_set.get("final_runner_participants", [])
+        if isinstance(row, Mapping)
+    ]
+    native_ids = [
+        str(row.get("source_native_runner_id") or "").strip()
+        for row in participants
+    ]
+    numeric_ids = [
+        value for value in native_ids if value.isascii() and value.isdecimal()
+    ]
+    return {
+        "schema_version": str(
+            canonical_runner_set.get("schema_version")
+            or "canonical_pre_race_runner_set_v1"
+        ),
+        "status": str(
+            canonical_runner_set.get("canonical_runner_set_status") or "unavailable"
+        ),
+        "native_identity_status": str(
+            canonical_runner_set.get("native_identity_status") or "unavailable"
+        ),
+        "native_identity_reasons": list(
+            canonical_runner_set.get("native_identity_reasons") or []
+        ),
+        "active_runner_count": len(participants),
+        "numeric_native_runner_id_count": len(numeric_ids),
+        "numeric_native_runner_ids_complete": bool(participants)
+        and len(numeric_ids) == len(participants)
+        and len(set(numeric_ids)) == len(numeric_ids),
+    }
+
+
+def _primary_evidence_directory(artifact_root: Path) -> tuple[Path, Path]:
+    try:
+        root = Path(artifact_root).resolve(strict=True)
+    except OSError as exc:
+        raise CaptureError("primary_race_page_artifact_root_invalid") from exc
+    if not root.is_dir():
+        raise CaptureError("primary_race_page_artifact_root_invalid")
+    current = root
+    for component in ("source_evidence", "primary_race_pages"):
+        current = current / component
+        try:
+            current.mkdir(mode=0o755)
+        except FileExistsError:
+            pass
+        if current.is_symlink() or not current.is_dir():
+            raise CaptureError("primary_race_page_evidence_path_invalid")
+        try:
+            resolved = current.resolve(strict=True)
+        except OSError as exc:
+            raise CaptureError("primary_race_page_evidence_path_invalid") from exc
+        if root not in resolved.parents:
+            raise CaptureError("primary_race_page_evidence_path_invalid")
+        current = resolved
+    return root, current
+
+
+def _write_or_verify_immutable(path: Path, payload: bytes, *, collision: str) -> None:
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        directory_flags |= os.O_NOFOLLOW
+    try:
+        directory_fd = os.open(path.parent, directory_flags)
+    except OSError as exc:
+        raise CaptureError("primary_race_page_evidence_path_invalid") from exc
+    file_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        file_flags |= os.O_NOFOLLOW
+    try:
+        try:
+            descriptor = os.open(
+                path.name,
+                file_flags,
+                0o444,
+                dir_fd=directory_fd,
+            )
+        except FileExistsError:
+            read_flags = os.O_RDONLY
+            if hasattr(os, "O_NOFOLLOW"):
+                read_flags |= os.O_NOFOLLOW
+            try:
+                descriptor = os.open(path.name, read_flags, dir_fd=directory_fd)
+            except OSError as exc:
+                raise CaptureError(collision) from exc
+            try:
+                if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+                    raise CaptureError(collision)
+                with os.fdopen(descriptor, "rb") as handle:
+                    descriptor = -1
+                    existing = handle.read()
+            finally:
+                if descriptor >= 0:
+                    os.close(descriptor)
+            if existing != payload:
+                raise CaptureError(collision)
+            return
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except Exception:
+            try:
+                os.unlink(path.name, dir_fd=directory_fd)
+            except OSError:
+                pass
+            raise
+    finally:
+        os.close(directory_fd)
+
+
+def persist_primary_race_page_evidence(
+    *,
+    artifact_root: Path,
+    race_discovery_key: str,
+    response: TimedResponse,
+    canonical_runner_set: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Persist an already-fetched primary race page without another request."""
+
+    discovery_key = str(race_discovery_key or "").strip()
+    if not discovery_key:
+        raise CaptureError("primary_race_page_discovery_key_required")
+    root, evidence_dir = _primary_evidence_directory(Path(artifact_root))
+    body_sha256 = sha256_bytes(response.body)
+    raw_path = evidence_dir / f"{body_sha256}.race-page.html"
+    raw_relative_path = raw_path.relative_to(root).as_posix()
+    receipt: dict[str, Any] = {
+        "schema_version": PRIMARY_RACE_PAGE_EVIDENCE_SCHEMA_VERSION,
+        "source": "thedogs_primary_race_page",
+        "provider": "thedogs",
+        "race_discovery_key": discovery_key,
+        "requested_url": response.requested_url,
+        "final_url": response.final_url,
+        "request_start_utc": iso_utc(response.request_start_utc),
+        "request_end_utc": iso_utc(response.request_end_utc),
+        "capture_timestamp": iso_utc(response.request_end_utc),
+        "status_code": response.status_code,
+        "headers": bounded_receipt_headers(response.headers),
+        "content_length": len(response.body),
+        "body_sha256": body_sha256,
+        "raw_path": raw_relative_path,
+        "canonical_runner_extraction": _primary_runner_extraction_summary(
+            canonical_runner_set
+        ),
+    }
+    receipt["receipt_core_sha256"] = sha256_bytes(canonical_json_bytes(receipt))
+    receipt_path = (
+        evidence_dir
+        / f"{receipt['receipt_core_sha256']}.race-page.receipt.json"
+    )
+    receipt_bytes = serialized_json_bytes(receipt)
+    _write_or_verify_immutable(
+        raw_path,
+        response.body,
+        collision="primary_race_page_body_hash_collision",
+    )
+    _write_or_verify_immutable(
+        receipt_path,
+        receipt_bytes,
+        collision="primary_race_page_receipt_hash_collision",
+    )
+    return {
+        "schema_version": PRIMARY_RACE_PAGE_EVIDENCE_SCHEMA_VERSION,
+        "raw_path": raw_relative_path,
+        "receipt_path": receipt_path.relative_to(root).as_posix(),
+        "body_sha256": receipt["body_sha256"],
+        "receipt_sha256": sha256_bytes(receipt_bytes),
+    }
+
+
+def verify_primary_race_page_evidence(
+    *, artifact_root: Path, reference: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Verify the immutable primary page reference, receipt, and exact bytes."""
+
+    root = Path(artifact_root).resolve()
+    try:
+        raw_candidate = root / str(reference["raw_path"])
+        receipt_candidate = root / str(reference["receipt_path"])
+        if raw_candidate.is_symlink() or receipt_candidate.is_symlink():
+            raise CaptureError("primary_race_page_evidence_path_invalid")
+        raw_path = raw_candidate.resolve(strict=True)
+        receipt_path = receipt_candidate.resolve(strict=True)
+    except (KeyError, OSError) as exc:
+        raise CaptureError("primary_race_page_evidence_missing") from exc
+    if root not in raw_path.parents or root not in receipt_path.parents:
+        raise CaptureError("primary_race_page_evidence_path_invalid")
+    raw_bytes = raw_path.read_bytes()
+    receipt_bytes = receipt_path.read_bytes()
+    if sha256_bytes(receipt_bytes) != str(reference.get("receipt_sha256") or ""):
+        raise CaptureError("primary_race_page_receipt_hash_mismatch")
+    try:
+        receipt = json.loads(receipt_bytes.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise CaptureError("primary_race_page_receipt_invalid") from exc
+    if not isinstance(receipt, Mapping):
+        raise CaptureError("primary_race_page_receipt_invalid")
+    receipt_core = dict(receipt)
+    recorded_core_hash = str(receipt_core.pop("receipt_core_sha256", ""))
+    if sha256_bytes(canonical_json_bytes(receipt_core)) != recorded_core_hash:
+        raise CaptureError("primary_race_page_receipt_core_hash_mismatch")
+    raw_hash = sha256_bytes(raw_bytes)
+    if raw_hash != str(receipt.get("body_sha256") or "") or raw_hash != str(
+        reference.get("body_sha256") or ""
+    ):
+        raise CaptureError("primary_race_page_body_hash_mismatch")
+    if len(raw_bytes) != receipt.get("content_length"):
+        raise CaptureError("primary_race_page_body_length_mismatch")
+    return dict(receipt)
 
 
 def _stored_response(

--- a/scripts/refresh_prejump_upcoming.py
+++ b/scripts/refresh_prejump_upcoming.py
@@ -847,6 +847,7 @@ def refresh_prejump_upcoming(args: argparse.Namespace) -> dict[str, Any]:
                 race_url,
                 race_info_hint={
                     **dict(race),
+                    "race_discovery_key": selected_record.get("race_id"),
                     "jump_datetime": selected_record.get("jump_datetime"),
                 },
             )

--- a/tests/test_capture_thedogs_market_history.py
+++ b/tests/test_capture_thedogs_market_history.py
@@ -12,14 +12,126 @@ from scripts.capture_thedogs_market_history import (
     canonical_json_bytes,
     capture_snapshot,
     parse_source_runners,
+    persist_primary_race_page_evidence,
     sha256_bytes,
     validate_response,
+    verify_primary_race_page_evidence,
 )
 
 RACE_ID = "race-immutable-0001"
 RACE_URL = "https://www.thedogs.com.au/racing/meadows/2026-06-01/1/test-race"
 ODDS_URL = f"{RACE_URL}/odds"
 JUMP = datetime(2026, 6, 1, 1, 0, tzinfo=timezone.utc)
+
+
+def test_primary_race_page_evidence_is_manifested_and_detects_mutation(tmp_path):
+    from scripts.shadow_autopilot_daemon import output_manifest
+
+    observed = JUMP - timedelta(minutes=20)
+    body = b"\x00<html>exact primary bytes\r\n</html>\xff"
+    response = TimedResponse(
+        requested_url=RACE_URL,
+        request_start_utc=observed - timedelta(milliseconds=100),
+        request_end_utc=observed,
+        final_url=RACE_URL,
+        status_code=200,
+        headers={
+            "Content-Type": "text/html; charset=utf-8",
+            "Date": format_datetime(observed, usegmt=True),
+            "Set-Cookie": "secret=never-persist",
+            "Authorization": "Bearer never-persist",
+        },
+        body=body,
+    )
+    canonical = {
+        "schema_version": "canonical_pre_race_runner_set_v1",
+        "canonical_runner_set_status": "unavailable",
+        "final_runner_participants": [],
+        "native_identity_status": "unavailable",
+        "native_identity_reasons": ["no_race_runner_rows"],
+    }
+
+    reference = persist_primary_race_page_evidence(
+        artifact_root=tmp_path,
+        race_discovery_key="Race 1 - MEA - 2026-06-01",
+        response=response,
+        canonical_runner_set=canonical,
+    )
+
+    raw_path = tmp_path / reference["raw_path"]
+    receipt_path = tmp_path / reference["receipt_path"]
+    assert raw_path.read_bytes() == body
+    receipt = verify_primary_race_page_evidence(
+        artifact_root=tmp_path,
+        reference=reference,
+    )
+    assert receipt["headers"] == {
+        "content-type": "text/html; charset=utf-8",
+        "date": format_datetime(observed, usegmt=True),
+    }
+    assert receipt["canonical_runner_extraction"] == {
+        "active_runner_count": 0,
+        "native_identity_reasons": ["no_race_runner_rows"],
+        "native_identity_status": "unavailable",
+        "numeric_native_runner_id_count": 0,
+        "numeric_native_runner_ids_complete": False,
+        "schema_version": "canonical_pre_race_runner_set_v1",
+        "status": "unavailable",
+    }
+    manifest = output_manifest(tmp_path)
+    raw_manifest = next(
+        value
+        for name, value in manifest["files"].items()
+        if name.endswith(reference["raw_path"])
+    )
+    receipt_manifest = next(
+        value
+        for name, value in manifest["files"].items()
+        if name.endswith(reference["receipt_path"])
+    )
+    assert raw_manifest == {"bytes": len(body), "sha256": sha256_bytes(body)}
+    assert receipt_manifest["sha256"] == reference["receipt_sha256"]
+    repeated_reference = persist_primary_race_page_evidence(
+        artifact_root=tmp_path,
+        race_discovery_key="Race 1 - MEA - 2026-06-01",
+        response=response,
+        canonical_runner_set=canonical,
+    )
+    assert repeated_reference == reference
+    assert raw_path.read_bytes() == body
+
+    raw_path.chmod(0o644)
+    raw_path.write_bytes(body + b"mutated")
+    with pytest.raises(CaptureError, match="primary_race_page_body_hash_mismatch"):
+        verify_primary_race_page_evidence(
+            artifact_root=tmp_path,
+            reference=reference,
+        )
+
+
+def test_primary_race_page_evidence_rejects_symlinked_parent(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (tmp_path / "source_evidence").symlink_to(outside, target_is_directory=True)
+    observed = JUMP - timedelta(minutes=20)
+    response = TimedResponse(
+        requested_url=RACE_URL,
+        request_start_utc=observed - timedelta(milliseconds=100),
+        request_end_utc=observed,
+        final_url=RACE_URL,
+        status_code=200,
+        headers={},
+        body=b"exact bytes",
+    )
+
+    with pytest.raises(CaptureError, match="primary_race_page_evidence_path_invalid"):
+        persist_primary_race_page_evidence(
+            artifact_root=tmp_path,
+            race_discovery_key="Race 1 - MEA - 2026-06-01",
+            response=response,
+            canonical_runner_set={},
+        )
+    assert list(outside.iterdir()) == []
 
 
 def source_html(jump: datetime = JUMP) -> bytes:

--- a/tests/test_csv_download_hardening.py
+++ b/tests/test_csv_download_hardening.py
@@ -286,6 +286,7 @@ def test_primary_download_reallocates_duplicate_refetches_to_native_identity(
     monkeypatch,
     _isolate_upcoming_dir,
 ):
+    import upcoming_race_browser as browser_module
     from upcoming_race_browser import UpcomingRaceBrowser
     from scripts.refresh_prejump_upcoming import (
         current_index_metadata_selection,
@@ -421,15 +422,17 @@ def test_primary_download_reallocates_duplicate_refetches_to_native_identity(
     browser = UpcomingRaceBrowser()
     session = Session()
     browser.session = session
+    race_info_hint = {
+        "race_discovery_key": "Race 1 - MEA - 2099-06-09",
+        "url": race_url,
+        "date": "2099-06-09",
+        "venue": "MEA",
+        "race_number": 1,
+        "jump_datetime": jump.isoformat(),
+    }
     result = browser.download_race_csv(
         race_url,
-        race_info_hint={
-            "url": race_url,
-            "date": "2099-06-09",
-            "venue": "MEA",
-            "race_number": 1,
-            "jump_datetime": jump.isoformat(),
-        },
+        race_info_hint=race_info_hint,
     )
 
     assert result["success"] is True, result
@@ -441,6 +444,34 @@ def test_primary_download_reallocates_duplicate_refetches_to_native_identity(
     assert session.calls.count(race_url) == 1
     assert session.calls.count(expert_url) == 1
     sidecar = json.loads(Path(f"{result['filepath']}.metadata.json").read_text())
+    page_evidence = sidecar["primary_race_page_evidence"]
+    raw_page_path = Path(_isolate_upcoming_dir) / page_evidence["raw_path"]
+    receipt_path = Path(_isolate_upcoming_dir) / page_evidence["receipt_path"]
+    evidence_dir = Path(_isolate_upcoming_dir) / "source_evidence" / "primary_race_pages"
+    assert list(evidence_dir.glob("*.race-page.html")) == [raw_page_path]
+    assert list(evidence_dir.glob("*.race-page.receipt.json")) == [receipt_path]
+    assert raw_page_path.read_bytes() == race_html
+    receipt = json.loads(receipt_path.read_text())
+    assert receipt["schema_version"] == "thedogs_primary_race_page_evidence_v1"
+    assert receipt["race_discovery_key"] == "Race 1 - MEA - 2099-06-09"
+    assert receipt["requested_url"] == race_url
+    assert receipt["final_url"] == race_url
+    assert receipt["status_code"] == 200
+    assert receipt["content_length"] == len(race_html)
+    assert receipt["body_sha256"] == hashlib.sha256(race_html).hexdigest()
+    assert receipt["headers"] == {
+        "content-type": "text/html; charset=utf-8",
+        "date": receipt["headers"]["date"],
+    }
+    assert receipt["canonical_runner_extraction"] == {
+        "active_runner_count": 4,
+        "native_identity_reasons": ["source_native_race_id_missing"],
+        "native_identity_status": "unavailable",
+        "numeric_native_runner_id_count": 4,
+        "numeric_native_runner_ids_complete": True,
+        "schema_version": "canonical_pre_race_runner_set_v1",
+        "status": "available",
+    }
     assert sidecar["source_native_race_id"] == "15900"
     evidence = sidecar["native_identity_evidence"]
     assert evidence["active_native_runner_ids"] == [
@@ -497,6 +528,16 @@ def test_primary_download_reallocates_duplicate_refetches_to_native_identity(
     )
     assert selection["status"] == "READY", (selection, identity_coverage)
     assert eligible[0]["source_native_race_id"] == "15900"
+    repeated = browser.download_race_csv(
+        race_url,
+        race_info_hint=race_info_hint,
+    )
+    assert repeated["success"] is True, repeated
+    assert repeated["already_exists"] is True
+    assert len(session.calls) == 9
+    assert session.calls.count(race_url) == 2
+    assert len(list(evidence_dir.glob("*.race-page.html"))) == 1
+    assert len(list(evidence_dir.glob("*.race-page.receipt.json"))) == 2
 
     verified_sidecar = json.loads(json.dumps(sidecar))
     sidecar["native_identity_evidence"]["source_native_race_id"] = "15999"
@@ -514,6 +555,51 @@ def test_primary_download_reallocates_duplicate_refetches_to_native_identity(
     assert missing["races"][0]["native_identity_evidence_reason"] == (
         "native_identity_evidence_missing"
     )
+
+    failure_root = Path(_isolate_upcoming_dir) / "parser_failure_cycle"
+    failure_root.mkdir()
+    failing_browser = UpcomingRaceBrowser()
+    failing_browser.upcoming_dir = str(failure_root)
+    failing_session = Session()
+    failing_browser.session = failing_session
+
+    def _raise_parser_failure(*_args, **_kwargs):
+        raise RuntimeError("synthetic_parser_failure")
+
+    monkeypatch.setattr(
+        browser_module,
+        "extract_canonical_runner_set_from_html",
+        _raise_parser_failure,
+    )
+    failed = failing_browser.download_race_csv(
+        race_url,
+        race_info_hint=race_info_hint,
+    )
+    assert failed == {
+        "success": False,
+        "error": "Error downloading race CSV: synthetic_parser_failure",
+    }
+    assert len(failing_session.calls) == 4
+    assert failing_session.calls.count(race_url) == 1
+    assert odds_url not in failing_session.calls
+    assert not any(url.startswith(api_url_prefix) for url in failing_session.calls)
+    failure_receipt_path = next(
+        (failure_root / "source_evidence" / "primary_race_pages").glob(
+            "*.race-page.receipt.json"
+        )
+    )
+    failure_receipt = json.loads(failure_receipt_path.read_text())
+    assert failure_receipt["canonical_runner_extraction"] == {
+        "active_runner_count": 0,
+        "native_identity_reasons": [
+            "canonical_runner_extraction_failed:RuntimeError"
+        ],
+        "native_identity_status": "unavailable",
+        "numeric_native_runner_id_count": 0,
+        "numeric_native_runner_ids_complete": False,
+        "schema_version": "canonical_pre_race_runner_set_v1",
+        "status": "unavailable",
+    }
 
 
 def _canonical_runner_set_for_test(race_url, runners):

--- a/tests/test_prejump_prediction_loop.py
+++ b/tests/test_prejump_prediction_loop.py
@@ -701,6 +701,7 @@ def test_refresh_prejump_upcoming_reports_top_level_artifact_counts(tmp_path, mo
                     "https://www.thedogs.com.au/racing/2026-05-29"
                 ),
                 "target_grade_source_sha256": "c" * 64,
+                "race_discovery_key": "Race 1 - TEST - 2026-05-29",
                 "jump_datetime": "2026-05-29T13:45:00+10:00",
             }
             upcoming_dir = tmp_path / "upcoming"

--- a/upcoming_race_browser.py
+++ b/upcoming_race_browser.py
@@ -38,6 +38,7 @@ from scripts.capture_thedogs_market_history import (
     TimedResponse,
     bounded_receipt_headers,
     capture_native_identity_from_retained_race_page,
+    persist_primary_race_page_evidence,
 )
 from utils.csv_metadata import (
     THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE,
@@ -2125,6 +2126,9 @@ class UpcomingRaceBrowser:
                 else:
                     race_info["race_time_source"] = "canonical_race_url"
                     race_info["race_time_mapping_status"] = "missing_race_time"
+            race_discovery_key = str(
+                (race_info_hint or {}).get("race_discovery_key") or ""
+            ).strip()
             self._merge_safe_weather_track_metadata(
                 race_info,
                 self._collect_safe_track_metadata_from_sportsbet(
@@ -2150,6 +2154,21 @@ class UpcomingRaceBrowser:
             if os.path.exists(filepath):
                 existing_contract = self._existing_prejump_sidecar_contract_status(filepath)
                 if existing_contract.get("status") == "PASS":
+                    if race_discovery_key:
+                        persist_primary_race_page_evidence(
+                            artifact_root=Path(self.upcoming_dir),
+                            race_discovery_key=race_discovery_key,
+                            response=retained_race_page,
+                            canonical_runner_set={
+                                "schema_version": "canonical_pre_race_runner_set_v1",
+                                "canonical_runner_set_status": "not_run",
+                                "final_runner_participants": [],
+                                "native_identity_status": "unavailable",
+                                "native_identity_reasons": [
+                                    "canonical_runner_extraction_not_run:existing_sidecar_contract_pass"
+                                ],
+                            },
+                        )
                     return {
                         "success": True,
                         "filename": filename,
@@ -2322,12 +2341,38 @@ class UpcomingRaceBrowser:
                 filename=filename,
                 allow_generic_fields=False,
             )
-            canonical_runner_set = extract_canonical_runner_set_from_html(
-                race_page_content.decode("utf-8", errors="strict"),
-                source_url=race_url,
-                expected_race_number=int(race_info["race_number"]),
-                extraction_timestamp=retained_race_page.request_end_utc.isoformat(),
-            )
+            try:
+                canonical_runner_set = extract_canonical_runner_set_from_html(
+                    race_page_content.decode("utf-8", errors="strict"),
+                    source_url=race_url,
+                    expected_race_number=int(race_info["race_number"]),
+                    extraction_timestamp=retained_race_page.request_end_utc.isoformat(),
+                )
+            except Exception as exc:
+                if race_discovery_key:
+                    persist_primary_race_page_evidence(
+                        artifact_root=Path(self.upcoming_dir),
+                        race_discovery_key=race_discovery_key,
+                        response=retained_race_page,
+                        canonical_runner_set={
+                            "schema_version": "canonical_pre_race_runner_set_v1",
+                            "canonical_runner_set_status": "unavailable",
+                            "final_runner_participants": [],
+                            "native_identity_status": "unavailable",
+                            "native_identity_reasons": [
+                                "canonical_runner_extraction_failed:"
+                                f"{type(exc).__name__}"
+                            ],
+                        },
+                    )
+                raise
+            if race_discovery_key:
+                race_info["primary_race_page_evidence"] = persist_primary_race_page_evidence(
+                    artifact_root=Path(self.upcoming_dir),
+                    race_discovery_key=race_discovery_key,
+                    response=retained_race_page,
+                    canonical_runner_set=canonical_runner_set,
+                )
             expected_native_runner_boxes = [
                 (
                     participant.get("source_native_runner_id"),

--- a/utils/csv_metadata.py
+++ b/utils/csv_metadata.py
@@ -1593,6 +1593,9 @@ def build_csv_download_provenance_payload(
     expert_form_metadata = race_info_dict.get("expert_form_metadata")
     if isinstance(expert_form_metadata, Mapping):
         payload["expert_form_metadata"] = dict(expert_form_metadata)
+    primary_race_page_evidence = race_info_dict.get("primary_race_page_evidence")
+    if isinstance(primary_race_page_evidence, Mapping):
+        payload["primary_race_page_evidence"] = dict(primary_race_page_evidence)
     if normalization:
         payload.update(dict(normalization))
     payload["prejump_shadow_metadata"] = build_prejump_shadow_metadata_payload(payload)


### PR DESCRIPTION
## Summary
- persist the exact already-fetched primary TheDogs race-page bytes under the cycle artifact root
- bind content-addressed raw/receipt artifacts to safe HTTP provenance and canonical runner extraction status
- preserve parser ordering, identity admission, odds-only publication rules, and the existing acquisition topology

## Validation
- 63 passed, 1 skipped: focused source/parser/artifact/index/odds-only tests
- 472 passed, 2 deselected: adjacent refresh/autopilot/daemon/deployment tests
- the two deselected tests fail unchanged on exact base because they expect odds refresh limit 8 while master defines 16
- py_compile passed for changed Python files
- focused fatal Flake8 checks passed
- JSON receipt round-trip/hash verification passed; no JSON/schema files changed
- git diff --check passed
- independent Standards review: PASS
- independent Spec review: PASS

## Acquisition boundary
No HTTP call, retry, endpoint, horizon, cadence, or scheduler was added. The covered primary identity path remains 6 logical requests / 18 maximum attempts per selected race.