### PR TITLE
Request identity encoding for TheDogs native identity

### DIFF
--- a/scripts/capture_thedogs_market_history.py
+++ b/scripts/capture_thedogs_market_history.py
@@ -97,6 +97,7 @@ class TimedResponse:
     status_code: int
     headers: dict[str, str]
     body: bytes
+    request_headers: dict[str, str] | None = None
 
 
 def utc_now() -> datetime:
@@ -387,8 +388,11 @@ def timed_get(
     accept: str,
     clock: Callable[[], datetime],
     xhr: bool = False,
+    require_identity_encoding: bool = False,
 ) -> TimedResponse:
     headers = {"Accept": accept}
+    if require_identity_encoding:
+        headers["Accept-Encoding"] = "identity"
     if referer:
         headers.update(
             {
@@ -410,6 +414,11 @@ def timed_get(
         status_code=int(response.status_code),
         headers=bounded_receipt_headers(response.headers),
         body=body,
+        request_headers=(
+            {"accept-encoding": "identity"}
+            if require_identity_encoding
+            else None
+        ),
     )
 
 
@@ -721,6 +730,7 @@ def capture_native_identity_from_retained_race_page(
         referer=str(identity["race_url"]),
         accept=PAGE_HEADERS["Accept"],
         clock=clock,
+        require_identity_encoding=True,
     )
     validate_response(
         odds,
@@ -742,6 +752,7 @@ def capture_native_identity_from_retained_race_page(
         accept="application/json",
         clock=clock,
         xhr=True,
+        require_identity_encoding=True,
     )
     validate_response(
         api,
@@ -853,6 +864,10 @@ def validate_primary_native_identity_evidence(
         retained_url = urlparse(expected_race_url)
         canonical_race_url = retained_url._replace(query="", fragment="").geturl().rstrip("/")
         identity = exact_odds_identity(f"{canonical_race_url}/odds")
+        _validate_identity_transport_receipt(
+            evidence.get("odds_page_http"),
+            field="odds_page_http",
+        )
         odds = _stored_response(
             evidence.get("odds_page_http"),
             field="odds_page_http",
@@ -867,6 +882,10 @@ def validate_primary_native_identity_evidence(
         if active_ids != sorted(expected_ids):
             raise CaptureError("expected_native_runner_set_mismatch")
         api_url = _api_url(source_runners)
+        _validate_identity_transport_receipt(
+            evidence.get("odds_api_http"),
+            field="odds_api_http",
+        )
         api = _stored_response(
             evidence.get("odds_api_http"),
             field="odds_api_http",
@@ -938,6 +957,20 @@ def validate_primary_native_identity_evidence(
     return True, None
 
 
+def _validate_identity_transport_receipt(payload: Any, *, field: str) -> None:
+    if not isinstance(payload, Mapping):
+        raise CaptureError(f"{field}_receipt_missing")
+    if payload.get("request_headers") != {"accept-encoding": "identity"}:
+        raise CaptureError(f"{field}_request_accept_encoding_invalid")
+    headers = payload.get("headers")
+    if not isinstance(headers, Mapping):
+        raise CaptureError(f"{field}_headers_invalid")
+    if "response_content_encoding" not in payload:
+        raise CaptureError(f"{field}_response_content_encoding_missing")
+    if payload.get("response_content_encoding") != headers.get("content-encoding"):
+        raise CaptureError(f"{field}_response_content_encoding_mismatch")
+
+
 def _response_receipt(response: TimedResponse, *, include_body: bool) -> dict[str, Any]:
     payload = {
         "requested_url": response.requested_url,
@@ -949,6 +982,11 @@ def _response_receipt(response: TimedResponse, *, include_body: bool) -> dict[st
         "body_sha256": sha256_bytes(response.body),
         "body_bytes": len(response.body),
     }
+    if response.request_headers is not None:
+        payload["request_headers"] = dict(response.request_headers)
+        payload["response_content_encoding"] = response.headers.get(
+            "content-encoding"
+        )
     if include_body:
         payload["body_base64"] = base64.b64encode(response.body).decode("ascii")
     return payload

--- a/tests/test_capture_thedogs_market_history.py
+++ b/tests/test_capture_thedogs_market_history.py
@@ -253,7 +253,13 @@ def mismatched_normal_api_payload() -> bytes:
 
 class FakeResponse:
     def __init__(
-        self, url: str, content: bytes, content_type: str, server_time: datetime
+        self,
+        url: str,
+        content: bytes,
+        content_type: str,
+        server_time: datetime,
+        *,
+        content_encoding: str | None = None,
     ):
         self.url = url
         self.content = content
@@ -263,6 +269,8 @@ class FakeResponse:
             "Date": format_datetime(server_time, usegmt=True),
             "X-Request-Id": "fixture-request",
         }
+        if content_encoding is not None:
+            self.headers["Content-Encoding"] = content_encoding
 
 
 class FakeSession:
@@ -275,6 +283,8 @@ class FakeSession:
         server_time: datetime | None = None,
         source_body: bytes | None = None,
         api_body: bytes | None = None,
+        odds_content_encoding: str | None = None,
+        api_content_encoding: str | None = None,
     ):
         self.provider = provider
         self.missing_runner = missing_runner
@@ -282,6 +292,8 @@ class FakeSession:
         self.mismatched_quote_id = mismatched_quote_id
         self.source_body = source_body or source_html()
         self.api_body = api_body
+        self.odds_content_encoding = odds_content_encoding
+        self.api_content_encoding = api_content_encoding
         self.calls: list[str] = []
         self.request_headers: list[dict[str, str]] = []
 
@@ -302,7 +314,11 @@ class FakeSession:
             )
         if url == ODDS_URL:
             return FakeResponse(
-                url, self.source_body, "text/html; charset=utf-8", self.server_time
+                url,
+                self.source_body,
+                "text/html; charset=utf-8",
+                self.server_time,
+                content_encoding=self.odds_content_encoding,
             )
         if "/api/runners/odds?" in url:
             return FakeResponse(
@@ -315,6 +331,7 @@ class FakeSession:
                     ),
                 "application/json; charset=utf-8",
                 self.server_time,
+                content_encoding=self.api_content_encoding,
             )
         raise AssertionError(url)
 
@@ -327,6 +344,32 @@ class FakeClock:
         value = self.value
         self.value += timedelta(milliseconds=100)
         return value
+
+
+def retained_primary_race_page(observed: datetime) -> TimedResponse:
+    return TimedResponse(
+        requested_url=RACE_URL,
+        request_start_utc=observed - timedelta(milliseconds=100),
+        request_end_utc=observed,
+        final_url=RACE_URL,
+        status_code=200,
+        headers={
+            "content-type": "text/html; charset=utf-8",
+            "date": format_datetime(observed, usegmt=True),
+        },
+        body=source_html(),
+    )
+
+
+def capture_primary_identity(session: FakeSession, observed: datetime):
+    return subject.capture_native_identity_from_retained_race_page(
+        session=session,
+        race_page=retained_primary_race_page(observed),
+        expected_active_runner_boxes=[("101", 1), ("102", 2)],
+        expected_jump_utc=JUMP,
+        current_time=observed + timedelta(seconds=1),
+        clock=FakeClock(observed + timedelta(milliseconds=100)),
+    )
 
 
 def plan(**overrides):
@@ -432,29 +475,13 @@ def test_complete_active_field_and_native_ids_are_captured(tmp_path):
 def test_retained_race_page_identity_binding_uses_exactly_two_requests():
     observed = JUMP - timedelta(minutes=20)
     session = FakeSession(server_time=observed)
-    race_page = TimedResponse(
-        requested_url=RACE_URL,
-        request_start_utc=observed - timedelta(milliseconds=100),
-        request_end_utc=observed,
-        final_url=RACE_URL,
-        status_code=200,
-        headers={
-            "content-type": "text/html; charset=utf-8",
-            "date": format_datetime(observed, usegmt=True),
-        },
-        body=source_html(),
-    )
-
-    evidence = subject.capture_native_identity_from_retained_race_page(
-        session=session,
-        race_page=race_page,
-        expected_active_runner_boxes=[("101", 1), ("102", 2)],
-        expected_jump_utc=JUMP,
-        current_time=observed + timedelta(seconds=1),
-        clock=FakeClock(observed + timedelta(milliseconds=100)),
-    )
+    evidence = capture_primary_identity(session, observed)
 
     assert session.calls == [ODDS_URL, subject._api_url(parse_source_runners(source_html()))]
+    assert [headers["Accept-Encoding"] for headers in session.request_headers] == [
+        "identity",
+        "identity",
+    ]
     assert evidence["source_native_race_id"] == "9001"
     assert evidence["active_native_runner_ids"] == ["101", "102"]
     assert evidence["request_accounting"] == {
@@ -462,6 +489,11 @@ def test_retained_race_page_identity_binding_uses_exactly_two_requests():
         "shared_session_max_attempts_per_request": 3,
         "worst_case_wire_attempts": 6,
     }
+    for field in ("odds_page_http", "odds_api_http"):
+        assert evidence[field]["request_headers"] == {
+            "accept-encoding": "identity"
+        }
+        assert evidence[field]["response_content_encoding"] is None
     assert evidence["evidence_sha256"] == sha256_bytes(
         canonical_json_bytes(
             {key: value for key, value in evidence.items() if key != "evidence_sha256"}
@@ -476,6 +508,94 @@ def test_primary_identity_request_accounting_matches_shared_retry_bound():
     assert retries.total == 2
     assert 1 + retries.total == 3
     assert 2 * (1 + retries.total) == 6
+
+
+@pytest.mark.parametrize("content_encoding", [None, "identity"])
+def test_primary_identity_accepts_only_unencoded_responses(content_encoding):
+    observed = JUMP - timedelta(minutes=20)
+    session = FakeSession(
+        server_time=observed,
+        odds_content_encoding=content_encoding,
+        api_content_encoding=content_encoding,
+    )
+    evidence = capture_primary_identity(session, observed)
+
+    assert session.calls == [ODDS_URL, subject._api_url(parse_source_runners(source_html()))]
+    assert evidence["odds_page_http"]["response_content_encoding"] == content_encoding
+    assert evidence["odds_api_http"]["response_content_encoding"] == content_encoding
+
+
+@pytest.mark.parametrize("content_encoding", ["gzip", "br", "deflate", "unknown"])
+def test_primary_identity_rejects_encoded_odds_without_retry(content_encoding):
+    observed = JUMP - timedelta(minutes=20)
+    session = FakeSession(
+        server_time=observed,
+        odds_content_encoding=content_encoding,
+    )
+
+    with pytest.raises(CaptureError, match="source_content_encoding_not_identity"):
+        capture_primary_identity(session, observed)
+
+    assert session.calls == [ODDS_URL]
+
+
+@pytest.mark.parametrize("content_encoding", ["gzip", "br", "deflate", "unknown"])
+def test_primary_identity_rejects_encoded_api_without_retry(content_encoding):
+    observed = JUMP - timedelta(minutes=20)
+    session = FakeSession(
+        server_time=observed,
+        api_content_encoding=content_encoding,
+    )
+
+    with pytest.raises(CaptureError, match="source_content_encoding_not_identity"):
+        capture_primary_identity(session, observed)
+
+    assert session.calls == [ODDS_URL, subject._api_url(parse_source_runners(source_html()))]
+
+
+@pytest.mark.parametrize(
+    ("field", "mutate", "reason"),
+    [
+        (
+            "odds_page_http",
+            lambda receipt: receipt.update(
+                {"request_headers": {"accept-encoding": "gzip"}}
+            ),
+            "odds_page_http_request_accept_encoding_invalid",
+        ),
+        (
+            "odds_api_http",
+            lambda receipt: receipt.update(
+                {"response_content_encoding": "identity"}
+            ),
+            "odds_api_http_response_content_encoding_mismatch",
+        ),
+    ],
+)
+def test_primary_identity_revalidation_rejects_transport_policy_tampering(
+    field,
+    mutate,
+    reason,
+):
+    observed = JUMP - timedelta(minutes=20)
+    evidence = capture_primary_identity(FakeSession(server_time=observed), observed)
+    mutate(evidence[field])
+    evidence["evidence_sha256"] = sha256_bytes(
+        canonical_json_bytes(
+            {key: value for key, value in evidence.items() if key != "evidence_sha256"}
+        )
+    )
+
+    valid, observed_reason = subject.validate_primary_native_identity_evidence(
+        evidence,
+        expected_race_url=RACE_URL,
+        expected_native_race_id="9001",
+        expected_active_runner_boxes=[("101", 1), ("102", 2)],
+        metadata_captured_at=evidence["odds_api_http"]["request_end_utc"],
+    )
+
+    assert valid is False
+    assert observed_reason == reason
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- explicitly request `Accept-Encoding: identity` on the two existing TheDogs native-identity GETs
- keep compressed or unknown response encodings fail-closed with no fallback retry
- bind the safe request policy and observed response encoding into hashed identity receipts
- preserve exact runner-ID/effective-box binding and primary-only index publication

## Request accounting

The request topology is unchanged: the helper still performs exactly two logical requests with the existing retry ceiling (6 attempts total), and the covered natural-primary path remains 6 logical requests / 18 maximum attempts per selected race. Acquisition-call delta: exactly zero.

## Validation

- identity transport and receipt suite: 60 passed
- focused identity/parser/refresh/publisher suites: 212 passed, 10 skipped
- explicit odds-only publication ownership tests: 2 passed
- adjacent daemon/deployment suites: 384 passed, 2 pre-existing failures reproduced on exact base (`DEFAULT_ODDS_CAPTURE_REFRESH_LIMIT` expectation 8 versus base value 16)
- py_compile passed for changed Python files
- JSON/evidence serialization and offline revalidation passed
- git diff --check passed
- independent Standards review: PASS
- independent Spec review: PASS

No deployment, live calls, parser changes, acquisition expansion, or response-validation relaxation were performed.