### PR TITLE
Fix Operator UI sealed bundle finalization

### DIFF
--- a/src/operator_ui/bootstrap.py
+++ b/src/operator_ui/bootstrap.py
@@ -24,7 +24,7 @@ from .job_store import JobInput, JobStore, Phase
 from .foundation import JsonSerializationPolicy, JsonSource, OperatorEvidenceReader, RawSourceConfig, SourceConfig, TimestampSyntax
 from .live_adapters import InstalledUnits, LiveEvidenceAdapters, PredictionBundleSource, UpcomingRaceSource
 from .prediction_worker import ServerChoice, WorkerConfig, run_once
-from .r3_api import R3Rejected, R3Services, ResolvedSubmission, build_verified_bundle_reader, install_r3_api
+from .r3_api import R3Rejected, R3Services, ResolvedSubmission, build_verified_bundle_reader, finalize_producer_bundle, install_r3_api
 
 CONFIG_KEY = "OPERATOR_UI_LIVE_EVIDENCE_ADAPTERS"
 R3_PROFILE_KEY = "OPERATOR_UI_R3_PROFILE"
@@ -258,8 +258,8 @@ def _runner(row: Mapping[str, Any]) -> dict[str, Any]:
 
 class _FixedDispatcher:
     """One fixed in-process dispatch lane; JobStore.claim_attempt owns execution."""
-    def __init__(self, store: JobStore, worker: WorkerConfig, clock, runner=None):
-        self._store,self._worker,self._clock,self._runner=store,worker,clock,runner or run_once
+    def __init__(self, store: JobStore, worker: WorkerConfig, clock, finalizer, runner=None):
+        self._store,self._worker,self._clock,self._runner,self._finalizer=store,worker,clock,runner or run_once,finalizer
         self._queue: queue.Queue[tuple[str,Any]] = queue.Queue(maxsize=256)
         self._pending:set[str]=set(); self._pending_lock=threading.Lock()
         self._thread=threading.Thread(target=self._serve,name="operator-ui-r3-dispatch",daemon=True)
@@ -275,7 +275,9 @@ class _FixedDispatcher:
     def _serve(self) -> None:
         while True:
             job_id,confirm=self._queue.get()
-            try:self._runner(self._store,job_id,self._worker,now=self._clock,confirm_audit=confirm)
+            try:
+                job=self._runner(self._store,job_id,self._worker,now=self._clock,confirm_audit=confirm)
+                if job.phase is Phase.PRODUCER_COMPLETED:self._finalizer(job,confirm)
             except BaseException as exc:
                 try:
                     job=self._store.get(job_id)
@@ -333,7 +335,8 @@ def _build_r3_services(app: Flask, profile: str) -> R3Services:
     choice=ServerChoice(config_path,"manual-default",_sha(config_path),resolved_model,model_sha,manifest_sha,schema_sha,model_path,manifest_path,schema_path)
     captures=(dirs["current_evidence"],) if profile=="repository-v1" else (dirs["current_evidence"],dirs["capture_evidence_a"],dirs["capture_evidence_b"])
     worker=WorkerConfig(layout["pinned_python"] if layout is not None else Path(sys.executable),product_root,{"latest-research":choice},paths["canonical.sqlite3"],dirs["prediction_bundles"],captures,dirs["collector_requests"],paths["current_index.json"],dirs["current_evidence"],1.0,45.0,90.0,2.0)
-    store=JobStore(paths["jobs.sqlite3"],separate_from=(paths["audit.sqlite3"],paths["canonical.sqlite3"]))
+    verifier_authority=object()
+    store=JobStore(paths["jobs.sqlite3"],separate_from=(paths["audit.sqlite3"],paths["canonical.sqlite3"]),verifier_authority=verifier_authority)
 
     def clock() -> datetime:return datetime.now(timezone.utc)
     def resolve(selected: Mapping[str,str], now: datetime) -> ResolvedSubmission:
@@ -349,8 +352,10 @@ def _build_r3_services(app: Flask, profile: str) -> R3Services:
         job_input=JobInput(str(race["race_id"]),str(jump),str(race["runner_set_sha256"]),model_id,resolved_model,model_sha,manifest_sha,schema_sha,config_id,choice.config_sha256,odds_source,runners)
         job_input.fields()
         return ResolvedSubmission(job_input,runners)
-    dispatcher=_FixedDispatcher(store,worker,clock)
-    return R3Services(store,resolve,dispatcher,build_verified_bundle_reader(dirs["prediction_bundles"],store),clock=clock)
+    def finalize(job: Job, confirm) -> Job:
+        return finalize_producer_bundle(dirs["prediction_bundles"],store,job,capability=verifier_authority,now=clock(),confirm_audit=confirm)
+    dispatcher=_FixedDispatcher(store,worker,clock,finalize)
+    return R3Services(store,resolve,dispatcher,finalize,build_verified_bundle_reader(dirs["prediction_bundles"],store),clock=clock)
 
 
 def bind_configured_r3(app: Flask) -> bool:

--- a/src/operator_ui/job_store.py
+++ b/src/operator_ui/job_store.py
@@ -200,6 +200,8 @@ _PROCESS_FACTS=frozenset({"attempt_id","pid","exit_code","stdout_complete","stdo
 _STREAM_REQUIRED=frozenset({"attempt_id","pid","exit_code","stdout_complete","stdout_prefix_length","stdout_prefix_sha256","stderr_complete","stderr_prefix_length","stderr_prefix_sha256"})
 _STREAM_OPTIONAL=frozenset({"stdout_reader_error","stdout_bytes","stdout_length","stdout_sha256","stderr_reader_error","stderr_bytes","stderr_length","stderr_sha256"})
 _VERIFIER_FACTS=frozenset({"prediction_id","job_id","race_id","jump_timestamp","runner_set_sha256","resolved_model_identity","model_sha256","model_manifest_sha256","model_schema_sha256","config_id","config_sha256","index_sha256","result_sha256","manifest_sha256","logical_bundle_sha256","bundle_locator","producer_status","research_only","production_persisted","betting_output","verification_status","blocker"})
+_VERIFIER_FAILURE_FACTS=frozenset({"prediction_id","job_id","race_id","jump_timestamp","runner_set_sha256","resolved_model_identity","model_sha256","model_manifest_sha256","model_schema_sha256","config_id","config_sha256","producer_status","verification_status","blocker"})
+_VERIFIER_FAILURE_CODES=frozenset({"BUNDLE_INDEX_VERIFICATION_FAILED","BUNDLE_IDENTITY_MISSING_OR_AMBIGUOUS","BUNDLE_VERIFICATION_FAILED","BUNDLE_JOB_IDENTITY_MISMATCH","BUNDLE_BLOCKER_IDENTITY_MISMATCH","BUNDLE_RESULT_IDENTITY_UNAVAILABLE"})
 
 def _event_contracts():
     empty=frozenset(); claim=frozenset({"attempt_id"}); start=frozenset({"attempt_id","pid"})
@@ -215,7 +217,7 @@ def _event_contracts():
       (Phase.ATTEMPT_STARTED,Phase.RESPONSE_RECORDED,"RECORDED","bounded_process_response"):(process,_STREAM_OPTIONAL|{"predictor_status","prediction_id","producer_job_id","producer_blocker","protocol_chain","authenticated_cutoff"},"process"),
       (Phase.RESPONSE_RECORDED,Phase.PRODUCER_COMPLETED,"PRODUCER_COMPLETED","PRODUCER_PREDICTION_READY"):(producer,_STREAM_OPTIONAL|{"protocol_chain","authenticated_cutoff"},"producer_ready"),
       (Phase.PRODUCER_COMPLETED,Phase.PREDICTION_READY,"READY","verified"):(_VERIFIER_FACTS,empty,"verifier_ready"),
-      (Phase.PRODUCER_COMPLETED,Phase.FAILED,"FAILED","verification_failed"):(_VERIFIER_FACTS,empty,"verifier_failed"),
+      (Phase.PRODUCER_COMPLETED,Phase.FAILED,"FAILED","verification_failed"):(empty,_VERIFIER_FACTS|_VERIFIER_FAILURE_FACTS,"verifier_failed"),
       (Phase.PRODUCER_COMPLETED,Phase.REJECTED,"REJECTED","verification_rejected"):(_VERIFIER_FACTS,empty,"verifier_rejected"),
     }
     for predecessor in (Phase.CLAIMED,Phase.ATTEMPT_STARTED,Phase.RESPONSE_RECORDED):
@@ -241,11 +243,15 @@ def _validate_facts(phase:Phase,facts:Any,prior:Phase|None,status:str="",reason:
     if contract is None: raise ValueError("undeclared event contract")
     required,optional,_kind=contract
     if not required.issubset(facts) or set(facts)-required-optional: raise ValueError("event facts do not match exact contract")
-    verifier=set(_VERIFIER_FACTS)
+    verifier=set(_VERIFIER_FACTS); verifier_failure=set(_VERIFIER_FAILURE_FACTS)
+    if prior is Phase.PRODUCER_COMPLETED and phase is Phase.FAILED and set(facts) not in {frozenset(verifier),frozenset(verifier_failure)}: raise ValueError("exact verifier failure evidence required")
     if "verification_status" in facts:
-        if set(facts)!=verifier: raise ValueError("exact verifier evidence required")
+        if phase is Phase.FAILED and set(facts)==verifier_failure:
+            blocker=facts.get("blocker")
+            if facts.get("verification_status")!="FAILED" or facts.get("producer_status") not in {"PREDICTION_READY","PREDICTION_BLOCKED"} or not isinstance(blocker,dict) or set(blocker)!={"code","stage"} or blocker.get("code") not in _VERIFIER_FAILURE_CODES or blocker.get("stage")!="BUNDLE_VERIFICATION": raise ValueError("invalid bundle verification failure facts")
+        elif set(facts)!=verifier: raise ValueError("exact verifier evidence required")
         if phase is Phase.PREDICTION_READY and (facts.get("verification_status")!="VERIFIED" or facts.get("producer_status")!="PREDICTION_READY" or facts.get("blocker") is not None): raise ValueError("invalid ready verification facts")
-        if phase in {Phase.FAILED,Phase.REJECTED}:
+        if phase in {Phase.FAILED,Phase.REJECTED} and set(facts)==verifier:
             blocker=facts.get("blocker")
             expected="FAILED" if phase is Phase.FAILED else "REJECTED"
             if facts.get("verification_status")!=expected or facts.get("producer_status")!="PREDICTION_BLOCKED" or not isinstance(blocker,dict) or set(blocker)!={"code","stage"}: raise ValueError("invalid verifier blocker facts")
@@ -520,16 +526,19 @@ class JobStore:
     def verifier_transition(self,job_id,phase,*,capability:object,now,status,reason,facts,confirm_audit:AuditConfirmation):
         if self._verifier_authority is None or capability is not self._verifier_authority: raise VerifierAuthorizationError("verifier authority required")
         if phase not in {Phase.PREDICTION_READY,Phase.FAILED,Phase.REJECTED}: raise IllegalTransition("invalid verifier transition")
-        required={"prediction_id","job_id","race_id","jump_timestamp","runner_set_sha256","resolved_model_identity","model_sha256","model_manifest_sha256","model_schema_sha256","config_id","config_sha256","index_sha256","result_sha256","manifest_sha256","logical_bundle_sha256","bundle_locator","producer_status","research_only","production_persisted","betting_output","verification_status","blocker"}
-        if not isinstance(facts,dict) or set(facts)!=required: raise ValueError("exact verifier evidence required")
-        for name in ("runner_set_sha256","model_sha256","model_manifest_sha256","model_schema_sha256","config_sha256","index_sha256","result_sha256","manifest_sha256","logical_bundle_sha256"): _hash(facts[name],name)
+        allowed={_VERIFIER_FACTS,_VERIFIER_FAILURE_FACTS}
+        if not isinstance(facts,dict) or frozenset(facts) not in allowed: raise ValueError("exact verifier evidence required")
+        for name in ("runner_set_sha256","model_sha256","model_manifest_sha256","model_schema_sha256","config_sha256"): _hash(facts[name],name)
+        for name in ("index_sha256","result_sha256","manifest_sha256","logical_bundle_sha256"):
+            if name in facts: _hash(facts[name],name)
         _canonical_uuid(facts["prediction_id"],"prediction_id"); _identifier(facts["verification_status"],"verification_status")
-        locator=facts["bundle_locator"]
-        if not isinstance(locator,str) or not locator or Path(locator).is_absolute() or "\\" in locator or any(part in {"",".",".."} for part in locator.split("/")): raise ValueError("unsafe bundle locator")
-        for flag in ("research_only","production_persisted","betting_output"):
-            if not isinstance(facts[flag],bool): raise ValueError("invalid verifier safety flag")
+        if "bundle_locator" in facts:
+            locator=facts["bundle_locator"]
+            if not isinstance(locator,str) or not locator or Path(locator).is_absolute() or "\\" in locator or any(part in {"",".",".."} for part in locator.split("/")): raise ValueError("unsafe bundle locator")
+            for flag in ("research_only","production_persisted","betting_output"):
+                if not isinstance(facts[flag],bool): raise ValueError("invalid verifier safety flag")
         if phase is Phase.PREDICTION_READY and (facts["verification_status"]!="VERIFIED" or facts["producer_status"]!="PREDICTION_READY" or facts["research_only"] is not True or facts["production_persisted"] is not False or facts["betting_output"] is not False or facts["blocker"] is not None): raise ValueError("readiness requires verified safe sealed evidence")
-        if phase in {Phase.FAILED,Phase.REJECTED}:
+        if phase in {Phase.FAILED,Phase.REJECTED} and frozenset(facts)==_VERIFIER_FACTS:
             expected_status="FAILED" if phase is Phase.FAILED else "REJECTED"
             blocker=facts["blocker"]
             if facts["verification_status"]!=expected_status or facts["producer_status"]!="PREDICTION_BLOCKED" or facts["research_only"] is not True or facts["production_persisted"] is not False or facts["betting_output"] is not False: raise ValueError("verifier blocker contradicts target phase")
@@ -546,9 +555,10 @@ class JobStore:
             actual=tuple(facts[n] for n in ("job_id","race_id","jump_timestamp","runner_set_sha256","resolved_model_identity","model_sha256","model_manifest_sha256","model_schema_sha256","config_id","config_sha256"))
             if actual!=expected: raise ValueError("verifier evidence identity mismatch")
             producer=json.loads(db.execute("SELECT facts_json FROM job_events WHERE job_id=? AND phase=? ORDER BY sequence DESC LIMIT 1",(job_id,Phase.PRODUCER_COMPLETED.value)).fetchone()[0])
+            if producer.get("prediction_id")!=facts["prediction_id"] or producer.get("predictor_status")!=facts["producer_status"]: raise ValueError("verifier differs from producer identity")
             if phase is Phase.PREDICTION_READY:
                 if producer.get("predictor_status")!="PREDICTION_READY" or producer.get("producer_blocker") is not None: raise ValueError("verifier readiness contradicts producer")
-            elif producer.get("predictor_status")!="PREDICTION_BLOCKED" or producer.get("producer_blocker")!=facts["blocker"]: raise ValueError("verifier blocker differs from producer")
+            elif phase is Phase.REJECTED and (producer.get("predictor_status")!="PREDICTION_BLOCKED" or producer.get("producer_blocker")!=facts["blocker"]): raise ValueError("verifier blocker differs from producer")
             intent,event_id,previous=self._mutation_intent(db,job,"verify",current,phase,at,status,reason,facts)
             receipt=self._confirm(confirm_audit,intent); audit=receipt.audit_sha256; self._append_event(db,job_id,phase,at,status,reason,facts,audit,prior=current,event_id=event_id,previous=previous); self._seal(db); anchor=db.execute("SELECT mutation_count,store_hash FROM store_anchor WHERE singleton=1").fetchone()
             if anchor[0]!=receipt.next_mutation_count or not hmac.compare_digest(anchor[1],receipt.next_store_hash): raise ConfirmationMismatch("persisted store differs from confirmation")

--- a/src/operator_ui/r3_api.py
+++ b/src/operator_ui/r3_api.py
@@ -62,6 +62,7 @@ class R3Services:
     job_store: JobStore
     resolve_submission: Callable[[Mapping[str, str], datetime], ResolvedSubmission]
     launch_once: Callable[[str, Callable[[Mapping[str, Any]], Any]], None]
+    finalize_once: Callable[[Job, Callable[[Mapping[str, Any]], Any]], Job]
     read_verified_result: Callable[[Job], Mapping[str, Any] | None]
     clock: Callable[[], datetime] = lambda: datetime.now(timezone.utc)
     rate_limit: int = 5
@@ -104,6 +105,71 @@ def build_verified_bundle_reader(root: Path, store: JobStore) -> Callable[[Job],
         except (OSError,ValueError,TypeError,JobStoreError,PredictionBlocked):
             return None
     return read
+
+
+def finalize_producer_bundle(root: Path, store: JobStore, job: Job, *, capability: object,
+                             now: datetime, confirm_audit) -> Job:
+    """Finalize one producer completion only from its verified indexed bundle."""
+    if job.phase is not Phase.PRODUCER_COMPLETED:
+        return job
+    events=list(store.events(job.job_id))
+    completed=[event for event in events if event["phase"]==Phase.PRODUCER_COMPLETED.value]
+    if len(completed)!=1:
+        raise JobStoreError("producer completion evidence is ambiguous")
+    producer=completed[0]["facts"]
+    prediction_id=producer.get("prediction_id")
+    producer_status=producer.get("predictor_status")
+    def fail(code: str) -> Job:
+        facts={
+            "prediction_id":prediction_id,"job_id":job.job_id,"race_id":job.input.race_id,
+            "jump_timestamp":job.input.jump_timestamp,"runner_set_sha256":job.input.runner_set_sha256,
+            "resolved_model_identity":job.input.resolved_model_identity,"model_sha256":job.input.model_sha256,
+            "model_manifest_sha256":job.input.model_manifest_sha256,"model_schema_sha256":job.input.model_schema_sha256,
+            "config_id":job.input.config_id,"config_sha256":job.input.config_sha256,
+            "producer_status":producer_status,"verification_status":"FAILED",
+            "blocker":{"code":code,"stage":"BUNDLE_VERIFICATION"},
+        }
+        return store.verifier_transition(job.job_id,Phase.FAILED,capability=capability,now=now,status="FAILED",reason="verification_failed",facts=facts,confirm_audit=confirm_audit)
+    try:view=verify_prediction_bundle_index(Path(root),return_verified_view=True)
+    except (OSError,ValueError,TypeError,PredictionBlocked):return fail("BUNDLE_INDEX_VERIFICATION_FAILED")
+    if not isinstance(view,VerifiedPredictionBundleIndex):
+        return fail("BUNDLE_INDEX_VERIFICATION_FAILED")
+    matches=[entry for entry in view.entries if entry.get("job_id")==job.job_id and entry.get("prediction_id")==prediction_id and entry.get("status")==producer_status]
+    if len(matches)!=1:
+        return fail("BUNDLE_IDENTITY_MISSING_OR_AMBIGUOUS")
+    try:bundle=verify_indexed_prediction_bundle(Path(root),matches[0])
+    except (OSError,ValueError,TypeError,PredictionBlocked):return fail("BUNDLE_VERIFICATION_FAILED")
+    result=bundle.result; entry=bundle.index_entry; manifest=bundle.manifest
+    if producer_status=="PREDICTION_READY":
+        if _verified_result(job,bundle,events) is None:
+            return fail("BUNDLE_JOB_IDENTITY_MISMATCH")
+        phase,status,reason,verification,blocker=Phase.PREDICTION_READY,"READY","verified","VERIFIED",None
+    elif producer_status=="PREDICTION_BLOCKED":
+        sealed_blocker=result.get("blocker")
+        stage=result.get("blocker_stage")
+        if not isinstance(sealed_blocker,Mapping) or set(sealed_blocker)!={"code"} or producer.get("producer_blocker")!={"code":sealed_blocker.get("code"),"stage":stage}:
+            return fail("BUNDLE_BLOCKER_IDENTITY_MISMATCH")
+        phase,status,reason,verification,blocker=Phase.REJECTED,"REJECTED","verification_rejected","REJECTED",{"code":sealed_blocker["code"],"stage":stage}
+    else:
+        raise JobStoreError("producer completion status is invalid")
+    files=manifest.get("files")
+    result_file=files.get("result.json") if isinstance(files,Mapping) else None
+    if not isinstance(result_file,Mapping):
+        return fail("BUNDLE_RESULT_IDENTITY_UNAVAILABLE")
+    facts={
+        "prediction_id":result["prediction_id"],"job_id":job.job_id,
+        "race_id":result["race"]["race_id"],"jump_timestamp":result["race"]["jump_timestamp"],
+        "runner_set_sha256":result["evidence"]["runner_set_sha256"],
+        "resolved_model_identity":result["model"]["resolved"],"model_sha256":result["model"]["artifact_sha256"],
+        "model_manifest_sha256":result["model"]["artifact_manifest_sha256"],"model_schema_sha256":result["model"]["schema_sha256"],
+        "config_id":job.input.config_id,"config_sha256":result["config"]["sha256"],
+        "index_sha256":view.sha256,"result_sha256":result_file["sha256"],
+        "manifest_sha256":entry["manifest_sha256"],"logical_bundle_sha256":entry["logical_bundle_sha256"],
+        "bundle_locator":bundle.directory,"producer_status":producer_status,
+        "research_only":result["research_only"],"production_persisted":result["production_persisted"],
+        "betting_output":result["betting_output"],"verification_status":verification,"blocker":blocker,
+    }
+    return store.verifier_transition(job.job_id,phase,capability=capability,now=now,status=status,reason=reason,facts=facts,confirm_audit=confirm_audit)
 
 
 def _bounded(value: Any, name: str, maximum: int = 256) -> str:
@@ -165,7 +231,7 @@ def _verified_result(job: Job, value: Any, events: list[Mapping[str,Any]] | None
 
 
 def _job_payload(store: JobStore, job: Job, result_reader: Callable[[Job], Mapping[str, Any] | None]) -> dict[str, Any]:
-    events = store.events(job.job_id)
+    events = list(store.events(job.job_id))
     timeline = [
         {"event_id": event["event_id"], "phase": event["phase"], "event_at": event["event_at"],
          "status": event["status"], "reason": event["reason"], "event_hash": event["event_hash"],
@@ -244,6 +310,9 @@ def install_r3_api(app: Flask, services: R3Services | None = None) -> bool:
         return resolve_audit_confirmation(intent, audit_hash)
 
     def dispatch_waiting(job: Job, confirm_audit) -> Job:
+        if job.phase is Phase.PRODUCER_COMPLETED:
+            try:return services.finalize_once(job,confirm_audit)
+            except Exception:return services.job_store.get(job.job_id)
         if job.phase is not Phase.WAITING_FOR_CLAIM or job.attempt_claimed:
             return job
         try:
@@ -341,4 +410,4 @@ def install_r3_api(app: Flask, services: R3Services | None = None) -> bool:
     return True
 
 
-__all__ = ["R3Rejected", "R3Services", "ResolvedSubmission", "install_r3_api"]
+__all__ = ["R3Rejected", "R3Services", "ResolvedSubmission", "finalize_producer_bundle", "install_r3_api"]

--- a/tests/operator_ui/test_bootstrap.py
+++ b/tests/operator_ui/test_bootstrap.py
@@ -5,6 +5,7 @@ import os
 import stat
 import tempfile
 import threading
+import time
 import json
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -19,7 +20,7 @@ from src.operator_ui.foundation import OperatorEvidenceReader
 from src.operator_ui.live_adapters import LiveEvidenceAdapters
 from src.operator_ui.security import install_connected_mode
 import src.operator_ui.bootstrap as bootstrap_module
-from src.predictor.on_demand import resolve_model
+from src.predictor.on_demand import VerifiedPredictionBundle, VerifiedPredictionBundleIndex, resolve_model
 from race_collection.synchronous_manual_capture import VerifiedCurrentRaceIndex
 from src.operator_ui.job_store import Phase
 
@@ -215,6 +216,69 @@ def test_repository_profile_binds_authoritative_sources_and_separate_operations_
     assert refresh_payload["generated_at"]=="2026-08-03T01:02:03Z"
     catalog_envelope,_=live._reader.read_payload("model_catalog")
     assert catalog_envelope.observed_at=="2026-08-03T01:02:03Z"
+
+
+def test_repository_profile_finalizes_one_verified_worker_bundle_before_disclosing_probabilities(tmp_path,monkeypatch):
+    from src.operator_ui import r3_api as r3_api_module
+    from src.operator_ui.prediction_worker import run_once as real_run_once
+    from tests.operator_ui.test_prediction_worker import H, Process, RACE_ID, ready
+
+    repo,evidence,_,operations,canonical=repository_binding_fixture(tmp_path,monkeypatch)
+    runners=(
+        {"box_number":1,"display_name":"ALPHA","identity":"ALPHA","source_native_runner_id":"dog-1"},
+        {"box_number":2,"display_name":"BETA","identity":"BETA","source_native_runner_id":"dog-2"},
+    )
+    race={"race_id":RACE_ID,"jump_datetime":"2026-08-01T01:00:00+00:00","runner_set_sha256":H,"runners":runners}
+    current_view=VerifiedCurrentRaceIndex("collector_current_race_index_v2","run","2026-08-01T00:00:00Z",H,b"{}",(race,),"source.json",H,H,H,H)
+    monkeypatch.setattr(bootstrap_module,"bounded_current_race_index",lambda **_:current_view)
+
+    worker_completed=threading.Event(); holder={}
+    prediction_id="12345678-1234-4123-8123-123456789abc"
+    directory="prediction_20260801T000001000000+0000_123456789abc"
+
+    def bundle_for(job):
+        result=json.loads(ready(job))
+        result_raw=ready(job)
+        manifest={"schema_version":"on_demand_prediction_bundle_manifest_v2","prediction_id":prediction_id,"job_id":job.job_id,"files":{"result.json":{"bytes":len(result_raw),"sha256":hashlib.sha256(result_raw).hexdigest()}}}
+        entry={"directory":directory,"prediction_id":prediction_id,"job_id":job.job_id,"generated_at":"2026-08-01T00:00:01+00:00","status":"PREDICTION_READY","blocker_stage":None,"manifest_sha256":H,"logical_bundle_sha256":H}
+        request={"job_id":job.job_id,"race_id":job.input.race_id,"jump_timestamp":job.input.jump_timestamp,"runner_set_sha256":job.input.runner_set_sha256,"odds_source":job.input.odds_source,"config_sha256":job.input.config_sha256,"model":{"requested":job.input.model_selector,"resolved":job.input.resolved_model_identity,"model_sha256":job.input.model_sha256,"manifest_sha256":job.input.model_manifest_sha256,"schema_sha256":job.input.model_schema_sha256},"runners":[{"box_number":row["box"],"display_name":row["name"],"identity":row["identity"],"source_native_runner_id":row.get("source_native_runner_id")} for row in job.input.fields()["ordered_runners"]]}
+        return VerifiedPredictionBundle(directory,entry,result,manifest,request)
+
+    monkeypatch.setattr(r3_api_module,"verify_prediction_bundle_index",lambda *_args,**_kwargs:VerifiedPredictionBundleIndex("on_demand_prediction_bundle_index_v1","2026-08-01T00:00:01+00:00",(bundle_for(holder["store"].get(holder["job_id"])).index_entry,),b"{}",H))
+    def verify_bundle(*_args,**_kwargs):
+        return bundle_for(holder["store"].get(holder["job_id"]))
+    monkeypatch.setattr(r3_api_module,"verify_indexed_prediction_bundle",verify_bundle)
+
+    def successful_runner(store,job_id,_worker,*,now,confirm_audit):
+        holder.update(store=store,job_id=job_id)
+        def popen(argv,**_kwargs):
+            holder["argv"]=argv
+            return Process(ready(store.get(job_id)))
+        completed=real_run_once(store,job_id,_worker,now=now,confirm_audit=confirm_audit,popen=popen,reader=lambda **_:current_view)
+        worker_completed.set()
+        return completed
+    monkeypatch.setattr(bootstrap_module,"run_once",successful_runner)
+
+    app=Flask(__name__);app.config.update(TESTING=True,OPERATOR_UI_CONNECTED_MODE=True,OPERATOR_UI_SECRET_KEY="repository-secret-"+"x"*40,OPERATOR_UI_USERNAME="operator",OPERATOR_UI_PASSWORD_HASH=generate_password_hash("correct horse"),OPERATOR_UI_LEVEL=2,OPERATOR_UI_DEPLOYED_COMMIT="21e7b02e60e82da9c4dbbb796ea435bc120e9862",OPERATOR_UI_DEPLOYED_TREE="2cfc75cd8a2af1a9e5da4986c969cb668b93af62",OPERATOR_UI_DEPLOYED_VERSION="operator-ui-v1",OPERATOR_UI_DEPLOYED_PROFILE="repository-v1")
+    app.config[R3_PROFILE_KEY]="repository-v1";assert bootstrap_module.configure_r3_startup(app) is True
+    install_connected_mode(app);assert bind_configured_r3(app) is True
+    holder["store"]=app.extensions["operator_ui_r3_services"].job_store
+    client=app.test_client();token=client.get("/operator-ui/login",base_url="https://localhost").get_json()["csrf_token"]
+    token=client.post("/operator-ui/login",base_url="https://localhost",data={"username":"operator","password":"correct horse","csrf_token":token}).get_json()["csrf_token"]
+    response=client.post("/operator-ui/api/v1/prediction-jobs",base_url="https://localhost",headers={"X-CSRF-Token":token},json={"race_id":RACE_ID,"model_id":"latest-research","config_id":"manual-default","odds_source_id":"receipt","idempotency_key":"12345678-1234-4123-8123-123456789abc"})
+    holder["job_id"]=response.get_json()["job_id"]
+    assert worker_completed.wait(timeout=5)
+    deadline=time.monotonic()+5
+    while True:
+        payload=client.get(f"/operator-ui/api/v1/prediction-jobs/{holder['job_id']}",base_url="https://localhost").get_json()
+        if payload["phase"]=="PREDICTION_READY" or time.monotonic()>=deadline:break
+        time.sleep(.01)
+    assert payload["phase"]=="PREDICTION_READY"
+    assert payload["result"]["verification_status"]=="VERIFIED"
+    assert [row["runner_id"] for row in payload["result"]["probabilities"]]==["ALPHA","BETA"]
+    assert holder["argv"][holder["argv"].index("--odds-source")+1]=="receipt"
+    assert canonical.read_bytes()==b"canonical-read-only"
+    assert holder["store"].verify()
 
 
 def test_repository_profile_schema_evidence_identities_pass_api_validation(tmp_path,monkeypatch):

--- a/tests/operator_ui/test_job_store.py
+++ b/tests/operator_ui/test_job_store.py
@@ -239,6 +239,14 @@ def test_verifier_failure_requires_exact_nonempty_blocker(tmp_path):
     with pytest.raises(ValueError): value.verifier_transition(job.job_id,Phase.FAILED,capability=authority,now=NOW,status="FAILED",reason="verification_failed",facts=facts,confirm_audit=CONFIRM)
     assert value.get(job.job_id).phase is Phase.PRODUCER_COMPLETED
 
+def test_verifier_can_terminally_record_exact_sealed_bundle_failure_without_fabricated_hashes(tmp_path):
+    authority=object(); value=JobStore(tmp_path/"jobs.db",verifier_authority=authority); job,evidence=producer_completed(value,authority)
+    facts={"prediction_id":evidence["prediction_id"],"job_id":job.job_id,"race_id":job.input.race_id,"jump_timestamp":job.input.jump_timestamp,"runner_set_sha256":job.input.runner_set_sha256,"resolved_model_identity":job.input.resolved_model_identity,"model_sha256":job.input.model_sha256,"model_manifest_sha256":job.input.model_manifest_sha256,"model_schema_sha256":job.input.model_schema_sha256,"config_id":job.input.config_id,"config_sha256":job.input.config_sha256,"producer_status":"PREDICTION_READY","verification_status":"FAILED","blocker":{"code":"BUNDLE_INDEX_VERIFICATION_FAILED","stage":"BUNDLE_VERIFICATION"}}
+    final=value.verifier_transition(job.job_id,Phase.FAILED,capability=authority,now=NOW,status="FAILED",reason="verification_failed",facts=facts,confirm_audit=CONFIRM)
+    assert final.phase is Phase.FAILED
+    assert value.events(job.job_id)[-1]["facts"]["blocker"]==facts["blocker"]
+    assert value.verify()
+
 def test_claimed_failure_rejects_reviewer_impossible_error_shape(tmp_path):
     value=store(tmp_path); job,attempt=value.claim_attempt(claimable(value,create(value)).job_id,now=NOW,confirm_audit=CONFIRM)
     with pytest.raises(JobStoreError):

--- a/tests/operator_ui/test_r3_api.py
+++ b/tests/operator_ui/test_r3_api.py
@@ -6,16 +6,17 @@ from datetime import datetime, timezone
 from flask import Flask
 from werkzeug.security import generate_password_hash
 
-from src.operator_ui.job_store import JobInput, JobStore, JobStoreError, Phase
-from src.operator_ui.r3_api import R3Rejected, R3Services, ResolvedSubmission, install_r3_api
+from src.operator_ui.job_store import JobInput, JobStore, JobStoreError, Phase, resolve_audit_confirmation
+from src.operator_ui.r3_api import R3Rejected, R3Services, ResolvedSubmission, finalize_producer_bundle, install_r3_api
 from src.operator_ui.security import install_connected_mode
+from src.predictor.on_demand import VerifiedPredictionBundle, VerifiedPredictionBundleIndex
 
 NOW = datetime(2026, 8, 1, tzinfo=timezone.utc)
 H = hashlib.sha256(b"r3").hexdigest()
 RACE = "race-20260801-richmond-r05"
 
 
-def application(tmp_path, *, level=2, resolver=None, result=lambda _job: None, rate=20, launch=None):
+def application(tmp_path, *, level=2, resolver=None, result=lambda _job: None, rate=20, launch=None, finalize=lambda job, _confirm: job):
     app = Flask(__name__)
     app.config.update(
         TESTING=True, OPERATOR_UI_CONNECTED_MODE=True,
@@ -38,7 +39,7 @@ def application(tmp_path, *, level=2, resolver=None, result=lambda _job: None, r
         runners = ({"box": 1, "name": "ALPHA", "identity": "ALPHA"},)
         return ResolvedSubmission(JobInput(RACE, "2026-08-01T01:00:00Z", H, "latest-research", "model-v1", H, H, H, "manual-default", H, "auto", runners), runners)
     dispatcher = launch or (lambda job_id, _confirm: launched.append(job_id))
-    install_r3_api(app, R3Services(store, resolve, dispatcher, result, clock=lambda: NOW, rate_limit=rate))
+    install_r3_api(app, R3Services(store, resolve, dispatcher, finalize, result, clock=lambda: NOW, rate_limit=rate))
     return app, store, launched
 
 
@@ -52,6 +53,15 @@ def body(**changes):
     value = {"race_id": RACE, "model_id": "latest-research", "config_id": "manual-default", "odds_source_id": "auto", "idempotency_key": "12345678-1234-4123-8123-123456789abc"}
     value.update(changes)
     return value
+
+
+def producer_complete(store, job_id):
+    confirm=lambda intent:resolve_audit_confirmation(intent,H)
+    job,attempt=store.claim_attempt(job_id,now=NOW,confirm_audit=confirm)
+    job=store.transition(job_id,Phase.ATTEMPT_STARTED,now=NOW,status="RUNNING",reason="predictor_started",facts={"attempt_id":attempt,"pid":123},confirm_audit=confirm)
+    empty=hashlib.sha256(b"").hexdigest(); facts={"attempt_id":attempt,"pid":123,"exit_code":0,"stdout_complete":True,"stdout_length":0,"stdout_sha256":empty,"stdout_prefix_length":0,"stdout_prefix_sha256":empty,"stderr_complete":True,"stderr_length":0,"stderr_sha256":empty,"stderr_prefix_length":0,"stderr_prefix_sha256":empty,"predictor_status":"PREDICTION_READY","prediction_id":"12345678-1234-4123-8123-123456789abc","producer_job_id":job_id}
+    job=store.transition(job_id,Phase.RESPONSE_RECORDED,now=NOW,status="RECORDED",reason="bounded_process_response",facts=facts,confirm_audit=confirm)
+    return store.transition(job_id,Phase.PRODUCER_COMPLETED,now=NOW,status="PRODUCER_COMPLETED",reason="PRODUCER_PREDICTION_READY",facts=facts,confirm_audit=confirm)
 
 
 def test_level2_csrf_exact_schema_idempotency_poll_and_actor_isolation(tmp_path):
@@ -153,6 +163,58 @@ def test_restart_get_alone_dispatches_and_claims_waiting_job_once(tmp_path):
     assert calls == [job_id]
     assert restarted.get(job_id).phase.value == "CLAIMED"
     assert restarted.verify()
+
+
+def test_restart_get_resumes_verification_of_durable_producer_completion(tmp_path):
+    app, store, _ = application(tmp_path)
+    client = app.test_client(); token = login(client)
+    created = client.post("/operator-ui/api/v1/prediction-jobs", base_url="https://localhost", json=body(), headers={"X-CSRF-Token": token})
+    job_id = created.get_json()["job_id"]
+    producer_complete(store,job_id)
+    finalized=[]
+    app, restarted, _ = application(tmp_path, finalize=lambda job, _confirm: (finalized.append(job.job_id) or job))
+    client=app.test_client(); login(client)
+    response=client.get(f"/operator-ui/api/v1/prediction-jobs/{job_id}",base_url="https://localhost")
+    assert response.status_code==200 and finalized==[job_id]
+    assert restarted.get(job_id).phase is Phase.PRODUCER_COMPLETED
+
+
+def test_missing_sealed_bundle_index_is_a_durable_exact_verifier_failure(tmp_path):
+    authority=object(); store=JobStore(tmp_path/"jobs.db",verifier_authority=authority)
+    runners=({"box":1,"name":"ALPHA","identity":"ALPHA"},)
+    inp=JobInput(RACE,"2026-08-01T01:00:00Z",H,"latest-research","model-v1",H,H,H,"manual-default",H,"receipt",runners)
+    confirm=lambda intent:resolve_audit_confirmation(intent,H)
+    job=store.create(actor_identity="operator",actor_level=2,operation="manual_prediction",idempotency_key="12345678-1234-4123-8123-123456789abc",job_input=inp,now=NOW,confirm_audit=confirm)
+    job=store.transition(job.job_id,Phase.VALIDATED,now=NOW,status="VALID",reason="validated",confirm_audit=confirm)
+    job=store.transition(job.job_id,Phase.WAITING_FOR_CLAIM,now=NOW,status="WAITING",reason="ready",confirm_audit=confirm)
+    job=producer_complete(store,job.job_id)
+    final=finalize_producer_bundle(tmp_path/"missing-bundles",store,job,capability=authority,now=NOW,confirm_audit=confirm)
+    assert final.phase is Phase.FAILED
+    assert store.events(job.job_id)[-1]["facts"]["blocker"]=={"code":"BUNDLE_INDEX_VERIFICATION_FAILED","stage":"BUNDLE_VERIFICATION"}
+    assert store.verify()
+
+
+def test_mismatched_sealed_blocker_is_a_durable_exact_verifier_failure(tmp_path,monkeypatch):
+    from src.operator_ui import r3_api as r3_api_module
+    authority=object(); store=JobStore(tmp_path/"jobs.db",verifier_authority=authority)
+    runners=({"box":1,"name":"ALPHA","identity":"ALPHA"},); confirm=lambda intent:resolve_audit_confirmation(intent,H)
+    inp=JobInput(RACE,"2026-08-01T01:00:00Z",H,"latest-research","model-v1",H,H,H,"manual-default",H,"receipt",runners)
+    job=store.create(actor_identity="operator",actor_level=2,operation="manual_prediction",idempotency_key="12345678-1234-4123-8123-123456789abc",job_input=inp,now=NOW,confirm_audit=confirm)
+    job=store.transition(job.job_id,Phase.VALIDATED,now=NOW,status="VALID",reason="validated",confirm_audit=confirm)
+    job=store.transition(job.job_id,Phase.WAITING_FOR_CLAIM,now=NOW,status="WAITING",reason="ready",confirm_audit=confirm)
+    job,attempt=store.claim_attempt(job.job_id,now=NOW,confirm_audit=confirm)
+    job=store.transition(job.job_id,Phase.ATTEMPT_STARTED,now=NOW,status="RUNNING",reason="predictor_started",facts={"attempt_id":attempt,"pid":123},confirm_audit=confirm)
+    empty=hashlib.sha256(b"").hexdigest(); facts={"attempt_id":attempt,"pid":123,"exit_code":2,"stdout_complete":True,"stdout_length":0,"stdout_sha256":empty,"stdout_prefix_length":0,"stdout_prefix_sha256":empty,"stderr_complete":True,"stderr_length":0,"stderr_sha256":empty,"stderr_prefix_length":0,"stderr_prefix_sha256":empty,"predictor_status":"PREDICTION_BLOCKED","prediction_id":"12345678-1234-4123-8123-123456789abc","producer_job_id":job.job_id,"producer_blocker":{"code":"POST_JUMP","stage":"VALIDATION"}}
+    job=store.transition(job.job_id,Phase.RESPONSE_RECORDED,now=NOW,status="RECORDED",reason="bounded_process_response",facts=facts,confirm_audit=confirm)
+    job=store.transition(job.job_id,Phase.PRODUCER_COMPLETED,now=NOW,status="PRODUCER_COMPLETED",reason="PRODUCER_PREDICTION_BLOCKED:POST_JUMP",facts=facts,confirm_audit=confirm)
+    entry={"directory":"prediction_safe","prediction_id":facts["prediction_id"],"job_id":job.job_id,"status":"PREDICTION_BLOCKED","manifest_sha256":H,"logical_bundle_sha256":H}
+    bundle=VerifiedPredictionBundle("prediction_safe",entry,{"blocker":{"code":"NO_MATCH"},"blocker_stage":"VALIDATION"},{},{})
+    monkeypatch.setattr(r3_api_module,"verify_prediction_bundle_index",lambda *_args,**_kwargs:VerifiedPredictionBundleIndex("on_demand_prediction_bundle_index_v1",NOW.isoformat(),(entry,),b"{}",H))
+    monkeypatch.setattr(r3_api_module,"verify_indexed_prediction_bundle",lambda *_args,**_kwargs:bundle)
+    final=finalize_producer_bundle(tmp_path,store,job,capability=authority,now=NOW,confirm_audit=confirm)
+    assert final.phase is Phase.FAILED
+    assert store.events(job.job_id)[-1]["facts"]["blocker"]=={"code":"BUNDLE_BLOCKER_IDENTITY_MISMATCH","stage":"BUNDLE_VERIFICATION"}
+    assert store.verify()
 
 
 def test_same_process_get_renotifies_when_dispatch_has_no_durable_outcome(tmp_path):

--- a/tests/operator_ui/test_r3_e2e_safety.py
+++ b/tests/operator_ui/test_r3_e2e_safety.py
@@ -124,7 +124,7 @@ def test_one_authenticated_submission_reaches_real_worker_once_without_false_rea
                  popen=lambda *args, **kwargs: Process(output),
                  reader=index)
 
-    install_r3_api(app, R3Services(store, resolved, launch, lambda job: None, clock=lambda: NOW, rate_limit=20))
+    install_r3_api(app, R3Services(store, resolved, launch, lambda job, _confirm: job, lambda job: None, clock=lambda: NOW, rate_limit=20))
     client = app.test_client()
     token = client.get("/operator-ui/login", base_url="https://localhost").get_json()["csrf_token"]
     token = client.post("/operator-ui/login", base_url="https://localhost", data={"username": "operator", "password": "safe-password", "csrf_token": token}).get_json()["csrf_token"]


### PR DESCRIPTION
## Summary

- wires producer completion through the existing strict sealed-bundle verifier before probability disclosure
- records exact terminal bundle-verification failures without fabricating unavailable hashes
- resumes verifier finalization for durable PRODUCER_COMPLETED jobs after process restart
- exercises the real receipt-only prediction worker path through the composed repository profile

## Proven defect

Current master stopped at PRODUCER_COMPLETED because no production service composed the verifier-owned final transition. Verifier errors could also leave that phase nonterminal.

## Scope boundaries

Offline only. No live UI POST, prediction invocation, collector or service change, deployment, acquisition, model/config change, journal mutation, scoring, DB migration, betting, merge, or cleanup.

## Validation

- 395 focused Operator UI store/API/bootstrap/worker/safety/deployment tests passed
- focused current-index/native-ID/receipt/bundle checks passed
- 13 browser-state tests passed
- Python compilation, JavaScript syntax, JSON parsing, and git diff --check passed
- Standards review: PASS
- Spec review: PASS

Playwright is not installed in the retained environment, so no new Playwright run was fabricated or installed.

## Remaining acceptance blocker

This PR does not make the UI ready for guarded live proof. The durable job input records race, jump, runner set, receipt-derived protocol facts, model, config, schema, and prediction-bundle identities, but it does not record the admission operational-index packet, source-refresh, publication, state, and report hashes. Correcting that requires a deliberate immutable JobInput/store-schema migration, which is excluded from this task.

Tracks #135.