### PR TITLE
Fix scorer race venue alias binding

### DIFF
--- a/scripts/predict_market_form_residual.py
+++ b/scripts/predict_market_form_residual.py
@@ -50,7 +50,7 @@ from src.predictor.scoring_parity import (  # noqa: E402
     build_scoring_input,
     parity_binding,
 )
-from config.venue_mapping import normalize_venue  # noqa: E402
+from config.venue_mapping import VENUE_MAPPING, normalize_venue  # noqa: E402
 from utils.csv_metadata import (  # noqa: E402
     THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE,
     THEDOGS_MEETING_CARD_GRADE_SOURCE,
@@ -310,6 +310,7 @@ EARLY_RESIDUAL_PARITY_KEYS = frozenset(
     }
 )
 VENUE_CODE_PATTERN = r"[A-Z0-9_]+(?:-[A-Z0-9_]+)*"
+NON_RACING_VENUE_IDENTITIES = frozenset({"UNKNOWN", "TEST_VEN", "RACE"})
 FORBIDDEN_EVIDENCE_PATH_MARKERS = frozenset({"form_only_v1", "pr51"})
 # Finite union of the exact GRADE_MAP and GRADE_VOCAB_MAP contracts, their
 # canonical values, and source-observed exact labels covered by the scorer
@@ -674,6 +675,71 @@ def _race_id_parts(race_id: str) -> tuple[int, str, date]:
         int(match.group(1)),
         match.group(2).strip().upper(),
         _parse_date(match.group(3), "discovery_race_date"),
+    )
+
+
+def _configured_venue_identity(value: Any) -> str | None:
+    """Resolve only venue spellings proved by the checked-in canonical map."""
+
+    if not isinstance(value, str):
+        return None
+    raw = value.strip().upper()
+    if not raw or re.fullmatch(VENUE_CODE_PATTERN, raw) is None:
+        return None
+    candidates = {
+        raw,
+        raw.replace("-", " "),
+        raw.replace("-", "_"),
+        raw.replace("_", " "),
+        raw.replace("_", "-"),
+    }
+    normalized = {
+        normalize_venue(candidate)
+        for candidate in candidates
+        if candidate in VENUE_MAPPING
+    }
+    if len(normalized) != 1:
+        return None
+    configured = next(iter(normalized))
+    canonical = canonical_thedogs_venue_identity(configured)
+    if (
+        configured in NON_RACING_VENUE_IDENTITIES
+        or canonical in NON_RACING_VENUE_IDENTITIES
+    ):
+        return None
+    return canonical
+
+
+def _race_identity_equivalent(
+    caller_race_id: Any,
+    evidence_race_id: Any,
+    *,
+    source_url: Any,
+) -> bool:
+    """Bind caller and sealed-source aliases by exact structured identity."""
+
+    try:
+        caller_number, caller_venue, caller_date = _race_id_parts(caller_race_id)
+        evidence_number, evidence_venue, evidence_date = _race_id_parts(
+            evidence_race_id
+        )
+    except ManualPredictionError:
+        return False
+    source_identity = canonical_thedogs_race_identity(source_url)
+    if source_identity is None:
+        return False
+    venues = (
+        _configured_venue_identity(caller_venue),
+        _configured_venue_identity(evidence_venue),
+        _configured_venue_identity(source_identity["venue_slug"]),
+    )
+    return bool(
+        all(venue is not None for venue in venues)
+        and len(set(venues)) == 1
+        and caller_date == evidence_date
+        and caller_date.isoformat() == source_identity["race_date"]
+        and caller_number == evidence_number
+        and caller_number == source_identity["race_number"]
     )
 
 
@@ -1723,7 +1789,12 @@ def _feature_packet(
     selected = [
         row
         for row in rows
-        if isinstance(row, Mapping) and row.get("race_id") == race_id
+        if isinstance(row, Mapping)
+        and _race_identity_equivalent(
+            race_id,
+            row.get("race_id"),
+            source_url=context["source_url"],
+        )
     ]
     if len(selected) < 2:
         raise ManualPredictionError("feature_rows_for_race_missing")
@@ -1766,7 +1837,10 @@ def _feature_packet(
             != context["target_race_date"]
         ):
             raise ManualPredictionError("feature_row_race_date_mismatch")
-        if str(row.get("venue") or "").strip().upper() != context["target_venue"]:
+        if (
+            _configured_venue_identity(row.get("venue"))
+            != _configured_venue_identity(context["target_venue"])
+        ):
             raise ManualPredictionError("feature_row_venue_mismatch")
         if (
             _integer(row.get("race_number"), "feature_row_race_number", minimum=1)
@@ -1833,9 +1907,10 @@ def discover_race_artifacts(
         raise ManualPredictionError("pr51_form_only_v1_evidence_forbidden")
     race_number, venue_query = _race_query_parts(race_query)
     exact_identity = None
+    exact_venue = None
     if exact_race_id is not None:
         exact_identity = str(exact_race_id).strip()
-        _race_id_parts(exact_identity)
+        _, exact_venue, _ = _race_id_parts(exact_identity)
 
     feature_candidates: list[dict[str, Any]] = []
     seen_feature_packets: set[Path] = set()
@@ -1881,8 +1956,6 @@ def discover_race_artifacts(
                 }
             )
             for race_id in race_ids:
-                if exact_identity is not None and race_id != exact_identity:
-                    continue
                 try:
                     candidate_number, candidate_venue, candidate_date = _race_id_parts(
                         race_id
@@ -1896,7 +1969,23 @@ def discover_race_artifacts(
                     for row in rows
                     if isinstance(row, Mapping) and row.get("race_id") == race_id
                 ]
+                source_urls = {
+                    str(row.get("target_metadata_source_url") or "").strip()
+                    for row in selected_rows
+                }
+                source_urls.discard("")
+                if exact_identity is not None and (
+                    len(source_urls) != 1
+                    or not _race_identity_equivalent(
+                        exact_identity,
+                        race_id,
+                        source_url=next(iter(source_urls), None),
+                    )
+                ):
+                    continue
                 aliases: list[str] = []
+                if exact_venue is not None:
+                    aliases.append(exact_venue)
                 for row in selected_rows:
                     row_venue = str(row.get("venue") or "")
                     if _runner_token(row_venue) != _runner_token(candidate_venue):
@@ -2009,7 +2098,7 @@ def discover_race_artifacts(
     if len(selected_features) != 1:
         raise ManualPredictionError("race_feature_packet_ambiguous")
     selected_feature = selected_features[0]
-    race_id = str(selected_feature["race_id"])
+    race_id = exact_identity or str(selected_feature["race_id"])
 
     capture_candidates: list[dict[str, Any]] = []
     seen_capture_reports: set[Path] = set()
@@ -2072,6 +2161,7 @@ def discover_race_artifacts(
 
     return {
         **selected_feature,
+        "race_id": race_id,
         "capture_path": selected_captures[0]["capture_path"],
     }
 
@@ -2605,7 +2695,11 @@ def score_from_artifacts(
         form_sha=form_sha,
     )
     context = _sidecar_context(sidecar)
-    if race_id != context["expected_race_id"]:
+    if not _race_identity_equivalent(
+        race_id,
+        context["expected_race_id"],
+        source_url=context["source_url"],
+    ):
         raise ManualPredictionError("race_id_sidecar_mismatch")
     implementation = _json_object(implementation_raw, "implementation_manifest")
     feature_by_box, feature_time, feature_generated_time = _feature_packet(

--- a/tests/fixtures/qot_r7_race_identity_alias_20260825.json
+++ b/tests/fixtures/qot_r7_race_identity_alias_20260825.json
@@ -1,0 +1,94 @@
+{
+  "caller_race_id": "Race 7 - QOT - 2026-08-25",
+  "source_race_id": "Race 7 - LADBROKES-Q1-LAKESIDE - 2026-08-25",
+  "source_url": "https://www.thedogs.com.au/racing/ladbrokes-q1-lakeside/2026-08-25/7/garrard-s-horse-and-hound?trial=false",
+  "race_date": "2026-08-25",
+  "race_number": 7,
+  "caller_venue": "QOT",
+  "source_venue": "LADBROKES-Q1-LAKESIDE",
+  "venue_slug": "ladbrokes-q1-lakeside",
+  "runners": [
+    {
+      "box_number": 1,
+      "display_name": "Haras Mosaic",
+      "capture_name": "Hara's Mosaic",
+      "identity": "HARASMOSAIC",
+      "source_native_runner_id": "7582938",
+      "odds_decimal": 4.2,
+      "features": [5, 9, 3.6666666666666665, 1, 0.2, 0.4, 6.5, 0.2, 0.4, 3.2, 0, 0, 0, 0, 3, 0]
+    },
+    {
+      "box_number": 2,
+      "display_name": "Big Grin",
+      "capture_name": "Big Grin",
+      "identity": "BIGGRIN",
+      "source_native_runner_id": "7582939",
+      "odds_decimal": 6.0,
+      "features": [5, 7, 3.6666666666666665, 2, 0, 0.6, 4.25, 0, 0.6, 3.4, 0, 0, 5, 0, 5, 0]
+    },
+    {
+      "box_number": 3,
+      "display_name": "Equal Impact",
+      "capture_name": "Equal Impact",
+      "identity": "EQUALIMPACT",
+      "source_native_runner_id": "7582940",
+      "odds_decimal": 3.3,
+      "features": [5, 7, 3.3333333333333335, 1, 0.2, 0.6, 3.15, 0.2, 0.6, 3.4, 0, 0, 1, 0, 2, 0]
+    },
+    {
+      "box_number": 4,
+      "display_name": "Flaming Valora",
+      "capture_name": "Flaming Valora",
+      "identity": "FLAMINGVALORA",
+      "source_native_runner_id": "7582941",
+      "odds_decimal": 41.0,
+      "features": [5, 7, 4, 3, 0, 0.4, 6.1, 0, 0.4, 4, 0, 0, 5, 0, 5, 0]
+    },
+    {
+      "box_number": 5,
+      "display_name": "Cyclone Saskia",
+      "capture_name": "Cyclone Saskia",
+      "identity": "CYCLONESASKIA",
+      "source_native_runner_id": "7582942",
+      "odds_decimal": 46.0,
+      "features": [5, 7, 4, 2, 0, 0.4, 7.25, 0, 0.4, 4.8, 0, 0, 0, 0, 5, 0]
+    },
+    {
+      "box_number": 6,
+      "display_name": "Elusive Suzie",
+      "capture_name": "Elusive Suzie",
+      "identity": "ELUSIVESUZIE",
+      "source_native_runner_id": "7582943",
+      "odds_decimal": 41.0,
+      "features": [2, 11, 3, 1, 0.5, 0.5, 6.25, 0.5, 0.5, 3, 0, 0, 0, 0, 0, 0]
+    },
+    {
+      "box_number": 7,
+      "display_name": "Lady Shazam",
+      "capture_name": "Lady Shazam",
+      "identity": "LADYSHAZAM",
+      "source_native_runner_id": "7582944",
+      "odds_decimal": 41.0,
+      "features": [5, 7, 6.333333333333333, 3, 0, 0.2, 8.7, 0, 0.2, 5.4, 0, 0, 5, 0, 5, 0]
+    },
+    {
+      "box_number": 8,
+      "display_name": "Get Ahead Tina",
+      "capture_name": "Get Ahead Tina",
+      "identity": "GETAHEADTINA",
+      "source_native_runner_id": "7582945",
+      "odds_decimal": 2.0,
+      "features": [3, 21, 3.6666666666666665, 1, 0.3333333333333333, 0.6666666666666666, 18.083333333333332, 0.3333333333333333, 0.6666666666666666, 3.6666666666666665, 0, 0, 0, 0, 1, 0]
+    }
+  ],
+  "runner_set_sha256": "0fccb99f24f2d9c6ce9fbb39ec37ba6d9c8d49935ad30aec4871a25d064adc95",
+  "preserved_input_sha256": {
+    "request.json": "0c4e5477ae5a07c0cf7762769fffca946907991a28fdcdd439cbe367811207d0",
+    "source/form.csv": "be242572be21e73b5bde88c5fba046ab02cb350bb8b0a425ecc4e0cb288ddea4",
+    "source/sidecar.metadata.json": "6982d1c63ebf56e2dbd8f74adebf951e57ac71c709476212e29d944eb1dbdaa6",
+    "source/capture.json": "d3d22d244ed27a558cdf81150c006bca7769f922ba85536a0de882397794c959",
+    "features/shadow_feature_rows.json": "e9ee8f7d94936a7d20f92b7bc8314cfa4ff4b88a1029085e1971df72a31eea94",
+    "features/shadow_manifest.json": "56ce5b94ea4d2a553cfa199f31337389348d9e1f245f7acfabd50434e177cab7",
+    "features/implementation_file_manifest.json": "29267243a1095f3e8fdf3ef54841d89b99bb6ae1f982e4d46be163e2a508c83d"
+  }
+}

--- a/tests/test_predict_market_form_residual.py
+++ b/tests/test_predict_market_form_residual.py
@@ -1379,17 +1379,19 @@ def _retarget_fixture_contract(
     venue_slug: str,
     sidecar_grade: str,
     feature_grade: str,
+    race_number: int | None = None,
 ) -> str:
     sidecar = _json(paths["sidecar"])
     assert isinstance(sidecar, dict)
     shadow = sidecar["prejump_shadow_metadata"]
-    race_number = int(shadow["race_number"])
+    race_number = race_number or int(shadow["race_number"])
     race_date = str(shadow["race_date"])
     race_id = f"Race {race_number} - {venue} - {race_date}"
     thedogs_url = (
         f"https://www.thedogs.com.au/racing/{venue_slug}/{race_date}/{race_number}/test"
     )
     shadow["venue"] = venue
+    shadow["race_number"] = race_number
     shadow["grade"] = sidecar_grade
     shadow["source_url"] = thedogs_url
     sidecar["race_url"] = thedogs_url
@@ -1451,6 +1453,282 @@ def _retarget_fixture_contract(
 
     _reseal(paths, retarget)
     return race_id
+
+
+def _apply_preserved_qot_r7_identity(paths: dict[str, Path]) -> dict:
+    evidence = _json(
+        ROOT / "tests/fixtures/qot_r7_race_identity_alias_20260825.json"
+    )
+    assert isinstance(evidence, dict)
+    source_race_id = str(evidence["source_race_id"])
+    source_url = str(evidence["source_url"])
+    race_date = str(evidence["race_date"])
+    race_number = int(evidence["race_number"])
+    source_venue = str(evidence["source_venue"])
+    runners = evidence["runners"]
+    assert isinstance(runners, list) and len(runners) == 8
+    participants = [
+        {
+            "box_number": int(runner["box_number"]),
+            "dog_name": str(runner["display_name"]),
+        }
+        for runner in runners
+    ]
+
+    sidecar = _json(paths["sidecar"])
+    assert isinstance(sidecar, dict)
+    shadow = sidecar["prejump_shadow_metadata"]
+    shadow.update(
+        {
+            "metadata_captured_at": "2026-08-25T16:52:43+10:00",
+            "race_date": race_date,
+            "race_number": race_number,
+            "venue": source_venue,
+            "jump_datetime": "2026-08-25T17:18:00+10:00",
+            "source_url": source_url,
+        }
+    )
+    shadow["runner_box_name_list"] = copy.deepcopy(participants)
+    sidecar["runner_completeness"].update(
+        {
+            "runner_count": len(participants),
+            "participants": copy.deepcopy(participants),
+        }
+    )
+    exact_url = source_url.removesuffix("?trial=false")
+    proof_values = {
+        "target_grade_source": "thedogs_exact_race_page",
+        "target_grade_context_schema": "thedogs_exact_race_page_v1",
+        "target_grade_race_date": race_date,
+        "target_grade_race_number": race_number,
+        "target_grade_race_url": exact_url,
+        "target_grade_source_url": exact_url,
+        "target_grade_venue": str(evidence["caller_venue"]),
+    }
+    sidecar.update({"race_url": source_url, **proof_values})
+    sidecar["race_info"].update(
+        {
+            "date": race_date,
+            "venue": source_venue,
+            "race_number": race_number,
+            "url": source_url,
+            **proof_values,
+        }
+    )
+    old_form_csv = paths["form_csv"]
+    old_sidecar = paths["sidecar"]
+    form_csv = old_form_csv.with_name(f"{source_race_id}.csv")
+    sidecar_path = form_csv.with_name(form_csv.name + ".metadata.json")
+    old_form_csv.rename(form_csv)
+    old_sidecar.rename(sidecar_path)
+    paths["form_csv"] = form_csv
+    paths["sidecar"] = sidecar_path
+    sidecar["filename"] = form_csv.name
+    _write_json(sidecar_path, sidecar)
+
+    capture = _json(paths["capture"])
+    assert isinstance(capture, dict)
+    attempt = capture["attempts"][0]
+    attempt.update(
+        {
+            "race_id": evidence["caller_race_id"],
+            "fetch_time": "2026-08-25T16:56:08+10:00",
+            "append_time": "2026-08-25T16:56:43+10:00",
+        }
+    )
+    attempt["validation"]["source_url"] = (
+        "https://www.sportsbet.com.au/greyhound-racing/australia-nz/"
+        "q1-lakeside/race-7-10845900"
+    )
+    attempt["validation"].update(
+        {
+            "accepted_rows": [
+                {
+                    "box_number": int(runner["box_number"]),
+                    "dog_name": str(runner["capture_name"]),
+                    "identity": str(runner["identity"]),
+                    "odds_decimal": float(runner["odds_decimal"]),
+                    "sportsbet_box_source": "runner_text",
+                }
+                for runner in runners
+            ],
+            "accepted_row_count": len(runners),
+            "expected_runner_count": len(runners),
+            "active_expected_runner_count": len(runners),
+        }
+    )
+    _write_json(paths["capture"], capture)
+
+    def retarget(rows, manifest):
+        manifest["generated_at"] = "2026-08-25T17:06:08+10:00"
+        manifest["feature_freeze_timestamp"] = "2026-08-25T17:06:08+10:00"
+        manifest["input_files"] = [str(form_csv.resolve())]
+        template = copy.deepcopy(rows[0])
+        rows[:] = []
+        for runner in runners:
+            row = copy.deepcopy(template)
+            row.update(
+                {
+                    "race_id": source_race_id,
+                    "race_date": race_date,
+                    "race_number": race_number,
+                    "venue": source_venue,
+                    "box_number": int(runner["box_number"]),
+                    "dog_name": str(runner["display_name"]),
+                    "target_metadata_source_url": source_url,
+                    "source_csv": str(form_csv.resolve()),
+                    **dict(zip(FEATURES, runner["features"])),
+                }
+            )
+            rows.append(row)
+
+    _reseal(paths, retarget)
+    return evidence
+
+
+def test_preserved_qot_r7_alias_reaches_scoring_with_caller_identity(tmp_path):
+    paths = _write_fixture(tmp_path)
+    evidence = _apply_preserved_qot_r7_identity(paths)
+
+    prediction = _score_paths(
+        paths,
+        race_id=evidence["caller_race_id"],
+        score_timestamp=datetime.fromisoformat("2026-08-25T17:06:09+10:00"),
+    )
+
+    assert prediction["race_id"] == evidence["caller_race_id"]
+    assert len(prediction["predictions"]) == len(evidence["runners"])
+    assert [row["box"] for row in prediction["canonical_runner_order"]] == list(
+        range(1, 9)
+    )
+    assert all(len(runner["features"]) == len(FEATURES) for runner in evidence["runners"])
+    assert evidence["preserved_input_sha256"]["features/shadow_feature_rows.json"] == (
+        "e9ee8f7d94936a7d20f92b7bc8314cfa4ff4b88a1029085e1971df72a31eea94"
+    )
+
+
+def test_preserved_qot_r7_alias_discovery_keeps_exact_caller_identity(tmp_path):
+    paths = _write_fixture(tmp_path)
+    evidence = _apply_preserved_qot_r7_identity(paths)
+
+    discovered = manual.discover_race_artifacts(
+        race_query="qot r7",
+        exact_race_id=evidence["caller_race_id"],
+        evidence_roots=[tmp_path],
+        score_timestamp=datetime.fromisoformat("2026-08-25T17:06:09+10:00"),
+    )
+
+    assert discovered["race_id"] == evidence["caller_race_id"]
+    assert discovered["feature_rows_path"] == paths["feature_rows"].resolve()
+
+
+@pytest.mark.parametrize(
+    "caller_race_id",
+    [
+        "Race 7 - QOT - 2026-08-24",
+        "Race 8 - QOT - 2026-08-25",
+        "Race 7 - WAR - 2026-08-25",
+        "Race 7 - UNMAPPED-Q1-LAKESIDE - 2026-08-25",
+    ],
+)
+def test_preserved_qot_r7_alias_rejects_different_or_unknown_race(
+    tmp_path, caller_race_id
+):
+    paths = _write_fixture(tmp_path)
+    _apply_preserved_qot_r7_identity(paths)
+
+    with pytest.raises(ManualPredictionError, match="race_id_sidecar_mismatch"):
+        _score_paths(
+            paths,
+            race_id=caller_race_id,
+            score_timestamp=datetime.fromisoformat("2026-08-25T17:06:09+10:00"),
+        )
+
+
+@pytest.mark.parametrize(
+    ("venue", "venue_slug"),
+    [
+        ("UNKNOWN", "unknown"),
+        ("TEST_VEN", "test-ven"),
+        ("RACE", "race"),
+        ("__R_", "unknown"),
+    ],
+)
+def test_structured_race_identity_rejects_non_racing_mapping_sentinels(
+    venue, venue_slug
+):
+    race_id = f"Race 7 - {venue} - 2026-08-25"
+
+    assert not manual._race_identity_equivalent(
+        race_id,
+        race_id,
+        source_url=(
+            f"https://www.thedogs.com.au/racing/{venue_slug}/"
+            "2026-08-25/7/example"
+        ),
+    )
+
+
+def test_preserved_qot_r7_alias_rejects_runner_set_mismatch(tmp_path):
+    paths = _write_fixture(tmp_path)
+    evidence = _apply_preserved_qot_r7_identity(paths)
+    sidecar = _json(paths["sidecar"])
+    assert isinstance(sidecar, dict)
+    sidecar["prejump_shadow_metadata"]["runner_box_name_list"][0]["dog_name"] = (
+        "Different Runner"
+    )
+    sidecar["runner_completeness"]["participants"][0]["dog_name"] = (
+        "Different Runner"
+    )
+    _write_json(paths["sidecar"], sidecar)
+
+    with pytest.raises(ManualPredictionError, match="feature_runner_set_mismatch"):
+        _score_paths(
+            paths,
+            race_id=evidence["caller_race_id"],
+            score_timestamp=datetime.fromisoformat("2026-08-25T17:06:09+10:00"),
+        )
+
+
+def test_preserved_qot_r7_alias_rejects_source_url_for_other_race(tmp_path):
+    paths = _write_fixture(tmp_path)
+    evidence = _apply_preserved_qot_r7_identity(paths)
+    sidecar = _json(paths["sidecar"])
+    assert isinstance(sidecar, dict)
+    wrong_url = str(evidence["source_url"]).replace("/7/", "/8/")
+    for mapping, key in (
+        (sidecar["prejump_shadow_metadata"], "source_url"),
+        (sidecar, "race_url"),
+        (sidecar["race_info"], "url"),
+    ):
+        mapping[key] = wrong_url
+    _write_json(paths["sidecar"], sidecar)
+
+    with pytest.raises(ManualPredictionError, match="target_grade_proof_mismatch"):
+        _score_paths(
+            paths,
+            race_id=evidence["caller_race_id"],
+            score_timestamp=datetime.fromisoformat("2026-08-25T17:06:09+10:00"),
+        )
+
+
+def test_non_aliased_war_r4_prediction_is_unchanged(tmp_path):
+    paths = _write_fixture(tmp_path)
+    baseline = _score_paths(paths)
+    race_id = _retarget_fixture_contract(
+        paths,
+        venue="WAR",
+        venue_slug="warrnambool",
+        sidecar_grade="Grade 5",
+        feature_grade="Grade 5",
+        race_number=4,
+    )
+
+    prediction = _score_paths(paths, race_id=race_id)
+
+    assert race_id == "Race 4 - WAR - 2026-07-16"
+    assert prediction["race_id"] == race_id
+    assert prediction["predictions"] == baseline["predictions"]
 
 
 def _early_residual_index_payload(


### PR DESCRIPTION
## Summary

- replace raw scorer race-ID equality with strict structured equivalence at the source-binding and feature-row seams
- reuse the canonical venue map for evidence-proven aliases such as `QOT` and `LADBROKES-Q1-LAKESIDE`, while rejecting unknown, ambiguous, and non-racing sentinel identities
- preserve the caller/output race ID and existing exact runner/effective-box binding
- add a compact regression fixture carrying the preserved QOT R7 identities, eight-runner set, odds, all 16 frozen feature values, and recorded input hashes

## Validation

- `307 passed` in `tests/test_predict_market_form_residual.py`
- `506 passed, 1 skipped` across adjacent manual-prediction, sealed-bundle, capture-sealer, and CSV-hardening tests
- preserved QOT R7 pre-jump bundle scored offline past the former mismatch with eight predictions and caller identity retained
- `py_compile`, fixture JSON parse, schema-focused test, and `git diff --check` passed
- independent Standards review: no findings
- independent Spec review: no findings

## Safety boundary

QOT R7 remains consumed and was not retried through the journal. No result or post-jump evidence was accessed. This PR does not deploy, mutate runtime/services, resume the journal, change models/features/config, collect data, or write predictions.