### PR TITLE
Bind Operator UI jobs to admission provenance

### DIFF
--- a/scripts/predict_race_now.py
+++ b/scripts/predict_race_now.py
@@ -72,6 +72,7 @@ from src.predictor.on_demand import (  # noqa: E402
     sha256_bytes,
     sha256_file,
     verify_bundle,
+    validate_operational_index_provenance,
     write_exact_bytes,
 )
 from utils.csv_metadata import canonical_thedogs_race_identity  # noqa: E402
@@ -919,6 +920,13 @@ def _run_prediction(
     if current_time.tzinfo is None or current_time.utcoffset() is None:
         raise PredictionBlocked("CURRENT_TIME_TIMEZONE_MISSING")
     job_id = _job_id(getattr(args, "job_id", None))
+    operational_index_provenance=None
+    if getattr(args,"operational_index_provenance",None) is not None:
+        try:
+            operational_index_provenance=json.loads(args.operational_index_provenance)
+        except (TypeError,json.JSONDecodeError) as exc:
+            raise PredictionBlocked("PREDICTION_BUNDLE_IDENTITY_MISMATCH",field="operational_index_provenance") from exc
+        operational_index_provenance=validate_operational_index_provenance(operational_index_provenance)
     model = resolve_model(args.model)
     config, config_sha, config_raw = load_config(Path(args.config), model)
     from race_collection.synchronous_manual_capture import (
@@ -1005,7 +1013,7 @@ def _run_prediction(
         or getattr(args, "race_url", None)
     )
     request = {
-        "schema_version": "on_demand_prediction_request_v1",
+        "schema_version": "on_demand_prediction_request_v2" if operational_index_provenance is not None else "on_demand_prediction_request_v1",
         "prediction_id": state["prediction_id"],
         "job_id": state["job_id"],
         "race_query": race_selector,
@@ -1019,6 +1027,8 @@ def _run_prediction(
         "runners": state["runners"],
         "runner_set_sha256": state["runner_set_sha256"],
     }
+    if operational_index_provenance is not None:
+        request["operational_index_provenance"]=operational_index_provenance
     _write_canonical(bundle / "request.json", request)
     write_exact_bytes(bundle / "config.json", config_raw)
     _copy_exact(model.schema_path, bundle / "model" / "config.schema.json")
@@ -1419,6 +1429,7 @@ def build_parser() -> argparse.ArgumentParser:
     target.add_argument("--list-configs", action="store_true")
     parser.add_argument("--model", default="latest-research")
     parser.add_argument("--job-id")
+    parser.add_argument("--operational-index-provenance")
     parser.add_argument(
         "--config", type=Path, default=ROOT / "configs/prediction/manual-default.json"
     )

--- a/src/operator_ui/bootstrap.py
+++ b/src/operator_ui/bootstrap.py
@@ -20,7 +20,7 @@ from flask import Flask
 from race_collection.synchronous_manual_capture import CaptureOneRejected, VerifiedCurrentRaceIndex, bounded_current_race_index
 from src.predictor.on_demand import PredictionBlocked
 from .api import register_level_1_provider
-from .job_store import JobInput, JobStore, Phase
+from .job_store import JobInput, JobStore, OperationalIndexProvenance, Phase
 from .foundation import JsonSerializationPolicy, JsonSource, OperatorEvidenceReader, RawSourceConfig, SourceConfig, TimestampSyntax
 from .live_adapters import InstalledUnits, LiveEvidenceAdapters, PredictionBundleSource, UpcomingRaceSource
 from .prediction_worker import ServerChoice, WorkerConfig, run_once
@@ -346,7 +346,8 @@ def _build_r3_services(app: Flask, profile: str) -> R3Services:
         if len(matches)!=1:raise R3Rejected("RACE_ID_MISSING_OR_AMBIGUOUS")
         race=matches[0]; runners=tuple(_runner(row) for row in race.get("runners",()))
         jump=race.get("jump_datetime",race.get("jump_timestamp"))
-        job_input=JobInput(str(race["race_id"]),str(jump),str(race["runner_set_sha256"]),model_id,resolved_model,model_sha,manifest_sha,schema_sha,config_id,choice.config_sha256,odds_source,runners)
+        provenance=OperationalIndexProvenance.from_verified_current_race_index(view)
+        job_input=JobInput(str(race["race_id"]),str(jump),str(race["runner_set_sha256"]),model_id,resolved_model,model_sha,manifest_sha,schema_sha,config_id,choice.config_sha256,odds_source,runners,provenance)
         job_input.fields()
         return ResolvedSubmission(job_input,runners)
     dispatcher=_FixedDispatcher(store,worker,clock)

--- a/src/operator_ui/job_store.py
+++ b/src/operator_ui/job_store.py
@@ -14,10 +14,13 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
-JOB_SCHEMA = "operator_ui_manual_prediction_job_v2"
+JOB_SCHEMA = "operator_ui_manual_prediction_job_v3"
+LEGACY_JOB_SCHEMA = "operator_ui_manual_prediction_job_v2"
 EVENT_SCHEMA = "operator_ui_manual_prediction_event_v2"
 ATTEMPT_SCHEMA = "operator_ui_manual_prediction_attempt_v2"
-STORE_SCHEMA = "operator_ui_manual_prediction_store_v2"
+STORE_SCHEMA = "operator_ui_manual_prediction_store_v3"
+LEGACY_STORE_SCHEMA = "operator_ui_manual_prediction_store_v2"
+OPERATIONAL_INDEX_PROVENANCE_SCHEMA = "operator_ui_operational_index_admission_v1"
 ZERO_HASH = "0" * 64
 AUDIT_HASH_BINDING = "<confirmed-audit-sha256>"
 
@@ -73,7 +76,7 @@ def _validate_confirmation_preimage(intent:Mapping[str,Any],proposal:Mapping[str
     _job_id(intent["job_id"]); _identifier(intent["actor_identity"],"actor"); _identifier(intent["job_operation"],"operation")
     if intent["actor_level"]!=2: raise ValueError("invalid mutation actor")
     _hash(intent["idempotency_key_sha256"],"idempotency"); _hash(intent["input_identity_sha256"],"input identity")
-    input_fields=JobInput(**_exact_mapping(intent["input"],set(JobInput.__dataclass_fields__),"input"))
+    input_fields=_job_input_from_mapping(intent["input"])
     if input_fields.identity_sha256!=intent["input_identity_sha256"]: raise ValueError("input identity mismatch")
     anchor=_exact_mapping(intent["prior_store_anchor"],{"singleton","schema","mutation_count","store_hash"},"prior anchor")
     if anchor["singleton"]!=1 or anchor["schema"]!=STORE_SCHEMA or isinstance(anchor["mutation_count"],bool) or not isinstance(anchor["mutation_count"],int) or anchor["mutation_count"]<0: raise ValueError("prior anchor invalid")
@@ -298,15 +301,41 @@ def _validate_facts(phase:Phase,facts:Any,prior:Phase|None,status:str="",reason:
     return facts
 
 @dataclass(frozen=True,slots=True)
+class OperationalIndexProvenance:
+    schema:str; index_schema_version:str; run_id:str; packet_sha256:str
+    source_refresh_sha256:str; publication_sha256:str; state_sha256:str
+    report_sha256:str
+    @classmethod
+    def from_verified_current_race_index(cls,value:Any)->OperationalIndexProvenance:
+        from race_collection.synchronous_manual_capture import VerifiedCurrentRaceIndex
+        if not isinstance(value,VerifiedCurrentRaceIndex): raise ValueError("verified current race index required")
+        return cls(
+            OPERATIONAL_INDEX_PROVENANCE_SCHEMA,value.schema_version,value.run_id,
+            value.packet_sha256,value.source_refresh_report_sha256,value.publication_sha256,
+            value.state_sha256,value.report_sha256,
+        )
+    def fields(self)->dict[str,str]:
+        values={name:getattr(self,name) for name in self.__dataclass_fields__}
+        if values["schema"]!=OPERATIONAL_INDEX_PROVENANCE_SCHEMA: raise ValueError("invalid operational index provenance schema")
+        for name,value in values.items():
+            _hash(value,name) if name.endswith("sha256") else _identifier(value,name)
+        return values
+
+
+@dataclass(frozen=True,slots=True)
 class JobInput:
     race_id:str; jump_timestamp:str; runner_set_sha256:str; model_selector:str
     resolved_model_identity:str; model_sha256:str; model_manifest_sha256:str
     model_schema_sha256:str; config_id:str; config_sha256:str; odds_source:str
     ordered_runners:tuple[Mapping[str,Any],...]=()
+    operational_index_provenance:OperationalIndexProvenance|None=None
     def __post_init__(self):
         if isinstance(self.ordered_runners,list): object.__setattr__(self,"ordered_runners",tuple(self.ordered_runners))
+        if isinstance(self.operational_index_provenance,Mapping):
+            object.__setattr__(self,"operational_index_provenance",OperationalIndexProvenance(**self.operational_index_provenance))
     def fields(self)->dict[str,Any]:
         values={n:getattr(self,n) for n in self.__dataclass_fields__}
+        provenance=values.pop("operational_index_provenance")
         for n,v in values.items():
             if n == "ordered_runners": continue
             _hash(v,n) if n.endswith("sha256") else _identifier(v,n)
@@ -323,11 +352,21 @@ class JobInput:
             if "source_native_runner_id" in row: normalized_row["source_native_runner_id"]=_identifier(row["source_native_runner_id"],"source native runner id")
             identities.add(identity); normalized.append(normalized_row)
         values["ordered_runners"]=normalized
+        if provenance is not None:
+            if not isinstance(provenance,OperationalIndexProvenance): raise ValueError("invalid operational index provenance")
+            values["operational_index_provenance"]=provenance.fields()
         parsed=datetime.fromisoformat(self.jump_timestamp.replace("Z","+00:00"))
         if parsed.tzinfo is None or parsed.utcoffset() is None: raise ValueError("jump_timestamp must be timezone aware")
         return values
     @property
     def identity_sha256(self)->str:return _sha(canonical(self.fields()))
+
+
+def _job_input_from_mapping(value:Any)->JobInput:
+    if not isinstance(value,Mapping): raise ValueError("invalid input shape")
+    keys=set(JobInput.__dataclass_fields__); legacy=keys-{"operational_index_provenance"}
+    if set(value) not in {frozenset(keys),frozenset(legacy)}: raise ValueError("invalid input shape")
+    return JobInput(**value)
 
 @dataclass(frozen=True,slots=True)
 class Job:
@@ -369,9 +408,10 @@ class JobStore:
         if st and (not stat.S_ISREG(st.st_mode) or self.path.is_symlink()): raise JobStoreError("job store must be a regular file")
         self._validate_separation(None if st is None else (st.st_dev,st.st_ino))
         existing=st is not None and st.st_size>0
-        db=sqlite3.connect(self.path,isolation_level=None)
+        db=sqlite3.connect(self.path,isolation_level=None); db.row_factory=sqlite3.Row
         try:
             if not existing: db.executescript(_SCHEMA_SQL)
+            else:self._migrate(db)
         finally: db.close()
         os.chmod(self.path,0o600); st=self.path.lstat(); self._identity=(st.st_dev,st.st_ino); self._validate_path()
         if not self.verify(): raise JobStoreError("job store integrity invalid")
@@ -396,10 +436,26 @@ class JobStore:
                     if [tuple(r) for r in db.execute(f"PRAGMA index_info('{name}')")] != [tuple(r) for r in expected.execute(f"PRAGMA index_info('{name}')")]: return False
             return True
         finally: expected.close()
-    def _verify_db(self,db):
+    def _migrate(self,db):
+        try:
+            db.execute("BEGIN IMMEDIATE")
+            anchor=db.execute("SELECT schema FROM store_anchor WHERE singleton=1").fetchone()
+            if anchor is None: raise JobStoreError("job store migration source invalid")
+            if anchor["schema"]==STORE_SCHEMA:
+                db.commit(); return
+            if anchor["schema"]!=LEGACY_STORE_SCHEMA or not self._verify_db(db,expected_store_schema=LEGACY_STORE_SCHEMA):
+                raise JobStoreError("job store migration source invalid")
+            db.execute("UPDATE store_anchor SET schema=? WHERE singleton=1",(STORE_SCHEMA,))
+            if not self._verify_db(db): raise JobStoreError("job store migration result invalid")
+            db.commit()
+        except JobStoreError:
+            db.rollback(); raise
+        except sqlite3.Error as exc:
+            db.rollback(); raise JobStoreError("job store migration source invalid") from exc
+    def _verify_db(self,db,*,expected_store_schema=STORE_SCHEMA):
         if not self._schema_valid(db) or db.execute("PRAGMA foreign_key_check").fetchone(): return False
         anchor=db.execute("SELECT * FROM store_anchor").fetchall()
-        if len(anchor)!=1 or anchor[0]["singleton"]!=1 or anchor[0]["schema"]!=STORE_SCHEMA or anchor[0]["store_hash"]!=(ZERO_HASH if anchor[0]["mutation_count"]==0 else self._rows_hash(db)): return False
+        if len(anchor)!=1 or anchor[0]["singleton"]!=1 or anchor[0]["schema"]!=expected_store_schema or anchor[0]["store_hash"]!=(ZERO_HASH if anchor[0]["mutation_count"]==0 else self._rows_hash(db)): return False
         jobs=db.execute("SELECT * FROM jobs ORDER BY sequence").fetchall(); events=db.execute("SELECT * FROM job_events ORDER BY sequence").fetchall(); attempts=db.execute("SELECT * FROM job_attempts ORDER BY sequence").fetchall()
         for rows in (jobs,events,attempts):
             if [r["sequence"] for r in rows]!=list(range(1,len(rows)+1)): return False
@@ -409,8 +465,9 @@ class JobStore:
         for e in events: by_job[e["job_id"]].append(e)
         for j in jobs:
             try:
-                if j["schema"]!=JOB_SCHEMA or j["actor_level"]!=2 or _hash(j["creation_audit_hash"],"audit")!=j["creation_audit_hash"]: return False
+                if j["schema"] not in {JOB_SCHEMA,LEGACY_JOB_SCHEMA} or expected_store_schema==LEGACY_STORE_SCHEMA and j["schema"]!=LEGACY_JOB_SCHEMA or j["actor_level"]!=2 or _hash(j["creation_audit_hash"],"audit")!=j["creation_audit_hash"]: return False
                 data=json.loads(j["input_json"]); inp=JobInput(**data)
+                if (j["schema"]==JOB_SCHEMA)!=(inp.operational_index_provenance is not None): return False
                 if canonical(inp.fields()).decode()!=j["input_json"] or inp.identity_sha256!=j["input_identity_sha256"] or j["created_at"]!=utc_text(datetime.fromisoformat(j["created_at"].replace("Z","+00:00"))): return False
                 _job_id(j["job_id"]); _identifier(j["actor_identity"],"actor"); _identifier(j["operation"],"operation"); _hash(j["idempotency_key_sha256"],"key")
                 rows=by_job[j["job_id"]]; previous=ZERO_HASH; prior=None; claimed=[]
@@ -480,6 +537,7 @@ class JobStore:
     def create(self,*,actor_identity,actor_level,operation,idempotency_key,job_input,now,confirm_audit:AuditConfirmation):
         actor=_identifier(actor_identity,"actor_identity"); operation=_identifier(operation,"operation")
         if actor_level!=2: raise ValueError("manual prediction requires exact Level 2 authority")
+        if not isinstance(job_input,JobInput) or job_input.operational_index_provenance is None: raise ValueError("operational index provenance required")
         key_hash=hash_idempotency_key(idempotency_key); input_json=canonical(job_input.fields()).decode(); identity=job_input.identity_sha256; created=utc_text(now)
         db=self._connect()
         try:
@@ -497,6 +555,15 @@ class JobStore:
         except (IdempotencyConflict,JobStoreError): db.rollback(); raise
         except (sqlite3.Error,ValueError,TypeError) as exc: db.rollback(); raise JobStoreError("job creation failed") from exc
         finally: db.close()
+    def find_by_idempotency(self,*,actor_identity,operation,idempotency_key):
+        actor=_identifier(actor_identity,"actor_identity"); operation=_identifier(operation,"operation"); key_hash=hash_idempotency_key(idempotency_key)
+        db=self._connect()
+        try:
+            db.execute("BEGIN"); self._require_valid(db)
+            row=db.execute("SELECT job_id FROM jobs WHERE actor_identity=? AND operation=? AND idempotency_key_sha256=?",(actor,operation,key_hash)).fetchone()
+            job_id=row["job_id"] if row is not None else None
+        finally: db.close()
+        return self.get(job_id) if job_id is not None else None
     def _current(self,db,job_id):
         row=db.execute("SELECT phase,event_at FROM job_events WHERE job_id=? ORDER BY sequence DESC LIMIT 1",(job_id,)).fetchone()
         if not row: raise JobStoreError("unknown job")
@@ -560,6 +627,9 @@ class JobStore:
         at=utc_text(now); db=self._connect()
         try:
             db.execute("BEGIN IMMEDIATE"); self._require_valid(db); current,current_at=self._current(db,job_id)
+            stored=db.execute("SELECT input_json FROM jobs WHERE job_id=?",(job_id,)).fetchone()
+            if stored is None or _job_input_from_mapping(json.loads(stored[0])).operational_index_provenance is None:
+                raise JobStoreError("legacy job missing operational index provenance")
             existing=db.execute("SELECT attempt_id FROM job_attempts WHERE job_id=?",(job_id,)).fetchone()
             if existing: raise AttemptAlreadyClaimed(existing[0])
             if current is not Phase.WAITING_FOR_CLAIM or at<current_at: raise IllegalTransition("job is not claimable")

--- a/src/operator_ui/prediction_worker.py
+++ b/src/operator_ui/prediction_worker.py
@@ -15,7 +15,7 @@ from typing import Any,Callable,Mapping
 
 from race_collection.synchronous_manual_capture import CaptureOneRejected,VerifiedCurrentRaceIndex,bounded_current_race_index
 from src.predictor.on_demand import PredictionBlocked,canonical_bytes,validate_prediction_result_v2
-from .job_store import AuditConfirmation,Job,JobStore,JobStoreError,Phase
+from .job_store import AuditConfirmation,Job,JobStore,JobStoreError,OperationalIndexProvenance,Phase
 
 MAX_STDOUT_BYTES=1_048_576; MAX_STDERR_BYTES=65_536; MAX_FAILED_STDOUT_DIAGNOSTIC_BYTES=4096
 class WorkerRejected(RuntimeError): pass
@@ -99,7 +99,10 @@ def _validate_runtime(config:WorkerConfig)->None:
 def fixed_argv(job:Job,config:WorkerConfig)->tuple[str,...]:
     choice=_validate_choice(job,config)
     _validate_runtime(config)
-    argv=[str(config.pinned_python),str(config.script),"--race-id",job.input.race_id,"--model",job.input.model_selector,"--job-id",job.job_id,"--config",str(choice.config_path),"--odds-source",job.input.odds_source,"--db",str(config.canonical_db),"--output-root",str(config.output_root)]
+    provenance=job.input.operational_index_provenance
+    if provenance is None: raise WorkerRejected("OPERATIONAL_INDEX_PROVENANCE_MISSING")
+    provenance_json=json.dumps(provenance.fields(),sort_keys=True,separators=(",",":"))
+    argv=[str(config.pinned_python),str(config.script),"--race-id",job.input.race_id,"--model",job.input.model_selector,"--job-id",job.job_id,"--config",str(choice.config_path),"--odds-source",job.input.odds_source,"--operational-index-provenance",provenance_json,"--db",str(config.canonical_db),"--output-root",str(config.output_root)]
     for root in config.capture_evidence_roots: argv.extend(("--capture-evidence-root",str(root)))
     argv.extend(("--collector-request-root",str(config.collector_request_root),"--fetch-timeout-seconds",str(config.fetch_timeout_seconds)))
     return tuple(argv)
@@ -135,6 +138,10 @@ def revalidate_current_race(job,config,*,now,reader=bounded_current_race_index):
     if len(matches)!=1: raise WorkerRejected("RACE_ID_MISSING_OR_AMBIGUOUS")
     if matches[0].get("jump_datetime")!=job.input.jump_timestamp: raise WorkerRejected("RACE_JUMP_CHANGED")
     if matches[0].get("runner_set_sha256")!=job.input.runner_set_sha256: raise WorkerRejected("RUNNER_SET_CHANGED")
+    provenance=job.input.operational_index_provenance
+    if provenance is None: raise WorkerRejected("OPERATIONAL_INDEX_PROVENANCE_MISSING")
+    actual=OperationalIndexProvenance.from_verified_current_race_index(view).fields()
+    if provenance.fields()!=actual: raise WorkerRejected("CURRENT_INDEX_PROVENANCE_CHANGED")
     return view
 
 def _drain(pipe:Any,cap:int,sink:dict[str,Any],name:str):

--- a/src/operator_ui/r3_api.py
+++ b/src/operator_ui/r3_api.py
@@ -123,6 +123,9 @@ def _verified_result(job: Job, value: Any, events: list[Mapping[str,Any]] | None
     request_value=value.request
     if not isinstance(request_value,Mapping):
         return None
+    provenance=job.input.operational_index_provenance
+    if provenance is None or request_value.get("schema_version")!="on_demand_prediction_request_v2" or request_value.get("operational_index_provenance")!=provenance.fields():
+        return None
     if result.get("status") != "PREDICTION_READY" or entry.get("status") != "PREDICTION_READY":
         return None
     chain=result.get("evidence",{}).get("protocol_chain"); cutoff=result.get("evidence",{}).get("authenticated_cutoff")
@@ -227,6 +230,11 @@ def install_r3_api(app: Flask, services: R3Services | None = None) -> bool:
         operation = str(intent["operation"])
         proposed = intent["proposed_event"]
         input_value = intent["input"]
+        provenance_value=input_value.get("operational_index_provenance")
+        provenance_hashes=(
+            {str(value) for name,value in provenance_value.items() if name.endswith("sha256")}
+            if isinstance(provenance_value,Mapping) else set()
+        )
         event = OperationAuditEvent(
             event_id=str(uuid.uuid4()), event_time_utc=services.clock().astimezone(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z"),
             actor_identity=str(intent["actor_identity"]), actor_level=2,
@@ -238,7 +246,10 @@ def install_r3_api(app: Flask, services: R3Services | None = None) -> bool:
             config_id=str(input_value["config_id"]), config_sha256=str(input_value["config_sha256"]),
             input_identity_sha256=str(intent["input_identity_sha256"]), prior_state=str(intent["prior_state"]),
             new_state=str(proposed["phase"]), status=str(proposed["status"]), reason=str(proposed["reason"]),
-            reference_hashes=tuple(sorted({str(input_value["model_manifest_sha256"]), str(input_value["model_schema_sha256"])})),
+            reference_hashes=tuple(sorted({
+                str(input_value["model_manifest_sha256"]),str(input_value["model_schema_sha256"]),
+                *provenance_hashes,
+            })),
         )
         audit_hash = audit.append_operation_and_confirm(event)
         return resolve_audit_confirmation(intent, audit_hash)
@@ -279,19 +290,37 @@ def install_r3_api(app: Flask, services: R3Services | None = None) -> bool:
         session_identifier = str(session["operator_session_id"])
         confirm_audit = lambda intent: confirm(intent, session_identifier)
         try:
-            resolved = services.resolve_submission(selected, now)
-            if type(resolved) is not ResolvedSubmission or type(resolved.job_input) is not JobInput or not resolved.ordered_runners:
-                raise R3Rejected("RACE_EVIDENCE_INVALID")
-            ordered_runners = tuple(dict(runner) for runner in resolved.ordered_runners)
-            if resolved.job_input.ordered_runners:
-                if resolved.job_input.fields()["ordered_runners"] != [dict(runner) for runner in ordered_runners]:
-                    raise R3Rejected("RUNNER_SET_BINDING_MISMATCH")
-                job_input = resolved.job_input
+            persisted = services.job_store.find_by_idempotency(
+                actor_identity=identity, operation="manual_prediction",
+                idempotency_key=selected["idempotency_key"],
+            )
+            persisted_selection_matches = persisted is not None and (
+                persisted.input.race_id == selected["race_id"]
+                and persisted.input.model_selector == selected["model_id"]
+                and persisted.input.config_id == selected["config_id"]
+                and persisted.input.odds_source == selected["odds_source_id"]
+            )
+            if persisted_selection_matches:
+                if persisted.input.operational_index_provenance is None:
+                    raise R3Rejected("RACE_EVIDENCE_INVALID")
+                job = persisted
+                newly_observed = False
             else:
-                job_input = replace(resolved.job_input, ordered_runners=ordered_runners)
-            job = services.job_store.create(actor_identity=identity, actor_level=2, operation="manual_prediction",
-                idempotency_key=selected["idempotency_key"], job_input=job_input, now=now, confirm_audit=confirm_audit)
-            newly_observed = job.phase is Phase.SUBMITTED
+                resolved = services.resolve_submission(selected, now)
+                if type(resolved) is not ResolvedSubmission or type(resolved.job_input) is not JobInput or not resolved.ordered_runners:
+                    raise R3Rejected("RACE_EVIDENCE_INVALID")
+                if resolved.job_input.operational_index_provenance is None:
+                    raise R3Rejected("RACE_EVIDENCE_INVALID")
+                ordered_runners = tuple(dict(runner) for runner in resolved.ordered_runners)
+                if resolved.job_input.ordered_runners:
+                    if resolved.job_input.fields()["ordered_runners"] != [dict(runner) for runner in ordered_runners]:
+                        raise R3Rejected("RUNNER_SET_BINDING_MISMATCH")
+                    job_input = resolved.job_input
+                else:
+                    job_input = replace(resolved.job_input, ordered_runners=ordered_runners)
+                job = services.job_store.create(actor_identity=identity, actor_level=2, operation="manual_prediction",
+                    idempotency_key=selected["idempotency_key"], job_input=job_input, now=now, confirm_audit=confirm_audit)
+                newly_observed = job.phase is Phase.SUBMITTED
             launch_eligible = False
             if job.phase is Phase.SUBMITTED:
                 try:

--- a/src/predictor/on_demand.py
+++ b/src/predictor/on_demand.py
@@ -208,6 +208,26 @@ def _exact_fields(value: Any, fields: set[str], label: str) -> Mapping[str, Any]
     return value
 
 
+OPERATIONAL_INDEX_PROVENANCE_FIELDS = {
+    "schema", "index_schema_version", "run_id", "packet_sha256",
+    "source_refresh_sha256", "publication_sha256", "state_sha256", "report_sha256",
+}
+
+
+def validate_operational_index_provenance(value: Any) -> dict[str, str]:
+    provenance = _exact_fields(value, OPERATIONAL_INDEX_PROVENANCE_FIELDS, "operational_index_provenance")
+    if provenance.get("schema") != "operator_ui_operational_index_admission_v1":
+        raise _blocked("PREDICTION_BUNDLE_IDENTITY_MISMATCH", field="operational_index_provenance.schema")
+    for name in ("index_schema_version", "run_id"):
+        item=provenance.get(name)
+        if not isinstance(item,str) or not item or len(item.encode())>256 or any(ord(char)<32 or ord(char)==127 for char in item):
+            raise _blocked("PREDICTION_BUNDLE_IDENTITY_MISMATCH", field=f"operational_index_provenance.{name}")
+    for name in OPERATIONAL_INDEX_PROVENANCE_FIELDS-{"schema","index_schema_version","run_id"}:
+        if not isinstance(provenance.get(name),str) or re.fullmatch(r"[0-9a-f]{64}",provenance[name]) is None:
+            raise _blocked("PREDICTION_BUNDLE_IDENTITY_MISMATCH", field=f"operational_index_provenance.{name}")
+    return dict(provenance)
+
+
 def _timestamp(value: Any, label: str) -> datetime:
     if not isinstance(value, str):
         raise _blocked("PREDICTION_BUNDLE_INVALID", field=label)
@@ -496,17 +516,18 @@ def validate_prediction_result_v2(value: Any) -> dict[str, Any]:
 
 
 def _validate_request_binding(raw: bytes, result: Mapping[str, Any]) -> dict[str, Any]:
-    request = _exact_fields(
-        _canonical_json(raw, max_bytes=BUNDLE_CONTROL_MAX_BYTES, label="request"),
-        {
+    value=_canonical_json(raw, max_bytes=BUNDLE_CONTROL_MAX_BYTES, label="request")
+    schema=value.get("schema_version") if isinstance(value,Mapping) else None
+    fields={
             "schema_version", "prediction_id", "job_id", "race_query", "race_id", "jump_timestamp",
             "request_timestamp", "odds_source", "model", "config_sha256",
             "research_only", "runners", "runner_set_sha256",
-        },
-        "request",
-    )
-    if request["schema_version"] != "on_demand_prediction_request_v1":
+        }
+    if schema=="on_demand_prediction_request_v2":fields.add("operational_index_provenance")
+    request = _exact_fields(value,fields,"request")
+    if schema not in {"on_demand_prediction_request_v1","on_demand_prediction_request_v2"}:
         raise _blocked("PREDICTION_BUNDLE_IDENTITY_MISMATCH", field="request.schema")
+    if schema=="on_demand_prediction_request_v2":validate_operational_index_provenance(request["operational_index_provenance"])
     _timestamp(request["jump_timestamp"], "request.jump_timestamp")
     _timestamp(request["request_timestamp"], "request.request_timestamp")
     _prediction_id(request["prediction_id"])

--- a/tests/operator_ui/test_bootstrap.py
+++ b/tests/operator_ui/test_bootstrap.py
@@ -403,6 +403,17 @@ def test_finite_testing_fixture_profile_builds_real_repository_composition(tmp_p
     assert runner_completed.wait(timeout=30), "terminal runner did not complete within 30 seconds"
     job=services.job_store.get(job_id)
     assert job.input.odds_source=="receipt"
+    assert job.input.operational_index_provenance is not None
+    assert job.input.operational_index_provenance.fields()=={
+        "schema":"operator_ui_operational_index_admission_v1",
+        "index_schema_version":view.schema_version,
+        "run_id":view.run_id,
+        "packet_sha256":view.packet_sha256,
+        "source_refresh_sha256":view.source_refresh_report_sha256,
+        "publication_sha256":view.publication_sha256,
+        "state_sha256":view.state_sha256,
+        "report_sha256":view.report_sha256,
+    }
     assert job.attempt_claimed and job.phase is Phase.FAILED
     assert [event["phase"] for event in services.job_store.events(job_id)][-3:]==["CLAIMED","ATTEMPT_STARTED","FAILED"]
 

--- a/tests/operator_ui/test_job_store.py
+++ b/tests/operator_ui/test_job_store.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from threading import Event
 
@@ -13,7 +14,7 @@ from src.predictor.on_demand import BLOCKER_STAGE_BY_CODE
 
 from src.operator_ui.job_store import (
     AttemptAlreadyClaimed, IdempotencyConflict, IllegalTransition, JobInput,
-    JobStore, JobStoreError, Phase, VerifierAuthorizationError,
+    JobStore, JobStoreError, OperationalIndexProvenance, Phase, VerifierAuthorizationError,
     canonical, resolve_audit_confirmation,
 )
 
@@ -23,8 +24,23 @@ AUDIT = hashlib.sha256(b"confirmed-operation-audit").hexdigest()
 CONFIRM = lambda intent: resolve_audit_confirmation(intent, AUDIT)
 
 
+def operational_provenance(**changes):
+    values = {
+        "schema": "operator_ui_operational_index_admission_v1",
+        "index_schema_version": "collector_current_race_index_v2",
+        "run_id": "collector-run-20260801T000000Z",
+        "packet_sha256": hashlib.sha256(b"packet").hexdigest(),
+        "source_refresh_sha256": hashlib.sha256(b"source-refresh").hexdigest(),
+        "publication_sha256": hashlib.sha256(b"publication").hexdigest(),
+        "state_sha256": hashlib.sha256(b"state").hexdigest(),
+        "report_sha256": hashlib.sha256(b"report").hexdigest(),
+    }
+    values.update(changes)
+    return OperationalIndexProvenance(**values)
+
+
 def inputs(race="race-5"):
-    return JobInput(race, "2026-08-01T01:00:00Z", H, "latest-research", "model-v1", H, H, H, "manual-default", H, "auto", ({"box":1,"name":"ALPHA","identity":"ALPHA"},))
+    return JobInput(race, "2026-08-01T01:00:00Z", H, "latest-research", "model-v1", H, H, H, "manual-default", H, "auto", ({"box":1,"name":"ALPHA","identity":"ALPHA"},), operational_provenance())
 
 
 def store(tmp_path):
@@ -71,6 +87,69 @@ def test_store_is_separate_and_immutable(tmp_path):
             with pytest.raises(sqlite3.IntegrityError): db.execute(sql)
     assert canonical.read_bytes() == b"canonical" and audit.read_bytes() == b"audit"
     assert value.get(job.job_id).input.race_id == "race-5"
+
+
+def test_operational_index_provenance_is_immutable_and_survives_restart(tmp_path):
+    value = store(tmp_path); job = create(value)
+    expected = operational_provenance()
+    assert job.input.operational_index_provenance == expected
+    assert store(tmp_path).get(job.job_id).input.operational_index_provenance == expected
+    with pytest.raises(sqlite3.IntegrityError):
+        with sqlite3.connect(value.path) as db:
+            payload = json.loads(db.execute("SELECT input_json FROM jobs WHERE job_id=?", (job.job_id,)).fetchone()[0])
+            payload["operational_index_provenance"]["run_id"] = "replacement-run"
+            db.execute("UPDATE jobs SET input_json=? WHERE job_id=?", (canonical(payload).decode(), job.job_id))
+
+
+def test_operational_index_provenance_factory_rejects_unverified_lookalike():
+    with pytest.raises(ValueError,match="verified current race index required"):
+        OperationalIndexProvenance.from_verified_current_race_index(operational_provenance().fields())
+
+
+@pytest.mark.parametrize("changes",[
+    {"schema":"operator_ui_operational_index_admission_v2"},
+    {"run_id":""},
+    {"packet_sha256":"not-a-sha256"},
+])
+def test_new_job_rejects_malformed_operational_index_provenance(tmp_path,changes):
+    value=store(tmp_path); malformed=replace(inputs(),operational_index_provenance=operational_provenance(**changes))
+    with pytest.raises(ValueError):
+        value.create(actor_identity="operator",actor_level=2,operation="manual_prediction",idempotency_key="idempotency-key-1234",job_input=malformed,now=NOW,confirm_audit=CONFIRM)
+
+
+def test_v2_store_migration_preserves_legacy_job_without_fabricating_provenance(tmp_path):
+    value = store(tmp_path); job = claimable(value, create(value))
+    with sqlite3.connect(value.path) as db:
+        db.row_factory = sqlite3.Row
+        db.execute("DROP TRIGGER jobs_no_update")
+        payload = json.loads(db.execute("SELECT input_json FROM jobs WHERE job_id=?", (job.job_id,)).fetchone()[0])
+        payload.pop("operational_index_provenance")
+        input_json = canonical(payload).decode()
+        db.execute("UPDATE jobs SET schema=?,input_json=?,input_identity_sha256=? WHERE job_id=?", (
+            "operator_ui_manual_prediction_job_v2", input_json, hashlib.sha256(input_json.encode()).hexdigest(), job.job_id,
+        ))
+        db.execute("CREATE TRIGGER jobs_no_update BEFORE UPDATE ON jobs BEGIN SELECT RAISE(ABORT,'jobs immutable'); END")
+        rows = {name:[dict(row) for row in db.execute(f"SELECT * FROM {name} ORDER BY sequence")] for name in ("jobs","job_events","job_attempts")}
+        db.execute("UPDATE store_anchor SET schema=?,store_hash=? WHERE singleton=1", (
+            "operator_ui_manual_prediction_store_v2", hashlib.sha256(canonical(rows)).hexdigest(),
+        ))
+    migrated = store(tmp_path)
+    legacy = migrated.get(job.job_id)
+    assert legacy.input.operational_index_provenance is None
+    assert legacy.phase is Phase.WAITING_FOR_CLAIM
+    with sqlite3.connect(value.path) as db:
+        assert db.execute("SELECT schema FROM store_anchor").fetchone()[0] == "operator_ui_manual_prediction_store_v3"
+        assert db.execute("SELECT schema FROM jobs WHERE job_id=?", (job.job_id,)).fetchone()[0] == "operator_ui_manual_prediction_job_v2"
+    with pytest.raises(JobStoreError, match="legacy job missing operational index provenance"):
+        migrated.claim_attempt(job.job_id, now=NOW, confirm_audit=CONFIRM)
+    assert migrated.get(job.job_id).phase is Phase.WAITING_FOR_CLAIM
+
+
+def test_migration_rejects_non_job_store_without_rewriting_it(tmp_path):
+    path=tmp_path/"jobs.db"; original=b"not a sqlite job store"; path.write_bytes(original)
+    with pytest.raises(JobStoreError,match="job store migration source invalid"):
+        JobStore(path)
+    assert path.read_bytes()==original
 
 
 def test_idempotency_duplicate_conflict_cross_actor_and_raw_key_absent(tmp_path):

--- a/tests/operator_ui/test_prediction_worker.py
+++ b/tests/operator_ui/test_prediction_worker.py
@@ -7,11 +7,15 @@ import pytest
 from race_collection.synchronous_manual_capture import VerifiedCurrentRaceIndex
 from scripts.refresh_prejump_upcoming import stable_race_id
 from src.predictor.on_demand import canonical_bytes
-from src.operator_ui.job_store import JobInput,JobStore,JobStoreError,Phase,resolve_audit_confirmation
+from src.operator_ui.job_store import JobInput,JobStore,JobStoreError,OperationalIndexProvenance,Phase,resolve_audit_confirmation
 from src.operator_ui.prediction_worker import MAX_STDERR_BYTES,MAX_STDOUT_BYTES,ServerChoice,WorkerConfig,WorkerRejected,drain_bounded,fixed_argv,revalidate_current_race,run_once
 
 NOW=datetime(2026,8,1,tzinfo=timezone.utc); H=hashlib.sha256(b"x").hexdigest(); AUDIT=hashlib.sha256(b"audit").hexdigest(); CONFIRM=lambda intent:resolve_audit_confirmation(intent,AUDIT)
 RACE={"race_number":5,"venue":"RICH","race_date":"2026-08-01","url":"https://www.thedogs.com.au/racing/richmond/2026-08-01/5"}; RACE_ID=stable_race_id(RACE)
+
+def provenance(**changes):
+    values={"schema":"operator_ui_operational_index_admission_v1","index_schema_version":"collector_current_race_index_v2","run_id":"run","packet_sha256":H,"source_refresh_sha256":H,"publication_sha256":H,"state_sha256":H,"report_sha256":H}
+    values.update(changes); return OperationalIndexProvenance(**values)
 
 def setup(tmp_path):
     paths=[]
@@ -24,7 +28,7 @@ def setup(tmp_path):
     current_index=evidence_a/"shadow_autopilot_daemon_runtime"/"manual_prediction_current_race_index.json"
     cfg=WorkerConfig(python,Path(__file__).parents[2],{"latest-research":choice},tmp_path/"canonical.db",tmp_path/"output",(evidence_a,tmp_path/"evidence-b"),tmp_path/"requests",current_index,evidence_a,1,45.0,90.0,2)
     value=JobStore(tmp_path/"jobs.db",separate_from=(tmp_path/"canonical.db",tmp_path/"audit.db"))
-    inp=JobInput(RACE_ID,"2026-08-01T01:00:00+00:00",H,"latest-research","market_form_residual_v1",H,H,H,"manual-default",H,"auto",({"box":1,"name":"ALPHA","identity":"ALPHA"},))
+    inp=JobInput(RACE_ID,"2026-08-01T01:00:00+00:00",H,"latest-research","market_form_residual_v1",H,H,H,"manual-default",H,"auto",({"box":1,"name":"ALPHA","identity":"ALPHA"},),provenance())
     job=value.create(actor_identity="op",actor_level=2,operation="manual_prediction",idempotency_key="idempotency-key-1234",job_input=inp,now=NOW,confirm_audit=CONFIRM)
     job=value.transition(job.job_id,Phase.VALIDATED,now=NOW,status="VALID",reason="validated",confirm_audit=CONFIRM)
     job=value.transition(job.job_id,Phase.WAITING_FOR_CLAIM,now=NOW,status="WAITING",reason="ready",confirm_audit=CONFIRM)
@@ -59,6 +63,8 @@ def test_exact_argv_and_forbidden_surface(tmp_path):
     cfg,_,job=setup(tmp_path); argv=fixed_argv(job,cfg)
     assert argv[0:6]==(str(cfg.pinned_python),str(cfg.script),"--race-id",RACE_ID,"--model","latest-research")
     assert {"--race","--race-url","--replay-bundle","--list-configs","--current-time","--lock-path","--current-index-path"}.isdisjoint(argv)
+    provenance_value=json.loads(argv[argv.index("--operational-index-provenance")+1])
+    assert provenance_value==job.input.operational_index_provenance.fields()
 
 def test_worker_rejects_current_index_outside_primary_evidence_root(tmp_path):
     cfg,_,_=setup(tmp_path)
@@ -98,6 +104,15 @@ def test_descriptor_backed_python_preserves_venv_prefix_via_fixed_argv0(tmp_path
 def test_revalidation_missing_changed(tmp_path,races,reason):
     cfg,_,job=setup(tmp_path)
     with pytest.raises(WorkerRejected,match=reason):revalidate_current_race(job,cfg,now=NOW,reader=lambda **_:view(races))
+
+def test_index_turnover_after_admission_fails_before_claim_without_rewriting_provenance(tmp_path):
+    cfg,store,job=setup(tmp_path); admitted=job.input.operational_index_provenance
+    turned_over=replace(view(),run_id="later-run",publication_sha256="0"*64)
+    with pytest.raises(WorkerRejected,match="CURRENT_INDEX_PROVENANCE_CHANGED"):
+        run_once(store,job.job_id,cfg,now=lambda:NOW,confirm_audit=CONFIRM,popen=lambda *_a,**_k:None,reader=lambda **_:turned_over)
+    persisted=store.get(job.job_id)
+    assert not persisted.attempt_claimed
+    assert persisted.input.operational_index_provenance==admitted
 
 def test_identity_change_before_claim_prevents_launch(tmp_path):
     cfg,store,job=setup(tmp_path); cfg.choices["latest-research"].model_path.write_bytes(b"changed"); calls=[]

--- a/tests/operator_ui/test_r3_api.py
+++ b/tests/operator_ui/test_r3_api.py
@@ -6,13 +6,20 @@ from datetime import datetime, timezone
 from flask import Flask
 from werkzeug.security import generate_password_hash
 
-from src.operator_ui.job_store import JobInput, JobStore, JobStoreError, Phase
+from src.operator_ui.job_store import JobInput, JobStore, JobStoreError, OperationalIndexProvenance, Phase
 from src.operator_ui.r3_api import R3Rejected, R3Services, ResolvedSubmission, install_r3_api
 from src.operator_ui.security import install_connected_mode
 
 NOW = datetime(2026, 8, 1, tzinfo=timezone.utc)
 H = hashlib.sha256(b"r3").hexdigest()
 RACE = "race-20260801-richmond-r05"
+
+
+def provenance():
+    return OperationalIndexProvenance(
+        "operator_ui_operational_index_admission_v1", "collector_current_race_index_v2",
+        "collector-run", H, H, H, H, H,
+    )
 
 
 def application(tmp_path, *, level=2, resolver=None, result=lambda _job: None, rate=20, launch=None):
@@ -36,7 +43,7 @@ def application(tmp_path, *, level=2, resolver=None, result=lambda _job: None, r
         if selected["race_id"] != RACE or selected["model_id"] != "latest-research" or selected["config_id"] != "manual-default" or selected["odds_source_id"] != "auto":
             raise R3Rejected("SELECTION_NOT_ALLOWLISTED")
         runners = ({"box": 1, "name": "ALPHA", "identity": "ALPHA"},)
-        return ResolvedSubmission(JobInput(RACE, "2026-08-01T01:00:00Z", H, "latest-research", "model-v1", H, H, H, "manual-default", H, "auto", runners), runners)
+        return ResolvedSubmission(JobInput(RACE, "2026-08-01T01:00:00Z", H, "latest-research", "model-v1", H, H, H, "manual-default", H, "auto", runners, provenance()), runners)
     dispatcher = launch or (lambda job_id, _confirm: launched.append(job_id))
     install_r3_api(app, R3Services(store, resolve, dispatcher, result, clock=lambda: NOW, rate_limit=rate))
     return app, store, launched
@@ -59,6 +66,7 @@ def test_level2_csrf_exact_schema_idempotency_poll_and_actor_isolation(tmp_path)
     client = app.test_client(); token = login(client)
     assert client.post("/operator-ui/api/v1/prediction-jobs", base_url="https://localhost", json=body()).status_code == 400
     assert client.post("/operator-ui/api/v1/prediction-jobs", base_url="https://localhost", json=body(extra="forbidden"), headers={"X-CSRF-Token": token}).get_json()["classification"] == "INVALID_REQUEST_SCHEMA"
+    assert client.post("/operator-ui/api/v1/prediction-jobs", base_url="https://localhost", json=body(operational_index_provenance=provenance().fields()), headers={"X-CSRF-Token": token}).get_json()["classification"] == "INVALID_REQUEST_SCHEMA"
     first = client.post("/operator-ui/api/v1/prediction-jobs", base_url="https://localhost", json=body(), headers={"X-CSRF-Token": token})
     assert first.status_code == 202 and first.get_json()["phase"] == "WAITING_FOR_CLAIM" and len(launched) == 1
     duplicate = client.post("/operator-ui/api/v1/prediction-jobs", base_url="https://localhost", json=body(), headers={"X-CSRF-Token": token})
@@ -71,12 +79,68 @@ def test_level2_csrf_exact_schema_idempotency_poll_and_actor_isolation(tmp_path)
     assert store.verify()
 
 
+def test_idempotent_retransmission_recovers_persisted_job_after_index_turnover(tmp_path):
+    resolutions = []
+
+    def resolve(_selected, _now):
+        run_id = f"collector-run-{len(resolutions) + 1}"
+        resolutions.append(run_id)
+        runners = ({"box": 1, "name": "ALPHA", "identity": "ALPHA"},)
+        admitted = OperationalIndexProvenance(
+            "operator_ui_operational_index_admission_v1",
+            "collector_current_race_index_v2",
+            run_id,
+            hashlib.sha256(run_id.encode()).hexdigest(),
+            H,
+            H,
+            H,
+            H,
+        )
+        return ResolvedSubmission(
+            JobInput(
+                RACE, "2026-08-01T01:00:00Z", H, "latest-research", "model-v1",
+                H, H, H, "manual-default", H, "auto", runners, admitted,
+            ),
+            runners,
+        )
+
+    app, store, launched = application(tmp_path, resolver=resolve)
+    client = app.test_client(); token = login(client)
+    first = client.post(
+        "/operator-ui/api/v1/prediction-jobs", base_url="https://localhost",
+        json=body(), headers={"X-CSRF-Token": token},
+    )
+    assert first.status_code == 202
+    admitted = store.get(first.get_json()["job_id"]).input.operational_index_provenance
+
+    duplicate = client.post(
+        "/operator-ui/api/v1/prediction-jobs", base_url="https://localhost",
+        json=body(), headers={"X-CSRF-Token": token},
+    )
+
+    assert duplicate.status_code == 200
+    assert duplicate.get_json()["job_id"] == first.get_json()["job_id"]
+    assert store.get(first.get_json()["job_id"]).input.operational_index_provenance == admitted
+    assert resolutions == ["collector-run-1"]
+    assert launched == [first.get_json()["job_id"], first.get_json()["job_id"]]
+
+
 def test_level1_cannot_submit_or_read_and_resolution_blockers_disclose_no_job(tmp_path):
     app, _, launched = application(tmp_path, level=1)
     client = app.test_client(); token = login(client)
     assert client.post("/operator-ui/api/v1/prediction-jobs", base_url="https://localhost", json=body(), headers={"X-CSRF-Token": token}).status_code == 403
     assert client.get("/operator-ui/api/v1/prediction-jobs/job_" + "0" * 32, base_url="https://localhost").status_code == 403
     assert launched == []
+
+
+def test_server_rejects_resolver_output_missing_durable_operational_index_provenance(tmp_path):
+    runners=({"box":1,"name":"ALPHA","identity":"ALPHA"},)
+    legacy=JobInput(RACE,"2026-08-01T01:00:00Z",H,"latest-research","model-v1",H,H,H,"manual-default",H,"auto",runners)
+    app,store,launched=application(tmp_path,resolver=lambda _selected,_now:ResolvedSubmission(legacy,runners))
+    client=app.test_client(); token=login(client)
+    response=client.post("/operator-ui/api/v1/prediction-jobs",base_url="https://localhost",json=body(),headers={"X-CSRF-Token":token})
+    assert response.status_code==409 and response.get_json()["classification"]=="RACE_EVIDENCE_INVALID"
+    assert launched==[] and store.verify()
 
 
 def test_capability_is_authenticated_exact_level2_and_server_owned(tmp_path):

--- a/tests/operator_ui/test_r3_e2e_safety.py
+++ b/tests/operator_ui/test_r3_e2e_safety.py
@@ -16,7 +16,7 @@ from flask import Flask
 from werkzeug.security import generate_password_hash
 
 from race_collection.synchronous_manual_capture import VerifiedCurrentRaceIndex
-from src.operator_ui.job_store import JobInput, JobStore, Phase
+from src.operator_ui.job_store import JobInput, JobStore, OperationalIndexProvenance, Phase
 from src.operator_ui.prediction_worker import ServerChoice, WorkerConfig, run_once
 from src.operator_ui.r3_api import R3Services, ResolvedSubmission, install_r3_api
 from src.operator_ui.security import install_connected_mode
@@ -110,7 +110,8 @@ def test_one_authenticated_submission_reaches_real_worker_once_without_false_rea
     install_connected_mode(app)
     store = JobStore(tmp_path / "jobs.db", separate_from=(tmp_path / "audit.db", tmp_path / "canonical.db"))
     runners = ({"box": 1, "name": "ALPHA", "identity": "ALPHA"},)
-    inp = JobInput(RACE_ID, "2026-08-01T01:00:00+00:00", DIGEST, "latest-research", "market_form_residual_v1", DIGEST, DIGEST, DIGEST, "manual-default", DIGEST, "receipt", runners)
+    provenance=OperationalIndexProvenance("operator_ui_operational_index_admission_v1","collector_current_race_index_v2","run",DIGEST,DIGEST,DIGEST,DIGEST,DIGEST)
+    inp = JobInput(RACE_ID, "2026-08-01T01:00:00+00:00", DIGEST, "latest-research", "market_form_residual_v1", DIGEST, DIGEST, DIGEST, "manual-default", DIGEST, "receipt", runners, provenance)
     resolved = lambda selected, now: ResolvedSubmission(inp, runners)
     launches = []
 

--- a/tests/test_predict_race_now.py
+++ b/tests/test_predict_race_now.py
@@ -799,6 +799,22 @@ def test_fixture_e2e_reuses_receipt_seals_features_selects_model_and_bundles(
     assert json.loads((bundle / "result.json").read_bytes()) == result
 
 
+def test_operator_job_seals_exact_admission_operational_index_provenance(tmp_path:Path):
+    provenance={
+        "schema":"operator_ui_operational_index_admission_v1",
+        "index_schema_version":"collector_current_race_index_v2",
+        "run_id":"collector-run-20260801T000000Z",
+        "packet_sha256":"1"*64,"source_refresh_sha256":"2"*64,
+        "publication_sha256":"3"*64,"state_sha256":"4"*64,"report_sha256":"5"*64,
+    }
+    result=run_prediction(args(tmp_path,job_id="job_"+"1"*32,operational_index_provenance=json.dumps(provenance,sort_keys=True,separators=(",",":"))),dependencies())
+    index=json.loads((tmp_path/"bundles/prediction_bundle_index_v1.json").read_bytes())
+    request=json.loads((tmp_path/"bundles"/index["entries"][0]["directory"]/"request.json").read_bytes())
+    assert result["status"]=="PREDICTION_READY"
+    assert request["schema_version"]=="on_demand_prediction_request_v2"
+    assert request["operational_index_provenance"]==provenance
+
+
 def scheduled_exact_receipt(
     tmp_path: Path,
 ) -> tuple[

--- a/tests/test_prediction_bundle_sealed.py
+++ b/tests/test_prediction_bundle_sealed.py
@@ -16,7 +16,7 @@ import pytest
 
 import src.predictor.on_demand as sealed
 from src.predictor.on_demand import PredictionBlocked, canonical_bytes, sha256_bytes
-from src.operator_ui.job_store import Job, JobInput, Phase
+from src.operator_ui.job_store import Job, JobInput, OperationalIndexProvenance, Phase
 from src.operator_ui.r3_api import _verified_result
 
 
@@ -127,13 +127,17 @@ def request_for(result: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def make_bundle(root: Path, result: dict[str, Any] | None = None) -> tuple[Path, dict[str, Any]]:
+def make_bundle(root: Path, result: dict[str, Any] | None = None, *, operational_provenance: dict[str,str] | None = None) -> tuple[Path, dict[str, Any]]:
     result = copy.deepcopy(result or ready_result())
     bundle = root / DIRECTORY
     (bundle / "model").mkdir(parents=True)
+    prediction_request=request_for(result)
+    if operational_provenance is not None:
+        prediction_request["schema_version"]="on_demand_prediction_request_v2"
+        prediction_request["operational_index_provenance"]=operational_provenance
     files = {
         "result.json": canonical_bytes(result),
-        "request.json": canonical_bytes(request_for(result)),
+        "request.json": canonical_bytes(prediction_request),
         "config.json": b"{}\n",
         "model/config.schema.json": b"{}\n",
     }
@@ -167,7 +171,11 @@ def make_bundle(root: Path, result: dict[str, Any] | None = None) -> tuple[Path,
         result["model"]["artifact_sha256"] = sha256_bytes(files["model/model.json"])
         result["model"]["artifact_manifest_sha256"] = sha256_bytes(files["model/manifest.json"])
     files["result.json"] = canonical_bytes(result)
-    files["request.json"] = canonical_bytes(request_for(result))
+    prediction_request=request_for(result)
+    if operational_provenance is not None:
+        prediction_request["schema_version"]="on_demand_prediction_request_v2"
+        prediction_request["operational_index_provenance"]=operational_provenance
+    files["request.json"] = canonical_bytes(prediction_request)
     for name, raw in files.items():
         target = bundle / name
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -187,6 +195,11 @@ def operator_result(job_id: str) -> dict[str, Any]:
     value=ready_result(job_id=job_id); value["model"].update(requested="latest-research",resolved="market_form_residual_v1",alias_resolved=True,artifact_identity="AVAILABLE",artifact_manifest_identity="AVAILABLE",artifact_sha256=ZERO_SHA,artifact_manifest_sha256=ZERO_SHA)
     value["evidence"].update(model_artifact="model/model.json",model_manifest="model/manifest.json")
     return value
+
+
+def operator_provenance(**changes) -> OperationalIndexProvenance:
+    values={"schema":"operator_ui_operational_index_admission_v1","index_schema_version":"collector_current_race_index_v2","run_id":"collector-run","packet_sha256":ZERO_SHA,"source_refresh_sha256":ZERO_SHA,"publication_sha256":ZERO_SHA,"state_sha256":ZERO_SHA,"report_sha256":ZERO_SHA}
+    values.update(changes); return OperationalIndexProvenance(**values)
 
 
 def assert_blocked(callable_: Any, *args: Any, **kwargs: Any) -> PredictionBlocked:
@@ -493,13 +506,13 @@ def test_request_schema_downgrade_blocks_after_attacker_reseals_entire_chain(tmp
 
 
 def test_operator_disclosure_binds_authenticated_request_odds_and_runner_projection(tmp_path: Path):
-    job_id="job_"+"1"*32; result=operator_result(job_id); _bundle,entry=make_bundle(tmp_path,result)
+    job_id="job_"+"1"*32; result=operator_result(job_id); provenance=operator_provenance(); _bundle,entry=make_bundle(tmp_path,result,operational_provenance=provenance.fields())
     sealed.publish_prediction_bundle_index_entry(tmp_path,entry)
     verified=sealed.verify_indexed_prediction_bundle(tmp_path,entry)
     model=verified.result["model"]; request=verified.request; assert request is not None
     ordered=tuple({"box":row["box_number"],"name":row["display_name"],"identity":row["identity"],**({"source_native_runner_id":row["source_native_runner_id"]} if row["source_native_runner_id"] is not None else {})} for row in request["runners"])
     def job(odds):
-        inp=JobInput(verified.result["race"]["race_id"],verified.result["race"]["jump_timestamp"],verified.result["evidence"]["runner_set_sha256"],"latest-research",model["resolved"],model["artifact_sha256"],model["artifact_manifest_sha256"],model["schema_sha256"],"manual-default",verified.result["config"]["sha256"],odds,ordered)
+        inp=JobInput(verified.result["race"]["race_id"],verified.result["race"]["jump_timestamp"],verified.result["evidence"]["runner_set_sha256"],"latest-research",model["resolved"],model["artifact_sha256"],model["artifact_manifest_sha256"],model["schema_sha256"],"manual-default",verified.result["config"]["sha256"],odds,ordered,provenance)
         return Job(job_id,"operator",2,"manual_prediction","0"*64,inp,"2026-07-19T01:00:00Z",Phase.PREDICTION_READY,"2026-07-19T02:00:00Z","READY","verified",None,None,True)
     chain=verified.result["evidence"]["protocol_chain"]; cutoff=verified.result["evidence"]["authenticated_cutoff"]
     events=[{"phase":"CLAIMED","facts":{"attempt_id":"attempt-1"}},{"phase":"RESPONSE_RECORDED","facts":{"attempt_id":"attempt-1","protocol_chain":chain,"authenticated_cutoff":cutoff}},{"phase":"PRODUCER_COMPLETED","facts":{"attempt_id":"attempt-1","protocol_chain":chain,"authenticated_cutoff":cutoff}}]
@@ -507,6 +520,19 @@ def test_operator_disclosure_binds_authenticated_request_odds_and_runner_project
     disclosed=_verified_result(job("receipt"),verified,events)
     assert disclosed is not None
     assert {(row["box"],row["runner_id"]) for row in disclosed["probabilities"]}=={(1,"ONE"),(2,"TWO")}
+
+
+def test_operator_terminal_verifier_rejects_sealed_operational_index_provenance_divergence(tmp_path:Path):
+    job_id="job_"+"1"*32; result=operator_result(job_id); admitted=operator_provenance()
+    _bundle,entry=make_bundle(tmp_path,result,operational_provenance=operator_provenance(run_id="different-run").fields())
+    sealed.publish_prediction_bundle_index_entry(tmp_path,entry); verified=sealed.verify_indexed_prediction_bundle(tmp_path,entry)
+    model=verified.result["model"]; request=verified.request; assert request is not None
+    ordered=tuple({"box":row["box_number"],"name":row["display_name"],"identity":row["identity"],**({"source_native_runner_id":row["source_native_runner_id"]} if row["source_native_runner_id"] is not None else {})} for row in request["runners"])
+    inp=JobInput(verified.result["race"]["race_id"],verified.result["race"]["jump_timestamp"],verified.result["evidence"]["runner_set_sha256"],"latest-research",model["resolved"],model["artifact_sha256"],model["artifact_manifest_sha256"],model["schema_sha256"],"manual-default",verified.result["config"]["sha256"],"receipt",ordered,admitted)
+    durable_job=Job(job_id,"operator",2,"manual_prediction","0"*64,inp,"2026-07-19T01:00:00Z",Phase.PREDICTION_READY,"2026-07-19T02:00:00Z","READY","verified",None,None,True)
+    chain=verified.result["evidence"]["protocol_chain"]; cutoff=verified.result["evidence"]["authenticated_cutoff"]
+    events=[{"phase":"CLAIMED","facts":{"attempt_id":"attempt-1"}},{"phase":"RESPONSE_RECORDED","facts":{"attempt_id":"attempt-1","protocol_chain":chain,"authenticated_cutoff":cutoff}},{"phase":"PRODUCER_COMPLETED","facts":{"attempt_id":"attempt-1","protocol_chain":chain,"authenticated_cutoff":cutoff}}]
+    assert _verified_result(durable_job,verified,events) is None
 
 
 @pytest.mark.parametrize("identity",["request_sha256","claim_sha256","attempt_sha256","response_sha256","receipt_sha256","consume_sha256","authenticated_receipt_sha256","cutoff_timestamp"])


### PR DESCRIPTION
## Summary

- add `operator_ui_operational_index_admission_v1` to immutable `JobInput`, sourced only from the already-verified `VerifiedCurrentRaceIndex`
- persist the collector run ID plus packet, source-refresh, publication, lifecycle/state, and source/publish-report SHA-256 identities under job/store schema v3
- migrate valid v2 operations stores without fabricating provenance; legacy jobs remain readable but cannot be claimed
- require exact durable provenance at worker launch and sealed terminal verification, including fail-closed turnover/tamper handling
- recover an existing idempotent submission from persisted intent before re-resolving a newer current index

Tracks #135. This is offline implementation only: no deployment, live prediction, live POST, collector acquisition, model/config, or canonical-history changes.

## Validation

- 341 focused job-store, API, bootstrap, Operator UI security, end-to-end safety, worker, producer, and verifier tests passed after the final review fix
- 363 prediction bundle/producer/CI-routing tests passed
- 13 connected UI state tests passed
- changed Python files pass `py_compile` and fatal Flake8 (`E9,F63,F7,F82`)
- `git diff --check` passed
- broader Operator UI run: 602 passed, with one pre-existing host timing-threshold failure independently reproduced on untouched `origin/master` (`test_lifetime_reader_error_matrix_is_bounded_truthful_and_closes_every_pipe[stall]`, elapsed just over 3 seconds)

## PR #171 composition

PR #171 was inspected as reference only. Cherry-picking this change onto exact #171 head `ec31337d7a17750c4cfc75a31252de1b46f91423` produced no source conflict; one shared test-helper conflict was resolved by retaining both finalization and provenance fixtures. Seven focused migration, idempotent-turnover, worker-turnover, restart-finalization, missing-bundle, and terminal-verifier tests passed in the isolated combined tree. No #171 code was merged or copied wholesale here.

## Review

- Standards: no hard findings; independent store/bundle provenance validators retained as a deliberate trust-boundary check
- Spec: initial idempotent recovery finding fixed test-first; re-review found no remaining issues
