### PR TITLE
Require exact receipt readiness before journal attempts

### DIFF
--- a/scripts/forward_prediction_journal.py
+++ b/scripts/forward_prediction_journal.py
@@ -1,0 +1,279 @@
+"""Read-only exact-receipt admission for forward prediction journal races.
+
+This module performs one bounded observation of already-published receipt state.
+It neither acquires evidence nor owns polling.  The supplied invocation callback
+is the sole job/output/attempt boundary and is called only for fully READY races.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Set as AbstractSet
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlparse
+
+from race_collection.manual_prediction_collector_request import (
+    ManualPredictionCollectorProtocol,
+    ProtocolRejected,
+    runner_set_sha256,
+)
+from scripts.predict_market_form_residual import (
+    _configured_venue_identity,
+    _race_identity_equivalent,
+)
+from scripts.predict_race_now import (
+    _parse_race_jump_datetime,
+    _request_expected_runners,
+    _request_race,
+    _selected_protocol_chain,
+    stable_race_id,
+)
+from src.predictor.on_demand import PredictionBlocked, receipt_from_handoff
+
+READY = "READY"
+PENDING_RECEIPT = "PENDING_RECEIPT"
+PREFLIGHT_EXCLUDED = "PREFLIGHT_EXCLUDED"
+ALREADY_RECORDED = "ALREADY_RECORDED"
+
+_MAX_INDEX_RACES = 64
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptAdmission:
+    race_id: str
+    jump_timestamp: str | None
+    state: str
+    reason: str | None
+
+
+def _sportsbet_source_matches_race(source_url: Any, race_id: str) -> bool:
+    """Require one exact supported Sportsbet venue/race URL identity."""
+
+    try:
+        parsed = urlparse(str(source_url or "").strip())
+    except ValueError:
+        return False
+    if (
+        parsed.scheme != "https"
+        or (parsed.hostname or "").lower()
+        not in {"sportsbet.com.au", "www.sportsbet.com.au"}
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        return False
+    match = re.fullmatch(
+        r"/greyhound-racing/(?:australia-nz/)?([^/]+)/race-([0-9]{1,2})-[0-9]+/?",
+        parsed.path,
+        flags=re.IGNORECASE,
+    )
+    race_match = re.fullmatch(
+        r"Race ([0-9]{1,2}) - (.+) - [0-9]{4}-[0-9]{2}-[0-9]{2}",
+        race_id,
+    )
+    if match is None or race_match is None:
+        return False
+    return bool(
+        int(match.group(2)) == int(race_match.group(1))
+        and _configured_venue_identity(match.group(1).upper()) is not None
+        and _configured_venue_identity(match.group(1).upper())
+        == _configured_venue_identity(race_match.group(2).upper())
+    )
+
+
+def validate_exact_receipt_for_race(
+    race: Mapping[str, Any],
+    handoff: Mapping[str, Any],
+    *,
+    current_time: datetime,
+    receipt_max_age_seconds: int,
+) -> Mapping[str, Any]:
+    """Apply predictor receipt validation plus exact index-race binding."""
+
+    if current_time.tzinfo is None or current_time.utcoffset() is None:
+        raise PredictionBlocked("CURRENT_TIME_TIMEZONE_MISSING")
+    race_id = str(stable_race_id(race) or "")
+    jump = _parse_race_jump_datetime(race, now=current_time)
+    if not race_id or jump is None:
+        raise PredictionBlocked("EXACT_RACE_IDENTITY_UNAVAILABLE")
+    target_race = _request_race(race, race_id=race_id, jump=jump)
+    target_runners = _request_expected_runners(race)
+    if not target_runners:
+        raise PredictionBlocked("RUNNER_SET_AMBIGUOUS")
+    if handoff.get("race_id") != race_id:
+        raise PredictionBlocked("RECEIPT_INVALID")
+
+    receipt, _, _, _ = receipt_from_handoff(
+        handoff,
+        current_time=current_time,
+        max_age_seconds=receipt_max_age_seconds,
+    )
+    expected_runner_hash = runner_set_sha256(
+        [
+            {
+                "box_number": row["box_number"],
+                "dog_name": row["display_name"],
+                "identity": row["identity"],
+            }
+            for row in target_runners
+        ]
+    )
+    if (
+        expected_runner_hash is None
+        or receipt.get("runner_set_sha256") != expected_runner_hash
+    ):
+        raise PredictionBlocked("RUNNER_SET_AMBIGUOUS")
+    if not _sportsbet_source_matches_race(receipt.get("source_url"), race_id):
+        raise PredictionBlocked("RECEIPT_INVALID")
+
+    if handoff.get("schema_version") == "on_demand_verified_collector_capture_v2":
+        source_race = handoff.get("race")
+        if not isinstance(source_race, Mapping):
+            raise PredictionBlocked("RECEIPT_INVALID")
+        if (
+            not _race_identity_equivalent(
+                race_id,
+                source_race.get("race_id"),
+                source_url=source_race.get("url"),
+            )
+            or source_race.get("jump_timestamp") != target_race["jump_timestamp"]
+            or handoff.get("runner_set_sha256") != expected_runner_hash
+        ):
+            raise PredictionBlocked("RECEIPT_INVALID")
+    return receipt
+
+
+def _preflight_one(
+    race: Mapping[str, Any],
+    *,
+    protocol: ManualPredictionCollectorProtocol,
+    current_time: datetime,
+    receipt_max_age_seconds: int,
+    minimum_prejump_margin_seconds: float,
+) -> ReceiptAdmission:
+    race_id = str(stable_race_id(race) or "")
+    jump = _parse_race_jump_datetime(race, now=current_time)
+    if not race_id or jump is None:
+        return ReceiptAdmission(
+            race_id, None, PREFLIGHT_EXCLUDED, "EXACT_RACE_IDENTITY_UNAVAILABLE"
+        )
+    jump_text = jump.isoformat()
+    remaining = (jump - current_time).total_seconds()
+    if remaining <= minimum_prejump_margin_seconds:
+        return ReceiptAdmission(
+            race_id, jump_text, PREFLIGHT_EXCLUDED, "INSUFFICIENT_PREJUMP_MARGIN"
+        )
+    try:
+        manual = protocol.discover_exact_handoff(
+            race_id=race_id,
+            current_time=current_time,
+            max_age_seconds=receipt_max_age_seconds,
+        )
+        scheduled = protocol.discover_collector_exact_handoff(
+            race_id=race_id,
+            current_time=current_time,
+            max_age_seconds=receipt_max_age_seconds,
+        )
+        candidates = [value for value in (manual, scheduled) if value is not None]
+        if not candidates:
+            return ReceiptAdmission(
+                race_id, jump_text, PENDING_RECEIPT, "RECEIPT_UNAVAILABLE"
+            )
+        selected = max(
+            candidates,
+            key=lambda value: datetime.fromisoformat(str(value["append_timestamp"])),
+        )
+        # Snapshot validation is read-only and is also performed by the predictor.
+        _, _, selected = _selected_protocol_chain(protocol, selected)
+        validate_exact_receipt_for_race(
+            race,
+            selected,
+            current_time=current_time,
+            receipt_max_age_seconds=receipt_max_age_seconds,
+        )
+    except ProtocolRejected as exc:
+        return ReceiptAdmission(race_id, jump_text, PREFLIGHT_EXCLUDED, exc.code)
+    except PredictionBlocked as exc:
+        return ReceiptAdmission(race_id, jump_text, PREFLIGHT_EXCLUDED, exc.code)
+    return ReceiptAdmission(race_id, jump_text, READY, None)
+
+
+def observe_receipt_ready_races(
+    races: Sequence[Mapping[str, Any]],
+    *,
+    protocol: ManualPredictionCollectorProtocol,
+    current_time: datetime,
+    receipt_max_age_seconds: int,
+    minimum_prejump_margin_seconds: float,
+    recorded_race_ids: AbstractSet[str],
+    invoke_ready: Callable[[Mapping[str, Any]], Any],
+) -> tuple[ReceiptAdmission, ...]:
+    """Observe once, then invoke only independently READY unrecorded races."""
+
+    if (
+        current_time.tzinfo is None
+        or current_time.utcoffset() is None
+        or type(receipt_max_age_seconds) is not int
+        or receipt_max_age_seconds <= 0
+        or isinstance(minimum_prejump_margin_seconds, bool)
+        or not isinstance(minimum_prejump_margin_seconds, (int, float))
+        or minimum_prejump_margin_seconds <= 0
+        or len(races) > _MAX_INDEX_RACES
+    ):
+        raise ValueError("invalid bounded forward-journal observation")
+    race_ids = [str(stable_race_id(race) or "") for race in races]
+    duplicates = {
+        race_id for race_id, count in Counter(race_ids).items() if race_id and count > 1
+    }
+    admissions: list[ReceiptAdmission] = []
+    ready: list[tuple[datetime, str, Mapping[str, Any]]] = []
+    for race, race_id in zip(races, race_ids, strict=True):
+        jump = _parse_race_jump_datetime(race, now=current_time)
+        if race_id in recorded_race_ids:
+            admissions.append(
+                ReceiptAdmission(
+                    race_id,
+                    jump.isoformat() if jump is not None else None,
+                    ALREADY_RECORDED,
+                    "NO_RETRY_OR_BACKFILL",
+                )
+            )
+            continue
+        if not race_id or race_id in duplicates:
+            admissions.append(
+                ReceiptAdmission(
+                    race_id,
+                    jump.isoformat() if jump is not None else None,
+                    PREFLIGHT_EXCLUDED,
+                    "RACE_ID_MISSING_OR_AMBIGUOUS",
+                )
+            )
+            continue
+        admission = _preflight_one(
+            race,
+            protocol=protocol,
+            current_time=current_time,
+            receipt_max_age_seconds=receipt_max_age_seconds,
+            minimum_prejump_margin_seconds=minimum_prejump_margin_seconds,
+        )
+        admissions.append(admission)
+        if admission.state == READY and jump is not None:
+            ready.append((jump, race_id, race))
+    for _, _, race in sorted(ready, key=lambda value: (value[0], value[1])):
+        invoke_ready(race)
+    return tuple(admissions)
+
+
+__all__ = [
+    "ALREADY_RECORDED",
+    "PENDING_RECEIPT",
+    "PREFLIGHT_EXCLUDED",
+    "READY",
+    "ReceiptAdmission",
+    "observe_receipt_ready_races",
+    "validate_exact_receipt_for_race",
+]

--- a/scripts/forward_prediction_journal.py
+++ b/scripts/forward_prediction_journal.py
@@ -1,45 +1,46 @@
-"""Read-only exact-receipt admission for forward prediction journal races.
-
-This module performs one bounded observation of already-published receipt state.
-It neither acquires evidence nor owns polling.  The supplied invocation callback
-is the sole job/output/attempt boundary and is called only for fully READY races.
-"""
+"""Receipt-ready outer admission for the durable forward prediction journal."""
 
 from __future__ import annotations
 
-import re
 from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
 from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
-from urllib.parse import urlparse
 
 from race_collection.manual_prediction_collector_request import (
     ManualPredictionCollectorProtocol,
-    ProtocolRejected,
-    runner_set_sha256,
 )
-from scripts.predict_market_form_residual import (
-    _configured_venue_identity,
-    _race_identity_equivalent,
-)
-from scripts.predict_race_now import (
-    _parse_race_jump_datetime,
-    _request_expected_runners,
-    _request_race,
-    _selected_protocol_chain,
-    stable_race_id,
-)
-from src.predictor.on_demand import PredictionBlocked, receipt_from_handoff
+from race_collection.synchronous_manual_capture import LatencyBudget
+from src.predictor.on_demand import PredictionBlocked
+from src.predictor.receipt_preflight import discover_exact_receipt_ready
 
 READY = "READY"
 PENDING_RECEIPT = "PENDING_RECEIPT"
 PREFLIGHT_EXCLUDED = "PREFLIGHT_EXCLUDED"
 ALREADY_RECORDED = "ALREADY_RECORDED"
-
 _MAX_INDEX_RACES = 64
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptPreflightPolicy:
+    receipt_max_age_seconds: int
+    minimum_prejump_margin_seconds: float
+
+    @classmethod
+    def from_prediction_config(
+        cls, config: Mapping[str, Any]
+    ) -> ReceiptPreflightPolicy:
+        try:
+            bundle = config["bundle"]
+            maximum_age = bundle["receipt_max_age_seconds"]
+            budget = LatencyBudget.from_config(bundle["latency_budget"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError("invalid receipt preflight config") from exc
+        if type(maximum_age) is not int or maximum_age <= 0:
+            raise ValueError("invalid receipt preflight config")
+        return cls(maximum_age, budget.reuse_margin_seconds)
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,189 +51,104 @@ class ReceiptAdmission:
     reason: str | None
 
 
-def _sportsbet_source_matches_race(source_url: Any, race_id: str) -> bool:
-    """Require one exact supported Sportsbet venue/race URL identity."""
-
+def _jump(race: Mapping[str, Any]) -> datetime | None:
+    value = race.get("jump_datetime", race.get("jump_timestamp"))
+    if not isinstance(value, str) or not value:
+        return None
     try:
-        parsed = urlparse(str(source_url or "").strip())
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
-        return False
-    if (
-        parsed.scheme != "https"
-        or (parsed.hostname or "").lower()
-        not in {"sportsbet.com.au", "www.sportsbet.com.au"}
-        or parsed.params
-        or parsed.query
-        or parsed.fragment
-    ):
-        return False
-    match = re.fullmatch(
-        r"/greyhound-racing/(?:australia-nz/)?([^/]+)/race-([0-9]{1,2})-[0-9]+/?",
-        parsed.path,
-        flags=re.IGNORECASE,
-    )
-    race_match = re.fullmatch(
-        r"Race ([0-9]{1,2}) - (.+) - [0-9]{4}-[0-9]{2}-[0-9]{2}",
-        race_id,
-    )
-    if match is None or race_match is None:
-        return False
-    return bool(
-        int(match.group(2)) == int(race_match.group(1))
-        and _configured_venue_identity(match.group(1).upper()) is not None
-        and _configured_venue_identity(match.group(1).upper())
-        == _configured_venue_identity(race_match.group(2).upper())
-    )
+        return None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        return None
+    return parsed
 
 
-def validate_exact_receipt_for_race(
-    race: Mapping[str, Any],
-    handoff: Mapping[str, Any],
-    *,
-    current_time: datetime,
-    receipt_max_age_seconds: int,
-) -> Mapping[str, Any]:
-    """Apply predictor receipt validation plus exact index-race binding."""
-
-    if current_time.tzinfo is None or current_time.utcoffset() is None:
-        raise PredictionBlocked("CURRENT_TIME_TIMEZONE_MISSING")
-    race_id = str(stable_race_id(race) or "")
-    jump = _parse_race_jump_datetime(race, now=current_time)
-    if not race_id or jump is None:
-        raise PredictionBlocked("EXACT_RACE_IDENTITY_UNAVAILABLE")
-    target_race = _request_race(race, race_id=race_id, jump=jump)
-    target_runners = _request_expected_runners(race)
-    if not target_runners:
-        raise PredictionBlocked("RUNNER_SET_AMBIGUOUS")
-    if handoff.get("race_id") != race_id:
-        raise PredictionBlocked("RECEIPT_INVALID")
-
-    receipt, _, _, _ = receipt_from_handoff(
-        handoff,
-        current_time=current_time,
-        max_age_seconds=receipt_max_age_seconds,
-    )
-    expected_runner_hash = runner_set_sha256(
-        [
-            {
-                "box_number": row["box_number"],
-                "dog_name": row["display_name"],
-                "identity": row["identity"],
-            }
-            for row in target_runners
-        ]
-    )
-    if (
-        expected_runner_hash is None
-        or receipt.get("runner_set_sha256") != expected_runner_hash
-    ):
-        raise PredictionBlocked("RUNNER_SET_AMBIGUOUS")
-    if not _sportsbet_source_matches_race(receipt.get("source_url"), race_id):
-        raise PredictionBlocked("RECEIPT_INVALID")
-
-    if handoff.get("schema_version") == "on_demand_verified_collector_capture_v2":
-        source_race = handoff.get("race")
-        if not isinstance(source_race, Mapping):
-            raise PredictionBlocked("RECEIPT_INVALID")
-        if (
-            not _race_identity_equivalent(
-                race_id,
-                source_race.get("race_id"),
-                source_url=source_race.get("url"),
-            )
-            or source_race.get("jump_timestamp") != target_race["jump_timestamp"]
-            or handoff.get("runner_set_sha256") != expected_runner_hash
-        ):
-            raise PredictionBlocked("RECEIPT_INVALID")
-    return receipt
-
-
-def _preflight_one(
+def preflight_race_receipt(
     race: Mapping[str, Any],
     *,
     protocol: ManualPredictionCollectorProtocol,
     current_time: datetime,
-    receipt_max_age_seconds: int,
-    minimum_prejump_margin_seconds: float,
+    policy: ReceiptPreflightPolicy,
+    completion_clock: Callable[[], datetime] | None = None,
 ) -> ReceiptAdmission:
-    race_id = str(stable_race_id(race) or "")
-    jump = _parse_race_jump_datetime(race, now=current_time)
-    if not race_id or jump is None:
+    """Return one race-local state without allocating a job or output path."""
+
+    race_id = race.get("race_id")
+    jump = _jump(race)
+    if not isinstance(race_id, str) or not race_id or jump is None:
         return ReceiptAdmission(
-            race_id, None, PREFLIGHT_EXCLUDED, "EXACT_RACE_IDENTITY_UNAVAILABLE"
+            str(race_id or ""),
+            jump.isoformat() if jump is not None else None,
+            PREFLIGHT_EXCLUDED,
+            "EXACT_RACE_IDENTITY_UNAVAILABLE",
         )
-    jump_text = jump.isoformat()
-    remaining = (jump - current_time).total_seconds()
-    if remaining <= minimum_prejump_margin_seconds:
+    race_url = race.get("race_url", race.get("url"))
+    runners = race.get("runners", race.get("participants"))
+    if (
+        current_time.tzinfo is None
+        or current_time.utcoffset() is None
+        or not isinstance(race_url, str)
+        or isinstance(runners, (str, bytes, bytearray))
+        or not isinstance(runners, Sequence)
+    ):
         return ReceiptAdmission(
-            race_id, jump_text, PREFLIGHT_EXCLUDED, "INSUFFICIENT_PREJUMP_MARGIN"
+            race_id,
+            jump.isoformat(),
+            PREFLIGHT_EXCLUDED,
+            "EXACT_RACE_IDENTITY_UNAVAILABLE",
+        )
+    remaining = (jump - current_time).total_seconds()
+    if remaining <= policy.minimum_prejump_margin_seconds:
+        return ReceiptAdmission(
+            race_id,
+            jump.isoformat(),
+            PREFLIGHT_EXCLUDED,
+            "INSUFFICIENT_PREJUMP_MARGIN",
         )
     try:
-        manual = protocol.discover_exact_handoff(
+        discover_exact_receipt_ready(
+            protocol=protocol,
             race_id=race_id,
+            race_url=race_url,
+            jump=jump,
+            expected_runners=runners,
             current_time=current_time,
-            max_age_seconds=receipt_max_age_seconds,
+            receipt_max_age_seconds=policy.receipt_max_age_seconds,
+            minimum_prejump_margin_seconds=policy.minimum_prejump_margin_seconds,
+            completion_clock=completion_clock,
         )
-        scheduled = protocol.discover_collector_exact_handoff(
-            race_id=race_id,
-            current_time=current_time,
-            max_age_seconds=receipt_max_age_seconds,
-        )
-        candidates = [value for value in (manual, scheduled) if value is not None]
-        if not candidates:
-            return ReceiptAdmission(
-                race_id, jump_text, PENDING_RECEIPT, "RECEIPT_UNAVAILABLE"
-            )
-        selected = max(
-            candidates,
-            key=lambda value: datetime.fromisoformat(str(value["append_timestamp"])),
-        )
-        # Snapshot validation is read-only and is also performed by the predictor.
-        _, _, selected = _selected_protocol_chain(protocol, selected)
-        validate_exact_receipt_for_race(
-            race,
-            selected,
-            current_time=current_time,
-            receipt_max_age_seconds=receipt_max_age_seconds,
-        )
-    except ProtocolRejected as exc:
-        return ReceiptAdmission(race_id, jump_text, PREFLIGHT_EXCLUDED, exc.code)
     except PredictionBlocked as exc:
-        return ReceiptAdmission(race_id, jump_text, PREFLIGHT_EXCLUDED, exc.code)
-    return ReceiptAdmission(race_id, jump_text, READY, None)
+        state = (
+            PENDING_RECEIPT
+            if exc.code == "RECEIPT_UNAVAILABLE"
+            else PREFLIGHT_EXCLUDED
+        )
+        return ReceiptAdmission(race_id, jump.isoformat(), state, exc.code)
+    return ReceiptAdmission(race_id, jump.isoformat(), READY, None)
 
 
 def observe_receipt_ready_races(
     races: Sequence[Mapping[str, Any]],
     *,
     protocol: ManualPredictionCollectorProtocol,
-    current_time: datetime,
-    receipt_max_age_seconds: int,
-    minimum_prejump_margin_seconds: float,
+    policy: ReceiptPreflightPolicy,
+    clock: Callable[[], datetime],
     recorded_race_ids: AbstractSet[str],
     invoke_ready: Callable[[Mapping[str, Any]], Any],
 ) -> tuple[ReceiptAdmission, ...]:
-    """Observe once, then invoke only independently READY unrecorded races."""
+    """Observe once and revalidate each READY race at its allocation boundary."""
 
-    if (
-        current_time.tzinfo is None
-        or current_time.utcoffset() is None
-        or type(receipt_max_age_seconds) is not int
-        or receipt_max_age_seconds <= 0
-        or isinstance(minimum_prejump_margin_seconds, bool)
-        or not isinstance(minimum_prejump_margin_seconds, (int, float))
-        or minimum_prejump_margin_seconds <= 0
-        or len(races) > _MAX_INDEX_RACES
-    ):
-        raise ValueError("invalid bounded forward-journal observation")
-    race_ids = [str(stable_race_id(race) or "") for race in races]
+    if len(races) > _MAX_INDEX_RACES:
+        raise ValueError("forward-journal index is unbounded")
+    race_ids = [str(race.get("race_id") or "") for race in races]
     duplicates = {
         race_id for race_id, count in Counter(race_ids).items() if race_id and count > 1
     }
     admissions: list[ReceiptAdmission] = []
-    ready: list[tuple[datetime, str, Mapping[str, Any]]] = []
+    ready: list[tuple[datetime, str, int, Mapping[str, Any]]] = []
     for race, race_id in zip(races, race_ids, strict=True):
-        jump = _parse_race_jump_datetime(race, now=current_time)
+        jump = _jump(race)
         if race_id in recorded_race_ids:
             admissions.append(
                 ReceiptAdmission(
@@ -253,18 +169,28 @@ def observe_receipt_ready_races(
                 )
             )
             continue
-        admission = _preflight_one(
+        admission = preflight_race_receipt(
             race,
             protocol=protocol,
-            current_time=current_time,
-            receipt_max_age_seconds=receipt_max_age_seconds,
-            minimum_prejump_margin_seconds=minimum_prejump_margin_seconds,
+            current_time=clock(),
+            policy=policy,
+            completion_clock=clock,
         )
+        offset = len(admissions)
         admissions.append(admission)
         if admission.state == READY and jump is not None:
-            ready.append((jump, race_id, race))
-    for _, _, race in sorted(ready, key=lambda value: (value[0], value[1])):
-        invoke_ready(race)
+            ready.append((jump, race_id, offset, race))
+    for _, _, offset, race in sorted(ready, key=lambda value: (value[0], value[1])):
+        admission = preflight_race_receipt(
+            race,
+            protocol=protocol,
+            current_time=clock(),
+            policy=policy,
+            completion_clock=clock,
+        )
+        admissions[offset] = admission
+        if admission.state == READY:
+            invoke_ready(race)
     return tuple(admissions)
 
 
@@ -274,6 +200,7 @@ __all__ = [
     "PREFLIGHT_EXCLUDED",
     "READY",
     "ReceiptAdmission",
+    "ReceiptPreflightPolicy",
     "observe_receipt_ready_races",
-    "validate_exact_receipt_for_race",
+    "preflight_race_receipt",
 ]

--- a/scripts/predict_market_form_residual.py
+++ b/scripts/predict_market_form_residual.py
@@ -19,13 +19,13 @@ import json
 import math
 import re
 import sys
+from collections.abc import Mapping, Sequence
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Mapping, Sequence
+from typing import Any
 from urllib.parse import urlparse
 from zoneinfo import ZoneInfo
-
 
 sys.dont_write_bytecode = True
 ROOT = Path(__file__).resolve().parents[1]
@@ -33,25 +33,25 @@ ROOT_TEXT = str(ROOT)
 if ROOT_TEXT not in sys.path:
     sys.path.insert(0, ROOT_TEXT)
 
-from src.predictor.market_form_residual import (  # noqa: E402
+from config.venue_mapping import normalize_venue
+from src.predictor.market_form_residual import (
     DEFAULT_ARTIFACT_DIR,
     EFFECTIVE_STATE_SCHEMA,
     FEATURES,
     NUMERICAL_CANONICALIZATION_CONTRACT,
-    ResidualContractError,
     SHADOW_RECORD_SCHEMA,
+    ResidualContractError,
     _runner_set_sha256,
     load_frozen_model,
     score_race,
 )
-from src.predictor.scoring_parity import (  # noqa: E402
+from src.predictor.scoring_parity import (
     SCORING_CONFIG_SHA256,
     build_core_output,
     build_scoring_input,
     parity_binding,
 )
-from config.venue_mapping import VENUE_MAPPING, normalize_venue  # noqa: E402
-from utils.csv_metadata import (  # noqa: E402
+from utils.csv_metadata import (
     THEDOGS_EXACT_RACE_PAGE_GRADE_SOURCE,
     THEDOGS_MEETING_CARD_GRADE_SOURCE,
     canonical_thedogs_meeting_card_url,
@@ -60,7 +60,10 @@ from utils.csv_metadata import (  # noqa: E402
     normalize_exact_target_grade,
     target_grade_equivalence_key,
 )
-
+from utils.race_identity_equivalence import (
+    configured_venue_identity as _configured_venue_identity,
+    race_identity_equivalent as _strict_race_identity_equivalent,
+)
 
 MELBOURNE = ZoneInfo("Australia/Melbourne")
 ALLOWED_BOX_SOURCES = {"explicit_dom", "runner_text"}
@@ -310,7 +313,6 @@ EARLY_RESIDUAL_PARITY_KEYS = frozenset(
     }
 )
 VENUE_CODE_PATTERN = r"[A-Z0-9_]+(?:-[A-Z0-9_]+)*"
-NON_RACING_VENUE_IDENTITIES = frozenset({"UNKNOWN", "TEST_VEN", "RACE"})
 FORBIDDEN_EVIDENCE_PATH_MARKERS = frozenset({"form_only_v1", "pr51"})
 # Finite union of the exact GRADE_MAP and GRADE_VOCAB_MAP contracts, their
 # canonical values, and source-observed exact labels covered by the scorer
@@ -678,38 +680,6 @@ def _race_id_parts(race_id: str) -> tuple[int, str, date]:
     )
 
 
-def _configured_venue_identity(value: Any) -> str | None:
-    """Resolve only venue spellings proved by the checked-in canonical map."""
-
-    if not isinstance(value, str):
-        return None
-    raw = value.strip().upper()
-    if not raw or re.fullmatch(VENUE_CODE_PATTERN, raw) is None:
-        return None
-    candidates = {
-        raw,
-        raw.replace("-", " "),
-        raw.replace("-", "_"),
-        raw.replace("_", " "),
-        raw.replace("_", "-"),
-    }
-    normalized = {
-        normalize_venue(candidate)
-        for candidate in candidates
-        if candidate in VENUE_MAPPING
-    }
-    if len(normalized) != 1:
-        return None
-    configured = next(iter(normalized))
-    canonical = canonical_thedogs_venue_identity(configured)
-    if (
-        configured in NON_RACING_VENUE_IDENTITIES
-        or canonical in NON_RACING_VENUE_IDENTITIES
-    ):
-        return None
-    return canonical
-
-
 def _race_identity_equivalent(
     caller_race_id: Any,
     evidence_race_id: Any,
@@ -718,28 +688,8 @@ def _race_identity_equivalent(
 ) -> bool:
     """Bind caller and sealed-source aliases by exact structured identity."""
 
-    try:
-        caller_number, caller_venue, caller_date = _race_id_parts(caller_race_id)
-        evidence_number, evidence_venue, evidence_date = _race_id_parts(
-            evidence_race_id
-        )
-    except ManualPredictionError:
-        return False
-    source_identity = canonical_thedogs_race_identity(source_url)
-    if source_identity is None:
-        return False
-    venues = (
-        _configured_venue_identity(caller_venue),
-        _configured_venue_identity(evidence_venue),
-        _configured_venue_identity(source_identity["venue_slug"]),
-    )
-    return bool(
-        all(venue is not None for venue in venues)
-        and len(set(venues)) == 1
-        and caller_date == evidence_date
-        and caller_date.isoformat() == source_identity["race_date"]
-        and caller_number == evidence_number
-        and caller_number == source_identity["race_number"]
+    return _strict_race_identity_equivalent(
+        caller_race_id, evidence_race_id, source_url=source_url
     )
 
 

--- a/scripts/predict_race_now.py
+++ b/scripts/predict_race_now.py
@@ -27,13 +27,13 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from race_collection.manual_prediction_collector_request import (  # noqa: E402
+from race_collection.manual_prediction_collector_request import (
     PROTOCOL_DIRECTORY,
     RECEIPT_READY,
     ManualPredictionCollectorProtocol,
     ProtocolRejected,
 )
-from scripts.predict_market_form_residual import (  # noqa: E402
+from scripts.predict_market_form_residual import (
     DEFAULT_EVIDENCE_ROOT,
     DEFAULT_RETAINED_EVIDENCE_ROOTS,
     FEATURE_GENERATOR_FILES,
@@ -43,40 +43,44 @@ from scripts.predict_market_form_residual import (  # noqa: E402
 from scripts.predict_market_form_residual import (
     ManualPredictionError as CaptureHandoffError,
 )
-from scripts.refresh_prejump_upcoming import (  # noqa: E402
+from scripts.refresh_prejump_upcoming import (
     _parse_race_jump_datetime,
     parse_current_time,
     stable_race_id,
     stable_race_id_variants,
     venue_exclusion_aliases,
 )
-from src.predictor.on_demand import (  # noqa: E402
+from src.predictor.on_demand import (
     BLOCKER_STAGE_BY_CODE,
     Dependencies,
     PredictionBlocked,
-    _job_id,
     _copy_exact,
+    _job_id,
     _write_canonical,
     build_prediction_bundle_manifest_v2,
-    bundle_manifest,
     canonical_bytes,
     create_bundle,
     load_config,
     market_only_prediction,
     prediction_bundle_index_entry,
     publish_prediction_bundle_index_entry,
-    receipt_from_handoff,
     resolve_model,
     seal_history_database,
     sealed_runner_set_sha256,
     sha256_bytes,
     sha256_file,
-    verify_bundle,
     validate_operational_index_provenance,
+    verify_bundle,
     write_exact_bytes,
 )
-from utils.csv_metadata import canonical_thedogs_race_identity  # noqa: E402
-from utils.csv_metadata import canonical_thedogs_venue_identity  # noqa: E402
+from src.predictor.receipt_preflight import (
+    ExactReceiptReady,
+    discover_exact_receipt_ready,
+)
+from utils.csv_metadata import (
+    canonical_thedogs_race_identity,
+    canonical_thedogs_venue_identity,
+)
 
 DEFAULT_DB = ROOT / "greyhound_racing_data.db"
 DEFAULT_OUTPUT_ROOT = ROOT / "artifacts/on_demand_prediction_runs"
@@ -492,29 +496,6 @@ def _sealed_result(
     }
 
 
-def _selected_protocol_chain(
-    protocol: ManualPredictionCollectorProtocol, handoff: Mapping[str, Any]
-) -> tuple[dict[str, str], dict[str, bytes], dict[str, Any]]:
-    """Bind the already-validated exact handoff to its immutable protocol chain."""
-    public={str(key):value for key,value in handoff.items() if not str(key).startswith("_")}
-    try:
-        if handoff.get("_scheduled_exact_receipt") is True:
-            chain, members, artifacts = protocol.snapshot_collector_exact_handoff(
-                public
-            )
-            coherent = {
-                **handoff,
-                "_report_bytes": artifacts["report"],
-                "_form_bytes": artifacts["form"],
-                "_sidecar_bytes": artifacts["sidecar"],
-            }
-            return chain, members, coherent
-        chain, members = protocol.snapshot_authenticated_handoff(public)
-        return chain, members, dict(handoff)
-    except ProtocolRejected as exc:
-        raise PredictionBlocked("COLLECTOR_PROTOCOL_INVALID",reason=exc.code) from exc
-
-
 def _seal_and_publish_v2(state: dict[str, Any], result: Mapping[str, Any]) -> None:
     bundle = Path(state["bundle"])
     _write_canonical(bundle / "result.json", result)
@@ -730,52 +711,40 @@ def _acquire_or_reuse(
     latency_budget: Any,
     receipt_max_age_seconds: int,
     fetch_timeout_seconds: float,
-) -> tuple[
-    Mapping[str, Any] | None,
-    list[dict[str, Any]],
-    datetime,
-]:
+) -> tuple[ExactReceiptReady, list[dict[str, Any]], datetime]:
     del db_path
     rejected_receipts: list[dict[str, Any]] = []
     if odds_source not in {"auto", "capture", "receipt"}:
         raise PredictionBlocked("ODDS_SOURCE_UNSUPPORTED", odds_source=odds_source)
+    protocol_race = _request_race(target, race_id=race_id, jump=jump)
+    protocol_race.pop("venue_slug")
+    expected_runners = [
+        {
+            "box_number": row["box_number"],
+            "dog_name": row["display_name"],
+            "identity": row["identity"],
+        }
+        for row in _request_expected_runners(target)
+    ]
     try:
-        manual_handoff = protocol.discover_exact_handoff(
-            race_id=race_id,
-            current_time=current_time,
-            max_age_seconds=receipt_max_age_seconds,
-        )
-        collector_handoff = protocol.discover_collector_exact_handoff(
-            race_id=race_id,
-            current_time=current_time,
-            max_age_seconds=receipt_max_age_seconds,
-        )
-        available_handoffs = [
-            value
-            for value in (manual_handoff, collector_handoff)
-            if value is not None
-        ]
-        handoff = (
-            max(
-                available_handoffs,
-                key=lambda value: datetime.fromisoformat(
-                    str(value["append_timestamp"])
-                ),
+        try:
+            ready = discover_exact_receipt_ready(
+                protocol=protocol,
+                race_id=race_id,
+                race_url=str(protocol_race["url"]),
+                jump=jump,
+                expected_runners=expected_runners,
+                current_time=current_time,
+                receipt_max_age_seconds=receipt_max_age_seconds,
+                minimum_prejump_margin_seconds=latency_budget.reuse_margin_seconds,
+                completion_clock=dependencies.now,
             )
-            if available_handoffs
-            else None
-        )
-        if handoff is not None:
-            if (jump - current_time).total_seconds() <= latency_budget.reuse_margin_seconds:
-                raise PredictionBlocked(
-                    "INSUFFICIENT_PREJUMP_MARGIN",
-                    phase="reuse_validation_and_scoring",
-                    remaining_seconds=(jump - current_time).total_seconds(),
-                    required_seconds=latency_budget.reuse_margin_seconds,
-                )
-            return handoff, rejected_receipts, current_time
-        if odds_source == "receipt":
-            raise PredictionBlocked("RECEIPT_UNAVAILABLE")
+        except PredictionBlocked as exc:
+            if exc.code != "RECEIPT_UNAVAILABLE" or odds_source == "receipt":
+                raise
+            ready = None
+        if ready is not None:
+            return ready, rejected_receipts, current_time
         remaining = (jump - current_time).total_seconds()
         if remaining <= latency_budget.capture_margin_seconds:
             raise PredictionBlocked(
@@ -784,18 +753,9 @@ def _acquire_or_reuse(
                 remaining_seconds=remaining,
                 required_seconds=latency_budget.capture_margin_seconds,
             )
-        protocol_race = _request_race(target, race_id=race_id, jump=jump)
-        protocol_race.pop("venue_slug")
         published = protocol.publish_request(
             race=protocol_race,
-            expected_runners=[
-                {
-                    "box_number": row["box_number"],
-                    "dog_name": row["display_name"],
-                    "identity": row["identity"],
-                }
-                for row in _request_expected_runners(target)
-            ],
+            expected_runners=expected_runners,
             created_at=current_time,
             expires_at=jump,
         )
@@ -870,34 +830,23 @@ def _acquire_or_reuse(
                     else {}
                 ),
             )
-        handoff = protocol.discover_exact_handoff(
+        ready = discover_exact_receipt_ready(
+            protocol=protocol,
             race_id=race_id,
+            race_url=str(protocol_race["url"]),
+            jump=jump,
+            expected_runners=expected_runners,
             current_time=response_observed_time,
-            max_age_seconds=receipt_max_age_seconds,
-        )
-        if handoff is None:
-            raise PredictionBlocked(
-                "RECEIPT_INVALID",
-                reason="sealed_response_receipt_unavailable",
-            )
-        normalized, _, _, _ = receipt_from_handoff(
-            handoff,
-            current_time=response_observed_time,
-            max_age_seconds=receipt_max_age_seconds,
+            receipt_max_age_seconds=receipt_max_age_seconds,
+            minimum_prejump_margin_seconds=latency_budget.reuse_margin_seconds,
+            completion_clock=dependencies.now,
+            margin_phase="post_capture_validation_and_scoring",
         )
         protocol.verify_ready_handoff(
             consumed["receipt"],
-            handoff=handoff,
-            normalized_receipt=normalized,
+            handoff=ready.handoff,
+            normalized_receipt=ready.receipt,
         )
-        remaining = (jump - response_observed_time).total_seconds()
-        if remaining <= latency_budget.reuse_margin_seconds:
-            raise PredictionBlocked(
-                "INSUFFICIENT_PREJUMP_MARGIN",
-                phase="post_capture_validation_and_scoring",
-                remaining_seconds=remaining,
-                required_seconds=latency_budget.reuse_margin_seconds,
-            )
     except PredictionBlocked:
         raise
     except ProtocolRejected as exc:
@@ -906,7 +855,7 @@ def _acquire_or_reuse(
             reason=exc.code,
             **exc.details,
         ) from exc
-    return handoff, rejected_receipts, response_observed_time
+    return ready, rejected_receipts, response_observed_time
 
 
 def _run_prediction(
@@ -1039,11 +988,7 @@ def _run_prediction(
     protocol=ManualPredictionCollectorProtocol(
             Path(getattr(args,"collector_request_root",DEFAULT_COLLECTOR_REQUEST_ROOT))
         )
-    (
-        handoff,
-        rejected_receipts,
-        receipt_validation_time,
-    ) = _acquire_or_reuse(
+    ready_receipt, rejected_receipts, _ = _acquire_or_reuse(
         dependencies,
         protocol=protocol,
         target=target,
@@ -1059,35 +1004,23 @@ def _run_prediction(
             ),
             fetch_timeout_seconds=float(args.fetch_timeout_seconds),
         )
-    if handoff is not None:
-        state["protocol_chain"],protocol_members,handoff=_selected_protocol_chain(protocol,handoff)
-        for member,raw in protocol_members.items():write_exact_bytes(bundle/"protocol"/(member+".json"),raw)
-        receipt, capture_raw, form_raw, sidecar_raw = receipt_from_handoff(
-            handoff,
-            current_time=receipt_validation_time,
-            max_age_seconds=int(config["bundle"]["receipt_max_age_seconds"]),
-        )
-        if (
-            receipt.get("race_id") != race_id
-            or (
-                handoff.get("schema_version")
-                == "on_demand_verified_collector_capture_v2"
-                and receipt.get("runner_set_sha256")
-                != handoff.get("runner_set_sha256")
-            )
-        ):
-            raise PredictionBlocked("RECEIPT_INVALID")
-        form_name = str(handoff.get("_form_name") or "form.csv")
-        if Path(form_name).name != form_name:
-            raise PredictionBlocked("RECEIPT_INVALID")
-        form_csv = bundle / "source" / form_name
-        sidecar = form_csv.with_name(form_csv.name + ".metadata.json")
-        capture_path = bundle / "source" / "capture.json"
-        write_exact_bytes(form_csv, form_raw)
-        write_exact_bytes(sidecar, sidecar_raw)
-        write_exact_bytes(capture_path, capture_raw)
-    else:
-        raise PredictionBlocked("RECEIPT_UNAVAILABLE")
+    handoff = ready_receipt.handoff
+    receipt = ready_receipt.receipt
+    state["protocol_chain"] = ready_receipt.protocol_chain
+    for member, raw in ready_receipt.protocol_members.items():
+        write_exact_bytes(bundle / "protocol" / (member + ".json"), raw)
+    capture_raw = bytes(handoff["_report_bytes"])
+    form_raw = bytes(handoff["_form_bytes"])
+    sidecar_raw = bytes(handoff["_sidecar_bytes"])
+    form_name = str(handoff.get("_form_name") or "form.csv")
+    if Path(form_name).name != form_name:
+        raise PredictionBlocked("RECEIPT_INVALID")
+    form_csv = bundle / "source" / form_name
+    sidecar = form_csv.with_name(form_csv.name + ".metadata.json")
+    capture_path = bundle / "source" / "capture.json"
+    write_exact_bytes(form_csv, form_raw)
+    write_exact_bytes(sidecar, sidecar_raw)
+    write_exact_bytes(capture_path, capture_raw)
 
     try:
         odds_captured_at = datetime.fromisoformat(str(receipt["captured_at"]))

--- a/src/operator_ui/bootstrap.py
+++ b/src/operator_ui/bootstrap.py
@@ -9,22 +9,55 @@ import re
 import stat
 import sys
 import threading
-import tomllib
 import warnings
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
+import tomllib
 from flask import Flask
 
-from race_collection.synchronous_manual_capture import CaptureOneRejected, VerifiedCurrentRaceIndex, bounded_current_race_index
+from race_collection.manual_prediction_collector_request import (
+    ManualPredictionCollectorProtocol,
+)
+from race_collection.synchronous_manual_capture import (
+    CaptureOneRejected,
+    VerifiedCurrentRaceIndex,
+    bounded_current_race_index,
+)
+from scripts.forward_prediction_journal import (
+    PENDING_RECEIPT,
+    READY,
+    ReceiptPreflightPolicy,
+    preflight_race_receipt,
+)
 from src.predictor.on_demand import PredictionBlocked
+
 from .api import register_level_1_provider
+from .foundation import (
+    JsonSerializationPolicy,
+    JsonSource,
+    OperatorEvidenceReader,
+    RawSourceConfig,
+    SourceConfig,
+    TimestampSyntax,
+)
 from .job_store import JobInput, JobStore, OperationalIndexProvenance, Phase
-from .foundation import JsonSerializationPolicy, JsonSource, OperatorEvidenceReader, RawSourceConfig, SourceConfig, TimestampSyntax
-from .live_adapters import InstalledUnits, LiveEvidenceAdapters, PredictionBundleSource, UpcomingRaceSource
+from .live_adapters import (
+    InstalledUnits,
+    LiveEvidenceAdapters,
+    PredictionBundleSource,
+    UpcomingRaceSource,
+)
 from .prediction_worker import ServerChoice, WorkerConfig, run_once
-from .r3_api import R3Rejected, R3Services, ResolvedSubmission, build_verified_bundle_reader, install_r3_api
+from .r3_api import (
+    R3Rejected,
+    R3Services,
+    ResolvedSubmission,
+    build_verified_bundle_reader,
+    install_r3_api,
+)
 
 CONFIG_KEY = "OPERATOR_UI_LIVE_EVIDENCE_ADAPTERS"
 R3_PROFILE_KEY = "OPERATOR_UI_R3_PROFILE"
@@ -331,6 +364,8 @@ def _build_r3_services(app: Flask, profile: str) -> R3Services:
     config=json.loads(config_path.read_text(encoding="utf-8"))
     if config.get("schema_version")!="on_demand_prediction_config_v1" or config.get("model")!=resolved_model:raise RuntimeError("fixed R3 config divergent")
     choice=ServerChoice(config_path,"manual-default",_sha(config_path),resolved_model,model_sha,manifest_sha,schema_sha,model_path,manifest_path,schema_path)
+    receipt_policy=ReceiptPreflightPolicy.from_prediction_config(config)
+    receipt_protocol=ManualPredictionCollectorProtocol(dirs["collector_requests"])
     captures=(dirs["current_evidence"],) if profile=="repository-v1" else (dirs["current_evidence"],dirs["capture_evidence_a"],dirs["capture_evidence_b"])
     worker=WorkerConfig(layout["pinned_python"] if layout is not None else Path(sys.executable),product_root,{"latest-research":choice},paths["canonical.sqlite3"],dirs["prediction_bundles"],captures,dirs["collector_requests"],paths["current_index.json"],dirs["current_evidence"],1.0,45.0,90.0,2.0)
     store=JobStore(paths["jobs.sqlite3"],separate_from=(paths["audit.sqlite3"],paths["canonical.sqlite3"]))
@@ -345,6 +380,9 @@ def _build_r3_services(app: Flask, profile: str) -> R3Services:
         matches=[row for row in view.races if row.get("race_id")==selected.get("race_id")]
         if len(matches)!=1:raise R3Rejected("RACE_ID_MISSING_OR_AMBIGUOUS")
         race=matches[0]; runners=tuple(_runner(row) for row in race.get("runners",()))
+        receipt_admission=preflight_race_receipt(race,protocol=receipt_protocol,current_time=now,policy=receipt_policy,completion_clock=clock)
+        if receipt_admission.state!=READY:
+            raise R3Rejected(PENDING_RECEIPT if receipt_admission.state==PENDING_RECEIPT else receipt_admission.reason or "PREFLIGHT_EXCLUDED")
         jump=race.get("jump_datetime",race.get("jump_timestamp"))
         provenance=OperationalIndexProvenance.from_verified_current_race_index(view)
         job_input=JobInput(str(race["race_id"]),str(jump),str(race["runner_set_sha256"]),model_id,resolved_model,model_sha,manifest_sha,schema_sha,config_id,choice.config_sha256,odds_source,runners,provenance)

--- a/src/operator_ui/job_store.py
+++ b/src/operator_ui/job_store.py
@@ -8,11 +8,12 @@ import os
 import sqlite3
 import stat
 import uuid
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import Any
 
 JOB_SCHEMA = "operator_ui_manual_prediction_job_v3"
 LEGACY_JOB_SCHEMA = "operator_ui_manual_prediction_job_v2"
@@ -42,6 +43,7 @@ INSERT INTO store_anchor VALUES(1,'{STORE_SCHEMA}',0,'{ZERO_HASH}');
 
 class JobStoreError(RuntimeError): pass
 class IdempotencyConflict(JobStoreError): pass
+class RaceAlreadyRecorded(JobStoreError): pass
 class IllegalTransition(JobStoreError): pass
 class AttemptAlreadyClaimed(JobStoreError): pass
 class VerifierAuthorizationError(JobStoreError): pass
@@ -546,13 +548,15 @@ class JobStore:
             if row:
                 if not hmac.compare_digest(row["input_identity_sha256"],identity): raise IdempotencyConflict("idempotency key is already bound to different inputs")
                 db.commit(); return self.get(row["job_id"])
+            prior_race=db.execute("SELECT job_id FROM jobs WHERE operation=? AND json_extract(input_json,'$.race_id')=? LIMIT 1",(operation,job_input.race_id)).fetchone()
+            if prior_race: raise RaceAlreadyRecorded("race already has a durable journal record")
             job_id="job_"+uuid.uuid4().hex; proposed={"job_id":job_id,"actor_identity":actor,"actor_level":2,"operation":operation,"idempotency_key_sha256":key_hash,"input_identity_sha256":identity,"input_json":input_json}; job_row={"job_id":job_id,"schema":JOB_SCHEMA,"actor_identity":actor,"actor_level":2,"operation":operation,"idempotency_key_sha256":key_hash,"input_identity_sha256":identity,"input_json":input_json,"created_at":created,"creation_audit_hash":AUDIT_HASH_BINDING}; intent,event_id,previous=self._mutation_intent(db,proposed,"create","NONE",Phase.SUBMITTED,created,"ACCEPTED","submitted",{},proposed_job=job_row); receipt=self._confirm(confirm_audit,intent); audit=receipt.audit_sha256
             db.execute("INSERT INTO jobs(job_id,schema,actor_identity,actor_level,operation,idempotency_key_sha256,input_identity_sha256,input_json,created_at,creation_audit_hash) VALUES(?,?,?,?,?,?,?,?,?,?)",(job_id,JOB_SCHEMA,actor,2,operation,key_hash,identity,input_json,created,audit))
             self._append_event(db,job_id,Phase.SUBMITTED,created,"ACCEPTED","submitted",{},audit,prior=None,event_id=event_id,previous=previous); self._seal(db)
             anchor=db.execute("SELECT mutation_count,store_hash FROM store_anchor WHERE singleton=1").fetchone()
             if anchor[0]!=receipt.next_mutation_count or not hmac.compare_digest(anchor[1],receipt.next_store_hash): raise ConfirmationMismatch("persisted store differs from confirmation")
             db.commit(); return self.get(job_id)
-        except (IdempotencyConflict,JobStoreError): db.rollback(); raise
+        except (IdempotencyConflict,RaceAlreadyRecorded,JobStoreError): db.rollback(); raise
         except (sqlite3.Error,ValueError,TypeError) as exc: db.rollback(); raise JobStoreError("job creation failed") from exc
         finally: db.close()
     def find_by_idempotency(self,*,actor_identity,operation,idempotency_key):

--- a/src/operator_ui/prediction_worker.py
+++ b/src/operator_ui/prediction_worker.py
@@ -13,8 +13,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any,Callable,Mapping
 
-from race_collection.synchronous_manual_capture import CaptureOneRejected,VerifiedCurrentRaceIndex,bounded_current_race_index
+from race_collection.manual_prediction_collector_request import ManualPredictionCollectorProtocol
+from race_collection.synchronous_manual_capture import CaptureOneRejected,LatencyBudget,VerifiedCurrentRaceIndex,bounded_current_race_index
 from src.predictor.on_demand import PredictionBlocked,canonical_bytes,validate_prediction_result_v2
+from src.predictor.receipt_preflight import discover_exact_receipt_ready
 from .job_store import AuditConfirmation,Job,JobStore,JobStoreError,OperationalIndexProvenance,Phase
 
 MAX_STDOUT_BYTES=1_048_576; MAX_STDERR_BYTES=65_536; MAX_FAILED_STDOUT_DIAGNOSTIC_BYTES=4096
@@ -142,7 +144,31 @@ def revalidate_current_race(job,config,*,now,reader=bounded_current_race_index):
     if provenance is None: raise WorkerRejected("OPERATIONAL_INDEX_PROVENANCE_MISSING")
     actual=OperationalIndexProvenance.from_verified_current_race_index(view).fields()
     if provenance.fields()!=actual: raise WorkerRejected("CURRENT_INDEX_PROVENANCE_CHANGED")
-    return view
+    return matches[0]
+
+def validate_receipt_before_claim(job,config,race,*,current_time,completion_clock):
+    try:
+        choice=config.choices[job.input.model_selector]
+        value=json.loads(choice.config_path.read_bytes())
+        bundle=value["bundle"]
+        maximum_age=bundle["receipt_max_age_seconds"]
+        budget=LatencyBudget.from_config(bundle["latency_budget"])
+        jump=datetime.fromisoformat(job.input.jump_timestamp.replace("Z","+00:00"))
+        discover_exact_receipt_ready(
+            protocol=ManualPredictionCollectorProtocol(config.collector_request_root),
+            race_id=job.input.race_id,
+            race_url=str(race.get("race_url",race.get("url")) or ""),
+            jump=jump,
+            expected_runners=race.get("runners",race.get("participants")) or (),
+            current_time=current_time,
+            receipt_max_age_seconds=maximum_age,
+            minimum_prejump_margin_seconds=budget.reuse_margin_seconds,
+            completion_clock=completion_clock,
+        )
+    except (KeyError,TypeError,ValueError,json.JSONDecodeError) as exc:
+        raise WorkerRejected("RECEIPT_PREFLIGHT_CONFIG_INVALID") from exc
+    except PredictionBlocked as exc:
+        raise WorkerRejected(exc.code) from exc
 
 def _drain(pipe:Any,cap:int,sink:dict[str,Any],name:str):
     captured=bytearray(); total=0; digest=hashlib.sha256()
@@ -339,7 +365,8 @@ def _stop_and_reap(process,grace):
 def run_once(store:JobStore,job_id:str,config:WorkerConfig,*,now:Callable[[],datetime],confirm_audit:AuditConfirmation,popen:Callable[...,Any]=subprocess.Popen,reader=bounded_current_race_index,cancel_requested:Callable[[],bool]|None=None)->Job:
     job=store.get(job_id)
     if job.phase is not Phase.WAITING_FOR_CLAIM or job.attempt_claimed:raise WorkerRejected("JOB_NOT_CLAIMABLE")
-    _validate_runtime(config); _validate_choice(job,config); revalidate_current_race(job,config,now=now(),reader=reader); _validate_choice(job,config); _validate_runtime(config)
+    _validate_runtime(config); _validate_choice(job,config); race=revalidate_current_race(job,config,now=now(),reader=reader); _validate_choice(job,config); _validate_runtime(config)
+    validate_receipt_before_claim(job,config,race,current_time=now(),completion_clock=now)
     job,attempt_id=store.claim_attempt(job_id,now=now(),confirm_audit=confirm_audit)
     argv=fixed_argv(job,config); process=None; owner=None; started=False; runtime_fds=()
     try:

--- a/src/operator_ui/r3_api.py
+++ b/src/operator_ui/r3_api.py
@@ -1,19 +1,27 @@
 """Narrow Level-2 submission and reconnect API for one exact prediction job."""
 from __future__ import annotations
 
-import hashlib
-import json
 import threading
 import time
 import uuid
-from dataclasses import replace
-from dataclasses import dataclass
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
-from typing import Any, Callable, Mapping
+from pathlib import Path
+from typing import Any
 
 from flask import Flask, jsonify, request, session
 
+from src.predictor.on_demand import (
+    PredictionBlocked,
+    VerifiedPredictionBundle,
+    VerifiedPredictionBundleIndex,
+    verify_indexed_prediction_bundle,
+    verify_prediction_bundle_index,
+)
+
 from .job_store import (
+    TERMINAL_PHASES,
     IdempotencyConflict,
     IllegalTransition,
     Job,
@@ -21,12 +29,10 @@ from .job_store import (
     JobStore,
     JobStoreError,
     Phase,
-    TERMINAL_PHASES,
+    RaceAlreadyRecorded,
     resolve_audit_confirmation,
 )
 from .security import AuditUnavailable, OperationAuditEvent
-from pathlib import Path
-from src.predictor.on_demand import PredictionBlocked, VerifiedPredictionBundle, VerifiedPredictionBundleIndex, verify_indexed_prediction_bundle, verify_prediction_bundle_index
 
 API_PREFIX = "/operator-ui/api/v1"
 SUBMISSION_FIELDS = frozenset(
@@ -343,6 +349,8 @@ def install_r3_api(app: Flask, services: R3Services | None = None) -> bool:
             return jsonify(_job_payload(services.job_store, job, services.read_verified_result)), 202 if newly_observed else 200
         except IdempotencyConflict:
             return response_error("IDEMPOTENCY_CONFLICT", 409)
+        except RaceAlreadyRecorded:
+            return response_error("RACE_ALREADY_RECORDED", 409)
         except R3Rejected as exc:
             return response_error(exc.classification, exc.status_code)
         except (AuditUnavailable, JobStoreError):

--- a/src/predictor/receipt_preflight.py
+++ b/src/predictor/receipt_preflight.py
@@ -1,0 +1,249 @@
+"""Exact read-only receipt readiness shared by predictor and operator admission."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlparse
+
+from race_collection.manual_prediction_collector_request import (
+    ManualPredictionCollectorProtocol,
+    ProtocolRejected,
+    runner_set_sha256,
+)
+from src.predictor.on_demand import PredictionBlocked, receipt_from_handoff
+from utils.race_identity_equivalence import (
+    configured_venue_identity,
+    race_id_parts,
+    race_identity_equivalent,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ExactReceiptReady:
+    handoff: Mapping[str, Any]
+    receipt: Mapping[str, Any]
+    protocol_chain: Mapping[str, str]
+    protocol_members: Mapping[str, bytes]
+
+
+def _expected_runner_hash(rows: Sequence[Mapping[str, Any]]) -> str:
+    expected: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise PredictionBlocked("RUNNER_SET_AMBIGUOUS")
+        box = row.get("box_number", row.get("box"))
+        name = row.get("display_name", row.get("dog_name", row.get("name")))
+        identity = row.get("identity")
+        expected.append(
+            {"box_number": box, "dog_name": name, "identity": identity}
+        )
+    try:
+        result = runner_set_sha256(expected)
+    except ProtocolRejected as exc:
+        raise PredictionBlocked("RUNNER_SET_AMBIGUOUS") from exc
+    if result is None:
+        raise PredictionBlocked("RUNNER_SET_AMBIGUOUS")
+    return result
+
+
+def _sportsbet_source_matches(source_url: Any, race_id: str) -> bool:
+    try:
+        parsed = urlparse(str(source_url or "").strip())
+    except ValueError:
+        return False
+    if (
+        parsed.scheme != "https"
+        or (parsed.hostname or "").lower()
+        not in {"sportsbet.com.au", "www.sportsbet.com.au"}
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        return False
+    match = re.fullmatch(
+        r"/(?:betting/)?greyhound-racing/(?:australia-nz/)?([^/]+)/race-([0-9]{1,2})-[0-9]+/?",
+        parsed.path,
+        flags=re.IGNORECASE,
+    )
+    caller = race_id_parts(race_id)
+    if match is None or caller is None:
+        return False
+    number, venue, _ = caller
+    source_venue = configured_venue_identity(match.group(1).upper())
+    return bool(
+        int(match.group(2)) == number
+        and source_venue is not None
+        and source_venue == configured_venue_identity(venue)
+    )
+
+
+def _snapshot(
+    protocol: ManualPredictionCollectorProtocol, handoff: Mapping[str, Any]
+) -> tuple[Mapping[str, str], Mapping[str, bytes], Mapping[str, Any]]:
+    public = {
+        str(key): value
+        for key, value in handoff.items()
+        if not str(key).startswith("_")
+    }
+    try:
+        if handoff.get("_scheduled_exact_receipt") is True:
+            chain, members, artifacts = protocol.snapshot_collector_exact_handoff(
+                public
+            )
+            return (
+                chain,
+                members,
+                {
+                    **handoff,
+                    "_report_bytes": artifacts["report"],
+                    "_form_bytes": artifacts["form"],
+                    "_sidecar_bytes": artifacts["sidecar"],
+                },
+            )
+        chain, members = protocol.snapshot_authenticated_handoff(public)
+        return chain, members, dict(handoff)
+    except ProtocolRejected as exc:
+        raise PredictionBlocked(
+            "COLLECTOR_PROTOCOL_INVALID", reason=exc.code
+        ) from exc
+
+
+def _validate_request_member(
+    members: Mapping[str, bytes],
+    *,
+    race_id: str,
+    race_url: str,
+    jump_timestamp: str,
+    expected_runner_hash: str,
+) -> None:
+    raw = members.get("request")
+    if raw is None:
+        return
+    try:
+        request = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PredictionBlocked("COLLECTOR_PROTOCOL_INVALID") from exc
+    race = request.get("race") if isinstance(request, Mapping) else None
+    if (
+        not isinstance(race, Mapping)
+        or not race_identity_equivalent(
+            race_id, race.get("race_id"), source_url=race.get("url")
+        )
+        or race.get("url") != race_url
+        or race.get("jump_timestamp") != jump_timestamp
+        or request.get("expected_runner_set_sha256") != expected_runner_hash
+    ):
+        raise PredictionBlocked("RECEIPT_INVALID")
+
+
+def discover_exact_receipt_ready(
+    *,
+    protocol: ManualPredictionCollectorProtocol,
+    race_id: str,
+    race_url: str,
+    jump: datetime,
+    expected_runners: Sequence[Mapping[str, Any]],
+    current_time: datetime,
+    receipt_max_age_seconds: int,
+    minimum_prejump_margin_seconds: float,
+    completion_clock: Callable[[], datetime] | None = None,
+    margin_phase: str = "reuse_validation_and_scoring",
+) -> ExactReceiptReady:
+    """Discover and validate one exact receipt before any one-shot allocation."""
+
+    if (
+        current_time.tzinfo is None
+        or current_time.utcoffset() is None
+        or jump.tzinfo is None
+        or jump.utcoffset() is None
+    ):
+        raise PredictionBlocked("CURRENT_TIME_TIMEZONE_MISSING")
+    if not race_identity_equivalent(race_id, race_id, source_url=race_url):
+        raise PredictionBlocked("EXACT_RACE_IDENTITY_UNAVAILABLE")
+    expected_runner_hash = _expected_runner_hash(expected_runners)
+    try:
+        manual = protocol.discover_exact_handoff(
+            race_id=race_id,
+            current_time=current_time,
+            max_age_seconds=receipt_max_age_seconds,
+        )
+        scheduled = protocol.discover_collector_exact_handoff(
+            race_id=race_id,
+            current_time=current_time,
+            max_age_seconds=receipt_max_age_seconds,
+        )
+    except ProtocolRejected as exc:
+        raise PredictionBlocked(
+            "COLLECTOR_PROTOCOL_INVALID", reason=exc.code
+        ) from exc
+    candidates = [value for value in (manual, scheduled) if value is not None]
+    if not candidates:
+        raise PredictionBlocked("RECEIPT_UNAVAILABLE")
+    remaining = (jump - current_time).total_seconds()
+    if remaining <= minimum_prejump_margin_seconds:
+        raise PredictionBlocked(
+            "INSUFFICIENT_PREJUMP_MARGIN",
+            phase=margin_phase,
+            remaining_seconds=remaining,
+            required_seconds=minimum_prejump_margin_seconds,
+        )
+    selected = max(
+        candidates,
+        key=lambda value: datetime.fromisoformat(str(value["append_timestamp"])),
+    )
+    chain, members, selected = _snapshot(protocol, selected)
+    if selected.get("race_id") != race_id:
+        raise PredictionBlocked("RECEIPT_INVALID")
+    receipt, _, _, _ = receipt_from_handoff(
+        selected,
+        current_time=current_time,
+        max_age_seconds=receipt_max_age_seconds,
+    )
+    if receipt.get("runner_set_sha256") != expected_runner_hash:
+        raise PredictionBlocked("RUNNER_SET_AMBIGUOUS")
+    if not _sportsbet_source_matches(receipt.get("source_url"), race_id):
+        raise PredictionBlocked("RECEIPT_INVALID")
+    if selected.get("schema_version") == "on_demand_verified_collector_capture_v2":
+        source_race = selected.get("race")
+        if (
+            not isinstance(source_race, Mapping)
+            or not race_identity_equivalent(
+                race_id, source_race.get("race_id"), source_url=source_race.get("url")
+            )
+            or source_race.get("url") != race_url
+            or source_race.get("jump_timestamp") != jump.isoformat()
+            or selected.get("runner_set_sha256") != expected_runner_hash
+        ):
+            raise PredictionBlocked("RECEIPT_INVALID")
+    _validate_request_member(
+        members,
+        race_id=race_id,
+        race_url=race_url,
+        jump_timestamp=jump.isoformat(),
+        expected_runner_hash=expected_runner_hash,
+    )
+    completed_at = completion_clock() if completion_clock is not None else current_time
+    if completed_at.tzinfo is None or completed_at.utcoffset() is None:
+        raise PredictionBlocked("CURRENT_TIME_TIMEZONE_MISSING")
+    receipt, _, _, _ = receipt_from_handoff(
+        selected,
+        current_time=completed_at,
+        max_age_seconds=receipt_max_age_seconds,
+    )
+    completed_remaining = (jump - completed_at).total_seconds()
+    if completed_remaining <= minimum_prejump_margin_seconds:
+        raise PredictionBlocked(
+            "INSUFFICIENT_PREJUMP_MARGIN",
+            phase=margin_phase,
+            remaining_seconds=completed_remaining,
+            required_seconds=minimum_prejump_margin_seconds,
+        )
+    return ExactReceiptReady(selected, receipt, chain, members)
+
+
+__all__ = ["ExactReceiptReady", "discover_exact_receipt_ready"]

--- a/tests/operator_ui/test_bootstrap.py
+++ b/tests/operator_ui/test_bootstrap.py
@@ -1,27 +1,37 @@
-import pytest
-import shutil
 import hashlib
+import json
 import os
+import shutil
 import stat
 import tempfile
 import threading
-import json
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
+
+import pytest
 from flask import Flask
 from werkzeug.security import generate_password_hash
 
-from src.operator_ui.api import install_level_1_api, register_level_1_provider
-from src.operator_ui.api import _validate_envelope
-from src.operator_ui.bootstrap import CONFIG_KEY, R3_PROFILE_KEY, bind_configured_live_evidence, bind_configured_r3
+import src.operator_ui.bootstrap as bootstrap_module
+from race_collection.synchronous_manual_capture import VerifiedCurrentRaceIndex
+from scripts.forward_prediction_journal import PENDING_RECEIPT, READY, ReceiptAdmission
+from src.operator_ui.api import (
+    _validate_envelope,
+    install_level_1_api,
+    register_level_1_provider,
+)
+from src.operator_ui.bootstrap import (
+    CONFIG_KEY,
+    R3_PROFILE_KEY,
+    bind_configured_live_evidence,
+    bind_configured_r3,
+)
 from src.operator_ui.foundation import OperatorEvidenceReader
+from src.operator_ui.job_store import Phase
 from src.operator_ui.live_adapters import LiveEvidenceAdapters
 from src.operator_ui.security import install_connected_mode
-import src.operator_ui.bootstrap as bootstrap_module
 from src.predictor.on_demand import resolve_model
-from race_collection.synchronous_manual_capture import VerifiedCurrentRaceIndex
-from src.operator_ui.job_store import Phase
 
 
 @pytest.fixture
@@ -369,6 +379,11 @@ def test_finite_testing_fixture_profile_builds_real_repository_composition(tmp_p
           "runners":[{"box_number":1,"display_name":"ALPHA","identity":"alpha","source_native_runner_id":"dog-1"}]}
     view=VerifiedCurrentRaceIndex("collector_current_race_index_v2","run","2026-08-01T00:00:00Z",digest,b"{}",(race,),"source.json",digest,digest,digest,digest)
     monkeypatch.setattr(bootstrap_module,"bounded_current_race_index",lambda **_:view)
+    receipt_state={"value":PENDING_RECEIPT}
+    def receipt_preflight(race,**_):
+        state=receipt_state["value"]
+        return ReceiptAdmission(str(race["race_id"]),str(race["jump_datetime"]),state,"RECEIPT_UNAVAILABLE" if state==PENDING_RECEIPT else None)
+    monkeypatch.setattr(bootstrap_module,"preflight_race_receipt",receipt_preflight)
     runner_completed = threading.Event()
     def terminal_runner(store,job_id,_worker,*,now,confirm_audit):
         job,attempt=store.claim_attempt(job_id,now=now(),confirm_audit=confirm_audit)
@@ -397,7 +412,13 @@ def test_finite_testing_fixture_profile_builds_real_repository_composition(tmp_p
     token=client.post("/operator-ui/login",base_url="https://localhost",data={"username":"viewer","password":"correct horse","csrf_token":token}).get_json()["csrf_token"]
     rejected=client.post("/operator-ui/api/v1/prediction-jobs",base_url="https://localhost",headers={"X-CSRF-Token":token},json={"race_id":"race-fixture","model_id":"latest-research","config_id":"manual-default","odds_source_id":"auto","idempotency_key":"aaaaaaaa-1234-4123-8123-123456789abc"})
     assert rejected.status_code==409 and rejected.get_json()["classification"]=="SELECTION_NOT_ALLOWLISTED"
-    response=client.post("/operator-ui/api/v1/prediction-jobs",base_url="https://localhost",headers={"X-CSRF-Token":token},json={"race_id":"race-fixture","model_id":"latest-research","config_id":"manual-default","odds_source_id":"receipt","idempotency_key":"12345678-1234-4123-8123-123456789abc"})
+    request={"race_id":"race-fixture","model_id":"latest-research","config_id":"manual-default","odds_source_id":"receipt","idempotency_key":"12345678-1234-4123-8123-123456789abc"}
+    pending=client.post("/operator-ui/api/v1/prediction-jobs",base_url="https://localhost",headers={"X-CSRF-Token":token},json=request)
+    assert pending.status_code==409 and pending.get_json()["classification"]==PENDING_RECEIPT
+    assert services.job_store.find_by_idempotency(actor_identity="viewer",operation="manual_prediction",idempotency_key=request["idempotency_key"]) is None
+    assert not runner_completed.is_set()
+    receipt_state["value"]=READY
+    response=client.post("/operator-ui/api/v1/prediction-jobs",base_url="https://localhost",headers={"X-CSRF-Token":token},json=request)
     assert response.status_code==202 and response.get_json()["phase"]=="WAITING_FOR_CLAIM",response.get_json()
     job_id=response.get_json()["job_id"]
     assert runner_completed.wait(timeout=30), "terminal runner did not complete within 30 seconds"

--- a/tests/operator_ui/test_job_store.py
+++ b/tests/operator_ui/test_job_store.py
@@ -10,13 +10,22 @@ from datetime import datetime, timedelta, timezone
 from threading import Event
 
 import pytest
-from src.predictor.on_demand import BLOCKER_STAGE_BY_CODE
 
 from src.operator_ui.job_store import (
-    AttemptAlreadyClaimed, IdempotencyConflict, IllegalTransition, JobInput,
-    JobStore, JobStoreError, OperationalIndexProvenance, Phase, VerifierAuthorizationError,
-    canonical, resolve_audit_confirmation,
+    AttemptAlreadyClaimed,
+    IdempotencyConflict,
+    IllegalTransition,
+    JobInput,
+    JobStore,
+    JobStoreError,
+    OperationalIndexProvenance,
+    Phase,
+    RaceAlreadyRecorded,
+    VerifierAuthorizationError,
+    canonical,
+    resolve_audit_confirmation,
 )
+from src.predictor.on_demand import BLOCKER_STAGE_BY_CODE
 
 NOW = datetime(2026, 8, 1, tzinfo=timezone.utc)
 H = hashlib.sha256(b"identity").hexdigest()
@@ -157,7 +166,25 @@ def test_idempotency_duplicate_conflict_cross_actor_and_raw_key_absent(tmp_path)
     assert create(value).job_id == first.job_id
     with pytest.raises(IdempotencyConflict):
         value.create(actor_identity="operator", actor_level=2, operation="manual_prediction", idempotency_key="idempotency-key-1234", job_input=inputs("race-6"), now=NOW, confirm_audit=CONFIRM)
-    assert create(value, actor="other").job_id != first.job_id
+    other=value.create(actor_identity="other",actor_level=2,operation="manual_prediction",idempotency_key="idempotency-key-1234",job_input=inputs("race-7"),now=NOW,confirm_audit=CONFIRM)
+    assert other.job_id != first.job_id
+
+
+def test_different_idempotency_key_cannot_allocate_second_job_for_same_race(tmp_path):
+    value = store(tmp_path)
+    first = create(value)
+    with pytest.raises(RaceAlreadyRecorded):
+        value.create(
+            actor_identity="operator",
+            actor_level=2,
+            operation="manual_prediction",
+            idempotency_key="different-idempotency-key",
+            job_input=inputs(),
+            now=NOW,
+            confirm_audit=CONFIRM,
+        )
+    assert value.get(first.job_id).input.race_id == inputs().race_id
+    assert value.verify()
     assert b"idempotency-key-1234" not in value.path.read_bytes()
 
 

--- a/tests/operator_ui/test_prediction_worker.py
+++ b/tests/operator_ui/test_prediction_worker.py
@@ -13,6 +13,14 @@ from src.operator_ui.prediction_worker import MAX_STDERR_BYTES,MAX_STDOUT_BYTES,
 NOW=datetime(2026,8,1,tzinfo=timezone.utc); H=hashlib.sha256(b"x").hexdigest(); AUDIT=hashlib.sha256(b"audit").hexdigest(); CONFIRM=lambda intent:resolve_audit_confirmation(intent,AUDIT)
 RACE={"race_number":5,"venue":"RICH","race_date":"2026-08-01","url":"https://www.thedogs.com.au/racing/richmond/2026-08-01/5"}; RACE_ID=stable_race_id(RACE)
 
+@pytest.fixture(autouse=True)
+def exact_receipt_ready(monkeypatch):
+    """Keep legacy worker tests focused; exact receipt semantics have their own suite."""
+    monkeypatch.setattr(
+        "src.operator_ui.prediction_worker.validate_receipt_before_claim",
+        lambda *_args, **_kwargs: None,
+    )
+
 def provenance(**changes):
     values={"schema":"operator_ui_operational_index_admission_v1","index_schema_version":"collector_current_race_index_v2","run_id":"run","packet_sha256":H,"source_refresh_sha256":H,"publication_sha256":H,"state_sha256":H,"report_sha256":H}
     values.update(changes); return OperationalIndexProvenance(**values)
@@ -113,6 +121,16 @@ def test_index_turnover_after_admission_fails_before_claim_without_rewriting_pro
     persisted=store.get(job.job_id)
     assert not persisted.attempt_claimed
     assert persisted.input.operational_index_provenance==admitted
+
+def test_receipt_is_revalidated_immediately_before_claim(tmp_path,monkeypatch):
+    cfg,store,job=setup(tmp_path); calls=[]
+    def pending(*_args,**_kwargs): raise WorkerRejected("PENDING_RECEIPT")
+    monkeypatch.setattr("src.operator_ui.prediction_worker.validate_receipt_before_claim",pending)
+    with pytest.raises(WorkerRejected,match="PENDING_RECEIPT"):
+        run_once(store,job.job_id,cfg,now=lambda:NOW,confirm_audit=CONFIRM,popen=lambda *a,**k:calls.append(1),reader=lambda **_:view())
+    persisted=store.get(job.job_id)
+    assert persisted.phase is Phase.WAITING_FOR_CLAIM
+    assert not persisted.attempt_claimed and not calls
 
 def test_identity_change_before_claim_prevents_launch(tmp_path):
     cfg,store,job=setup(tmp_path); cfg.choices["latest-research"].model_path.write_bytes(b"changed"); calls=[]

--- a/tests/operator_ui/test_r3_api.py
+++ b/tests/operator_ui/test_r3_api.py
@@ -6,8 +6,18 @@ from datetime import datetime, timezone
 from flask import Flask
 from werkzeug.security import generate_password_hash
 
-from src.operator_ui.job_store import JobInput, JobStore, JobStoreError, OperationalIndexProvenance, Phase
-from src.operator_ui.r3_api import R3Rejected, R3Services, ResolvedSubmission, install_r3_api
+from src.operator_ui.job_store import (
+    JobInput,
+    JobStore,
+    OperationalIndexProvenance,
+    Phase,
+)
+from src.operator_ui.r3_api import (
+    R3Rejected,
+    R3Services,
+    ResolvedSubmission,
+    install_r3_api,
+)
 from src.operator_ui.security import install_connected_mode
 
 NOW = datetime(2026, 8, 1, tzinfo=timezone.utc)
@@ -76,6 +86,18 @@ def test_level2_csrf_exact_schema_idempotency_poll_and_actor_isolation(tmp_path)
     with client.session_transaction() as session:
         session["operator_actor"] = "different-actor"
     assert client.get(f"/operator-ui/api/v1/prediction-jobs/{job_id}", base_url="https://localhost").status_code in {401, 404}
+    assert store.verify()
+
+
+def test_different_key_cannot_retry_race_with_durable_job(tmp_path):
+    app, store, launched = application(tmp_path)
+    client = app.test_client(); token = login(client)
+    first = client.post("/operator-ui/api/v1/prediction-jobs",base_url="https://localhost",json=body(),headers={"X-CSRF-Token":token})
+    retry = client.post("/operator-ui/api/v1/prediction-jobs",base_url="https://localhost",json=body(idempotency_key="aaaaaaaa-1234-4123-8123-123456789abc"),headers={"X-CSRF-Token":token})
+    assert first.status_code == 202
+    assert retry.status_code == 409
+    assert retry.get_json()["classification"] == "RACE_ALREADY_RECORDED"
+    assert len(launched) == 1
     assert store.verify()
 
 

--- a/tests/operator_ui/test_r3_e2e_safety.py
+++ b/tests/operator_ui/test_r3_e2e_safety.py
@@ -88,8 +88,12 @@ class Process:
     def poll(self): return self.returncode
 
 
-def test_one_authenticated_submission_reaches_real_worker_once_without_false_ready(tmp_path):
+def test_one_authenticated_submission_reaches_real_worker_once_without_false_ready(tmp_path,monkeypatch):
     """One POST crosses API/store/worker; only the verifier may make it ready."""
+    monkeypatch.setattr(
+        "src.operator_ui.prediction_worker.validate_receipt_before_claim",
+        lambda *_args, **_kwargs: None,
+    )
     files = []
     for name in ("config.json", "model.json", "manifest.json", "schema.json"):
         path = tmp_path / name

--- a/tests/test_forward_prediction_journal.py
+++ b/tests/test_forward_prediction_journal.py
@@ -15,12 +15,15 @@ from scripts.forward_prediction_journal import (
     PENDING_RECEIPT,
     PREFLIGHT_EXCLUDED,
     READY,
+    ReceiptPreflightPolicy,
     observe_receipt_ready_races,
-    validate_exact_receipt_for_race,
 )
-from src.predictor.on_demand import PredictionBlocked, canonical_bytes, sha256_bytes
+from src.predictor.on_demand import canonical_bytes, sha256_bytes
 
 NOW = datetime(2026, 8, 25, 10, 0, tzinfo=timezone(timedelta(hours=10)))
+POLICY = ReceiptPreflightPolicy.from_prediction_config(
+    json.loads(Path("configs/prediction/manual-default.json").read_bytes())
+)
 
 
 def race(venue: str, slug: str, number: int, minutes: int) -> dict[str, Any]:
@@ -218,9 +221,8 @@ def test_four_races_wait_for_independent_staggered_exact_receipts(tmp_path: Path
     first = observe_receipt_ready_races(
         RACES,
         protocol=protocol,
-        current_time=NOW,
-        receipt_max_age_seconds=900,
-        minimum_prejump_margin_seconds=53,
+        policy=POLICY,
+        clock=lambda: NOW,
         recorded_race_ids=frozenset(),
         invoke_ready=invoke,
     )
@@ -234,9 +236,8 @@ def test_four_races_wait_for_independent_staggered_exact_receipts(tmp_path: Path
     second = observe_receipt_ready_races(
         RACES,
         protocol=protocol,
-        current_time=first_arrival,
-        receipt_max_age_seconds=900,
-        minimum_prejump_margin_seconds=53,
+        policy=POLICY,
+        clock=lambda: first_arrival,
         recorded_race_ids=frozenset(),
         invoke_ready=invoke,
     )
@@ -253,9 +254,8 @@ def test_four_races_wait_for_independent_staggered_exact_receipts(tmp_path: Path
     third = observe_receipt_ready_races(
         RACES,
         protocol=protocol,
-        current_time=second_arrival,
-        receipt_max_age_seconds=900,
-        minimum_prejump_margin_seconds=53,
+        policy=POLICY,
+        clock=lambda: second_arrival,
         recorded_race_ids=recorded,
         invoke_ready=invoke,
     )
@@ -278,15 +278,55 @@ def test_expired_pending_race_never_allocates_or_invokes(tmp_path: Path):
     result = observe_receipt_ready_races(
         [value],
         protocol=ManualPredictionCollectorProtocol(tmp_path / "requests"),
-        current_time=NOW + timedelta(seconds=7),
-        receipt_max_age_seconds=900,
-        minimum_prejump_margin_seconds=53,
+        policy=POLICY,
+        clock=lambda: NOW + timedelta(seconds=7),
         recorded_race_ids=frozenset(),
         invoke_ready=lambda row: invoked.append(str(row["race_id"])),
     )
     assert result[0].state == PREFLIGHT_EXCLUDED
     assert result[0].reason == "INSUFFICIENT_PREJUMP_MARGIN"
     assert invoked == []
+
+
+def test_ready_race_is_revalidated_at_allocation_boundary(tmp_path: Path):
+    value = race("GEE", "geelong", 13, 1)
+    protocol = ManualPredictionCollectorProtocol(tmp_path / "requests")
+    publish_manual_receipt(protocol, value, NOW, tmp_path)
+    observations = iter((NOW, NOW, NOW, NOW + timedelta(seconds=8)))
+    invoked: list[str] = []
+    result = observe_receipt_ready_races(
+        [value],
+        protocol=protocol,
+        policy=POLICY,
+        clock=lambda: next(observations),
+        recorded_race_ids=frozenset(),
+        invoke_ready=lambda row: invoked.append(str(row["race_id"])),
+    )
+    assert result[0].state == PREFLIGHT_EXCLUDED
+    assert result[0].reason == "INSUFFICIENT_PREJUMP_MARGIN"
+    assert invoked == []
+
+
+class StaticReceiptProtocol:
+    def __init__(self, value: Mapping[str, Any]):
+        self.value = value
+
+    def discover_exact_handoff(self, **_: Any) -> None:
+        return None
+
+    def discover_collector_exact_handoff(self, **_: Any) -> Mapping[str, Any]:
+        return self.value
+
+    def snapshot_collector_exact_handoff(self, _public: Mapping[str, Any]):
+        return (
+            {},
+            {},
+            {
+                "report": self.value["_report_bytes"],
+                "form": self.value["_form_bytes"],
+                "sidecar": self.value["_sidecar_bytes"],
+            },
+        )
 
 
 @pytest.mark.parametrize(
@@ -365,14 +405,18 @@ def test_exact_receipt_negative_controls_fail_closed(mutation: str, reason: str)
             value_handoff["_report_bytes"]
         )
 
-    with pytest.raises(PredictionBlocked) as captured:
-        validate_exact_receipt_for_race(
-            value,
-            value_handoff,
-            current_time=NOW,
-            receipt_max_age_seconds=900,
-        )
-    assert captured.value.code == reason
+    invoked: list[str] = []
+    result = observe_receipt_ready_races(
+        [value],
+        protocol=StaticReceiptProtocol(value_handoff),
+        policy=POLICY,
+        clock=lambda: NOW,
+        recorded_race_ids=frozenset(),
+        invoke_ready=lambda row: invoked.append(str(row["race_id"])),
+    )
+    assert result[0].state == PREFLIGHT_EXCLUDED
+    assert result[0].reason == reason
+    assert invoked == []
 
 
 def test_recorded_race_is_never_retried_or_backfilled(tmp_path: Path):
@@ -380,9 +424,8 @@ def test_recorded_race_is_never_retried_or_backfilled(tmp_path: Path):
     result = observe_receipt_ready_races(
         [RACES[0]],
         protocol=ManualPredictionCollectorProtocol(tmp_path / "requests"),
-        current_time=NOW,
-        receipt_max_age_seconds=900,
-        minimum_prejump_margin_seconds=53,
+        policy=POLICY,
+        clock=lambda: NOW,
         recorded_race_ids={str(RACES[0]["race_id"])},
         invoke_ready=lambda value: invoked.append(str(value["race_id"])),
     )

--- a/tests/test_forward_prediction_journal.py
+++ b/tests/test_forward_prediction_journal.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from race_collection.manual_prediction_collector_request import (
+    ManualPredictionCollectorProtocol,
+)
+from scripts.forward_prediction_journal import (
+    PENDING_RECEIPT,
+    PREFLIGHT_EXCLUDED,
+    READY,
+    observe_receipt_ready_races,
+    validate_exact_receipt_for_race,
+)
+from src.predictor.on_demand import PredictionBlocked, canonical_bytes, sha256_bytes
+
+NOW = datetime(2026, 8, 25, 10, 0, tzinfo=timezone(timedelta(hours=10)))
+
+
+def race(venue: str, slug: str, number: int, minutes: int) -> dict[str, Any]:
+    race_date = NOW.date().isoformat()
+    jump = NOW + timedelta(minutes=minutes)
+    return {
+        "race_id": f"Race {number} - {venue} - {race_date}",
+        "date": race_date,
+        "venue": venue,
+        "race_number": number,
+        "race_time": jump.strftime("%H:%M"),
+        "jump_datetime": jump.isoformat(),
+        "race_url": (
+            f"https://www.thedogs.com.au/racing/{slug}/{race_date}/{number}/race"
+        ),
+        "runners": [
+            {
+                "box": 1,
+                "display_name": f"{venue} Alpha",
+                "identity": f"{venue} ALPHA",
+                "source_native_runner_id": f"{number}01",
+            },
+            {
+                "box": 2,
+                "display_name": f"{venue} Beta",
+                "identity": f"{venue} BETA",
+                "source_native_runner_id": f"{number}02",
+            },
+        ],
+    }
+
+
+RACES = (
+    race("GEE", "geelong", 13, 20),
+    race("TWN", "townsville", 3, 18),
+    race("QOT", "ladbrokes-q1-lakeside", 13, 15),
+    race("WRGL", "warragul", 2, 22),
+)
+
+
+def validation(value: Mapping[str, Any], captured_at: datetime) -> dict[str, Any]:
+    rows = [
+        {
+            "box_number": row["box"],
+            "dog_name": row["display_name"],
+            "identity": row["identity"],
+            "odds_decimal": 2.0 + offset,
+        }
+        for offset, row in enumerate(value["runners"], start=1)
+    ]
+    del captured_at
+    return {
+        "schema_version": "autonomous_live_odds_capture_validation_v1",
+        "status": "PASS",
+        "source_url": (
+            "https://www.sportsbet.com.au/greyhound-racing/australia-nz/"
+            f"{str(value['race_url']).split('/racing/', 1)[1].split('/', 1)[0]}"
+            f"/race-{value['race_number']}-999"
+        ),
+        "accepted_rows": rows,
+        "accepted_row_count": len(rows),
+        "rejected_rows": [],
+        "accepted_place_rows": rows,
+        "accepted_place_row_count": len(rows),
+        "rejected_place_rows": [],
+        "expected_runner_count": len(rows),
+        "active_expected_runner_count": len(rows),
+        "scratched_expected_runner_count": 0,
+        "scratched_expected_runners": [],
+        "scratched_expected_runners_with_odds": [],
+        "missing_expected_runners": [],
+        "extra_unexpected_runners": [],
+        "failure_root_cause": None,
+        "reasons": [],
+    }
+
+
+def handoff(value: Mapping[str, Any], captured_at: datetime) -> dict[str, Any]:
+    source_validation = validation(value, captured_at)
+    report = {
+        "schema_version": "autonomous_live_odds_capture_report_v1",
+        "attempts": [
+            {
+                "schema_version": "autonomous_live_odds_capture_attempt_v1",
+                "race_id": value["race_id"],
+                "status": "APPENDED",
+                "reasons": [],
+                "fetch_time": captured_at.isoformat(),
+                "append_time": captured_at.isoformat(),
+                "validation": source_validation,
+            }
+        ],
+    }
+    report_raw = canonical_bytes(report)
+    form_raw = canonical_bytes({"race_id": value["race_id"], "kind": "form"})
+    sidecar_raw = canonical_bytes(
+        {"race_id": value["race_id"], "participants": value["runners"]}
+    )
+    return {
+        "schema_version": "on_demand_verified_collector_capture_v2",
+        "race_id": value["race_id"],
+        "race": {
+            "race_id": value["race_id"],
+            "url": value["race_url"],
+            "venue": value["venue"],
+            "race_number": value["race_number"],
+            "race_date": value["date"],
+            "jump_timestamp": value["jump_datetime"],
+        },
+        "append_timestamp": captured_at.isoformat(),
+        "runner_set_sha256": "0" * 64,
+        "source_report_sha256": sha256_bytes(report_raw),
+        "source_form_sha256": sha256_bytes(form_raw),
+        "source_sidecar_sha256": sha256_bytes(sidecar_raw),
+        "capture_attempt_sha256": "1" * 64,
+        "append_report_sha256": "2" * 64,
+        "_report_bytes": report_raw,
+        "_form_bytes": form_raw,
+        "_sidecar_bytes": sidecar_raw,
+        "_form_name": f"{value['race_id']}.csv",
+        "_scheduled_exact_receipt": True,
+    }
+
+
+def publish_manual_receipt(
+    protocol: ManualPredictionCollectorProtocol,
+    value: Mapping[str, Any],
+    captured_at: datetime,
+    root: Path,
+) -> None:
+    expected = [
+        {
+            "box_number": row["box"],
+            "dog_name": row["display_name"],
+            "identity": row["identity"],
+        }
+        for row in value["runners"]
+    ]
+    request = protocol.publish_request(
+        race={
+            "race_id": value["race_id"],
+            "url": value["race_url"],
+            "venue": value["venue"],
+            "race_number": value["race_number"],
+            "race_date": value["date"],
+            "jump_timestamp": value["jump_datetime"],
+        },
+        expected_runners=expected,
+        created_at=NOW - timedelta(minutes=1),
+        expires_at=datetime.fromisoformat(str(value["jump_datetime"])),
+    )
+    context = protocol.claim_request(
+        request["request_id"], now=captured_at, collector_run_id="fixture-collector"
+    )
+    protocol.begin_attempt(
+        context, now=captured_at, collector_run_id="fixture-collector"
+    )
+    value_handoff = handoff(value, captured_at)
+    from src.predictor.on_demand import receipt_from_handoff
+
+    normalized, _, _, _ = receipt_from_handoff(
+        value_handoff, current_time=captured_at, max_age_seconds=900
+    )
+    value_handoff["runner_set_sha256"] = normalized["runner_set_sha256"]
+    source = root / str(value["venue"])
+    source.mkdir()
+    paths = {
+        "report": source / "capture.json",
+        "form": source / value_handoff["_form_name"],
+        "sidecar": source / f"{value_handoff['_form_name']}.metadata.json",
+    }
+    for label, path in paths.items():
+        path.write_bytes(value_handoff[f"_{label}_bytes"])
+        value_handoff[f"_{label}_path"] = path.resolve()
+    protocol.publish_receipt_ready(
+        context,
+        now=captured_at,
+        handoff=value_handoff,
+        normalized_receipt=normalized,
+    )
+    protocol.consume_response(request["request_id"], now=captured_at)
+
+
+def test_four_races_wait_for_independent_staggered_exact_receipts(tmp_path: Path):
+    protocol = ManualPredictionCollectorProtocol(tmp_path / "collector-requests")
+    invocations: list[str] = []
+    outputs = tmp_path / "outputs"
+
+    def invoke(value: Mapping[str, Any]) -> str:
+        race_id = str(value["race_id"])
+        invocations.append(race_id)
+        (outputs / race_id).mkdir(parents=True)
+        return f"job-{len(invocations)}"
+
+    first = observe_receipt_ready_races(
+        RACES,
+        protocol=protocol,
+        current_time=NOW,
+        receipt_max_age_seconds=900,
+        minimum_prejump_margin_seconds=53,
+        recorded_race_ids=frozenset(),
+        invoke_ready=invoke,
+    )
+    assert [row.state for row in first] == [PENDING_RECEIPT] * 4
+    assert invocations == []
+    assert not outputs.exists()
+
+    first_arrival = NOW + timedelta(seconds=70)
+    publish_manual_receipt(protocol, RACES[1], first_arrival, tmp_path)
+    publish_manual_receipt(protocol, RACES[3], first_arrival, tmp_path)
+    second = observe_receipt_ready_races(
+        RACES,
+        protocol=protocol,
+        current_time=first_arrival,
+        receipt_max_age_seconds=900,
+        minimum_prejump_margin_seconds=53,
+        recorded_race_ids=frozenset(),
+        invoke_ready=invoke,
+    )
+    assert [row.race_id for row in second if row.state == READY] == [
+        RACES[1]["race_id"],
+        RACES[3]["race_id"],
+    ]
+    assert invocations == [RACES[1]["race_id"], RACES[3]["race_id"]]
+
+    second_arrival = NOW + timedelta(seconds=130)
+    publish_manual_receipt(protocol, RACES[0], second_arrival, tmp_path)
+    publish_manual_receipt(protocol, RACES[2], second_arrival, tmp_path)
+    recorded = frozenset(invocations)
+    third = observe_receipt_ready_races(
+        RACES,
+        protocol=protocol,
+        current_time=second_arrival,
+        receipt_max_age_seconds=900,
+        minimum_prejump_margin_seconds=53,
+        recorded_race_ids=recorded,
+        invoke_ready=invoke,
+    )
+    assert [row.race_id for row in third if row.state == READY] == [
+        RACES[0]["race_id"],
+        RACES[2]["race_id"],
+    ]
+    assert invocations == [
+        RACES[1]["race_id"],
+        RACES[3]["race_id"],
+        RACES[2]["race_id"],
+        RACES[0]["race_id"],
+    ]
+    assert len(list(outputs.iterdir())) == 4
+
+
+def test_expired_pending_race_never_allocates_or_invokes(tmp_path: Path):
+    value = race("GEE", "geelong", 13, 1)
+    invoked: list[str] = []
+    result = observe_receipt_ready_races(
+        [value],
+        protocol=ManualPredictionCollectorProtocol(tmp_path / "requests"),
+        current_time=NOW + timedelta(seconds=7),
+        receipt_max_age_seconds=900,
+        minimum_prejump_margin_seconds=53,
+        recorded_race_ids=frozenset(),
+        invoke_ready=lambda row: invoked.append(str(row["race_id"])),
+    )
+    assert result[0].state == PREFLIGHT_EXCLUDED
+    assert result[0].reason == "INSUFFICIENT_PREJUMP_MARGIN"
+    assert invoked == []
+
+
+@pytest.mark.parametrize(
+    ("mutation", "reason"),
+    [
+        ("stale", "RECEIPT_STALE"),
+        ("wrong_race", "RECEIPT_INVALID"),
+        ("wrong_date", "RECEIPT_INVALID"),
+        ("wrong_number", "RECEIPT_INVALID"),
+        ("wrong_runner", "RUNNER_SET_AMBIGUOUS"),
+        ("tampered", "RECEIPT_TAMPERED"),
+        ("ambiguous", "RECEIPT_AMBIGUOUS"),
+        ("alias_mismatch", "RECEIPT_INVALID"),
+        ("malformed_url", "RECEIPT_INVALID"),
+        ("unknown_alias", "RECEIPT_INVALID"),
+    ],
+)
+def test_exact_receipt_negative_controls_fail_closed(mutation: str, reason: str):
+    value = RACES[2]
+    captured_at = NOW - timedelta(seconds=30)
+    value_handoff = handoff(value, captured_at)
+    if mutation == "stale":
+        captured_at = NOW - timedelta(seconds=901)
+        value_handoff = handoff(value, captured_at)
+    elif mutation == "wrong_race":
+        value_handoff["race_id"] = RACES[0]["race_id"]
+    elif mutation == "wrong_date":
+        value_handoff["race"] = {
+            **value_handoff["race"],
+            "race_id": "Race 13 - QOT - 2026-08-24",
+            "race_date": "2026-08-24",
+            "url": "https://www.thedogs.com.au/racing/ladbrokes-q1-lakeside/2026-08-24/13/race",
+        }
+    elif mutation == "wrong_number":
+        value_handoff["race"] = {
+            **value_handoff["race"],
+            "race_id": f"Race 12 - QOT - {value['date']}",
+            "race_number": 12,
+            "url": f"https://www.thedogs.com.au/racing/ladbrokes-q1-lakeside/{value['date']}/12/race",
+        }
+    elif mutation == "wrong_runner":
+        report = json.loads(value_handoff["_report_bytes"])
+        report["attempts"][0]["validation"]["accepted_rows"][0]["identity"] = "WRONG"
+        report["attempts"][0]["validation"]["accepted_place_rows"][0]["identity"] = (
+            "WRONG"
+        )
+        value_handoff["_report_bytes"] = canonical_bytes(report)
+        value_handoff["source_report_sha256"] = sha256_bytes(
+            value_handoff["_report_bytes"]
+        )
+    elif mutation == "tampered":
+        value_handoff["_form_bytes"] += b"tampered"
+    elif mutation == "ambiguous":
+        report = json.loads(value_handoff["_report_bytes"])
+        report["attempts"].append(dict(report["attempts"][0]))
+        value_handoff["_report_bytes"] = canonical_bytes(report)
+        value_handoff["source_report_sha256"] = sha256_bytes(
+            value_handoff["_report_bytes"]
+        )
+    elif mutation == "alias_mismatch":
+        value_handoff["race"] = {
+            **value_handoff["race"],
+            "race_id": f"Race 13 - GEE - {value['date']}",
+            "venue": "GEE",
+            "url": str(RACES[0]["race_url"]),
+        }
+    elif mutation in {"malformed_url", "unknown_alias"}:
+        report = json.loads(value_handoff["_report_bytes"])
+        report["attempts"][0]["validation"]["source_url"] = (
+            "not-a-url"
+            if mutation == "malformed_url"
+            else "https://www.sportsbet.com.au/greyhound-racing/australia-nz/unknown-track/race-13-999"
+        )
+        value_handoff["_report_bytes"] = canonical_bytes(report)
+        value_handoff["source_report_sha256"] = sha256_bytes(
+            value_handoff["_report_bytes"]
+        )
+
+    with pytest.raises(PredictionBlocked) as captured:
+        validate_exact_receipt_for_race(
+            value,
+            value_handoff,
+            current_time=NOW,
+            receipt_max_age_seconds=900,
+        )
+    assert captured.value.code == reason
+
+
+def test_recorded_race_is_never_retried_or_backfilled(tmp_path: Path):
+    invoked: list[str] = []
+    result = observe_receipt_ready_races(
+        [RACES[0]],
+        protocol=ManualPredictionCollectorProtocol(tmp_path / "requests"),
+        current_time=NOW,
+        receipt_max_age_seconds=900,
+        minimum_prejump_margin_seconds=53,
+        recorded_race_ids={str(RACES[0]["race_id"])},
+        invoke_ready=lambda value: invoked.append(str(value["race_id"])),
+    )
+    assert result[0].state == "ALREADY_RECORDED"
+    assert invoked == []

--- a/utils/race_identity_equivalence.py
+++ b/utils/race_identity_equivalence.py
@@ -1,0 +1,100 @@
+"""Strict structured equivalence for evidence-proven greyhound race aliases."""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from typing import Any
+
+from config.venue_mapping import VENUE_MAPPING, normalize_venue
+from utils.csv_metadata import (
+    canonical_thedogs_race_identity,
+    canonical_thedogs_venue_identity,
+)
+
+VENUE_CODE_PATTERN = r"[A-Z0-9_]+(?:-[A-Z0-9_]+)*"
+NON_RACING_VENUE_IDENTITIES = frozenset({"UNKNOWN", "TEST_VEN", "RACE"})
+
+
+def race_id_parts(race_id: Any) -> tuple[int, str, date] | None:
+    match = re.fullmatch(
+        r"Race\s+([0-9]{1,2})\s+-\s+(.+?)\s+-\s+([0-9]{4}-[0-9]{2}-[0-9]{2})",
+        str(race_id or "").strip(),
+        flags=re.IGNORECASE,
+    )
+    if match is None:
+        return None
+    try:
+        race_date = date.fromisoformat(match.group(3))
+    except ValueError:
+        return None
+    return int(match.group(1)), match.group(2).strip().upper(), race_date
+
+
+def configured_venue_identity(value: Any) -> str | None:
+    """Resolve only venue spellings proved by the checked-in canonical map."""
+
+    if not isinstance(value, str):
+        return None
+    raw = value.strip().upper()
+    if not raw or re.fullmatch(VENUE_CODE_PATTERN, raw) is None:
+        return None
+    candidates = {
+        raw,
+        raw.replace("-", " "),
+        raw.replace("-", "_"),
+        raw.replace("_", " "),
+        raw.replace("_", "-"),
+    }
+    normalized = {
+        normalize_venue(candidate)
+        for candidate in candidates
+        if candidate in VENUE_MAPPING
+    }
+    if len(normalized) != 1:
+        return None
+    configured = next(iter(normalized))
+    canonical = canonical_thedogs_venue_identity(configured)
+    if (
+        configured in NON_RACING_VENUE_IDENTITIES
+        or canonical in NON_RACING_VENUE_IDENTITIES
+    ):
+        return None
+    return canonical
+
+
+def race_identity_equivalent(
+    caller_race_id: Any,
+    evidence_race_id: Any,
+    *,
+    source_url: Any,
+) -> bool:
+    """Bind caller and sealed-source aliases by exact structured identity."""
+
+    caller = race_id_parts(caller_race_id)
+    evidence = race_id_parts(evidence_race_id)
+    source = canonical_thedogs_race_identity(source_url)
+    if caller is None or evidence is None or source is None:
+        return False
+    caller_number, caller_venue, caller_date = caller
+    evidence_number, evidence_venue, evidence_date = evidence
+    venues = (
+        configured_venue_identity(caller_venue),
+        configured_venue_identity(evidence_venue),
+        configured_venue_identity(source["venue_slug"]),
+    )
+    return bool(
+        all(venue is not None for venue in venues)
+        and len(set(venues)) == 1
+        and caller_date == evidence_date
+        and caller_date.isoformat() == source["race_date"]
+        and caller_number == evidence_number
+        and caller_number == source["race_number"]
+    )
+
+
+__all__ = [
+    "configured_venue_identity",
+    "race_id_parts",
+    "race_identity_equivalent",
+]


### PR DESCRIPTION
## Summary\n\n- require an exact fresh validated receipt before R3 job allocation\n- revalidate receipt readiness immediately before the worker claims the one-shot attempt\n- share the production receipt discovery and strict race/source/runner validation seam with the predictor\n- keep missing receipts pending, reject expired or invalid receipts preflight, and invoke only READY races in deterministic jump order\n- durably reject a second job record for an already-recorded race\n\n## Preservation\n\n- no journal artifacts or historical rows changed\n- GEE R13, TWN R3, QOT R13, WRGL R2, and QOT R7 remain consumed exactly as recorded\n- no acquisition, timer, collector, model, config, feature, deployment, result, or betting changes\n- live journal remains paused\n\n## Validation\n\n- 94 forward-journal and predictor tests\n- 421 scorer/manual residual tests\n- 285 operator boundary tests\n- 115 manual collector and synchronous receipt tests\n- 326 sealed bundle/schema tests\n- 403 final receipt/predictor/scorer boundary regression tests\n- py_compile, Ruff on new focused modules, forecasting classifier tests, and git diff --check\n- independent Standards review: PASS\n- independent Spec review: PASS\n\n## Resume gate\n\nMerge and deploy are still required before the live journal can resume.